### PR TITLE
new DomainMetaStore interface support in ZMS

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/DomainMetaStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/DomainMetaStore.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.yahoo.athenz.common.server.metastore;
+
+/**
+ * An interface that allows the server to verify and update domain's
+ * meta attributes in some external store
+ */
+public interface DomainMetaStore {
+
+    // bit sets identifying meta attributes
+
+    int META_ATTR_BUSINESS_SERVICE    = 0;
+    int META_ATTR_AWS_ACCOUNT         = 1;
+    int META_ATTR_AZURE_SUBSCRIPTION  = 2;
+    int META_ATTR_PRODUCT_ID          = 3;
+
+    /**
+     * Validate if the given business service is valid for the domain.
+     * @param domainName - name of the domain
+     * @param businessService - name of the business service (can be null)
+     * @return true if valid, false otherwise
+     */
+    boolean isValidBusinessService(final String domainName, final String businessService);
+
+    /**
+     * Sets the athenz domain for the given business service. This attribute
+     * is a regular domain meta attribute and can be changed by domain administrators.
+     * @param domainName - name of the domain
+     * @param businessService - name of the business service
+     * @throws com.yahoo.athenz.common.server.rest.ResourceException in case of any failure
+     */
+    void setBusinessServiceDomain(final String domainName, final String businessService);
+
+    /**
+     * Validate if the given AWS account number is valid for the domain
+     * @param domainName - name of the domain
+     * @param awsAccountId - aws account id (can be null)
+     * @return true if valid, false otherwise
+     */
+    boolean isValidAWSAccount(final String domainName, final String awsAccountId);
+
+    /**
+     * Sets the athenz domain for the aws account id. This attribute is a domain system
+     * meta attribute can only be changed by athenz system administrators.
+     * @param domainName - name of the domain
+     * @param awsAccountId - aws account id (can be null)
+     * @throws com.yahoo.athenz.common.server.rest.ResourceException in case of any failure
+     */
+    void setAWSAccountDomain(final String domainName, final String awsAccountId);
+
+    /**
+     * Validate if the given Azure subscription id is valid for the domain
+     * @param domainName - name of the domain
+     * @param azureSubscription - azure subscription id (can be null)
+     * @return true if valid, false otherwise
+     */
+    boolean isValidAzureSubscription(final String domainName, final String azureSubscription);
+
+    /**
+     * Sets the athenz domain for the azure subscription. This attribute is a domain
+     * system meta attribute can only be changed by athenz system administrators.
+     * @param domainName - name of the domain
+     * @param azureSubscription - azure subscription id (can be null)
+     * @throws com.yahoo.athenz.common.server.rest.ResourceException in case of any failure
+     */
+    void setAzureSubscriptionDomain(final String domainName, final String azureSubscription);
+
+    /**
+     * Validate if the given product id is valid for the domain
+     * @param domainName - name of the domain
+     * @param productId - product id (can be null)
+     * @return true if valid, false otherwise
+     */
+    boolean isValidProductId(final String domainName, Integer productId);
+
+    /**
+     * Sets the athenz domain for the given product id. This attribute is a domain
+     * system meta attribute can only be changed by athenz system administrators.
+     * @param domainName - name of the domain
+     * @param productId - product id (can be null)
+     * @throws com.yahoo.athenz.common.server.rest.ResourceException in case of any failure
+     */
+    void setProductIdDomain(final String domainName, Integer productId);
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/DomainMetaStoreFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/DomainMetaStoreFactory.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.yahoo.athenz.common.server.metastore;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+
+public interface DomainMetaStoreFactory {
+
+    /**
+     * Create and return a new DomainMetaStore instance
+     * @param privateKeyStore Private Key Store object from the server
+     * @return DomainMetaStore instance
+     */
+    DomainMetaStore create(PrivateKeyStore privateKeyStore);
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/impl/NoOpDomainMetaStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/impl/NoOpDomainMetaStore.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.yahoo.athenz.common.server.metastore.impl;
+
+import com.yahoo.athenz.common.server.metastore.DomainMetaStore;
+
+/**
+ * Default and empty implementation for {@link DomainMetaStore}
+ */
+public class NoOpDomainMetaStore implements DomainMetaStore {
+
+    @Override
+    public boolean isValidBusinessService(final String domainName, final String businessService) {
+        return true;
+    }
+
+    @Override
+    public void setBusinessServiceDomain(final String domainName, final String businessService) {
+    }
+
+    @Override
+    public boolean isValidAWSAccount(final String domainName, final String awsAccountId) {
+        return true;
+    }
+
+    @Override
+    public void setAWSAccountDomain(final String domainName, final String awsAccountId) {
+    }
+
+    @Override
+    public boolean isValidAzureSubscription(final String domainName, final String azureSubscription) {
+        return true;
+    }
+
+    @Override
+    public void setAzureSubscriptionDomain(final String domainName, final String azureSubscription) {
+    }
+
+    @Override
+    public boolean isValidProductId(final String domainName, Integer productId) {
+        return true;
+    }
+
+    @Override
+    public void setProductIdDomain(final String domainName, Integer productId) {
+    }
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/impl/NoOpDomainMetaStoreFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/metastore/impl/NoOpDomainMetaStoreFactory.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.yahoo.athenz.common.server.metastore.impl;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.common.server.metastore.DomainMetaStore;
+import com.yahoo.athenz.common.server.metastore.DomainMetaStoreFactory;
+
+public class NoOpDomainMetaStoreFactory implements DomainMetaStoreFactory {
+    @Override
+    public DomainMetaStore create(PrivateKeyStore privateKeyStore) {
+        return new NoOpDomainMetaStore();
+    }
+}

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/metastore/DomainMetaStoreTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/metastore/DomainMetaStoreTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.common.server.metastore;
+
+import com.yahoo.athenz.common.server.metastore.impl.NoOpDomainMetaStoreFactory;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class DomainMetaStoreTest {
+
+    @Test
+    public void testDomainMetaStoreDefaults() {
+
+        DomainMetaStoreFactory metaStoreFactory = new NoOpDomainMetaStoreFactory();
+        assertNotNull(metaStoreFactory);
+
+        DomainMetaStore metaStore = metaStoreFactory.create(null);
+
+        assertTrue(metaStore.isValidAzureSubscription("athenz", "azure"));
+        assertTrue(metaStore.isValidAzureSubscription("athenz", null));
+
+        assertTrue(metaStore.isValidAWSAccount("athenz", "aws"));
+        assertTrue(metaStore.isValidAWSAccount("athenz", null));
+
+        assertTrue(metaStore.isValidProductId("athenz", 42));
+        assertTrue(metaStore.isValidProductId("athenz", null));
+
+        assertTrue(metaStore.isValidBusinessService("athenz", "security"));
+        assertTrue(metaStore.isValidBusinessService("athenz", null));
+
+        // these methods would throw no exceptions
+
+        metaStore.setAzureSubscriptionDomain("athenz", "azure");
+        metaStore.setAWSAccountDomain("athenz", "aws");
+        metaStore.setBusinessServiceDomain("athenz", "security");
+        metaStore.setProductIdDomain("athenz", 42);
+
+        assertEquals(DomainMetaStore.META_ATTR_BUSINESS_SERVICE, 0);
+        assertEquals(DomainMetaStore.META_ATTR_AWS_ACCOUNT, 1);
+        assertEquals(DomainMetaStore.META_ATTR_AZURE_SUBSCRIPTION, 2);
+        assertEquals(DomainMetaStore.META_ATTR_PRODUCT_ID, 3);
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -2806,7 +2806,7 @@ public class DBService implements RolesProvider {
         }
     }
 
-    void executePutDomainMeta(ResourceContext ctx, String domainName, DomainMeta meta,
+    void executePutDomainMeta(ResourceContext ctx, Domain domain, DomainMeta meta,
             final String systemAttribute, boolean deleteAllowed, String auditRef, String caller) {
 
         // our exception handling code does the check for retry count
@@ -2817,11 +2817,7 @@ public class DBService implements RolesProvider {
 
             try (ObjectStoreConnection con = store.getConnection(false, true)) {
 
-                Domain domain = con.getDomain(domainName);
-                if (domain == null) {
-                    con.rollbackChanges();
-                    throw ZMSUtils.notFoundError(caller + ": Unknown domain: " + domainName, caller);
-                }
+                final String domainName = domain.getName();
 
                 // first verify that auditing requirements are met
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -125,6 +125,9 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_OBJECT_STORE_FACTORY_CLASS      = "athenz.zms.object_store_factory_class";
     public static final String ZMS_OBJECT_STORE_FACTORY_CLASS           = "com.yahoo.athenz.zms.store.impl.FileObjectStoreFactory";
 
+    public static final String ZMS_PROP_DOMAIN_META_STORE_FACTORY_CLASS = "athenz.zms.domain_meta_store_factory_class";
+    public static final String ZMS_DOMAIN_META_STORE_FACTORY_CLASS      = "com.yahoo.athenz.common.server.metastore.impl.NoOpDomainMetaStoreFactory";
+
     // properties for our default quota limits
 
     public static final String ZMS_PROP_QUOTA_CHECK        = "athenz.zms.quota_check";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -421,4 +421,8 @@ public class ZMSUtils {
 
         return SimplePrincipal.create(domain, name, (String) null);
     }
+
+    public static boolean metaValueChanged(Object domainValue, Object metaValue) {
+        return (metaValue == null) ? false : !metaValue.equals(domainValue);
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -1112,11 +1112,12 @@ public class DBServiceTest {
     @Test
     public void testExecutePutDomainMeta() {
 
-        TopLevelDomain dom1 = createTopLevelDomainObject("MetaDom1",
+        final String domainName = "metadom1";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
                 "Test Domain1", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
-        Domain resDom1 = zms.getDomain(mockDomRsrcCtx, "MetaDom1");
+        Domain resDom1 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom1);
         assertEquals("Test Domain1", resDom1.getDescription());
         assertEquals("testorg", resDom1.getOrg());
@@ -1135,13 +1136,18 @@ public class DBServiceTest {
                 .setEnabled(true).setAuditEnabled(false).setAccount("12345").setYpmId(1001)
                 .setCertDnsDomain("athenz1.cloud").setMemberExpiryDays(10).setTokenExpiryMins(20)
                 .setServiceExpiryDays(45).setGroupExpiryDays(50).setBusinessService("service1");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, null, false, auditRef, "putDomainMeta");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, "productid", true, auditRef, "putDomainMeta");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, "account", true, auditRef, "putDomainMeta");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, "certdnsdomain", true, auditRef, "putDomainMeta");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, "org", true, auditRef, "putDomainMeta");
+        Domain metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "productid", true, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "account", true, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "certdnsdomain", true, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "org", true, auditRef, "putDomainMeta");
 
-        Domain resDom2 = zms.getDomain(mockDomRsrcCtx, "MetaDom1");
+        Domain resDom2 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom2);
         assertEquals("Test2 Domain", resDom2.getDescription());
         assertEquals("NewOrg", resDom2.getOrg());
@@ -1164,10 +1170,12 @@ public class DBServiceTest {
                 .setEnabled(true).setAuditEnabled(false).setRoleCertExpiryMins(30)
                 .setServiceCertExpiryMins(40).setSignAlgorithm("rsa")
                 .setServiceExpiryDays(45).setGroupExpiryDays(50);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, null, false, auditRef, "putDomainMeta");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, "org", true, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "org", true, auditRef, "putDomainMeta");
 
-        Domain resDom3 = zms.getDomain(mockDomRsrcCtx, "MetaDom1");
+        Domain resDom3 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom3);
         assertEquals("Test2 Domain-New", resDom3.getDescription());
         assertEquals("NewOrg-New", resDom3.getOrg());
@@ -1190,9 +1198,10 @@ public class DBServiceTest {
                 .setServiceCertExpiryMins(400).setTokenExpiryMins(500)
                 .setSignAlgorithm("ec").setServiceExpiryDays(20).setGroupExpiryDays(25)
                 .setBusinessService("service2");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, null, false, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
 
-        Domain resDom4 = zms.getDomain(mockDomRsrcCtx, "MetaDom1");
+        Domain resDom4 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom4);
         assertEquals("Test2 Domain-New", resDom4.getDescription());
         assertEquals("NewOrg-New", resDom4.getOrg());
@@ -1210,7 +1219,7 @@ public class DBServiceTest {
         assertEquals(resDom4.getSignAlgorithm(), "ec");
         assertEquals("service2", resDom4.getBusinessService());
 
-        zms.deleteTopLevelDomain(mockDomRsrcCtx, "MetaDom1", auditRef);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 
     @Test
@@ -1237,7 +1246,8 @@ public class DBServiceTest {
         zms.dbService.defaultRetryCount = 2;
 
         try {
-            zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta,
+            Domain metaDomain = zms.dbService.getDomain(domainName, true);
+            zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta,
                     null, false, auditRef, "testExecutePutDomainMetaRetryException");
             fail();
         } catch (ResourceException ex) {
@@ -5226,7 +5236,8 @@ public class DBServiceTest {
         Domain d1 = zms.dbService.getDomain(domainName, false);
         zms.dbService.updateSystemMetaFields(d1, "auditenabled", false, meta2);
 
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta2, "auditenabled", false, auditRef, "");
+        Domain metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta2, "auditenabled", false, auditRef, "");
 
         Role role1 = createRoleObject(domainName, roleName, null,"user.joe", "user.jane");
         zms.dbService.executePutRole(mockDomRsrcCtx, domainName, roleName, role1, auditRef, "putRole");
@@ -5429,9 +5440,11 @@ public class DBServiceTest {
         DomainMeta meta = new DomainMeta().setDescription("Test2 Domain").setOrg("NewOrg")
                 .setEnabled(true).setAuditEnabled(false).setAccount("12345").setYpmId(1001)
                 .setCertDnsDomain("athenz1.cloud");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, null, false, auditRef, "putDomainMeta");
+        Domain metaDomain = zms.dbService.getDomain("metadom1", true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
         try {
-            zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "metadom1", meta, "org", false, auditRef, "putDomainMeta");
+            metaDomain = zms.dbService.getDomain("metadom1", true);
+            zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "org", false, auditRef, "putDomainMeta");
             fail();
         } catch (ResourceException re) {
             assertEquals(re.getCode(), 403);
@@ -5886,8 +5899,9 @@ public class DBServiceTest {
         Role role3 = createRoleObject(domainName, "role3", "coretech", null, null);
         zms.dbService.executePutRole(mockDomRsrcCtx, domainName, "role3", role3, "test", "putrole");
 
+        Domain metaDomain = zms.dbService.getDomain(domainName, true);
         DomainMeta meta = new DomainMeta().setMemberExpiryDays(40);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta, null, false, auditRef, "putDomainMeta");
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
 
         Role resRole1 = zms.dbService.getRole(domainName, "role1", false, true, false);
 
@@ -5933,7 +5947,8 @@ public class DBServiceTest {
         // now reduce limit to 5 days
 
         meta.setMemberExpiryDays(5);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta, null, false, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
 
         resRole1 = zms.dbService.getRole(domainName, "role1", false, true, false);
 
@@ -5975,7 +5990,8 @@ public class DBServiceTest {
         // now set it back to 40 but nothing will change
 
         meta.setMemberExpiryDays(40);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta, null, false, auditRef, "putDomainMeta");
+        metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
 
         resRole1 = zms.dbService.getRole(domainName, "role1", false, true, false);
 
@@ -6050,7 +6066,8 @@ public class DBServiceTest {
         zms.dbService.executePutRole(mockDomRsrcCtx, domainName, "role3", role3, "test", "putrole");
 
         DomainMeta meta = new DomainMeta().setUserAuthorityFilter("employee");
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta, "userauthorityfilter", false, auditRef, "putDomainMeta");
+        Domain metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, "userauthorityfilter", false, auditRef, "putDomainMeta");
 
         Role resRole1 = zms.dbService.getRole(domainName, "role1", false, true, false);
 
@@ -6113,7 +6130,8 @@ public class DBServiceTest {
         // since the both roles have values set.
 
         DomainMeta meta = new DomainMeta().setMemberExpiryDays(5);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domainName, meta, null, false, auditRef, "putDomainMeta");
+        Domain metaDomain = zms.dbService.getDomain(domainName, true);
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, metaDomain, meta, null, false, auditRef, "putDomainMeta");
 
         // verify that all users in role1 have not changed since the role already
         // has an expiration
@@ -9817,7 +9835,7 @@ public class DBServiceTest {
 
         // update domain meta
         DomainMeta meta = new DomainMeta().setTags(newDomainTags);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "newDomain", meta, null, false, auditRef, "putDomainMeta");
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domain, meta, null, false, auditRef, "putDomainMeta");
 
         // assert tags to remove
         Set<String> expectedTagsToBeRemoved = new HashSet<>(Collections.singletonList("tagToBeRemoved")) ;
@@ -9884,7 +9902,7 @@ public class DBServiceTest {
 
         // update domain meta
         DomainMeta meta = new DomainMeta().setTags(newDomainTags);
-        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, "newDomainTagsUpdate", meta, null, false, auditRef, "putDomainMeta");
+        zms.dbService.executePutDomainMeta(mockDomRsrcCtx, domain, meta, null, false, auditRef, "putDomainMeta");
 
         // assert tags to remove is empty
         ArgumentCaptor<Set<String>> tagCapture = ArgumentCaptor.forClass(Set.class);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/TestDomainMetaStore.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/TestDomainMetaStore.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms;
+
+import com.yahoo.athenz.common.server.metastore.DomainMetaStore;
+import com.yahoo.athenz.common.server.rest.ResourceException;
+
+public class TestDomainMetaStore implements DomainMetaStore {
+
+    @Override
+    public boolean isValidBusinessService(String domainName, String businessService) {
+        return isValidAttribute(businessService);
+    }
+
+    @Override
+    public void setBusinessServiceDomain(String domainName, String businessService) {
+        setAttribute(businessService);
+    }
+
+    @Override
+    public boolean isValidAWSAccount(String domainName, String awsAccountId) {
+        return isValidAttribute(awsAccountId);
+    }
+
+    @Override
+    public void setAWSAccountDomain(String domainName, String awsAccountId) {
+        setAttribute(awsAccountId);
+    }
+
+    @Override
+    public boolean isValidAzureSubscription(String domainName, String azureSubscription) {
+        return isValidAttribute(azureSubscription);
+    }
+
+    @Override
+    public void setAzureSubscriptionDomain(String domainName, String azureSubscription) {
+        setAttribute(azureSubscription);
+    }
+
+    @Override
+    public boolean isValidProductId(String domainName, Integer productId) {
+        return isValidAttribute(productId);
+    }
+
+    @Override
+    public void setProductIdDomain(String domainName, Integer productId) {
+        setAttribute(productId);
+    }
+
+    private boolean isValidAttribute(String value) {
+        return !(value != null && value.startsWith("invalid-"));
+    }
+
+    private boolean isValidAttribute(Integer value) {
+        return value == null || value != 100;
+    }
+
+    private void setAttribute(String value) {
+        if (value != null && value.startsWith("exc-")) {
+            throw new ResourceException(400, "Invalid value");
+        }
+    }
+
+    private void setAttribute(Integer value) {
+        if (value != null && value == 99) {
+            throw new ResourceException(400, "Invalid value");
+        }
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -330,4 +330,20 @@ public class ZMSUtilsTest {
         assertFalse(ZMSUtils.emitMonmetricError(400, "unittest"));
         ZMSImpl.metric = savedMetric;
     }
+
+    @Test
+    public void testMetaValueChanged() {
+        assertTrue(ZMSUtils.metaValueChanged("account-1", "account-2"));
+        assertFalse(ZMSUtils.metaValueChanged("account-1", "account-1"));
+
+        assertTrue(ZMSUtils.metaValueChanged(null, "account-1"));
+        assertFalse(ZMSUtils.metaValueChanged(null, null));
+        assertFalse(ZMSUtils.metaValueChanged("account-1", null));
+
+        assertTrue(ZMSUtils.metaValueChanged(10, 15));
+        assertFalse(ZMSUtils.metaValueChanged(10, 10));
+
+        assertTrue(ZMSUtils.metaValueChanged(null, 10));
+        assertFalse(ZMSUtils.metaValueChanged(10, null));
+    }
 }


### PR DESCRIPTION
 A new DomainMetaStore interface that allows the server to verify and update domain's meta attributes in some external store. By default we have a No-Op implementation that does nothing. The current supported attributes are:

businessService
awsAccount
azureSubscription
productId

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>