### PR TITLE
add support for groups for resource lookup api 

### DIFF
--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -1807,7 +1807,7 @@ func init() {
 	sb.AddResource(mGetAccessExt.Build())
 
 	mGetResourceAccessList := rdl.NewResourceBuilder("ResourceAccessList", "GET", "/resource")
-	mGetResourceAccessList.Comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified unless the caller has authorization from sys.auth domain to check access for all user principals. (action: access, resource: resource-lookup-all)")
+	mGetResourceAccessList.Comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
 	mGetResourceAccessList.Input("principal", "ResourceName", false, "principal", "", true, nil, "specifies principal to query the resource list for")
 	mGetResourceAccessList.Input("action", "ActionName", false, "action", "", true, nil, "action as specified in the policy assertion")
 	mGetResourceAccessList.Auth("", "", true, "")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -2101,7 +2101,7 @@ public class ZMSSchema {
 ;
 
         sb.resource("ResourceAccessList", "GET", "/resource")
-            .comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified unless the caller has authorization from sys.auth domain to check access for all user principals. (action: access, resource: resource-lookup-all)")
+            .comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
             .queryParam("principal", "principal", "ResourceName", null, "specifies principal to query the resource list for")
             .queryParam("action", "action", "ActionName", null, "action as specified in the policy assertion")
             .auth("", "", true)

--- a/core/zms/src/main/rdl/Access.rdli
+++ b/core/zms/src/main/rdl/Access.rdli
@@ -61,9 +61,8 @@ type ResourceAccessList Struct {
     Array<ResourceAccess> resources;
 }
 
-//Return list of resources that the given principal has access to. Even though the principal
-//is marked as optional, it must be specified unless the caller has authorization from sys.auth
-//domain to check access for all user principals. (action: access, resource: resource-lookup-all)
+//Return list of resources that the given principal has access to. Even
+//though the principal is marked as optional, it must be specified
 resource ResourceAccessList GET "/resource?principal={principal}&action={action}" {
     ResourceName principal (optional); //specifies principal to query the resource list for
     ActionName action (optional); //action as specified in the policy assertion

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <jackson.annotations.version>2.12.1</jackson.annotations.version>
     <jackson.jaxrs.version>2.12.1</jackson.jaxrs.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <rdl.version>1.5.3</rdl.version>
+    <rdl.version>1.5.4</rdl.version>
     <bouncycastle.version>1.68</bouncycastle.version>
     <aws.version>1.11.942</aws.version>
     <aws2.version>2.10.11</aws2.version>
@@ -309,17 +309,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>bintray-yahoo-maven</id>
-      <name>bintray</name>
-      <url>https://yahoo.bintray.com/maven</url>
-    </repository>
-  </repositories>
   
   <profiles>
     <profile>

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -2997,7 +2997,7 @@ public class ZMSResources {
     @GET
     @Path("/resource")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified unless the caller has authorization from sys.auth domain to check access for all user principals. (action: access, resource: resource-lookup-all)")
+    @Operation(description = "Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
     public ResourceAccessList getResourceAccessList(
         @Parameter(description = "specifies principal to query the resource list for", required = false) @QueryParam("principal") String principal,
         @Parameter(description = "action as specified in the policy assertion", required = false) @QueryParam("action") String action) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
@@ -17,22 +17,19 @@ package com.yahoo.athenz.zms;
 
 import com.wix.mysql.EmbeddedMysql;
 import com.wix.mysql.Sources;
-import com.wix.mysql.SqlScriptSource;
 import com.wix.mysql.config.MysqldConfig;
 import com.yahoo.rdl.Timestamp;
 import com.yahoo.rdl.UUID;
-import org.testng.internal.junit.ArrayAsserts;
 
 import java.io.File;
-import java.util.Calendar;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static com.wix.mysql.EmbeddedMysql.anEmbeddedMysql;
 import static com.wix.mysql.ScriptResolver.classPathScript;
 import static com.wix.mysql.config.MysqldConfig.aMysqldConfig;
 import static com.wix.mysql.distribution.Version.v5_7_latest;
-import static org.testng.AssertJUnit.assertEquals;
 
 public class ZMSTestUtils {
 
@@ -152,9 +149,6 @@ public class ZMSTestUtils {
     }
 
     public static Timestamp addDays(Timestamp date, int days) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(date.millis());
-        cal.add(Calendar.DATE, days);
-        return Timestamp.fromMillis(cal.getTime().getTime());
+        return Timestamp.fromMillis(date.millis() + TimeUnit.MILLISECONDS.convert(days, TimeUnit.DAYS));
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
@@ -275,7 +275,7 @@ public class GroupMemberExpiryNotificationTaskTest {
 
     @Test
     public void testGetNotificationAsMetric() {
-        Timestamp currentTimeStamp = Timestamp.fromMillis(System.currentTimeMillis());
+        Timestamp currentTimeStamp = Timestamp.fromCurrentTime();
         Timestamp twentyDaysFromNow = ZMSTestUtils.addDays(currentTimeStamp, 20);
         Timestamp twentyFiveDaysFromNow = ZMSTestUtils.addDays(currentTimeStamp, 25);
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
@@ -301,7 +301,7 @@ public class RoleMemberExpiryNotificationTaskTest {
 
     @Test
     public void testGetNotificationAsMetric() {
-        Timestamp currentTimeStamp = Timestamp.fromMillis(System.currentTimeMillis());
+        Timestamp currentTimeStamp = Timestamp.fromCurrentTime();
         Timestamp twentyDaysFromNow = ZMSTestUtils.addDays(currentTimeStamp, 20);
         Timestamp twentyFiveDaysFromNow = ZMSTestUtils.addDays(currentTimeStamp, 25);
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTaskTest.java
@@ -307,7 +307,7 @@ public class RoleMemberReviewNotificationTaskTest {
 
     @Test
     public void testGetNotificationAsMetric() {
-        Timestamp currentTimeStamp = Timestamp.fromMillis(System.currentTimeMillis());
+        Timestamp currentTimeStamp = Timestamp.fromCurrentTime();
         Timestamp twentyDaysFromNow = ZMSTestUtils.addDays(currentTimeStamp, 20);
         Timestamp twentyFiveDaysFromNow = ZMSTestUtils.addDays(currentTimeStamp, 25);
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSTestUtils.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSTestUtils.java
@@ -27,13 +27,11 @@ import com.yahoo.athenz.zms.ServiceIdentity;
 import com.yahoo.athenz.zts.store.DataStore;
 import com.yahoo.rdl.Timestamp;
 import org.eclipse.jetty.util.StringUtil;
-import org.testng.internal.junit.ArrayAsserts;
 
 import java.io.File;
 import java.security.PrivateKey;
 import java.util.*;
-
-import static org.testng.AssertJUnit.assertEquals;
+import java.util.concurrent.TimeUnit;
 
 public class ZTSTestUtils {
 
@@ -384,10 +382,7 @@ public class ZTSTestUtils {
     }
 
     public static Timestamp addDays(Timestamp date, int days) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(date.millis());
-        cal.add(Calendar.DATE, days);
-        return Timestamp.fromMillis(cal.getTime().getTime());
+        return Timestamp.fromMillis(date.millis() + TimeUnit.MILLISECONDS.convert(days, TimeUnit.DAYS));
     }
 
     public static Map<String, AttributeValue> generateAttributeValues(String service,

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
@@ -687,7 +687,7 @@ public class CertFailedRefreshNotificationTaskTest {
 
     @Test
     public void testGetNotificationAsMetric() {
-        Timestamp currentTimeStamp = Timestamp.fromMillis(System.currentTimeMillis());
+        Timestamp currentTimeStamp = Timestamp.fromCurrentTime();
         Timestamp fiveDaysAgo = ZTSTestUtils.addDays(currentTimeStamp, -5);
         Timestamp twentyFiveDaysFromNow = ZTSTestUtils.addDays(currentTimeStamp, 25);
 


### PR DESCRIPTION
the api option to return all resource access for all users becomes too expensive since we have to process all roles/polices/etc within the server. that option is now removed and the caller must always specify which principal the check is carried out for.