### PR TITLE
Upgrade jakarta.mail dependency to 2.0.0

### DIFF
--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>jakarta.mail</artifactId>
-      <version>1.6.5</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.yahoo.athenz</groupId>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/EmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/EmailProvider.java
@@ -16,7 +16,7 @@
 
 package com.yahoo.athenz.common.server.notification;
 
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage;
 import java.util.Collection;
 
 public interface EmailProvider {

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
@@ -27,7 +27,7 @@ import com.yahoo.athenz.common.server.notification.EmailProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMessage;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.Collection;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
@@ -24,12 +24,12 @@ import com.yahoo.athenz.common.server.notification.NotificationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -128,7 +128,7 @@ public class EmailNotificationService implements NotificationService {
         // Add subject, from and to lines.
         message.setSubject(subject, CHARSET_UTF_8);
         message.setFrom(new InternetAddress(from));
-        message.setRecipients(javax.mail.Message.RecipientType.BCC, InternetAddress.parse(String.join(",", recipients)));
+        message.setRecipients(jakarta.mail.Message.RecipientType.BCC, InternetAddress.parse(String.join(",", recipients)));
 
         // Set the HTML part.
         MimeBodyPart htmlPart = new MimeBodyPart();


### PR DESCRIPTION
According to https://eclipse-ee4j.github.io/mail/:
"...This release contains no other enhancements nor bug fixes, except for the minimal required Java SE version which is now Java SE 8. This is also the release included in Jakarta EE 9. Applications are able to switch to this new version by just changing all imports that use javax.mail.* to instead use jakarta.mail.*."