### PR TITLE
zts access check was not converting checkprincipal to lowercase before using it

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3883,7 +3883,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // check against that principal
         
         if (checkPrincipal != null) {
-            principal = createPrincipalForName(checkPrincipal);
+            principal = createPrincipalForName(checkPrincipal.toLowerCase());
         }
         
         // create our response object and set the flag whether

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -3398,10 +3398,19 @@ public class ZTSImplTest {
         access = zts.getResourceAccess(ctx, "update", domainName + ":table1", null, "user.user2");
         assertFalse(access.getGranted());
 
+        access = zts.getResourceAccess(ctx, "update", domainName + ":table1", null, "user.USER2");
+        assertFalse(access.getGranted());
+
         access = zts.getResourceAccess(ctx, "update", domainName + ":table1", null, "user.user3");
         assertTrue(access.getGranted());
 
+        access = zts.getResourceAccess(ctx, "update", domainName + ":table1", null, "user.USER3");
+        assertTrue(access.getGranted());
+
         access = zts.getResourceAccess(ctx, "update", domainName + ":table2", null, "user.user3");
+        assertFalse(access.getGranted());
+
+        access = zts.getResourceAccess(ctx, "update", domainName + ":table2", null, "user.USER3");
         assertFalse(access.getGranted());
 
         store.getCacheStore().invalidate(domainName);


### PR DESCRIPTION
Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>