### PR TITLE
Enhance security:

### DIFF
--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -15,6 +15,8 @@
  */
 package com.yahoo.athenz.container;
 
+import sun.security.provider.certpath.OCSP;
+
 /**
  * Contains constants shared by classes throughout the service.
  **/
@@ -52,6 +54,7 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_RESPONSE_HEADER_SIZE   = "athenz.http_response_header_size";
     public static final String ATHENZ_PROP_LISTEN_HOST            = "athenz.listen_host";
     public static final String ATHENZ_PROP_KEEP_ALIVE             = "athenz.keep_alive";
+    public static final String ATHENZ_PROP_RESPONSE_HEADERS_JSON  = "athenz.response_headers_json";
     public static final String ATHENZ_PROP_GZIP_SUPPORT           = "athenz.gzip_support";
     public static final String ATHENZ_PROP_GZIP_MIN_SIZE          = "athenz.gzip_min_size";
     public static final String ATHENZ_PROP_MAX_THREADS            = "athenz.http_max_threads";

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -15,8 +15,6 @@
  */
 package com.yahoo.athenz.container;
 
-import sun.security.provider.certpath.OCSP;
-
 /**
  * Contains constants shared by classes throughout the service.
  **/

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -179,7 +179,7 @@ public class AthenzJettyContainer {
             rewriteHandler.addRule(disableKeepAliveRule);
         }
         
-        // Security: Respond the "Expect-CT: max-age=31536000, report-uri=..." header (see http://yo/expect-ct)
+        // Security: Respond the "Expect-CT: max-age=31536000, report-uri=..." header
 
         HeaderPatternRule expectCtRule = new HeaderPatternRule();
         expectCtRule.setPattern("/*");
@@ -187,7 +187,7 @@ public class AthenzJettyContainer {
         expectCtRule.setValue("max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\"");
         rewriteHandler.addRule(expectCtRule);
 
-        // Security: Respond the "Strict-Transport-Security: max-age=31536000" header (see http://yo/hsts)
+        // Security: Respond the "Strict-Transport-Security: max-age=31536000" header
 
         HeaderPatternRule hstsRule = new HeaderPatternRule();
         hstsRule.setPattern("/*");

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -164,15 +164,15 @@ public class AthenzJettyContainer {
     public void addServletHandlers(String serverHostName) {
 
         // Handler Structure
-
+        
         RewriteHandler rewriteHandler = new RewriteHandler();
-
+        
         // Check whether or not to disable Keep-Alive support in Jetty.
         // This will be the first handler in our array so we always set
         // the appropriate header in response. However, since we're now
         // behind ATS, we want to keep the connections alive so ATS
         // can re-use them as necessary
-
+        
         boolean keepAlive = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_KEEP_ALIVE, "true"));
 
         if (!keepAlive) {
@@ -182,7 +182,7 @@ public class AthenzJettyContainer {
             disableKeepAliveRule.setValue(HttpHeaderValue.CLOSE.asString());
             rewriteHandler.addRule(disableKeepAliveRule);
         }
-
+        
         // Add response-headers, according to configuration
 
         String responseHeadersJson = System.getProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON, "");
@@ -416,7 +416,7 @@ public class AthenzJettyContainer {
         }
 
         if (enableOCSP) {
-            // https://stackoverflow.com/questions/49904935/jetty-9-enable-ocsp-stapling-for-domain-validated-certificate
+            // See https://stackoverflow.com/questions/49904935/jetty-9-enable-ocsp-stapling-for-domain-validated-certificate
             Security.setProperty("ocsp.enable", "true");
             System.setProperty("jdk.tls.server.enableStatusRequestExtension", "true");
             System.setProperty("com.sun.net.ssl.checkRevocation", "true");

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -773,9 +773,27 @@ public class AthenzJettyContainerTest {
     }
 
     @Test
-    public void testOCSP() {
-        System.setProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "true");
+    public void testNoOCSP() {
+        System.setProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "false");
 
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+        HttpConfiguration httpConfig = container.newHttpConfiguration();
+        container.addHTTPConnectors(httpConfig, 0, 8083, 0);
+
+        Server server = container.getServer();
+        Connector[] connectors = server.getConnectors();
+        assertEquals(connectors.length, 1);
+        SslContextFactory sslContextFactory = connectors[0].getConnectionFactory(SslConnectionFactory.class).getSslContextFactory();
+
+        assertFalse(sslContextFactory.isEnableOCSP());
+        assertFalse(sslContextFactory.isValidateCerts());
+
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP);
+    }
+
+    @Test
+    public void testOCSP() {
         AthenzJettyContainer container = new AthenzJettyContainer();
         container.createServer(100);
         HttpConfiguration httpConfig = container.newHttpConfiguration();
@@ -791,7 +809,5 @@ public class AthenzJettyContainerTest {
         assertEquals(System.getProperty("com.sun.net.ssl.checkRevocation"), "true");
         assertTrue(sslContextFactory.isEnableOCSP());
         assertTrue(sslContextFactory.isValidateCerts());
-
-        System.clearProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP);
     }
 }


### PR DESCRIPTION
  - OCSP-Stapling enabled by default
  - Client re-negotiation disabled by default
  - Various response headers for better security:
       - Expect-CT: max-age=31536000, report-uri="http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only"
       - Strict-Transport-Security: max-age=31536000
       - X-Content-Type-Options: nosniff
       - Referrer-Policy: strict-origin-when-cross-origin
       - Cache-Control: must-revalidate,no-cache,no-store