### PR TITLE
Pass keyRefresherListener through to getKeyRefresher

### DIFF
--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
@@ -207,7 +207,7 @@ public class Utils {
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         TrustStore trustStore = new TrustStore(trustStorePath,
                 new JavaKeyStoreProvider(trustStorePath, trustStorePassword));
-        return getKeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore);
+        return getKeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore, keyRefresherListener);
     }
 
     /**


### PR DESCRIPTION
The `generateKeyRefresher` method that accepts a KeyRefresherListener is not actually passing it through to `getKeyRefresher`, thus making it impossible to register a key refresher with a listener.