### PR TITLE
Enhance security:

### DIFF
--- a/containers/jetty/conf/athenz.properties
+++ b/containers/jetty/conf/athenz.properties
@@ -75,9 +75,6 @@ athenz.access_log_dir=/home/athenz/logs/athenz
 # Configure if client TLS renegotiation is allowed or not
 #athenz.ssl_renegotiation_allowed=true
 
-# Enable OCSP support
-#athenz.ssl_enable_ocsp=false
-
 # Enable the SSL Connection logger to log all TLS handshake
 # failures such as clients connecting with unsupported TLS
 # versions, ciphers or expired client certificates.

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -52,6 +52,7 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_RESPONSE_HEADER_SIZE   = "athenz.http_response_header_size";
     public static final String ATHENZ_PROP_LISTEN_HOST            = "athenz.listen_host";
     public static final String ATHENZ_PROP_KEEP_ALIVE             = "athenz.keep_alive";
+    public static final String ATHENZ_PROP_RESPONSE_HEADERS_JSON  = "athenz.response_headers_json";
     public static final String ATHENZ_PROP_GZIP_SUPPORT           = "athenz.gzip_support";
     public static final String ATHENZ_PROP_GZIP_MIN_SIZE          = "athenz.gzip_min_size";
     public static final String ATHENZ_PROP_MAX_THREADS            = "athenz.http_max_threads";

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -40,7 +40,6 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_INCLUDED_CIPHER_SUITES = "athenz.ssl_included_cipher_suites";
     public static final String ATHENZ_PROP_EXCLUDED_PROTOCOLS     = "athenz.ssl_excluded_protocols";
     public static final String ATHENZ_PROP_CLIENT_AUTH            = "athenz.ssl_need_client_auth";
-    public static final String ATHENZ_PROP_ENABLE_OCSP            = "athenz.ssl_enable_ocsp";
     public static final String ATHENZ_PROP_RENEGOTIATION_ALLOWED  = "athenz.ssl_renegotiation_allowed";
     public static final String ATHENZ_PROP_SSL_LOG_FAILURES       = "athenz.ssl_log_failures";
     public static final String ATHENZ_PROP_IDLE_TIMEOUT           = "athenz.http_idle_timeout";

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -417,9 +417,10 @@ public class AthenzJettyContainer {
 
         if (enableOCSP) {
             // See https://stackoverflow.com/questions/49904935/jetty-9-enable-ocsp-stapling-for-domain-validated-certificate
-            Security.setProperty("ocsp.enable", "true");
-            System.setProperty("jdk.tls.server.enableStatusRequestExtension", "true");
-            System.setProperty("com.sun.net.ssl.checkRevocation", "true");
+            // Note that for OCSP-Stapling to actually work - these commands must also be performed:
+            //            Security.setProperty("ocsp.enable", "true");
+            //            System.setProperty("jdk.tls.server.enableStatusRequestExtension", "true");
+            //            System.setProperty("com.sun.net.ssl.checkRevocation", "true");
             sslContextFactory.setEnableOCSP(true);
             sslContextFactory.setValidateCerts(true);   // not sure what this does... OCSP works even without this - but it is recommended.
         }

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -18,7 +18,6 @@ package com.yahoo.athenz.container;
 
 import java.io.File;
 import java.net.InetAddress;
-import java.security.Security;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -346,15 +345,14 @@ public class AthenzJettyContainer {
         try {
             pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).newInstance();
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid PrivateKeyStoreFactory class: " + pkeyFactoryClass
-                    + " error: " + e.getMessage());
+            LOG.error("Invalid PrivateKeyStoreFactory class: " + pkeyFactoryClass + " error: ", e);
             throw new IllegalArgumentException("Invalid private key store");
         }
         this.privateKeyStore = pkeyFactory.create();
     }
-    
+
     SslContextFactory.Server createSSLContextObject(boolean needClientAuth) {
-        
+
         final String keyStorePath = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PATH);
         final String keyStorePasswordAppName = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PASSWORD_APPNAME);
         final String keyStorePassword = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PASSWORD);
@@ -367,10 +365,8 @@ public class AthenzJettyContainer {
         final String trustStoreType = System.getProperty(AthenzConsts.ATHENZ_PROP_TRUSTSTORE_TYPE, "PKCS12");
         final String includedCipherSuites = System.getProperty(AthenzConsts.ATHENZ_PROP_INCLUDED_CIPHER_SUITES);
         final String excludedCipherSuites = System.getProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_CIPHER_SUITES);
