### PR TITLE
Fix invalid environment in athenz_ui script

### DIFF
--- a/ui/scripts/athenz_ui
+++ b/ui/scripts/athenz_ui
@@ -36,7 +36,7 @@ if [ -z "${ZMS_SERVER}" ]; then
     exit 1
 fi
 
-if [ -z "${ZMS_SERVER_URL}" ]; then
+if [ -z "${ZMS_SERVER}" ]; then
     export ZMS_SERVER_URL=https://${ZMS_SERVER}:4443/zms/v1/
 fi
 


### PR DESCRIPTION
## Changes
I found an invalid environment `ZMS_SERVER_URL` -> `ZMS_SERVER` in athenz_ui script and fixed it.