### PR TITLE
Enhance security:

### DIFF
--- a/containers/jetty/conf/athenz.properties
+++ b/containers/jetty/conf/athenz.properties
@@ -75,9 +75,6 @@ athenz.access_log_dir=/home/athenz/logs/athenz
 # Configure if client TLS renegotiation is allowed or not
 #athenz.ssl_renegotiation_allowed=true
 
-# Enable OCSP support
-#athenz.ssl_enable_ocsp=false
-
 # Enable the SSL Connection logger to log all TLS handshake
 # failures such as clients connecting with unsupported TLS
 # versions, ciphers or expired client certificates.

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -40,7 +40,6 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_INCLUDED_CIPHER_SUITES = "athenz.ssl_included_cipher_suites";
     public static final String ATHENZ_PROP_EXCLUDED_PROTOCOLS     = "athenz.ssl_excluded_protocols";
     public static final String ATHENZ_PROP_CLIENT_AUTH            = "athenz.ssl_need_client_auth";
-    public static final String ATHENZ_PROP_ENABLE_OCSP            = "athenz.ssl_enable_ocsp";
     public static final String ATHENZ_PROP_RENEGOTIATION_ALLOWED  = "athenz.ssl_renegotiation_allowed";
     public static final String ATHENZ_PROP_SSL_LOG_FAILURES       = "athenz.ssl_log_failures";
     public static final String ATHENZ_PROP_IDLE_TIMEOUT           = "athenz.http_idle_timeout";
@@ -52,6 +51,7 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_RESPONSE_HEADER_SIZE   = "athenz.http_response_header_size";
     public static final String ATHENZ_PROP_LISTEN_HOST            = "athenz.listen_host";
     public static final String ATHENZ_PROP_KEEP_ALIVE             = "athenz.keep_alive";
+    public static final String ATHENZ_PROP_RESPONSE_HEADERS_JSON  = "athenz.response_headers_json";
     public static final String ATHENZ_PROP_GZIP_SUPPORT           = "athenz.gzip_support";
     public static final String ATHENZ_PROP_GZIP_MIN_SIZE          = "athenz.gzip_min_size";
     public static final String ATHENZ_PROP_MAX_THREADS            = "athenz.http_max_threads";

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -19,9 +19,13 @@ package com.yahoo.athenz.container;
 import java.io.File;
 import java.net.InetAddress;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.DispatcherType;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.athenz.common.server.log.jetty.JettyConnectionLogger;
 import com.yahoo.athenz.common.server.log.jetty.JettyConnectionLoggerFactory;
 import org.eclipse.jetty.deploy.DeploymentManager;
@@ -178,6 +182,27 @@ public class AthenzJettyContainer {
             rewriteHandler.addRule(disableKeepAliveRule);
         }
         
+        // Add response-headers, according to configuration
+
+        String responseHeadersJson = System.getProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON, "");
+        if (!responseHeadersJson.isEmpty()) {
+            HashMap<String, String> responseHeaders;
+            try {
+                responseHeaders = new ObjectMapper().readValue(responseHeadersJson, new TypeReference<HashMap<String, String>>() {
+                });
+            } catch (Exception exception) {
+                throw new RuntimeException("System-property \"" + AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON + "\" must be a JSON object with string values. System property's value: " + responseHeadersJson);
+            }
+
+            for (Map.Entry<String, String>  responseHeader : responseHeaders.entrySet()) {
+                HeaderPatternRule rule = new HeaderPatternRule();
+                rule.setPattern("/*");
+                rule.setName(responseHeader.getKey());
+                rule.setValue(responseHeader.getValue());
+                rewriteHandler.addRule(rule);
+            }
+        }
+
         // Return a Host field in the response so during debugging
         // we know what server was handling request
         
@@ -341,10 +366,8 @@ public class AthenzJettyContainer {
         final String trustStoreType = System.getProperty(AthenzConsts.ATHENZ_PROP_TRUSTSTORE_TYPE, "PKCS12");
         final String includedCipherSuites = System.getProperty(AthenzConsts.ATHENZ_PROP_INCLUDED_CIPHER_SUITES);
         final String excludedCipherSuites = System.getProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_CIPHER_SUITES);
-        final String excludedProtocols = System.getProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS,
-                ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
-        boolean enableOCSP = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "false"));
-        boolean renegotiationAllowed = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_RENEGOTIATION_ALLOWED, "true"));
+        final String excludedProtocols = System.getProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS, ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
+        final boolean renegotiationAllowed = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_RENEGOTIATION_ALLOWED, "false"));
 
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setEndpointIdentificationAlgorithm(null);
@@ -389,7 +412,6 @@ public class AthenzJettyContainer {
             sslContextFactory.setWantClientAuth(true);
         }
 
-        sslContextFactory.setEnableOCSP(enableOCSP);
         sslContextFactory.setRenegotiationAllowed(renegotiationAllowed);
 
         return sslContextFactory;
