### PR TITLE
during provider admin setup, ignore deletes

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -3805,7 +3805,7 @@ public class DBService implements RolesProvider {
     }
 
     void executePutTenantRoles(ResourceContext ctx, String provSvcDomain, String provSvcName, String tenantDomain,
-            String resourceGroup, List<TenantRoleAction> roles, String auditRef, String caller) {
+            String resourceGroup, List<TenantRoleAction> roles, boolean ignoreDeletes, String auditRef, String caller) {
 
         // our exception handling code does the check for retry count
         // and throws the exception it had received when the retry
@@ -3850,7 +3850,7 @@ public class DBService implements RolesProvider {
 
                     auditDetails.append("{\"role\": ");
                     if (!processRole(con, originalRole, provSvcDomain, trustedName, role,
-                            getPrincipalName(ctx), auditRef, false, auditDetails)) {
+                            getPrincipalName(ctx), auditRef, ignoreDeletes, auditDetails)) {
                         con.rollbackChanges();
                         throw ZMSUtils.internalServerError("unable to put role: " + trustedRole, caller);
                     }
@@ -3877,7 +3877,7 @@ public class DBService implements RolesProvider {
                     // now process the request
 
                     auditDetails.append(", \"policy\": ");
-                    if (!processPolicy(con, originalPolicy, provSvcDomain, trustedName, policy, false, auditDetails)) {
+                    if (!processPolicy(con, originalPolicy, provSvcDomain, trustedName, policy, ignoreDeletes, auditDetails)) {
                         con.rollbackChanges();
                         throw ZMSUtils.internalServerError("unable to put policy: " + policy.getName(), caller);
                     }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -6373,7 +6373,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // then setup the requested resource group roles
 
         dbService.executePutTenantRoles(ctx, provSvcDomain, provSvcName, tenantDomain,
-                resourceGroup, detail.getRoles(), auditRef, caller);
+                resourceGroup, detail.getRoles(), false, auditRef, caller);
         return detail;
     }
 
@@ -6885,7 +6885,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             // now onboard the requested resource group
 
             dbService.executePutTenantRoles(ctx, provSvcDomain, provSvcName, tenantDomain,
-                    resourceGroup, roleActions, auditRef, caller);
+                    resourceGroup, roleActions, false, auditRef, caller);
         }
 
         return detail;
@@ -6904,7 +6904,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // is based on resource groups otherwise null
 
         dbService.executePutTenantRoles(ctx, provSvcDomain, provSvcName, tenantDomain,
-                resourceGroupComp ? "" : null, roles, auditRef, caller);
+                resourceGroupComp ? "" : null, roles, true, auditRef, caller);
     }
 
     String getProviderRoleAction(String provSvcDomain, String roleName) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -2158,7 +2158,7 @@ public class DBServiceTest {
         }
 
         zms.dbService.executePutTenantRoles(mockDomRsrcCtx, providerDomain, providerService,
-                tenantDomain, null, roleActions, auditRef, "putTenantRoles");
+                tenantDomain, null, roleActions, false, auditRef, "putTenantRoles");
 
         zms.deleteTenancy(mockDomRsrcCtx, tenantDomain, "coretech.storage", auditRef);
 


### PR DESCRIPTION
when we're setting up the admin role/policy during onboarding a resource group, we should override the role/policy every time in case the admin has made changes directly. We'll add new assertions but we won't delete any old ones.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>