### PR TITLE
Support using customized PrivateKey object from HSM provider in Crypto.java for signing

### DIFF
--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -161,6 +161,24 @@ public class CryptoTest {
     }
 
     @Test
+    public void testSignatureProviderException() {
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        assertNotNull(privateKey);
+
+        PublicKey publicKey = Crypto.loadPublicKey(ecPublicKey);
+        assertNotNull(publicKey);
+
+        System.setProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER, "C");
+        assertThrows(CryptoException.class, () -> Crypto.sign(serviceToken, privateKey));
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER);
+
+
+        System.setProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER, "C");
+        assertThrows(CryptoException.class, () -> Crypto.verify(serviceToken, publicKey, serviceECSignature));
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER);
+    }
+
+    @Test
     public void testExtractPublicKeyRSAException() {
 
         PrivateKey privateKey = Crypto.loadPrivateKey(rsaPrivateKey);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -172,9 +172,16 @@ public class CryptoTest {
         assertThrows(CryptoException.class, () -> Crypto.sign(serviceToken, privateKey));
         System.clearProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER);
 
+        System.setProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER, "C");
+        assertThrows(CryptoException.class, () -> Crypto.sign(serviceToken.getBytes(StandardCharsets.UTF_8), privateKey, Crypto.SHA256));
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER);
 
         System.setProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> Crypto.verify(serviceToken, publicKey, serviceECSignature));
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER);
+
+        System.setProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER, "C");
+        assertThrows(CryptoException.class, () -> Crypto.verify(serviceToken.getBytes(StandardCharsets.UTF_8), publicKey, serviceECSignature.getBytes(StandardCharsets.UTF_8), Crypto.SHA256));
         System.clearProperty(Crypto.ATHENZ_CRYPTO_SIGNATURE_PROVIDER);
     }
 

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -155,9 +155,9 @@ public class CryptoTest {
         assertThrows(CryptoException.class, () -> Crypto.extractPublicKey(privateKey));
         System.clearProperty(Crypto.ATHENZ_CRYPTO_ALGO_ECDSA);
 
-        System.setProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER, "C");
+        System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> Crypto.extractPublicKey(privateKey));
-        System.clearProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER);
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER);
     }
 
     @Test
@@ -170,9 +170,9 @@ public class CryptoTest {
         assertThrows(CryptoException.class, () -> Crypto.extractPublicKey(privateKey));
         System.clearProperty(Crypto.ATHENZ_CRYPTO_ALGO_RSA);
 
-        System.setProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER, "C");
+        System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> Crypto.extractPublicKey(privateKey));
-        System.clearProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER);
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER);
     }
 
     @Test
@@ -320,9 +320,9 @@ public class CryptoTest {
 
         Crypto.sign(serviceToken, privateKey);
 
-        System.setProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER, "C");
+        System.setProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER, "C");
         assertThrows(CryptoException.class, () -> Crypto.loadPublicKey(ecPublicParamsKey));
-        System.clearProperty(Crypto.ATHENZ_CRYPTO_BC_PROVIDER);
+        System.clearProperty(Crypto.ATHENZ_CRYPTO_KEY_FACTORY_PROVIDER);
 
         System.setProperty(Crypto.ATHENZ_CRYPTO_ALGO_ECDSA, "TESTAlgo");
         assertThrows(CryptoException.class, () -> Crypto.loadPublicKey(ecPublicParamsKey));


### PR DESCRIPTION
## Issue
The implement for signing is hard-coded to use the BouncyCastle provider. As the HSM provider that we are planing to use has its own implementation on the PrivateKey object, which is not compatible with BouncyCastle's implementation for creating signature. Signature cannot be created with HSM provider specific PrivateKey object.

## Fix
1. remove the hard-coded part in Crypto.java
1. replace system properties athenz.crypto.bc_provider
    1. add athenz.crypto.key_factory_provider
    1. add athenz.crypto.signature_provider

### related issue
- #1408