### PR TITLE
fix mvn warning

### DIFF
--- a/clients/java/zpe/pom.xml
+++ b/clients/java/zpe/pom.xml
@@ -177,6 +177,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven-jar-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-jar</id>

--- a/libs/java/auth_core/pom.xml
+++ b/libs/java/auth_core/pom.xml
@@ -119,6 +119,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven-jar-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-jar</id>

--- a/libs/java/cert_refresher/pom.xml
+++ b/libs/java/cert_refresher/pom.xml
@@ -110,6 +110,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven-jar-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-jar</id>

--- a/libs/java/client_common/pom.xml
+++ b/libs/java/client_common/pom.xml
@@ -91,6 +91,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven-jar-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-jar</id>

--- a/utils/zpe_policy_updater/pom.xml
+++ b/utils/zpe_policy_updater/pom.xml
@@ -153,6 +153,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-jar-plugin</artifactId>
+            <version>${maven-jar-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-jar</id>


### PR DESCRIPTION
add version for `maven-jar-plugin` in pom.xml
```
[WARNING] Some problems were encountered while building the effective model for com.yahoo.athenz:athenz-auth-core:jar:1.10.10-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 119, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.yahoo.athenz:athenz-client-common:jar:1.10.10-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 91, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.yahoo.athenz:athenz-cert-refresher:jar:1.10.10-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 110, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.yahoo.athenz:athenz-zpe-java-client:jar:1.10.10-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 177, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.yahoo.athenz:athenz-zpe-policy-updater:jar:1.10.10-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 153, column 19
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
```