### PR TITLE
exclude group settings from signature

### DIFF
--- a/libs/java/client_common/src/main/java/com/yahoo/athenz/common/utils/SignUtils.java
+++ b/libs/java/client_common/src/main/java/com/yahoo/athenz/common/utils/SignUtils.java
@@ -86,8 +86,6 @@ public class SignUtils {
     private static final String ATTR_SERVICE_CERT_EXPIRY_MINS = "serviceCertExpiryMins";
     private static final String ATTR_MEMBER_REVIEW_DAYS = "memberReviewDays";
     private static final String ATTR_SERVICE_REVIEW_DAYS = "serviceReviewDays";
-    private static final String ATTR_GROUP_REVIEW_DAYS = "groupReviewDays";
-    private static final String ATTR_GROUP_EXPIRY_DAYS = "groupExpiryDays";
     private static final String ATTR_SIGN_ALGORITHM = "signAlgorithm";
 
     private static Struct asStruct(DomainPolicies domainPolicies) {
@@ -153,8 +151,6 @@ public class SignUtils {
         Struct struct = new Struct();
         appendObject(struct, ATTR_AUDIT_ENABLED, role.getAuditEnabled());
         appendObject(struct, ATTR_CERT_EXPIRY_MINS, role.getCertExpiryMins());
-        appendObject(struct, ATTR_GROUP_EXPIRY_DAYS, role.getGroupExpiryDays());
-        appendObject(struct, ATTR_GROUP_REVIEW_DAYS, role.getGroupReviewDays());
         appendObject(struct, ATTR_MEMBER_EXPIRY_DAYS, role.getMemberExpiryDays());
         appendObject(struct, ATTR_MEMBER_REVIEW_DAYS, role.getMemberReviewDays());
         appendList(struct, ATTR_MEMBERS, role.getMembers());

--- a/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/SignUtilsTest.java
+++ b/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/SignUtilsTest.java
@@ -208,7 +208,7 @@ public class SignUtilsTest {
 
         final String check = SignUtils.asCanonicalString(data);
         final String expected = "{\"enabled\":true,\"roles\":[{\"certExpiryMins\":300,"
-            +"\"groupExpiryDays\":70,\"groupReviewDays\":80,\"memberExpiryDays\":30,\"name\":\"role1\","
+            +"\"memberExpiryDays\":30,\"name\":\"role1\","
             +"\"roleMembers\":[],\"serviceExpiryDays\":40,\"tokenExpiryMins\":450},"
             +"{\"name\":\"role2\",\"roleMembers\":[{\"expiration\":\"1970-01-01T00:00:00.000Z\","
             +"\"memberName\":\"user.joe\"},{\"expiration\":\"1970-01-01T00:00:00.000Z\","


### PR DESCRIPTION
since the attributes are not used by ZTS they don't need to be signed. furthermore, if we already have cached domain files with signatures those will fail to validate if we add these fields afterward.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>