### PR TITLE
improve aws temp creds failure by reporting sts error message

### DIFF
--- a/clients/go/zts/zts_schema.go
+++ b/clients/go/zts/zts_schema.go
@@ -574,7 +574,7 @@ func init() {
 	sb.AddResource(mPostInstanceRefreshRequest.Build())
 
 	mGetAWSTemporaryCredentials := rdl.NewResourceBuilder("AWSTemporaryCredentials", "GET", "/domain/{domainName}/role/{role}/creds")
-	mGetAWSTemporaryCredentials.Comment("perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.")
+	mGetAWSTemporaryCredentials.Comment("perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to assume_aws_role in Athenz for this to succeed.")
 	mGetAWSTemporaryCredentials.Input("domainName", "DomainName", true, "", "", false, nil, "name of the domain containing the role, which implies the target account")
 	mGetAWSTemporaryCredentials.Input("role", "AWSArnRoleName", true, "", "", false, nil, "the target AWS role name in the domain account, in Athenz terms, i.e. \"the.role\"")
 	mGetAWSTemporaryCredentials.Input("durationSeconds", "Int32", false, "durationSeconds", "", true, nil, "how long the aws temp creds should be issued for")

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
@@ -556,7 +556,7 @@ public class ZTSSchema {
 ;
 
         sb.resource("AWSTemporaryCredentials", "GET", "/domain/{domainName}/role/{role}/creds")
-            .comment("perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.")
+            .comment("perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to assume_aws_role in Athenz for this to succeed.")
             .pathParam("domainName", "DomainName", "name of the domain containing the role, which implies the target account")
             .pathParam("role", "AWSArnRoleName", "the target AWS role name in the domain account, in Athenz terms, i.e. \"the.role\"")
             .queryParam("durationSeconds", "durationSeconds", "Int32", null, "how long the aws temp creds should be issued for")

--- a/core/zts/src/main/rdl/AWSAuth.rdli
+++ b/core/zts/src/main/rdl/AWSAuth.rdli
@@ -24,7 +24,7 @@ type AWSTemporaryCredentials Struct {
 
 // perform an AWS AssumeRole of the target role and return the credentials. ZTS
 // must have been granted the ability to assume the role in IAM, and granted
-// the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.
+// the ability to assume_aws_role in Athenz for this to succeed.
 resource AWSTemporaryCredentials GET "/domain/{domainName}/role/{role}/creds?durationSeconds={durationSeconds}&externalId={externalId}" {
     DomainName domainName; //name of the domain containing the role, which implies the target account
     AWSArnRoleName role; //the target AWS role name in the domain account, in Athenz terms, i.e. "the.role"

--- a/docs/aws_temp_creds.md
+++ b/docs/aws_temp_creds.md
@@ -462,7 +462,7 @@ ZTS Server returns a unique error message indicating what part of the configurat
 ### Athenz Domain Configuration
 
 ```
-getAWSTemporaryCredentials: unable to retrieve AWS account for: <domainName>
+Athenz Configuration Error: unable to retrieve AWS account for: <domainName>
 ```
 
 The domain, identified in the `<domainName>` field, does not have AWS account id configured. Follow the steps in the `AWS Account ID Registration` section to register your AWS account id for your domain.
@@ -470,7 +470,7 @@ The domain, identified in the `<domainName>` field, does not have AWS account id
 ### Athenz Role Configuration
 
 ```
-getAWSTemporaryCredentials: Forbidden (ASSUME_AWS_ROLE on <resource-name> for <principal>)
+Athenz Configuration Error: Forbidden (assume_aws_role on <resource-name> for <principal>)
 ```
 
 This error indicates that the principal, identified in the `<principal>` field, requesting the temporary credentials is not authorized. There are two common issues that generate this error message:
@@ -482,7 +482,7 @@ This error indicates that the principal, identified in the `<principal>` field, 
 ### AWS Configuration
 
 ```
-getAWSTemporaryCredentials: unable to assume role <roleName> in domain <domainName> for principal <principal>
+AWS Configuration Error: unable to assume role <roleName> in domain <domainName> for principal <principal> error: <aws-error-message>
 ```
 
 This error indicates that AWS STS refused to issue temporary credentials to the Athenz ZTS service. This usually indicates that either the role name specified in the request is incorrect (you must specify the IAM Role name you're trying to assume and not the Athenz Role Name) or the role in IAM does not have the trust relationship setup for ZTS service as described in the `AWS Configuration Setup` section in this document.

--- a/docs/zts_api.md
+++ b/docs/zts_api.md
@@ -450,7 +450,7 @@ Exception:
 
 Perform an AWS AssumeRole of the target role and return the credentials. ZTS
 must have been granted the ability to assume the role in IAM, and granted
-the ability to ASSUME_AWS_ROLE in Athenz for this to succeed. There are two
+the ability to assume_aws_role in Athenz for this to succeed. There are two
 optional query parameters to specify the duration in seconds for the requested
 credentials and the external id. Both of these options require the role to be
 configured accordingly in AWS IAM.

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2477,8 +2477,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         }
         
         if (!cloudStore.isAwsEnabled()) {
-            throw requestError("getAWSTemporaryCredentials: AWS support is not available",
-                    caller, domainName, principalDomain);
+            throw requestError("AWS support is not available", caller, domainName, principalDomain);
         }
         
         // get our principal's name
@@ -2490,7 +2489,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // with aws assume role assertion for the specified role and domain
         
         if (!verifyAWSAssumeRole(domainName, roleResource, principalName)) {
-            throw forbiddenError("getAWSTemporaryCredentials: Forbidden (ASSUME_AWS_ROLE on "
+            throw forbiddenError("Athenz Configuration Error: Forbidden (assume_aws_role on "
                     + roleResource + " for " + principalName + ")", caller, domainName, principalDomain);
         }
         
@@ -2498,18 +2497,19 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         
         String account = cloudStore.getAwsAccount(domainName);
         if (account == null) {
-            throw requestError("getAWSTemporaryCredentials: unable to retrieve AWS account for: "
+            throw requestError("Athenz Configuration Error: unable to retrieve AWS account for: "
                     + domainName, caller, domainName, principalDomain);
         }
         
         // obtain the credentials from the cloud store
-        
+
+        StringBuilder errorMessage = new StringBuilder();
         AWSTemporaryCredentials creds = cloudStore.assumeAWSRole(account, roleName, principalName,
-                durationSeconds, externalId);
+                durationSeconds, externalId, errorMessage);
         if (creds == null) {
-            throw requestError("getAWSTemporaryCredentials: unable to assume role " + roleName
-                    + " in domain " + domainName + " for principal " + principalName,
-                    caller, domainName, principalDomain);
+            throw requestError("AWS Configuration Error: Unable to assume role " + roleName + " in domain " +
+                            domainName + " for principal " + principalName + "error: " + errorMessage,
+                            caller, domainName, principalDomain);
         }
         
         return creds;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
@@ -440,7 +440,7 @@ public class ZTSResources {
     @GET
     @Path("/domain/{domainName}/role/{role}/creds")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.")
+    @Operation(description = "perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to assume_aws_role in Athenz for this to succeed.")
     public AWSTemporaryCredentials getAWSTemporaryCredentials(
         @Parameter(description = "name of the domain containing the role, which implies the target account", required = true) @PathParam("domainName") String domainName,
         @Parameter(description = "the target AWS role name in the domain account, in Athenz terms, i.e. \"the.role\"", required = true) @PathParam("role") String role,

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/MockCloudStore.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/MockCloudStore.java
@@ -82,7 +82,7 @@ public class MockCloudStore extends CloudStore {
 
     @Override
     public AWSTemporaryCredentials assumeAWSRole(String account, String roleName, String principal,
-                                                 Integer durationSeconds, String externalId) {
+                                                 Integer durationSeconds, String externalId, StringBuilder errorMessage) {
 
         if (!returnSuperAWSRole) {
             AWSTemporaryCredentials tempCreds = null;
@@ -93,7 +93,7 @@ public class MockCloudStore extends CloudStore {
 
             return tempCreds;
         } else {
-            return super.assumeAWSRole(account, roleName, principal, durationSeconds, externalId);
+            return super.assumeAWSRole(account, roleName, principal, durationSeconds, externalId, errorMessage);
         }
     }
 


### PR DESCRIPTION
a) consistent use assume_aws_role action - must be all lowercase not to be confused with case sensitive policies
b) when rejecting the AWS Temp request due to STS call failure, return back to the user the actual error message from STS so the user can debug and understand what they have done wrong in their setup rather than contacting Athenz support