-        final String excludedProtocols = System.getProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS,
-                ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
-        boolean enableOCSP = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "true"));
-        boolean renegotiationAllowed = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_RENEGOTIATION_ALLOWED, "false"));
+        final String excludedProtocols = System.getProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS, ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
+        final boolean renegotiationAllowed = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_RENEGOTIATION_ALLOWED, "false"));
 
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setEndpointIdentificationAlgorithm(null);
@@ -413,16 +409,6 @@ public class AthenzJettyContainer {
             sslContextFactory.setNeedClientAuth(true);
         } else {
             sslContextFactory.setWantClientAuth(true);
-        }
-
-        if (enableOCSP) {
-            // See https://stackoverflow.com/questions/49904935/jetty-9-enable-ocsp-stapling-for-domain-validated-certificate
-            // Note that for OCSP-Stapling to actually work - these commands must also be performed:
-            //            Security.setProperty("ocsp.enable", "true");
-            //            System.setProperty("jdk.tls.server.enableStatusRequestExtension", "true");
-            //            System.setProperty("com.sun.net.ssl.checkRevocation", "true");
-            sslContextFactory.setEnableOCSP(true);
-            sslContextFactory.setValidateCerts(true);   // not sure what this does... OCSP works even without this - but it is recommended.
         }
 
         sslContextFactory.setRenegotiationAllowed(renegotiationAllowed);
@@ -593,7 +579,7 @@ public class AthenzJettyContainer {
             System.out.println("Jetty server running at " + banner);
             server.join();
         } catch (Exception e) {
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -771,43 +771,4 @@ public class AthenzJettyContainerTest {
 
         System.clearProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON);
     }
-
-    @Test
-    public void testNoOCSP() {
-        System.setProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "false");
-
-        AthenzJettyContainer container = new AthenzJettyContainer();
-        container.createServer(100);
-        HttpConfiguration httpConfig = container.newHttpConfiguration();
-        container.addHTTPConnectors(httpConfig, 0, 8083, 0);
-
-        Server server = container.getServer();
-        Connector[] connectors = server.getConnectors();
-        assertEquals(connectors.length, 1);
-        SslContextFactory sslContextFactory = connectors[0].getConnectionFactory(SslConnectionFactory.class).getSslContextFactory();
-
-        assertFalse(sslContextFactory.isEnableOCSP());
-        assertFalse(sslContextFactory.isValidateCerts());
-
-        System.clearProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP);
-    }
-
-    @Test
-    public void testOCSP() {
-        AthenzJettyContainer container = new AthenzJettyContainer();
-        container.createServer(100);
-        HttpConfiguration httpConfig = container.newHttpConfiguration();
-        container.addHTTPConnectors(httpConfig, 0, 8083, 0);
-
-        Server server = container.getServer();
-        Connector[] connectors = server.getConnectors();
-        assertEquals(connectors.length, 1);
-        SslContextFactory sslContextFactory = connectors[0].getConnectionFactory(SslConnectionFactory.class).getSslContextFactory();
-
-        assertEquals(Security.getProperty("ocsp.enable"), "true");
-        assertEquals(System.getProperty("jdk.tls.server.enableStatusRequestExtension"), "true");
-        assertEquals(System.getProperty("com.sun.net.ssl.checkRevocation"), "true");
-        assertTrue(sslContextFactory.isEnableOCSP());
-        assertTrue(sslContextFactory.isValidateCerts());
-    }
 }

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -15,12 +15,15 @@
  */
 package com.yahoo.athenz.container;
 
+import org.eclipse.jetty.rewrite.handler.RewriteHandler;
+import org.eclipse.jetty.rewrite.handler.Rule;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Slf4jRequestLog;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
@@ -34,6 +37,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.container.log.AthenzRequestLog;
+
+import java.security.Security;
 
 import static org.testng.Assert.*;
 
