### PR TITLE
Add JSON output support for remaining commands of zms-cli

### DIFF
--- a/libs/go/zmscli/access.go
+++ b/libs/go/zmscli/access.go
@@ -57,7 +57,7 @@ func (cli Zms) ShowAccess(dn string, action string, resource string, altIdent *s
 	if !access.Granted {
 		s = "access: denied"
 	}
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 // ShowAccessExt returns access indicator as string:
@@ -75,7 +75,7 @@ func (cli Zms) ShowAccessExt(dn string, action string, resource string, altIdent
 	if !access.Granted {
 		s = "access: denied"
 	}
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) ShowResourceAccess(principal string, action string) (*string, error) {
@@ -93,6 +93,5 @@ func (cli Zms) ShowResourceAccess(principal string, action string) (*string, err
 			cli.dumpAssertion(&buf, assertion, "", indent2)
 		}
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(rsrcAccessList, buf.String())
 }

--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -160,7 +160,7 @@ func (cli *Zms) EvalCommand(params []string) (*string, error) {
 				cli.Domain = ""
 				s = "[not using any domain]"
 			}
-			return cli.switchOverFormats(&StandardJSONMessage{Message: s}, s)
+			return cli.switchOverFormats(s)
 		case "show-domain":
 			if argc == 1 {
 				//override the default domain, this command can show any of them
@@ -182,11 +182,11 @@ func (cli *Zms) EvalCommand(params []string) (*string, error) {
 		case "export-domain":
 			if argc == 1 || argc == 2 {
 				dn = args[0]
-				yamlfile := "-"
+				filename := "-"
 				if argc == 2 {
-					yamlfile = args[1]
+					filename = args[1]
 				}
-				return cli.ExportDomain(dn, yamlfile)
+				return cli.ExportDomain(dn, filename)
 			}
 			return cli.helpCommand(params)
 		case "import-domain":
@@ -1236,7 +1236,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   import-domain coretech coretech.yaml " + cli.UserDomain + ".john\n")
 	case "export-domain":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   [-o json] export-domain domain [file.yaml] - no file means stdout\n")
+		buf.WriteString("   [-o json] export-domain domain [file.yaml or file.json] - no file means stdout\n")
 		buf.WriteString(" parameters:\n")
 		buf.WriteString("   domain    : name of the domain to be exported\n")
 		buf.WriteString("   file.yaml : filename where the domain data is stored\n")

--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -5,7 +5,6 @@ package zmscli
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,36 +15,6 @@ import (
 	"github.com/AthenZ/athenz/clients/go/zms"
 	"gopkg.in/yaml.v2"
 )
-
-func (cli Zms) buildJSONOutput(res interface{}) (*string, error) {
-	jsonOutput, err := json.MarshalIndent(res, "", indentLevel1)
-	if err != nil {
-		return nil, fmt.Errorf("failed to produce JSON output: %v", err)
-	}
-	output := string(jsonOutput)
-	return &output, nil
-}
-
-func (cli Zms) switchOverFormats(res interface{}, msg ...string) (*string, error) {
-	var op string
-	if msg == nil {
-		op = res.(string)
-	}
-	switch cli.OutputFormat {
-	case JSONOutputFormat:
-		if msg == nil {
-			return cli.buildJSONOutput(&StandardJSONMessage{Message: op})
-		}
-		return cli.buildJSONOutput(res)
-	case DefaultOutputFormat:
-		if msg == nil {
-			return &op, nil
-		}
-		return &msg[0], nil
-	default:
-		return nil, fmt.Errorf(ErrInvalidOutputFormat, cli.OutputFormat)
-	}
-}
 
 // DeleteDomain deletes the given ZMS domain.
 func (cli Zms) DeleteDomain(dn string) (*string, error) {

--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -214,7 +214,7 @@ func (cli Zms) UpdateDomain(dn string, filename string) (*string, error) {
 		}
 	}
 	s := "[updated domain '" + dn + "' successfully]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) ExportDomain(dn string, filename string) (*string, error) {
@@ -224,6 +224,10 @@ func (cli Zms) ExportDomain(dn string, filename string) (*string, error) {
 	cli.Verbose = verbose
 	if err == nil && data != nil {
 		s := *data
+		msg, err := cli.switchOverFormats(*data)
+		if err == nil {
+			s = *msg
+		}
 		if filename == "-" {
 			fmt.Println(s)
 		} else {
@@ -251,7 +255,7 @@ func (cli Zms) SystemBackup(dir string) (*string, error) {
 	}
 	cli.Verbose = verbose
 	s := "[exported " + strconv.Itoa(len(res.Names)) + " domains to " + dir + " directory]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) AddDomain(dn string, productID *int32, addSelf bool, admins []string) (*string, error) {
@@ -335,8 +339,7 @@ func (cli Zms) LookupDomainByBusinessService(businessService string) (*string, e
 		for _, name := range res.Names {
 			buf.WriteString(indentLevel1Dash + string(name) + "\n")
 		}
-		s := buf.String()
-		return &s, nil
+		return cli.switchOverFormats(res, buf.String())
 	}
 	return nil, err
 }
@@ -362,8 +365,7 @@ func (cli Zms) LookupDomainByTag(tagKey string, tagValue string) (*string, error
 		for _, name := range res.Names {
 			buf.WriteString(indentLevel1Dash + string(name) + "\n")
 		}
-		s := buf.String()
-		return &s, nil
+		return cli.switchOverFormats(res, buf.String())
 	}
 	return nil, err
 }
@@ -394,8 +396,7 @@ func (cli Zms) GetSignedDomains(dn string, matchingTag string) (*string, error) 
 			cli.dumpSignedDomain(&buf, domain, false)
 		}
 	}
-	s := buf.String()
-	return cli.switchOverFormats(res, s)
+	return cli.switchOverFormats(res, buf.String())
 }
 
 func (cli Zms) ShowOverdueReview(dn string) (*string, error) {
@@ -412,9 +413,7 @@ func (cli Zms) ShowOverdueReview(dn string) (*string, error) {
 	}
 
 	cli.dumpDomainRoleMembers(&buf, domainRoleMembers, true)
-	s := buf.String()
-
-	return cli.switchOverFormats(domainRoleMembers, s)
+	return cli.switchOverFormats(domainRoleMembers, buf.String())
 }
 
 func (cli Zms) ShowDomain(dn string) (*string, error) {
@@ -709,7 +708,7 @@ func (cli Zms) AddDomainTags(dn string, tagKey string, tagValues []string) (*str
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.showDomainTags(dn)
 	}
-	return &output, err
+	return cli.switchOverFormats(output)
 
 }
 
@@ -754,7 +753,7 @@ func (cli Zms) DeleteDomainTags(dn string, tagKey string, tagValue string) (*str
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.showDomainTags(dn)
 	}
-	return &output, err
+	return cli.switchOverFormats(output)
 }
 
 func (cli Zms) SetDomainAccount(dn string, account string) (*string, error) {
@@ -828,7 +827,7 @@ func (cli Zms) SetDomainBusinessService(dn string, businessService string) (*str
 		return nil, err
 	}
 	s := "[domain " + dn + " business-service successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) SetDomainCertDnsDomain(dn string, dnsDomain string) (*string, error) {
@@ -851,7 +850,7 @@ func (cli Zms) SetDefaultAdmins(dn string, admins []string) (*string, error) {
 		return nil, err
 	}
 	s := "[domain " + dn + " administrators successfully set]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) ListPendingDomainRoleMembers(principal string) (*string, error) {
@@ -864,7 +863,5 @@ func (cli Zms) ListPendingDomainRoleMembers(principal string) (*string, error) {
 	for _, domainRoleMembers := range domainMembership.DomainRoleMembersList {
 		cli.dumpDomainRoleMembers(&buf, domainRoleMembers, true)
 	}
-	s := buf.String()
-
-	return &s, nil
+	return cli.switchOverFormats(domainMembership, buf.String())
 }

--- a/libs/go/zmscli/entity.go
+++ b/libs/go/zmscli/entity.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ardielle/ardielle-go/rdl"
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 func (cli Zms) ShowEntity(dn string, en string) (*string, error) {
@@ -20,8 +20,7 @@ func (cli Zms) ShowEntity(dn string, en string) (*string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("entity:\n")
 	cli.dumpEntity(&buf, *entity, indentLevel1Dash, indentLevel1DashLvl)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(entity, buf.String())
 }
 
 func (cli Zms) AddEntity(dn string, en string, values []string) (*string, error) {
@@ -48,7 +47,7 @@ func (cli Zms) AddEntity(dn string, en string, values []string) (*string, error)
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowEntity(dn, en)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) DeleteEntity(dn string, en string) (*string, error) {
@@ -57,7 +56,7 @@ func (cli Zms) DeleteEntity(dn string, en string) (*string, error) {
 		return nil, err
 	}
 	s := "[Deleted entity: " + dn + "." + en + "]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) entityNames(dn string) ([]string, error) {
@@ -80,6 +79,5 @@ func (cli Zms) ListEntities(dn string) (*string, error) {
 	}
 	buf.WriteString("entities:\n")
 	cli.dumpObjectList(&buf, entities, dn, "entity")
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(entities, buf.String())
 }

--- a/libs/go/zmscli/group.go
+++ b/libs/go/zmscli/group.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ardielle/ardielle-go/rdl"
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 func (cli Zms) groupNames(dn string) ([]string, error) {
@@ -35,8 +35,7 @@ func (cli Zms) ListGroups(dn string) (*string, error) {
 	}
 	buf.WriteString("groups:\n")
 	cli.dumpObjectList(&buf, groups, dn, "group")
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(groups, buf.String())
 }
 
 func (cli Zms) ShowGroup(dn string, gn string, auditLog, pending bool) (*string, error) {
@@ -59,8 +58,7 @@ func (cli Zms) ShowGroup(dn string, gn string, auditLog, pending bool) (*string,
 	var buf bytes.Buffer
 	buf.WriteString("group:\n")
 	cli.dumpGroup(&buf, *group, auditLog, indentLevel1Dash, indentLevel1DashLvl)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(group, buf.String())
 }
 
 func (cli Zms) AddGroup(dn string, gn string, groupMembers []*zms.GroupMember) (*string, error) {
@@ -95,7 +93,7 @@ func (cli Zms) AddGroup(dn string, gn string, groupMembers []*zms.GroupMember) (
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowGroup(dn, gn, false, false)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) DeleteGroup(dn string, gn string) (*string, error) {
@@ -104,7 +102,7 @@ func (cli Zms) DeleteGroup(dn string, gn string) (*string, error) {
 		return nil, err
 	}
 	s := "[Deleted group: " + gn + "]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) AddGroupMembers(dn string, group string, members []string) (*string, error) {
@@ -125,7 +123,7 @@ func (cli Zms) AddGroupMembers(dn string, group string, members []string) (*stri
 	} else {
 		s = "[Added to " + group + ": " + strings.Join(ms, ",") + "]"
 	}
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) DeleteGroupMembers(dn string, group string, members []string) (*string, error) {
@@ -143,7 +141,7 @@ func (cli Zms) DeleteGroupMembers(dn string, group string, members []string) (*s
 	} else {
 		s = "[Deleted from " + group + ": " + strings.Join(ms, ",") + "]"
 	}
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) CheckGroupMembers(dn string, group string, members []string) (*string, error) {
@@ -156,8 +154,7 @@ func (cli Zms) CheckGroupMembers(dn string, group string, members []string) (*st
 		}
 		cli.dumpGroupMembership(&buf, *member)
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(ms, buf.String())
 }
 
 func (cli Zms) CheckActiveGroupMember(dn string, group string, mbr string) (*string, error) {
@@ -170,8 +167,7 @@ func (cli Zms) CheckActiveGroupMember(dn string, group string, mbr string) (*str
 		return nil, errors.New("Member " + mbr + " is not active")
 	}
 	cli.dumpGroupMembership(&buf, *member)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(member, buf.String())
 }
 
 func (cli Zms) ShowGroupsPrincipal(principal string, dn string) (*string, error) {
@@ -181,8 +177,7 @@ func (cli Zms) ShowGroupsPrincipal(principal string, dn string) (*string, error)
 		return nil, err
 	}
 	cli.dumpGroupsPrincipal(&buf, domainGroupMember)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(domainGroupMember, buf.String())
 }
 
 func (cli Zms) SetGroupAuditEnabled(dn string, group string, auditEnabled bool) (*string, error) {
@@ -194,7 +189,7 @@ func (cli Zms) SetGroupAuditEnabled(dn string, group string, auditEnabled bool) 
 		return nil, err
 	}
 	s := "[domain " + dn + " group " + group + " audit-enabled successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func getGroupMetaObject(group *zms.Group) zms.GroupMeta {
@@ -220,7 +215,7 @@ func (cli Zms) SetGroupReviewEnabled(dn string, gn string, reviewEnabled bool) (
 		return nil, err
 	}
 	s := "[domain " + dn + " group " + gn + " review-enabled attribute successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) SetGroupSelfServe(dn string, gn string, selfServe bool) (*string, error) {
@@ -236,7 +231,7 @@ func (cli Zms) SetGroupSelfServe(dn string, gn string, selfServe bool) (*string,
 		return nil, err
 	}
 	s := "[domain " + dn + " group " + gn + " self-serve attribute successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) SetGroupUserAuthorityFilter(dn string, gn, filter string) (*string, error) {
@@ -252,7 +247,7 @@ func (cli Zms) SetGroupUserAuthorityFilter(dn string, gn, filter string) (*strin
 		return nil, err
 	}
 	s := "[domain " + dn + " group " + gn + " user-authority-filter attribute successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) SetGroupUserAuthorityExpiration(dn string, gn, filter string) (*string, error) {
@@ -268,7 +263,7 @@ func (cli Zms) SetGroupUserAuthorityExpiration(dn string, gn, filter string) (*s
 		return nil, err
 	}
 	s := "[domain " + dn + " group " + gn + " user-authority-expiration attribute successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) SetGroupNotifyRoles(dn string, gn string, notifyRoles string) (*string, error) {
@@ -284,7 +279,7 @@ func (cli Zms) SetGroupNotifyRoles(dn string, gn string, notifyRoles string) (*s
 		return nil, err
 	}
 	s := "[domain " + dn + " group " + gn + " notify-roles attribute successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) PutGroupMembershipDecision(dn string, group string, mbr string, approval bool) (*string, error) {
@@ -304,7 +299,7 @@ func (cli Zms) PutGroupMembershipDecision(dn string, group string, mbr string, a
 		s = s + " rejected."
 	}
 	s = s + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) ListPendingDomainGroupMembers(principal string) (*string, error) {
@@ -317,7 +312,5 @@ func (cli Zms) ListPendingDomainGroupMembers(principal string) (*string, error) 
 	for _, domainGroupMembers := range domainMembership.DomainGroupMembersList {
 		cli.dumpDomainGroupMembers(&buf, domainGroupMembers, true)
 	}
-	s := buf.String()
-
-	return &s, nil
+	return cli.switchOverFormats(domainMembership, buf.String())
 }

--- a/libs/go/zmscli/policy.go
+++ b/libs/go/zmscli/policy.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ardielle/ardielle-go/rdl"
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 func (cli Zms) policyNames(dn string) ([]string, error) {
@@ -34,8 +34,7 @@ func (cli Zms) ListPolicies(dn string) (*string, error) {
 	}
 	buf.WriteString("policies:\n")
 	cli.dumpObjectList(&buf, policies, dn, "policy")
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(policies, buf.String())
 }
 
 func (cli Zms) ShowPolicy(dn string, name string) (*string, error) {
@@ -46,8 +45,7 @@ func (cli Zms) ShowPolicy(dn string, name string) (*string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("policy:\n")
 	cli.dumpPolicy(&buf, *policy, indentLevel1Dash, indentLevel1DashLvl)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(policy, buf.String())
 }
 
 func parseAssertion(dn string, lst []string) (*zms.Assertion, error) {
@@ -163,7 +161,7 @@ func (cli Zms) AddPolicy(dn string, pn string, assertion []string) (*string, err
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowPolicy(dn, pn)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) AddAssertion(dn string, pn string, assertion []string) (*string, error) {
@@ -179,7 +177,11 @@ func (cli Zms) AddAssertion(dn string, pn string, assertion []string) (*string, 
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowPolicy(dn, pn)
+	output, err := cli.ShowPolicy(dn, pn)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) assertionMatch(assertion1 *zms.Assertion, assertion2 *zms.Assertion) bool {
@@ -242,7 +244,11 @@ func (cli Zms) DeleteAssertion(dn string, pn string, assertion []string) (*strin
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowPolicy(dn, pn)
+	output, err := cli.ShowPolicy(dn, pn)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) DeletePolicy(dn string, pn string) (*string, error) {
@@ -251,5 +257,5 @@ func (cli Zms) DeletePolicy(dn string, pn string) (*string, error) {
 		return nil, err
 	}
 	s := "[Deleted policy: " + pn + "]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }

--- a/libs/go/zmscli/quota.go
+++ b/libs/go/zmscli/quota.go
@@ -16,7 +16,7 @@ func (cli Zms) DeleteQuota(dn string) (*string, error) {
 	err := cli.Zms.DeleteQuota(zms.DomainName(dn), cli.AuditRef)
 	if err == nil {
 		s := "[Removed quota for domain " + dn + "]"
-		return cli.switchOverFormats(&StandardJSONMessage{Message: s}, s)
+		return cli.switchOverFormats(s)
 	}
 	return nil, err
 }
@@ -83,5 +83,5 @@ func (cli Zms) SetQuota(dn string, attrs []string) (*string, error) {
 		return nil, err
 	}
 	s := "[domain " + dn + " quota successfully set]\n"
-	return cli.switchOverFormats(&StandardJSONMessage{Message: s}, s)
+	return cli.switchOverFormats(s)
 }

--- a/libs/go/zmscli/service.go
+++ b/libs/go/zmscli/service.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ardielle/ardielle-go/rdl"
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 func shortname(dn string, sn string) string {
@@ -45,8 +45,8 @@ func (cli Zms) ListServices(dn string) (*string, error) {
 		buf.WriteString("services:\n")
 		cli.dumpObjectList(&buf, services, dn, "service")
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(services, buf.String())
+
 }
 
 func (cli Zms) ShowService(dn string, sn string) (*string, error) {
@@ -57,8 +57,7 @@ func (cli Zms) ShowService(dn string, sn string) (*string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("service:\n")
 	cli.dumpService(&buf, *service, indentLevel1Dash, indentLevel1DashLvl)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(service, buf.String())
 }
 
 func (cli Zms) AddService(dn string, sn string, keyID string, pubKey *string) (*string, error) {
@@ -103,7 +102,7 @@ func (cli Zms) AddService(dn string, sn string, keyID string, pubKey *string) (*
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowService(dn, shortName)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) AddProviderService(dn string, sn string, keyID string, pubKey *string) (*string, error) {
@@ -201,7 +200,7 @@ func (cli Zms) AddProviderService(dn string, sn string, keyID string, pubKey *st
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowService(dn, shortName)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) AddServiceWithKeys(dn string, sn string, publicKeys []*zms.PublicKeyEntry) (*string, error) {
@@ -250,7 +249,7 @@ func (cli Zms) SetServiceEndpoint(dn string, sn string, endpoint string) (*strin
 		return nil, err
 	}
 	s := "[domain " + dn + " service " + sn + " service-endpoint successfully updated]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) SetServiceExe(dn string, sn string, exe string, user string, group string) (*string, error) {
@@ -270,7 +269,11 @@ func (cli Zms) SetServiceExe(dn string, sn string, exe string, user string, grou
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowService(dn, shortName)
+	output, err := cli.ShowService(dn, shortName)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) AddServiceHost(dn string, sn string, hosts []string) (*string, error) {
@@ -296,7 +299,11 @@ func (cli Zms) AddServiceHost(dn string, sn string, hosts []string) (*string, er
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowService(dn, shortName)
+	output, err := cli.ShowService(dn, shortName)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) DeleteServiceHost(dn string, sn string, hosts []string) (*string, error) {
@@ -316,7 +323,11 @@ func (cli Zms) DeleteServiceHost(dn string, sn string, hosts []string) (*string,
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowService(dn, shortName)
+	output, err := cli.ShowService(dn, shortName)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) AddServicePublicKey(dn string, sn string, keyID string, pubKey *string) (*string, error) {
@@ -333,7 +344,11 @@ func (cli Zms) AddServicePublicKey(dn string, sn string, keyID string, pubKey *s
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowService(dn, shortName)
+	output, err := cli.ShowService(dn, shortName)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) ShowServicePublicKey(dn string, sn string, keyID string) (*string, error) {
@@ -346,8 +361,7 @@ func (cli Zms) ShowServicePublicKey(dn string, sn string, keyID string) (*string
 	buf.WriteString("public-key:\n")
 	buf.WriteString(indentLevel1 + "keyID: " + pkey.Id + "\n")
 	buf.WriteString(indentLevel1 + "value: " + pkey.Key + "\n")
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(pkey, buf.String())
 }
 
 func (cli Zms) DeleteServicePublicKey(dn string, sn string, keyID string) (*string, error) {
@@ -360,7 +374,11 @@ func (cli Zms) DeleteServicePublicKey(dn string, sn string, keyID string) (*stri
 		s := ""
 		return &s, nil
 	}
-	return cli.ShowService(dn, shortName)
+	output, err := cli.ShowService(dn, shortName)
+	if err != nil {
+		return nil, err
+	}
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) DeleteService(dn string, sn string) (*string, error) {
@@ -369,5 +387,5 @@ func (cli Zms) DeleteService(dn string, sn string) (*string, error) {
 		return nil, err
 	}
 	s := "[Deleted service identity: " + dn + "." + sn + "]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }

--- a/libs/go/zmscli/template.go
+++ b/libs/go/zmscli/template.go
@@ -21,8 +21,7 @@ func (cli Zms) ListServerTemplates() (*string, error) {
 	for _, name := range templates.TemplateNames {
 		buf.WriteString(indentLevel1Dash + string(name) + "\n")
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(templates, buf.String())
 }
 
 func (cli Zms) ListDomainTemplates(dn string) (*string, error) {
@@ -35,8 +34,7 @@ func (cli Zms) ListDomainTemplates(dn string) (*string, error) {
 	for _, name := range templates.TemplateNames {
 		buf.WriteString(indentLevel1Dash + string(name) + "\n")
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(templates, buf.String())
 }
 
 func (cli Zms) ShowServerTemplate(templateName string) (*string, error) {
@@ -61,8 +59,7 @@ func (cli Zms) ShowServerTemplate(templateName string) (*string, error) {
 			cli.dumpService(&buf, *service, indentLevel2Dash, indentLevel2DashLvl)
 		}
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(template, buf.String())
 }
 
 func (cli Zms) SetDomainTemplate(dn string, templateArgs []string) (*string, error) {
@@ -94,7 +91,7 @@ func (cli Zms) SetDomainTemplate(dn string, templateArgs []string) (*string, err
 		return nil, err
 	}
 	s := "[Template(s) successfully applied to domain]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) DeleteDomainTemplate(dn string, template string) (*string, error) {
@@ -103,5 +100,5 @@ func (cli Zms) DeleteDomainTemplate(dn string, template string) (*string, error)
 		return nil, err
 	}
 	s := "[Deleted template: " + template + "]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }

--- a/libs/go/zmscli/tenant.go
+++ b/libs/go/zmscli/tenant.go
@@ -17,14 +17,14 @@ func (cli Zms) DeleteTenancy(dn string, provider string) (*string, error) {
 		return nil, err
 	}
 	s := "[Successfully deleted tenant " + dn + " from provider " + provider + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) AddTenancy(dn string, provider string, createAdminRole bool) (*string, error) {
 	tenancy := zms.Tenancy{
-		Domain:         zms.DomainName(dn),
-		Service:        zms.ServiceName(provider),
-		ResourceGroups: nil,
+		Domain:          zms.DomainName(dn),
+		Service:         zms.ServiceName(provider),
+		ResourceGroups:  nil,
 		CreateAdminRole: &createAdminRole,
 	}
 	err := cli.Zms.PutTenancy(zms.DomainName(dn), zms.ServiceName(provider), cli.AuditRef, &tenancy)
@@ -32,7 +32,7 @@ func (cli Zms) AddTenancy(dn string, provider string, createAdminRole bool) (*st
 		return nil, err
 	}
 	s := "[Successfully added tenant " + dn + " to provider " + provider + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) AddTenant(provDomain string, provService string, tenantDomain string) (*string, error) {
@@ -46,7 +46,7 @@ func (cli Zms) AddTenant(provDomain string, provService string, tenantDomain str
 		return nil, err
 	}
 	s := "[Successfully added tenant " + tenantDomain + " to provider " + provDomain + "." + provService + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) DeleteTenant(provDomain string, provService string, tenantDomain string) (*string, error) {
@@ -55,7 +55,7 @@ func (cli Zms) DeleteTenant(provDomain string, provService string, tenantDomain 
 		return nil, err
 	}
 	s := "[Successfully deleted tenant " + tenantDomain + " from provider " + provDomain + "." + provService + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) ShowTenantResourceGroupRoles(provDomain string, provService string, tenantDomain string, resourceGroup string) (*string, error) {
@@ -66,8 +66,7 @@ func (cli Zms) ShowTenantResourceGroupRoles(provDomain string, provService strin
 	var buf bytes.Buffer
 	buf.WriteString("resource-group:\n")
 	cli.dumpTenantResourceGroupRoles(&buf, tenantRoles, indentLevel1Dash, indentLevel1DashLvl)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(tenantRoles, buf.String())
 }
 
 func (cli Zms) DeleteTenantResourceGroupRoles(provDomain string, provService string, tenantDomain string, resourceGroup string) (*string, error) {
@@ -76,7 +75,7 @@ func (cli Zms) DeleteTenantResourceGroupRoles(provDomain string, provService str
 		return nil, err
 	}
 	s := "[Successfully deleted resource group " + resourceGroup + " roles for tenant: " + tenantDomain + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) AddTenantResourceGroupRoles(provDomain string, provService string, tenantDomain string, resourceGroup string, roleActions []string) (*string, error) {
@@ -110,7 +109,7 @@ func (cli Zms) AddTenantResourceGroupRoles(provDomain string, provService string
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowTenantResourceGroupRoles(provDomain, provService, tenantDomain, resourceGroup)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }
 
 func (cli Zms) ShowProviderResourceGroupRoles(tenantDomain string, providerDomain string, providerService string, resourceGroup string) (*string, error) {
@@ -121,8 +120,7 @@ func (cli Zms) ShowProviderResourceGroupRoles(tenantDomain string, providerDomai
 	var buf bytes.Buffer
 	buf.WriteString("resource-group:\n")
 	cli.dumpProviderResourceGroupRoles(&buf, providerRoles, indentLevel1Dash, indentLevel1DashLvl)
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(providerRoles, buf.String())
 }
 
 func (cli Zms) DeleteProviderResourceGroupRoles(tenantDomain string, providerDomain string, providerService string, resourceGroup string) (*string, error) {
@@ -131,7 +129,7 @@ func (cli Zms) DeleteProviderResourceGroupRoles(tenantDomain string, providerDom
 		return nil, err
 	}
 	s := "[Successfully deleted resource group " + resourceGroup + " roles for tenant: " + tenantDomain + "]\n"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }
 
 func (cli Zms) AddProviderResourceGroupRoles(tenantDomain string, providerDomain string, providerService string, resourceGroup string, createAdminRole bool, roleActions []string) (*string, error) {
@@ -147,11 +145,11 @@ func (cli Zms) AddProviderResourceGroupRoles(tenantDomain string, providerDomain
 		}
 	}
 	providerRoles := zms.ProviderResourceGroupRoles{
-		Domain:        zms.DomainName(providerDomain),
-		Service:       zms.SimpleName(providerService),
-		Tenant:        zms.DomainName(tenantDomain),
-		Roles:         tenantRoleActions,
-		ResourceGroup: zms.EntityName(resourceGroup),
+		Domain:          zms.DomainName(providerDomain),
+		Service:         zms.SimpleName(providerService),
+		Tenant:          zms.DomainName(tenantDomain),
+		Roles:           tenantRoleActions,
+		ResourceGroup:   zms.EntityName(resourceGroup),
 		CreateAdminRole: &createAdminRole,
 	}
 
@@ -167,5 +165,5 @@ func (cli Zms) AddProviderResourceGroupRoles(tenantDomain string, providerDomain
 		time.Sleep(500 * time.Millisecond)
 		output, err = cli.ShowProviderResourceGroupRoles(tenantDomain, providerDomain, providerService, resourceGroup)
 	}
-	return output, err
+	return cli.switchOverFormats(*output)
 }

--- a/libs/go/zmscli/user.go
+++ b/libs/go/zmscli/user.go
@@ -19,8 +19,7 @@ func (cli Zms) ListUsers() (*string, error) {
 	for _, item := range users.Names {
 		buf.WriteString("    - " + string(item) + "\n")
 	}
-	s := buf.String()
-	return &s, nil
+	return cli.switchOverFormats(users, buf.String())
 }
 
 func (cli Zms) DeleteUser(user string) (*string, error) {
@@ -29,5 +28,5 @@ func (cli Zms) DeleteUser(user string) (*string, error) {
 		return nil, err
 	}
 	s := "[Deleted user: " + user + "]"
-	return &s, nil
+	return cli.switchOverFormats(s)
 }


### PR DESCRIPTION
This PR adds JSON output support for the remaining commands of `zms-cli`, as required by https://github.com/AthenZ/athenz/issues/1395.

Signed-off-by: Abhishek Patra <abhishek.patra01@verizonmedia.com>