### PR TITLE
more specific resource for tenancy admins with resource groups

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -6108,7 +6108,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         if (authzServiceTokenOperation) {
             setupTenantAdminPolicyInProvider(ctx, provSvcDomain, provSvcName, tenantDomain,
-                    auditRef, caller);
+                    false, auditRef, caller);
         }
     }
 
@@ -6216,7 +6216,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         }
 
         setupTenantAdminPolicyInProvider(ctx, providerDomain, providerService, tenantDomain,
-                auditRef, caller);
+                false, auditRef, caller);
     }
 
     @Override
@@ -6368,7 +6368,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // first setup the domain as a tenant in the provider domain
 
         setupTenantAdminPolicyInProvider(ctx, provSvcDomain, provSvcName, tenantDomain,
-                auditRef, caller);
+                true, auditRef, caller);
 
         // then setup the requested resource group roles
 
@@ -6880,7 +6880,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             // happens to be the first resource group
 
             setupTenantAdminPolicyInProvider(ctx, provSvcDomain, provSvcName, tenantDomain,
-                    auditRef, caller);
+                    true, auditRef, caller);
 
             // now onboard the requested resource group
 
@@ -6892,14 +6892,19 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     }
 
     void setupTenantAdminPolicyInProvider(ResourceContext ctx, final String provSvcDomain,
-            final String provSvcName, final String tenantDomain, final String auditRef,
-            final String caller) {
+            final String provSvcName, final String tenantDomain, boolean resourceGroupComp,
+            final String auditRef, final String caller) {
 
         List<TenantRoleAction> roles = new ArrayList<>();
         TenantRoleAction roleAction = new TenantRoleAction().setAction("*").setRole(ADMIN_ROLE_NAME);
         roles.add(roleAction);
-        dbService.executePutTenantRoles(ctx, provSvcDomain, provSvcName, tenantDomain, null,
-                roles, auditRef, caller);
+
+        // if we want the admin policy with a resource group component then we'll
+        // pass an empty string for the resource group which indicate that tenancy
+        // is based on resource groups otherwise null
+
+        dbService.executePutTenantRoles(ctx, provSvcDomain, provSvcName, tenantDomain,
+                resourceGroupComp ? "" : null, roles, auditRef, caller);
     }
 
     String getProviderRoleAction(String provSvcDomain, String roleName) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -97,7 +97,10 @@ public class ZMSUtils {
         StringBuilder rolePrefix = new StringBuilder(256);
         rolePrefix.append(provSvcName).append(".tenant.").append(tenantDomain).append('.');
         if (resourceGroup != null) {
-            rolePrefix.append("res_group.").append(resourceGroup).append('.');
+            rolePrefix.append("res_group.");
+            if (!resourceGroup.isEmpty()) {
+                rolePrefix.append(resourceGroup).append('.');
+            }
         }
         return rolePrefix.toString();
     }
@@ -106,7 +109,7 @@ public class ZMSUtils {
         
         StringBuilder rolePrefix = new StringBuilder(256);
         rolePrefix.append(provSvcDomain).append('.').append(provSvcName).append('.');
-        if (resourceGroup != null) {
+        if (!StringUtil.isEmpty(resourceGroup)) {
             rolePrefix.append("res_group.").append(resourceGroup).append('.');
         }
         return rolePrefix.toString();
@@ -118,7 +121,7 @@ public class ZMSUtils {
         StringBuilder trustedRole = new StringBuilder(256);
         trustedRole.append(provSvcDomain).append(AuthorityConsts.ROLE_SEP).append(provSvcName)
                 .append(".tenant.").append(tenantDomain).append('.');
-        if (resourceGroup != null) {
+        if (!StringUtil.isEmpty(resourceGroup)) {
             trustedRole.append("res_group.").append(resourceGroup).append('.');
         }
         return trustedRole.toString();

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -50,6 +50,8 @@ public class ZMSUtilsTest {
 
         assertEquals("storage.tenant.sports.api.",
                 ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", null));
+        assertEquals("storage.tenant.sports.api.res_group.",
+                ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", ""));
         assertEquals("storage.tenant.sports.api.res_group.Group1.",
                 ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", "Group1"));
     }
@@ -58,6 +60,8 @@ public class ZMSUtilsTest {
     public void testGetTrustedResourceGroupRolePrefix() {
         assertEquals("coretech:role.storage.tenant.sports.api.",
                 ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", null));
+        assertEquals("coretech:role.storage.tenant.sports.api.",
+                ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", ""));
         assertEquals("coretech:role.storage.tenant.sports.api.res_group.group1.",
                 ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", "group1"));
     }
@@ -68,6 +72,8 @@ public class ZMSUtilsTest {
                 ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", "hockey"));
         assertEquals("sports.hosted.",
                 ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", null));
+        assertEquals("sports.hosted.",
+                ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", ""));
     }
 
     @Test


### PR DESCRIPTION
when creating the tenant admin role for resource group access, the resource is setup as follows:

grant * to admin-role on service.provider-service.tenant.tenant-domain.*

this is too broad since tenant-domain.* would also match tenant-domain.subdomain.* and we may not want the parent admin to have access to its children's resources.

A more specific role would be to include the "res_group" separator when the tenancy is auto-set with resource group api:

grant * to admin-role on service.provider-service.tenant.tenant-domain.res_group.*