@@ -735,5 +740,74 @@ public class AthenzJettyContainerTest {
         assertNotNull(contextHandlerCollection);
         assertNotNull(statisticsHandler);
         assertEquals(statisticsHandler.getHandler(), contextHandlerCollection);
+    }
+
+    @Test
+    public void testHttpResponseHeaders() {
+        System.setProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON, "{\"Header-1\":\"Value-1\",\"Header-2\":\"Value-2\"}");
+
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+        container.addServletHandlers("localhost");
+
+        boolean header1Handled = false;
+        boolean header2Handled = false;
+        Handler[] handlers = container.getHandlers().getHandlers();
+        for (Handler handler : handlers) {
+            if (handler instanceof RewriteHandler) {
+                RewriteHandler rewriteHandler = (RewriteHandler) handler;
+                for (Rule rule : rewriteHandler.getRules()) {
+                    if (rule.toString().equals("org.eclipse.jetty.rewrite.handler.HeaderPatternRule[ht][/*][Header-1,Value-1]")) {
+                        header1Handled = true;
+                    }
+                    if (rule.toString().equals("org.eclipse.jetty.rewrite.handler.HeaderPatternRule[ht][/*][Header-2,Value-2]")) {
+                        header2Handled = true;
+                    }
+                }
+            }
+        }
+        assertTrue(header1Handled);
+        assertTrue(header2Handled);
+
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON);
+    }
+
+    @Test
+    public void testNoOCSP() {
+        System.setProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "false");
+
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+        HttpConfiguration httpConfig = container.newHttpConfiguration();
+        container.addHTTPConnectors(httpConfig, 0, 8083, 0);
+
+        Server server = container.getServer();
+        Connector[] connectors = server.getConnectors();
+        assertEquals(connectors.length, 1);
+        SslContextFactory sslContextFactory = connectors[0].getConnectionFactory(SslConnectionFactory.class).getSslContextFactory();
+
+        assertFalse(sslContextFactory.isEnableOCSP());
+        assertFalse(sslContextFactory.isValidateCerts());
+
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP);
+    }
+
+    @Test
+    public void testOCSP() {
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+        HttpConfiguration httpConfig = container.newHttpConfiguration();
+        container.addHTTPConnectors(httpConfig, 0, 8083, 0);
+
+        Server server = container.getServer();
+        Connector[] connectors = server.getConnectors();
+        assertEquals(connectors.length, 1);
+        SslContextFactory sslContextFactory = connectors[0].getConnectionFactory(SslConnectionFactory.class).getSslContextFactory();
+
+        assertEquals(Security.getProperty("ocsp.enable"), "true");
+        assertEquals(System.getProperty("jdk.tls.server.enableStatusRequestExtension"), "true");
+        assertEquals(System.getProperty("com.sun.net.ssl.checkRevocation"), "true");
+        assertTrue(sslContextFactory.isEnableOCSP());
+        assertTrue(sslContextFactory.isValidateCerts());
     }
 }

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Slf4jRequestLog;
-import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
@@ -37,8 +36,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.container.log.AthenzRequestLog;
-
-import java.security.Security;
 
 import static org.testng.Assert.*;
 

--- a/libs/java/server_common/src/test/resources/testFileConfig.properties
+++ b/libs/java/server_common/src/test/resources/testFileConfig.properties
@@ -75,9 +75,6 @@ athenz.access_log_dir=
 # Configure if client TLS renegotiation is allowed or not
 #athenz.ssl_renegotiation_allowed=true
 
-# Enable OCSP support
-#athenz.ssl_enable_ocsp=false
-
 # In milliseconds how long that connector will be allowed to
 # remain idle with no traffic before it is shutdown
 #athenz.http_idle_timeout=30000

--- a/servers/zms/conf/athenz.properties
+++ b/servers/zms/conf/athenz.properties
@@ -92,6 +92,10 @@ athenz.ssl_key_store_password=athenz
 # the Keep Alive connection option or just connections right away
 #athenz.keep_alive=false
 
+# A JSON object with string values: every HTTP response will contain these headers (default is none).
+# This is a good place to put security enhancing headers - see example below:
+#athenz.response_headers_json={ "Expect-CT": "max-age=31536000, report-uri=\"http://csp.athenz.io/beacon\"", "Strict-Transport-Security": "max-age=31536000", "X-Content-Type-Options": "nosniff", "Referrer-Policy": "strict-origin-when-cross-origin", "Cache-Control": "must-revalidate,no-cache,no-store" }
+
 # Max number of threads Jetty is allowed to spawn to handle incoming requests
 #athenz.http_max_threads=1024
 

--- a/servers/zts/conf/athenz.properties
+++ b/servers/zts/conf/athenz.properties
@@ -92,6 +92,10 @@ athenz.ssl_trust_store_password=athenz
 # the Keep Alive connection option or just connections right away
 #athenz.keep_alive=false
 
+# A JSON object with string values: every HTTP response will contain these headers (default is none).
+# This is a good place to put security enhancing headers - see example below:
+#athenz.response_headers_json={ "Expect-CT": "max-age=31536000, report-uri=\"http://csp.athenz.io/beacon\"", "Strict-Transport-Security": "max-age=31536000", "X-Content-Type-Options": "nosniff", "Referrer-Policy": "strict-origin-when-cross-origin", "Cache-Control": "must-revalidate,no-cache,no-store" }
+
 # Max number of threads Jetty is allowed to spawn to handle incoming requests
 #athenz.http_max_threads=1024
 


### PR DESCRIPTION
  - OCSP-Stapling enabled by default
  - Client re-negotiation disabled by default
  - Any response headers can be configured. Suggestion for better security: set the system-property "athenz.response_headers_json" to something like this:
       { "Expect-CT": "max-age=31536000, report-uri=\"http://........\"", "Strict-Transport-Security": "max-age=31536000", "X-Content-Type-Options": "nosniff", "Referrer-Policy": "strict-origin-when-cross-origin", "Cache-Control": "must-revalidate,no-cache,no-store" }

Signed-off-by: Gilad Ben-Dor <gilad.bendor@verizonmedia.com>