@@ -558,7 +580,7 @@ public class AthenzJettyContainer {
             System.out.println("Jetty server running at " + banner);
             server.join();
         } catch (Exception e) {
-            throw new RuntimeException(e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -15,12 +15,15 @@
  */
 package com.yahoo.athenz.container;
 
+import org.eclipse.jetty.rewrite.handler.RewriteHandler;
+import org.eclipse.jetty.rewrite.handler.Rule;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Slf4jRequestLog;
+import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
@@ -735,5 +738,35 @@ public class AthenzJettyContainerTest {
         assertNotNull(contextHandlerCollection);
         assertNotNull(statisticsHandler);
         assertEquals(statisticsHandler.getHandler(), contextHandlerCollection);
+    }
+
+    @Test
+    public void testHttpResponseHeaders() {
+        System.setProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON, "{\"Header-1\":\"Value-1\",\"Header-2\":\"Value-2\"}");
+
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+        container.addServletHandlers("localhost");
+
+        boolean header1Handled = false;
+        boolean header2Handled = false;
+        Handler[] handlers = container.getHandlers().getHandlers();
+        for (Handler handler : handlers) {
+            if (handler instanceof RewriteHandler) {
+                RewriteHandler rewriteHandler = (RewriteHandler) handler;
+                for (Rule rule : rewriteHandler.getRules()) {
+                    if (rule.toString().equals("org.eclipse.jetty.rewrite.handler.HeaderPatternRule[ht][/*][Header-1,Value-1]")) {
+                        header1Handled = true;
+                    }
+                    if (rule.toString().equals("org.eclipse.jetty.rewrite.handler.HeaderPatternRule[ht][/*][Header-2,Value-2]")) {
+                        header2Handled = true;
+                    }
+                }
+            }
+        }
+        assertTrue(header1Handled);
+        assertTrue(header2Handled);
+
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON);
     }
 }

--- a/libs/java/server_common/src/test/resources/testFileConfig.properties
+++ b/libs/java/server_common/src/test/resources/testFileConfig.properties
@@ -75,9 +75,6 @@ athenz.access_log_dir=
 # Configure if client TLS renegotiation is allowed or not
 #athenz.ssl_renegotiation_allowed=true
 
-# Enable OCSP support
-#athenz.ssl_enable_ocsp=false
-
 # In milliseconds how long that connector will be allowed to
 # remain idle with no traffic before it is shutdown
 #athenz.http_idle_timeout=30000

--- a/servers/zms/conf/athenz.properties
+++ b/servers/zms/conf/athenz.properties
@@ -92,6 +92,10 @@ athenz.ssl_key_store_password=athenz
 # the Keep Alive connection option or just connections right away
 #athenz.keep_alive=false
 
+# A JSON object with string values: every HTTP response will contain these headers (default is none).
+# This is a good place to put security enhancing headers - see example below:
+#athenz.response_headers_json={ "Expect-CT": "max-age=31536000, report-uri=\"http://csp.athenz.io/beacon\"", "Strict-Transport-Security": "max-age=31536000", "X-Content-Type-Options": "nosniff", "Referrer-Policy": "strict-origin-when-cross-origin", "Cache-Control": "must-revalidate,no-cache,no-store" }
+
 # Max number of threads Jetty is allowed to spawn to handle incoming requests
 #athenz.http_max_threads=1024
 

--- a/servers/zts/conf/athenz.properties
+++ b/servers/zts/conf/athenz.properties
@@ -92,6 +92,10 @@ athenz.ssl_trust_store_password=athenz
 # the Keep Alive connection option or just connections right away
 #athenz.keep_alive=false
 
+# A JSON object with string values: every HTTP response will contain these headers (default is none).
+# This is a good place to put security enhancing headers - see example below:
+#athenz.response_headers_json={ "Expect-CT": "max-age=31536000, report-uri=\"http://csp.athenz.io/beacon\"", "Strict-Transport-Security": "max-age=31536000", "X-Content-Type-Options": "nosniff", "Referrer-Policy": "strict-origin-when-cross-origin", "Cache-Control": "must-revalidate,no-cache,no-store" }
+
 # Max number of threads Jetty is allowed to spawn to handle incoming requests
 #athenz.http_max_threads=1024
 


### PR DESCRIPTION
  - Client re-negotiation disabled by default
  - Any response headers can be configured. Suggestion for better security: set the system-property "athenz.response_headers_json" to something like this:
       { "Expect-CT": "max-age=31536000, report-uri=\"http://........\"", "Strict-Transport-Security": "max-age=31536000", "X-Content-Type-Options": "nosniff", "Referrer-Policy": "strict-origin-when-cross-origin", "Cache-Control": "must-revalidate,no-cache,no-store" }
  - OCSP-Stapling has nothing to do with Jetty - and should be configured via java flags.

Signed-off-by: Gilad Ben-Dor <gilad.bendor@verizonmedia.com>