### PR TITLE
allow role/group review regardless of role/group expiry/reminder settings

### DIFF
--- a/servers/zms/pom.xml
+++ b/servers/zms/pom.xml
@@ -39,7 +39,7 @@
   </dependencyManagement>
 
   <properties>
-    <code.coverage.min>0.9653</code.coverage.min>
+    <code.coverage.min>0.9652</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/servers/zms/pom.xml
+++ b/servers/zms/pom.xml
@@ -39,7 +39,7 @@
   </dependencyManagement>
 
   <properties>
-    <code.coverage.min>0.9641</code.coverage.min>
+    <code.coverage.min>0.9653</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -42,10 +42,7 @@ import com.yahoo.athenz.common.server.util.ResourceUtils;
 import com.yahoo.athenz.common.server.util.ServletRequestUtil;
 import com.yahoo.athenz.common.server.util.AuthzHelper;
 import com.yahoo.athenz.common.utils.SignUtils;
-import com.yahoo.athenz.zms.config.AllowedOperation;
-import com.yahoo.athenz.zms.config.AuthorizedService;
-import com.yahoo.athenz.zms.config.AuthorizedServices;
-import com.yahoo.athenz.zms.config.SolutionTemplates;
+import com.yahoo.athenz.zms.config.*;
 import com.yahoo.athenz.zms.notification.*;
 import com.yahoo.athenz.zms.store.AthenzDomain;
 import com.yahoo.athenz.zms.store.ObjectStore;
@@ -3426,24 +3423,19 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // update role expiry based on our configurations
 
-        updateRoleMemberExpiration(
-                domain.getMemberExpiryDays(),
-                role.getMemberExpiryDays(),
-                domain.getServiceExpiryDays(),
-                role.getServiceExpiryDays(),
-                domain.getGroupExpiryDays(),
-                role.getGroupExpiryDays(),
-                role.getRoleMembers());
+        MemberDueDays memberExpiryDueDays = new MemberDueDays(domain, role, MemberDueDays.Type.EXPIRY);
+        MemberDueDays memberReminderDueDays = new MemberDueDays(null, role, MemberDueDays.Type.REMINDER);
+
+        updateRoleMemberExpiration(memberExpiryDueDays, role.getRoleMembers());
+
+        // update role review based on our configurations
+
+        updateRoleMemberReviewReminder(memberReminderDueDays, role.getRoleMembers());
 
         // update role expiry based on user authority expiry
         // if configured
 
         updateRoleMemberUserAuthorityExpiry(role, caller);
-
-        // update role review based on our configurations
-
-        updateRoleMemberReviewReminder(role.getMemberReviewDays(), role.getServiceReviewDays(),
-                role.getGroupReviewDays(), role.getRoleMembers());
 
         // process our request
 
@@ -3758,19 +3750,6 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         return dbService.listOverdueReviewRoleMembers(domainName);
     }
 
-    long configuredDueDateMillis(Integer domainDueDateDays, Integer roleDueDateDays) {
-
-        // the role expiry days settings overrides the domain one if one configured
-
-        int expiryDays = 0;
-        if (roleDueDateDays != null && roleDueDateDays > 0) {
-            expiryDays = roleDueDateDays;
-        } else if (domainDueDateDays != null && domainDueDateDays > 0) {
-            expiryDays = domainDueDateDays;
-        }
-        return expiryDays == 0 ? 0 : System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(expiryDays, TimeUnit.DAYS);
-    }
-
     Timestamp getMemberDueDate(long cfgDueDateMillis, Timestamp memberDueDate) {
         if (memberDueDate == null) {
             return Timestamp.fromMillis(cfgDueDateMillis);
@@ -3781,54 +3760,33 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         }
     }
 
-    void updateRoleMemberExpiration(Integer domainUserMemberDueDateDays,
-                                    Integer roleUserMemberDueDateDays,
-                                    Integer domainServiceMemberDueDateDays,
-                                    Integer roleServiceMemberDueDateDays,
-                                    Integer domainGroupMemberDueDateDays,
-                                    Integer roleGroupMemberDueDateDays,
-                                    List<RoleMember> roleMembers) {
-        updateRoleMemberDueDate(
-                domainUserMemberDueDateDays,
-                roleUserMemberDueDateDays,
-                domainServiceMemberDueDateDays,
-                roleServiceMemberDueDateDays,
-                domainGroupMemberDueDateDays,
-                roleGroupMemberDueDateDays,
+    void updateRoleMemberExpiration(MemberDueDays memberExpiryDueDays, List<RoleMember> roleMembers) {
+        updateMemberDueDate(
+                memberExpiryDueDays,
                 roleMembers,
                 roleMember -> roleMember.getExpiration(),
-                (roleMember, expiration) -> roleMember.setExpiration(expiration));
+                (roleMember, expiration) -> roleMember.setExpiration(expiration),
+                roleMember -> roleMember.getPrincipalType());
     }
 
-    void updateRoleMemberReviewReminder(Integer roleUserMemberDueDateDays,
-                                        Integer roleServiceMemberDueDateDays,
-                                        Integer roleGroupMemberDueDateDays,
-                                        List<RoleMember> roleMembers) {
-        updateRoleMemberDueDate(
-                null,
-                roleUserMemberDueDateDays,
-                null,
-                roleServiceMemberDueDateDays,
-                null,
-                roleGroupMemberDueDateDays,
+    void updateRoleMemberReviewReminder(MemberDueDays memberReminderDueDays, List<RoleMember> roleMembers) {
+        updateMemberDueDate(
+                memberReminderDueDays,
                 roleMembers,
                 roleMember -> roleMember.getReviewReminder(),
-                (roleMember, reviewReminder) -> roleMember.setReviewReminder(reviewReminder));
+                (roleMember, reviewReminder) -> roleMember.setReviewReminder(reviewReminder),
+                roleMember -> roleMember.getPrincipalType());
     }
 
-    private <T> void updateMemberDueDate(Integer domainUserMemberDueDateDays,
-                                         Integer userMemberDueDateDays,
-                                         Integer domainServiceMemberDueDateDays,
-                                         Integer serviceMemberDueDateDays,
-                                         Integer domainGroupMemberDueDateDays,
-                                         Integer groupMemberDueDateDays,
+    private <T> void updateMemberDueDate(MemberDueDays memberDueDays,
                                          List<T> members,
                                          Function<T, Timestamp> dueDateGetter,
                                          BiConsumer<T, Timestamp> dueDateSetter,
                                          Function<T, Integer> principalTypeGetter) {
-        long cfgUserMemberDueDateMillis = configuredDueDateMillis(domainUserMemberDueDateDays, userMemberDueDateDays);
-        long cfgServiceMemberDueDateMillis = configuredDueDateMillis(domainServiceMemberDueDateDays, serviceMemberDueDateDays);
-        long cfgGroupMemberDueDateMillis = configuredDueDateMillis(domainGroupMemberDueDateDays, groupMemberDueDateDays);
+
+        long cfgUserMemberDueDateMillis = memberDueDays.getUserDueDateMillis();
+        long cfgServiceMemberDueDateMillis = memberDueDays.getServiceDueDateMillis();
+        long cfgGroupMemberDueDateMillis = memberDueDays.getGroupDueDateMillis();
 
         // if we have no value configured then we have nothing to
         // do so we'll just return right away
@@ -3864,31 +3822,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             }
         }
     }
-    private void updateRoleMemberDueDate(Integer domainUserMemberDueDateDays,
-                                 Integer roleUserMemberDueDateDays,
-                                 Integer domainServiceMemberDueDateDays,
-                                 Integer roleServiceMemberDueDateDays,
-                                 Integer domainGroupMemberDueDateDays,
-                                 Integer roleGroupMemberDueDateDays,
-                                 List<RoleMember> roleMembers,
-                                 Function<RoleMember, Timestamp> dueDateGetter,
-                                 BiConsumer<RoleMember, Timestamp> dueDateSetter) {
-
-        updateMemberDueDate(domainUserMemberDueDateDays,
-                roleUserMemberDueDateDays,
-                domainServiceMemberDueDateDays,
-                roleServiceMemberDueDateDays,
-                domainGroupMemberDueDateDays,
-                roleGroupMemberDueDateDays,
-                roleMembers,
-                dueDateGetter,
-                dueDateSetter,
-                roleMember -> roleMember.getPrincipalType());
-    }
 
     Timestamp memberDueDateTimestamp(Integer domainDueDateDays, Integer roleDueDateDays, Timestamp memberDueDate) {
 
-        long cfgExpiryMillis = configuredDueDateMillis(domainDueDateDays, roleDueDateDays);
+        long cfgExpiryMillis = ZMSUtils.configuredDueDateMillis(domainDueDateDays, roleDueDateDays);
 
         // if we have no value configured then return
         // the membership expiration as is
@@ -8451,34 +8388,25 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         Role dbRole = getRoleFromDomain(roleName, domain);
 
-        if (configuredDueDateMillis(domain.getDomain().getMemberExpiryDays(), dbRole.getMemberExpiryDays()) == 0 &&
-                configuredDueDateMillis(domain.getDomain().getServiceExpiryDays(), dbRole.getServiceExpiryDays()) == 0) {
-            throw ZMSUtils.requestError(caller + ": Domain member expiry / Role member expiry must be set to review the role. ", caller);
-        }
-
         // normalize and remove duplicate members
 
         normalizeRoleMembers(role);
 
         // update role expiry based on our configurations
 
-        updateRoleMemberExpiration(
-                domain.getDomain().getMemberExpiryDays(),
-                dbRole.getMemberExpiryDays(),
-                domain.getDomain().getServiceExpiryDays(),
-                dbRole.getServiceExpiryDays(),
-                domain.getDomain().getGroupExpiryDays(),
-                dbRole.getGroupExpiryDays(),
-                role.getRoleMembers());
+        MemberDueDays memberExpiryDueDays = new MemberDueDays(domain.getDomain(), dbRole, MemberDueDays.Type.EXPIRY);
+        MemberDueDays memberReminderDueDays = new MemberDueDays(null, dbRole, MemberDueDays.Type.REMINDER);
+
+        updateRoleMemberExpiration(memberExpiryDueDays, role.getRoleMembers());
 
         // update role review based on our configurations
 
-        updateRoleMemberReviewReminder(dbRole.getMemberReviewDays(), dbRole.getServiceReviewDays(),
-                dbRole.getGroupReviewDays(), role.getRoleMembers());
+        updateRoleMemberReviewReminder(memberReminderDueDays, role.getRoleMembers());
 
         // process our request
 
-        dbService.executePutRoleReview(ctx, domainName, roleName, role, auditRef, caller);
+        dbService.executePutRoleReview(ctx, domainName, roleName, role, memberExpiryDueDays,
+                memberReminderDueDays, auditRef, caller);
     }
 
     List<Group> setupGroupList(AthenzDomain domain, Boolean members) {
@@ -8725,12 +8653,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // update group expiry based on our configurations
 
-        updateGroupMemberExpiration(
-                domain.getMemberExpiryDays(),
-                group.getMemberExpiryDays(),
-                domain.getServiceExpiryDays(),
-                group.getServiceExpiryDays(),
-                group.getGroupMembers());
+        MemberDueDays memberExpiryDueDays = new MemberDueDays(domain, group);
+        updateGroupMemberExpiration(memberExpiryDueDays, group.getGroupMembers());
 
         // update group expiry based on user authority expiry if configured
 
@@ -8741,36 +8665,23 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         dbService.executePutGroup(ctx, domainName, groupName, group, auditRef);
     }
 
-    void updateGroupMemberExpiration(Integer domainUserMemberDueDateDays,
-                                    Integer groupUserMemberDueDateDays,
-                                    Integer domainServiceMemberDueDateDays,
-                                    Integer groupServiceMemberDueDateDays,
+    void updateGroupMemberExpiration(MemberDueDays memberExpiryDueDays,
                                     List<GroupMember> groupMembers) {
+
         updateGroupMemberDueDate(
-                domainUserMemberDueDateDays,
-                groupUserMemberDueDateDays,
-                domainServiceMemberDueDateDays,
-                groupServiceMemberDueDateDays,
+                memberExpiryDueDays,
                 groupMembers,
                 groupMember -> groupMember.getExpiration(),
                 (groupMember, expiration) -> groupMember.setExpiration(expiration));
     }
 
-    private void updateGroupMemberDueDate(Integer domainUserMemberDueDateDays,
-                                          Integer groupUserMemberDueDateDays,
-                                          Integer domainServiceMemberDueDateDays,
-                                          Integer groupServiceMemberDueDateDays,
+    private void updateGroupMemberDueDate(MemberDueDays memberExpiryDueDays,
                                           List<GroupMember> groupMembers,
                                           Function<GroupMember, Timestamp> dueDateGetter,
                                           BiConsumer<GroupMember, Timestamp> dueDateSetter) {
 
         updateMemberDueDate(
-                domainUserMemberDueDateDays,
-                groupUserMemberDueDateDays,
-                domainServiceMemberDueDateDays,
-                groupServiceMemberDueDateDays,
-                null,
-                null,
+                memberExpiryDueDays,
                 groupMembers,
                 dueDateGetter,
                 dueDateSetter,
@@ -9374,9 +9285,14 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         normalizeGroupMembers(group);
 
+        // update group expiry based on our configurations
+
+        MemberDueDays memberExpiryDueDays = new MemberDueDays(domain.getDomain(), group);
+        updateGroupMemberExpiration(memberExpiryDueDays, group.getGroupMembers());
+
         // process our request
 
-        dbService.executePutGroupReview(ctx, domainName, groupName, group, auditRef);
+        dbService.executePutGroupReview(ctx, domainName, groupName, group, memberExpiryDueDays, auditRef);
     }
 
     @Override

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/config/MemberDueDays.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/config/MemberDueDays.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.config;
+
+import com.yahoo.athenz.zms.Domain;
+import com.yahoo.athenz.zms.Group;
+import com.yahoo.athenz.zms.Role;
+import com.yahoo.athenz.zms.utils.ZMSUtils;
+
+public class MemberDueDays {
+
+    long userDueDateMillis;
+    long serviceDueDateMillis;
+    long groupDueDateMillis;
+
+    public enum Type {
+        EXPIRY,
+        REMINDER
+    }
+
+    public MemberDueDays(Domain domain, Role role, Type type) {
+
+        Integer domainUserDays;
+        Integer domainServiceDays;
+        Integer domainGroupDays;
+        Integer roleUserDays;
+        Integer roleServiceDays;
+        Integer roleGroupDays;
+
+        // domain is null in the case of review reminder due dates but
+        // for expiry we always have both domains and roles
+
+        if (type == Type.EXPIRY) {
+            domainUserDays = domain.getMemberExpiryDays();
+            domainServiceDays = domain.getServiceExpiryDays();
+            domainGroupDays = domain.getGroupExpiryDays();
+            roleUserDays = role.getMemberExpiryDays();
+            roleServiceDays = role.getServiceExpiryDays();
+            roleGroupDays = role.getGroupExpiryDays();
+        } else {
+            domainUserDays = null;
+            domainServiceDays = null;
+            domainGroupDays = null;
+            roleUserDays = role.getMemberReviewDays();
+            roleServiceDays = role.getServiceReviewDays();
+            roleGroupDays = role.getGroupReviewDays();
+        }
+
+        userDueDateMillis = ZMSUtils.configuredDueDateMillis(domainUserDays, roleUserDays);
+        serviceDueDateMillis = ZMSUtils.configuredDueDateMillis(domainServiceDays, roleServiceDays);
+        groupDueDateMillis = ZMSUtils.configuredDueDateMillis(domainGroupDays, roleGroupDays);
+    }
+
+    public MemberDueDays(Domain domain, Group group) {
+
+        // for groups we only have user and service members
+        // groups cannot include other groups
+
+        Integer domainUserDays = domain.getMemberExpiryDays();
+        Integer domainServiceDays = domain.getServiceExpiryDays();
+        Integer groupUserDays = group.getMemberExpiryDays();
+        Integer groupServiceDays = group.getServiceExpiryDays();
+
+        userDueDateMillis = ZMSUtils.configuredDueDateMillis(domainUserDays, groupUserDays);
+        serviceDueDateMillis = ZMSUtils.configuredDueDateMillis(domainServiceDays, groupServiceDays);
+        groupDueDateMillis = 0;
+    }
+
+    public long getUserDueDateMillis() {
+        return userDueDateMillis;
+    }
+
+    public long getServiceDueDateMillis() {
+        return serviceDueDateMillis;
+    }
+
+    public long getGroupDueDateMillis() {
+        return groupDueDateMillis;
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.zms.utils;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.impl.SimplePrincipal;
@@ -427,5 +428,18 @@ public class ZMSUtils {
 
     public static boolean metaValueChanged(Object domainValue, Object metaValue) {
         return (metaValue == null) ? false : !metaValue.equals(domainValue);
+    }
+
+    public static long configuredDueDateMillis(Integer domainDueDateDays, Integer roleDueDateDays) {
+
+        // the role expiry days settings overrides the domain one if one configured
+
+        int expiryDays = 0;
+        if (roleDueDateDays != null && roleDueDateDays > 0) {
+            expiryDays = roleDueDateDays;
+        } else if (domainDueDateDays != null && domainDueDateDays > 0) {
+            expiryDays = domainDueDateDays;
+        }
+        return expiryDays == 0 ? 0 : System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(expiryDays, TimeUnit.DAYS);
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -44,6 +44,7 @@ import com.yahoo.athenz.common.server.notification.Notification;
 import com.yahoo.athenz.common.server.notification.NotificationManager;
 import com.yahoo.athenz.common.server.util.AuthzHelper;
 import com.yahoo.athenz.common.server.util.ResourceUtils;
+import com.yahoo.athenz.zms.config.MemberDueDays;
 import com.yahoo.athenz.zms.notification.PutRoleMembershipNotificationTask;
 import com.yahoo.athenz.zms.status.MockStatusCheckerThrowException;
 import com.yahoo.athenz.zms.status.MockStatusCheckerNoException;
@@ -20220,43 +20221,6 @@ public class ZMSImplTest {
         zms.deleteTopLevelDomain(mockDomRsrcCtx, "testdomain1", auditRef);
     }
 
-    private boolean validateDueDate(long millis, long extMillis) {
-        return (millis > System.currentTimeMillis() + extMillis - 5000 && millis < System.currentTimeMillis() + extMillis + 5000);
-    }
-
-    @Test
-    public void testConfiguredExpiryMillis() {
-
-        assertEquals(zms.configuredDueDateMillis(null, null), 0);
-        assertEquals(zms.configuredDueDateMillis(null, -3), 0);
-        assertEquals(zms.configuredDueDateMillis(null, 0), 0);
-        assertEquals(zms.configuredDueDateMillis(-3, null), 0);
-        assertEquals(zms.configuredDueDateMillis(0, null), 0);
-        assertEquals(zms.configuredDueDateMillis(-3, -3), 0);
-        assertEquals(zms.configuredDueDateMillis(0, 0), 0);
-
-        long extMillis = TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS);
-        long millis = zms.configuredDueDateMillis(null, 10);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(null, 10);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(-1, 10);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(0, 10);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(5, 10);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(20, 10);
-        assertTrue(validateDueDate(millis, extMillis));
-
-        millis = zms.configuredDueDateMillis(10, null);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(10, -1);
-        assertTrue(validateDueDate(millis, extMillis));
-        millis = zms.configuredDueDateMillis(10, 0);
-        assertTrue(validateDueDate(millis, extMillis));
-    }
-
     @Test
     public void testGetMemberDueDate() {
         assertEquals(zms.getMemberDueDate(100, null), Timestamp.fromMillis(100));
@@ -20275,10 +20239,10 @@ public class ZMSImplTest {
         long ext100Millis = TimeUnit.MILLISECONDS.convert(100, TimeUnit.DAYS);
 
         Timestamp stamp = zms.memberDueDateTimestamp(100, 50, Timestamp.fromMillis(System.currentTimeMillis() + ext75Millis));
-        assertTrue(validateDueDate(stamp.millis(), ext50Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext50Millis));
 
         stamp = zms.memberDueDateTimestamp(75, null, Timestamp.fromMillis(System.currentTimeMillis() + ext100Millis));
-        assertTrue(validateDueDate(stamp.millis(), ext75Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext75Millis));
     }
 
     @Test
@@ -20306,29 +20270,27 @@ public class ZMSImplTest {
                 .setReviewReminder(Timestamp.fromMillis(System.currentTimeMillis() + ext100Millis))
                 .setPrincipalType(Principal.Type.GROUP.getValue()));
 
-        zms.updateRoleMemberReviewReminder(
-                125,
-                150,
-                175,
-                members);
+        Role role = new Role().setMemberReviewDays(125).setServiceReviewDays(150).setGroupReviewDays(175);
+        MemberDueDays memberDueDays = new MemberDueDays(null, role, MemberDueDays.Type.REMINDER);
+        zms.updateRoleMemberReviewReminder(memberDueDays, members);
 
         Timestamp stamp = members.get(0).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext125Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext125Millis));
 
         stamp = members.get(1).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(2).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext150Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext150Millis));
 
         stamp = members.get(3).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(4).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext175Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext175Millis));
 
         stamp = members.get(5).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
     }
 
     @Test
@@ -20355,28 +20317,27 @@ public class ZMSImplTest {
                 .setReviewReminder(Timestamp.fromMillis(System.currentTimeMillis() + ext100Millis))
                 .setPrincipalType(Principal.Type.GROUP.getValue()));
 
-        zms.updateRoleMemberReviewReminder(
-                0,
-                150,
-                175,
-                members);
+        Role role = new Role().setMemberReviewDays(0).setServiceReviewDays(150).setGroupReviewDays(175);
+        MemberDueDays memberDueDays = new MemberDueDays(null, role, MemberDueDays.Type.REMINDER);
+
+        zms.updateRoleMemberReviewReminder(memberDueDays, members);
 
         assertNull(members.get(0).getReviewReminder());
 
         Timestamp stamp = members.get(1).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(2).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext150Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext150Millis));
 
         stamp = members.get(3).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(4).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext175Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext175Millis));
 
         stamp = members.get(5).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
     }
 
     @Test
@@ -20384,7 +20345,6 @@ public class ZMSImplTest {
 
         long ext100Millis = TimeUnit.MILLISECONDS.convert(100, TimeUnit.DAYS);
         long ext125Millis = TimeUnit.MILLISECONDS.convert(125, TimeUnit.DAYS);
-        long ext175Millis = TimeUnit.MILLISECONDS.convert(175, TimeUnit.DAYS);
 
         List<RoleMember> members = new ArrayList<>();
         members.add(new RoleMember().setMemberName("user.joe").setReviewReminder(null)
@@ -20403,18 +20363,20 @@ public class ZMSImplTest {
                 .setReviewReminder(Timestamp.fromMillis(System.currentTimeMillis() + ext100Millis))
                 .setPrincipalType(Principal.Type.GROUP.getValue()));
 
-        zms.updateRoleMemberReviewReminder(125, 0, 175, members);
+        Role role = new Role().setMemberReviewDays(125).setServiceReviewDays(0).setGroupReviewDays(175);
+        MemberDueDays memberDueDays = new MemberDueDays(null, role, MemberDueDays.Type.REMINDER);
+        zms.updateRoleMemberReviewReminder(memberDueDays, members);
 
         Timestamp stamp = members.get(0).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext125Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext125Millis));
 
         stamp = members.get(1).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         assertNull(members.get(2).getReviewReminder());
 
         stamp = members.get(3).getReviewReminder();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
     }
 
     @Test
@@ -20443,32 +20405,29 @@ public class ZMSImplTest {
 
         // for user members we have 50/125 setup while for service members 75/150
 
-        zms.updateRoleMemberExpiration(
-                50,
-                125,
-                75,
-                150,
-                100,
-                125,
-                members);
+        Role role = new Role().setMemberExpiryDays(125).setServiceExpiryDays(150).setGroupExpiryDays(125);
+        Domain domain = new Domain().setMemberExpiryDays(50).setServiceExpiryDays(75).setGroupExpiryDays(100);
+        MemberDueDays memberDueDays = new MemberDueDays(domain, role, MemberDueDays.Type.EXPIRY);
+
+        zms.updateRoleMemberExpiration(memberDueDays, members);
 
         Timestamp stamp = members.get(0).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext125Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext125Millis));
 
         stamp = members.get(1).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(2).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext150Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext150Millis));
 
         stamp = members.get(3).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(4).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext125Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext125Millis));
 
         stamp = members.get(5).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
     }
 
     @Test
@@ -20496,30 +20455,27 @@ public class ZMSImplTest {
 
         // for user members we have 0 setup while for service members 75/150
 
-        zms.updateRoleMemberExpiration(
-                0,
-                0,
-                75,
-                150,
-                0,
-                0,
-                members);
+        Role role = new Role().setMemberExpiryDays(0).setServiceExpiryDays(150).setGroupExpiryDays(0);
+        Domain domain = new Domain().setMemberExpiryDays(0).setServiceExpiryDays(75).setGroupExpiryDays(0);
+        MemberDueDays memberDueDays = new MemberDueDays(domain, role, MemberDueDays.Type.EXPIRY);
+
+        zms.updateRoleMemberExpiration(memberDueDays, members);
 
         assertNull(members.get(0).getExpiration());
 
         Timestamp stamp = members.get(1).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         stamp = members.get(2).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext150Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext150Millis));
 
         stamp = members.get(3).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         assertNull(members.get(4).getExpiration());
 
         stamp = members.get(5).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
     }
 
     @Test
@@ -20542,25 +20498,22 @@ public class ZMSImplTest {
 
         // for user members we have 50/125 setup while for service members 0
 
-        zms.updateRoleMemberExpiration(
-                50,
-                125,
-                0,
-                0,
-                0,
-                0,
-                members);
+        Role role = new Role().setMemberExpiryDays(125).setServiceExpiryDays(0).setGroupExpiryDays(0);
+        Domain domain = new Domain().setMemberExpiryDays(50).setServiceExpiryDays(0).setGroupExpiryDays(0);
+        MemberDueDays memberDueDays = new MemberDueDays(domain, role, MemberDueDays.Type.EXPIRY);
+
+        zms.updateRoleMemberExpiration(memberDueDays, members);
 
         Timestamp stamp = members.get(0).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext125Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext125Millis));
 
         stamp = members.get(1).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
 
         assertNull(members.get(2).getExpiration());
 
         stamp = members.get(3).getExpiration();
-        assertTrue(validateDueDate(stamp.millis(), ext100Millis));
+        assertTrue(ZMSTestUtils.validateDueDate(stamp.millis(), ext100Millis));
     }
 
     @Test
@@ -20675,88 +20628,293 @@ public class ZMSImplTest {
     }
 
     @Test
-    public void testPutRoleReview() {
+    public void testPutRoleReviewExpiration() {
 
-        TopLevelDomain dom1 = createTopLevelDomainObject("role-review-dom",
+        final String domainName = "role-review-dom";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
                 "Role review Test Domain1", "testOrg", "user.user1");
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
-        Role role1 = createRoleObject("role-review-dom", "role1", null,
+        Role role1 = createRoleObject(domainName, "role1", null,
                 "user.john", "user.jane");
-        zms.putRole(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, role1);
+        zms.putRole(mockDomRsrcCtx, domainName, "role1", auditRef, role1);
 
         Timestamp tenDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS));
         Timestamp sixtyDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(60, TimeUnit.DAYS));
+
         Timestamp fortyFiveDaysLowerBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS));
+        Timestamp fortyFiveDaysUpperBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
+
+        Timestamp fiftyDaysLowerBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(50, TimeUnit.DAYS));
+        Timestamp fiftyDaysUpperBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(50, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
+
+        Timestamp fiftyFiveDaysLowerBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(55, TimeUnit.DAYS));
+        Timestamp fiftyFiveDaysUpperBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(55, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
 
         Membership mbr = generateMembership("role1", "user.doe", tenDaysExpiry);
-        zms.putMembership(mockDomRsrcCtx, "role-review-dom", "role1", "user.doe", auditRef, mbr);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.doe", auditRef, mbr);
+
+        Group group1 = createGroupObject(domainName, "group1", null);
+        zms.putGroup(mockDomRsrcCtx, domainName, "group1", auditRef, group1);
+
+        mbr = generateMembership("role1", domainName + ":group.group1", tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", domainName + ":group.group1", auditRef, mbr);
+
+        mbr = generateMembership("role1", "sys.auth.zms", tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "sys.auth.zms", auditRef, mbr);
 
         RoleMeta rm = createRoleMetaObject(true);
         rm.setMemberExpiryDays(45);
-        zms.putRoleMeta(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, rm);
+        rm.setServiceExpiryDays(50);
+        rm.setGroupExpiryDays(55);
+        zms.putRoleMeta(mockDomRsrcCtx, domainName, "role1", auditRef, rm);
 
         Role inputRole = new Role().setName("role1");
         List<RoleMember> inputMembers = new ArrayList<>();
         inputRole.setRoleMembers(inputMembers);
         inputMembers.add(new RoleMember().setMemberName("user.john").setActive(false));
-        inputMembers.add(new RoleMember().setMemberName("user.doe").setActive(true).setExpiration(sixtyDaysExpiry));
-        zms.putRoleReview(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, inputRole);
+        inputMembers.add(new RoleMember().setMemberName("user.doe").setActive(true)
+                .setExpiration(sixtyDaysExpiry));
+        inputMembers.add(new RoleMember().setMemberName(domainName + ":group.group1").setActive(true)
+                .setExpiration(sixtyDaysExpiry));
+        inputMembers.add(new RoleMember().setMemberName("sys.auth.zms").setActive(true)
+                .setExpiration(sixtyDaysExpiry));
+        zms.putRoleReview(mockDomRsrcCtx, domainName, "role1", auditRef, inputRole);
 
-        Role resRole1 = zms.getRole(mockDomRsrcCtx, "role-review-dom", "role1", false, false, false);
-
-        Timestamp fortyFiveDaysUpperBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
+        Role resRole1 = zms.getRole(mockDomRsrcCtx, domainName, "role1", false, false, false);
 
         int userChecked = 0;
         for (RoleMember roleMember : resRole1.getRoleMembers()) {
-            if (roleMember.getMemberName().equals("user.jane") || roleMember.getMemberName().equals("user.doe")) {
-                userChecked += 1;
-                assertTrue(roleMember.getExpiration().toDate().after(fortyFiveDaysLowerBoundExpiry.toDate()) && roleMember.getExpiration().toDate().before(fortyFiveDaysUpperBoundExpiry.toDate()));
-                assertTrue(roleMember.getApproved());
+            switch (roleMember.getMemberName()) {
+                case "user.jane":
+                case "user.doe":
+                    userChecked += 1;
+                    assertTrue(roleMember.getExpiration().toDate().after(fortyFiveDaysLowerBoundExpiry.toDate()) && roleMember.getExpiration().toDate().before(fortyFiveDaysUpperBoundExpiry.toDate()));
+                    assertTrue(roleMember.getApproved());
+                    break;
+                case "sys.auth.zms":
+                    userChecked += 1;
+                    assertTrue(roleMember.getExpiration().toDate().after(fiftyDaysLowerBoundExpiry.toDate()) && roleMember.getExpiration().toDate().before(fiftyDaysUpperBoundExpiry.toDate()));
+                    assertTrue(roleMember.getApproved());
+                    break;
+                case domainName + ":group.group1":
+                    userChecked += 1;
+                    assertTrue(roleMember.getExpiration().toDate().after(fiftyFiveDaysLowerBoundExpiry.toDate()) && roleMember.getExpiration().toDate().before(fiftyFiveDaysUpperBoundExpiry.toDate()));
+                    assertTrue(roleMember.getApproved());
+                    break;
             }
         }
-        assertEquals(userChecked, 2);
-        zms.deleteTopLevelDomain(mockDomRsrcCtx, "role-review-dom", auditRef);
+        assertEquals(userChecked, 4);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
+    }
+
+    @Test
+    public void testPutRoleReviewReviewReminder() {
+
+        final String domainName = "role-review-reminder";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
+                "Role review Test Domain1", "testOrg", "user.user1");
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
+
+        Role role1 = createRoleObject(domainName, "role1", null,
+                "user.john", "user.jane");
+        zms.putRole(mockDomRsrcCtx, domainName, "role1", auditRef, role1);
+
+        Timestamp tenDaysReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS));
+        Timestamp sixtyDaysReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(60, TimeUnit.DAYS));
+
+        Timestamp fortyFiveDaysLowerBoundReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS));
+        Timestamp fortyFiveDaysUpperBoundReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
+
+        Timestamp fiftyDaysLowerBoundReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(50, TimeUnit.DAYS));
+        Timestamp fiftyDaysUpperBoundReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(50, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
+
+        Timestamp fiftyFiveDaysLowerBoundReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(55, TimeUnit.DAYS));
+        Timestamp fiftyFiveDaysUpperBoundReminder = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(55, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
+
+        Membership mbr = generateMembership("role1", "user.doe", tenDaysReminder);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.doe", auditRef, mbr);
+
+        Group group1 = createGroupObject(domainName, "group1", null);
+        zms.putGroup(mockDomRsrcCtx, domainName, "group1", auditRef, group1);
+
+        mbr = generateMembership("role1", domainName + ":group.group1", tenDaysReminder);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", domainName + ":group.group1", auditRef, mbr);
+
+        mbr = generateMembership("role1", "sys.auth.zms", tenDaysReminder);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "sys.auth.zms", auditRef, mbr);
+
+        RoleMeta rm = createRoleMetaObject(true);
+        rm.setMemberReviewDays(45);
+        rm.setServiceReviewDays(50);
+        rm.setGroupReviewDays(55);
+        zms.putRoleMeta(mockDomRsrcCtx, domainName, "role1", auditRef, rm);
+
+        Role inputRole = new Role().setName("role1");
+        List<RoleMember> inputMembers = new ArrayList<>();
+        inputRole.setRoleMembers(inputMembers);
+        inputMembers.add(new RoleMember().setMemberName("user.john").setActive(false));
+        inputMembers.add(new RoleMember().setMemberName("user.doe").setActive(true)
+                .setReviewReminder(sixtyDaysReminder));
+        inputMembers.add(new RoleMember().setMemberName(domainName + ":group.group1").setActive(true)
+                .setReviewReminder(sixtyDaysReminder));
+        inputMembers.add(new RoleMember().setMemberName("sys.auth.zms").setActive(true)
+                .setReviewReminder(sixtyDaysReminder));
+        zms.putRoleReview(mockDomRsrcCtx, domainName, "role1", auditRef, inputRole);
+
+        Role resRole1 = zms.getRole(mockDomRsrcCtx, domainName, "role1", false, false, false);
+
+        int userChecked = 0;
+        for (RoleMember roleMember : resRole1.getRoleMembers()) {
+            switch (roleMember.getMemberName()) {
+                case "user.jane":
+                case "user.doe":
+                    userChecked += 1;
+                    assertTrue(roleMember.getReviewReminder().toDate().after(fortyFiveDaysLowerBoundReminder.toDate()) && roleMember.getReviewReminder().toDate().before(fortyFiveDaysUpperBoundReminder.toDate()));
+                    assertTrue(roleMember.getApproved());
+                    break;
+                case "sys.auth.zms":
+                    userChecked += 1;
+                    assertTrue(roleMember.getReviewReminder().toDate().after(fiftyDaysLowerBoundReminder.toDate()) && roleMember.getReviewReminder().toDate().before(fiftyDaysUpperBoundReminder.toDate()));
+                    assertTrue(roleMember.getApproved());
+                    break;
+                case domainName + ":group.group1":
+                    userChecked += 1;
+                    assertTrue(roleMember.getReviewReminder().toDate().after(fiftyFiveDaysLowerBoundReminder.toDate()) && roleMember.getReviewReminder().toDate().before(fiftyFiveDaysUpperBoundReminder.toDate()));
+                    assertTrue(roleMember.getApproved());
+                    break;
+            }
+        }
+        assertEquals(userChecked, 4);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
+    }
+
+    @Test
+    public void testPutRoleReviewNoChanges() {
+
+        final String domainName = "role-review-no-changes";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
+                "Role review Test Domain1", "testOrg", "user.user1");
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
+
+        Role role1 = createRoleObject(domainName, "role1", null,
+                "user.john", "user.jane");
+        zms.putRole(mockDomRsrcCtx, domainName, "role1", auditRef, role1);
+
+        Timestamp tenDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS));
+        Timestamp twentyDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(20, TimeUnit.DAYS));
+
+        Membership mbr = generateMembership("role1", "user.doe", tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.doe", auditRef, mbr);
+
+        mbr = generateMembership("role1", "user.user1", null);
+        mbr.setReviewReminder(tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.user1", auditRef, mbr);
+
+        mbr = generateMembership("role1", "user.user2", null);
+        mbr.setReviewReminder(tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.user2", auditRef, mbr);
+
+        mbr = generateMembership("role1", "sys.auth.zms", tenDaysExpiry);
+        mbr.setReviewReminder(tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "sys.auth.zms", auditRef, mbr);
+
+        Group group1 = createGroupObject(domainName, "group1", null);
+        zms.putGroup(mockDomRsrcCtx, domainName, "group1", auditRef, group1);
+
+        mbr = generateMembership("role1", domainName + ":group.group1", tenDaysExpiry);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", domainName + ":group.group1", auditRef, mbr);
+
+        Role inputRole = new Role().setName("role1");
+        List<RoleMember> inputMembers = new ArrayList<>();
+        inputRole.setRoleMembers(inputMembers);
+        inputMembers.add(new RoleMember().setMemberName("user.john").setActive(false));
+        inputMembers.add(new RoleMember().setMemberName("user.doe").setActive(true)
+                .setExpiration(twentyDaysExpiry));
+        inputMembers.add(new RoleMember().setMemberName("user.jane").setActive(true)
+                .setExpiration(tenDaysExpiry));
+        inputMembers.add(new RoleMember().setMemberName("user.user1").setActive(true)
+                .setReviewReminder(twentyDaysExpiry));
+        inputMembers.add(new RoleMember().setMemberName("user.user2").setActive(true));
+        inputMembers.add(new RoleMember().setMemberName("sys.auth.zms").setActive(true)
+                .setReviewReminder(twentyDaysExpiry));
+        inputMembers.add(new RoleMember().setMemberName(domainName + ":group.group1").setActive(true)
+                .setReviewReminder(twentyDaysExpiry));
+
+        zms.putRoleReview(mockDomRsrcCtx, domainName, "role1", auditRef, inputRole);
+
+        Role resRole1 = zms.getRole(mockDomRsrcCtx, domainName, "role1", false, false, false);
+
+        // john should be deleted and all others should stay as before - no changes
+
+        int userChecked = 0;
+        for (RoleMember roleMember : resRole1.getRoleMembers()) {
+            switch (roleMember.getMemberName()) {
+                case "user.jane":
+                    assertTrue(roleMember.getApproved());
+                    assertNull(roleMember.getExpiration());
+                    assertNull(roleMember.getReviewReminder());
+                    userChecked += 1;
+                    break;
+                case "user.doe":
+                case domainName + ":group.group1":
+                    assertTrue(roleMember.getApproved());
+                    assertEquals(roleMember.getExpiration(), tenDaysExpiry);
+                    assertNull(roleMember.getReviewReminder());
+                    userChecked += 1;
+                    break;
+                case "user.user1":
+                case "user.user2":
+                    assertTrue(roleMember.getApproved());
+                    assertEquals(roleMember.getReviewReminder(), tenDaysExpiry);
+                    assertNull(roleMember.getExpiration());
+                    userChecked += 1;
+                    break;
+                case "sys.auth.zms":
+                    assertTrue(roleMember.getApproved());
+                    assertEquals(roleMember.getReviewReminder(), tenDaysExpiry);
+                    assertEquals(roleMember.getExpiration(), tenDaysExpiry);
+                    userChecked += 1;
+                    break;
+                case "user.john":
+                    fail();
+                    break;
+            }
+        }
+        assertEquals(userChecked, 6);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 
     @Test
     public void testPutRoleReviewError() {
 
-        TopLevelDomain dom1 = createTopLevelDomainObject("role-review-dom",
+        final String domainName = "role-review-error";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
                 "Role review Test Domain1", "testOrg", "user.user1");
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
-        Role role1 = createRoleObject("role-review-dom", "role1", null,
+        Role role1 = createRoleObject(domainName, "role1", null,
                 "user.john", "user.jane");
-        zms.putRole(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, role1);
+        zms.putRole(mockDomRsrcCtx, domainName, "role1", auditRef, role1);
 
         Timestamp tenDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS));
         Timestamp sixtyDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(60, TimeUnit.DAYS));
 
         Membership mbr = generateMembership("role1", "user.doe", tenDaysExpiry);
-        zms.putMembership(mockDomRsrcCtx, "role-review-dom", "role1", "user.doe", auditRef, mbr);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.doe", auditRef, mbr);
 
-        Role inputRole = new Role().setName("role1");
+        RoleMeta rm = createRoleMetaObject(true);
+        rm.setMemberExpiryDays(45);
+        zms.putRoleMeta(mockDomRsrcCtx, domainName, "role1", auditRef, rm);
+
+        Role inputRole = new Role().setName("role2");
         List<RoleMember> inputMembers = new ArrayList<>();
         inputRole.setRoleMembers(inputMembers);
         inputMembers.add(new RoleMember().setMemberName("user.john").setActive(false));
         inputMembers.add(new RoleMember().setMemberName("user.doe").setActive(true).setExpiration(sixtyDaysExpiry));
 
         try {
-            zms.putRoleReview(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, inputRole);
-            fail();
-        } catch (ResourceException re) {
-            assertEquals(re.getCode(), 400);
-        }
-
-        inputRole.setName("role2");
-
-        RoleMeta rm = createRoleMetaObject(true);
-        rm.setMemberExpiryDays(45);
-        zms.putRoleMeta(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, rm);
-
-        try {
-            zms.putRoleReview(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, inputRole);
+            zms.putRoleReview(mockDomRsrcCtx, domainName, "role1", auditRef, inputRole);
             fail();
         } catch (ResourceException re) {
             assertEquals(re.getCode(), 400);
@@ -20770,47 +20928,48 @@ public class ZMSImplTest {
             assertEquals(re.getCode(), 404);
         }
 
-        zms.deleteTopLevelDomain(mockDomRsrcCtx, "role-review-dom", auditRef);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 
     @Test
     public void testPutRoleReviewAuditEnabled() {
 
-        TopLevelDomain dom1 = createTopLevelDomainObject("role-review-dom",
+        final String domainName = "role-review-audit-enabled";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
                 "Role review Test Domain1", "testOrg", "user.user1");
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
-        Role role1 = createRoleObject("role-review-dom", "role1", null,
+        Role role1 = createRoleObject(domainName, "role1", null,
                 "user.john", "user.jane");
-        zms.putRole(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, role1);
+        zms.putRole(mockDomRsrcCtx, domainName, "role1", auditRef, role1);
 
         Timestamp tenDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS));
         Timestamp sixtyDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(60, TimeUnit.DAYS));
         Timestamp fortyFiveDaysLowerBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS));
 
         Membership mbr = generateMembership("role1", "user.doe", tenDaysExpiry);
-        zms.putMembership(mockDomRsrcCtx, "role-review-dom", "role1", "user.doe", auditRef, mbr);
+        zms.putMembership(mockDomRsrcCtx, domainName, "role1", "user.doe", auditRef, mbr);
 
         RoleMeta rm = createRoleMetaObject(true);
         rm.setMemberExpiryDays(45);
-        zms.putRoleMeta(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, rm);
+        zms.putRoleMeta(mockDomRsrcCtx, domainName, "role1", auditRef, rm);
 
         DomainMeta meta = createDomainMetaObject("Domain Meta for Role review test", "NewOrg",
                 true, true, "12345", 1001);
-        zms.putDomainMeta(mockDomRsrcCtx, "role-review-dom", auditRef, meta);
-        zms.putDomainSystemMeta(mockDomRsrcCtx, "role-review-dom", "auditenabled", auditRef, meta);
+        zms.putDomainMeta(mockDomRsrcCtx, domainName, auditRef, meta);
+        zms.putDomainSystemMeta(mockDomRsrcCtx, domainName, "auditenabled", auditRef, meta);
 
         RoleSystemMeta rsm = createRoleSystemMetaObject(true);
-        zms.putRoleSystemMeta(mockDomRsrcCtx, "role-review-dom", "role1", "auditenabled", auditRef, rsm);
+        zms.putRoleSystemMeta(mockDomRsrcCtx, domainName, "role1", "auditenabled", auditRef, rsm);
 
         Role inputRole = new Role().setName("role1");
         List<RoleMember> inputMembers = new ArrayList<>();
         inputRole.setRoleMembers(inputMembers);
         inputMembers.add(new RoleMember().setMemberName("user.john").setActive(false));
         inputMembers.add(new RoleMember().setMemberName("user.doe").setActive(true).setExpiration(sixtyDaysExpiry));
-        zms.putRoleReview(mockDomRsrcCtx, "role-review-dom", "role1", auditRef, inputRole);
+        zms.putRoleReview(mockDomRsrcCtx, domainName, "role1", auditRef, inputRole);
 
-        Role resRole1 = zms.getRole(mockDomRsrcCtx, "role-review-dom", "role1", false, false, true);
+        Role resRole1 = zms.getRole(mockDomRsrcCtx, domainName, "role1", false, false, true);
 
         Timestamp fortyFiveDaysUpperBoundExpiry = Timestamp.fromMillis(System.currentTimeMillis() +
                 TimeUnit.MILLISECONDS.convert(45, TimeUnit.DAYS) + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES));
@@ -20839,7 +20998,7 @@ public class ZMSImplTest {
             }
         }
         assertEquals(userChecked, 3);
-        zms.deleteTopLevelDomain(mockDomRsrcCtx, "role-review-dom", auditRef);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 
     @Test
@@ -21683,8 +21842,6 @@ public class ZMSImplTest {
         mbrResult = zms.getMembership(mockDomRsrcCtx, domainName, roleName, "userexpirydomain.api", null);
         assertNotNull(mbrResult);
 
-
-
         // add a role with group expiry days set
 
         Group group1 = createGroupObject(domainName, "group1", null);
@@ -21859,13 +22016,13 @@ public class ZMSImplTest {
 
     @Test
     public void testRecordMetricsUnauthenticated() {
-        zms.metric = Mockito.mock(Metric.class);
+        ZMSImpl.metric = Mockito.mock(Metric.class);
         RsrcCtxWrapper ctx = (RsrcCtxWrapper) zms.newResourceContext(mockServletRequest, mockServletResponse, "someApiMethod");
         String testDomain = "testDomain";
         int httpStatus = 200;
         ctx.setRequestDomain(testDomain);
         zms.recordMetrics(ctx, httpStatus);
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).increment (
                 eq("zms_api"),
                 eq(testDomain),
@@ -21873,7 +22030,7 @@ public class ZMSImplTest {
                 eq("GET"),
                 eq(httpStatus),
                 eq("someapimethod"));
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).stopTiming (
                 eq(ctx.getTimerMetric()),
                 eq(testDomain),
@@ -21881,7 +22038,7 @@ public class ZMSImplTest {
                 eq("GET"),
                 eq(httpStatus),
                 eq("someapimethod_timing"));
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).startTiming (
                 eq("zms_api_latency"),
                 eq(null),
@@ -21892,13 +22049,13 @@ public class ZMSImplTest {
 
     @Test
     public void testRecordMetricsAuthenticated() {
-        zms.metric = Mockito.mock(Metric.class);
+        ZMSImpl.metric = Mockito.mock(Metric.class);
         RsrcCtxWrapper ctx = mockDomRsrcCtx;
         String testDomain = "testDomain";
         int httpStatus = 200;
         Mockito.when(ctx.getRequestDomain()).thenReturn(testDomain);
         zms.recordMetrics(ctx, httpStatus);
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).increment (
                 eq("zms_api"),
                 eq(testDomain),
@@ -21906,7 +22063,7 @@ public class ZMSImplTest {
                 eq("GET"),
                 eq(httpStatus),
                 eq("someApiMethod"));
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).stopTiming (
                 eq(ctx.getTimerMetric()),
                 eq(testDomain),
@@ -21917,9 +22074,9 @@ public class ZMSImplTest {
     @Test
     public void testRecordMetricsNoCtx() {
         int httpStatus = 200;
-        zms.metric = Mockito.mock(Metric.class);
+        ZMSImpl.metric = Mockito.mock(Metric.class);
         zms.recordMetrics(null, httpStatus);
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).increment (
                 eq("zms_api"),
                 eq(null),
@@ -21927,7 +22084,7 @@ public class ZMSImplTest {
                 eq(null),
                 eq(httpStatus),
                 eq(null));
-        Mockito.verify(zms.metric,
+        Mockito.verify(ZMSImpl.metric,
                 times(1)).stopTiming (
                 eq(null),
                 eq(null),
@@ -23977,6 +24134,66 @@ public class ZMSImplTest {
         assertEquals(resGroup.getGroupMembers().size(), 1);
         assertEquals(resGroup.getGroupMembers().get(0).getMemberName(), "user.jane");
 
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
+    }
+
+    @Test
+    public void testPutGroupReviewNoChanges() {
+
+        final String domainName = "group-review-no-changes";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
+                "Role review Test Domain1", "testOrg", "user.user1");
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
+
+        Group group1 = createGroupObject(domainName, "group1", "user.john", "user.jane");
+        zms.putGroup(mockDomRsrcCtx, domainName, "group1", auditRef, group1);
+
+        Timestamp tenDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS));
+        Timestamp twentyDaysExpiry = Timestamp.fromMillis(System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(20, TimeUnit.DAYS));
+
+        GroupMembership mbr = generateGroupMembership("group1", "user.doe", tenDaysExpiry);
+        zms.putGroupMembership(mockDomRsrcCtx, domainName, "group1", "user.doe", auditRef, mbr);
+
+        mbr = generateGroupMembership("group1", "sys.auth.zms", tenDaysExpiry);
+        zms.putGroupMembership(mockDomRsrcCtx, domainName, "group1", "sys.auth.zms", auditRef, mbr);
+
+        Group inputGroup = new Group().setName("group1");
+        List<GroupMember> inputMembers = new ArrayList<>();
+        inputGroup.setGroupMembers(inputMembers);
+        inputMembers.add(new GroupMember().setMemberName("user.john").setActive(false));
+        inputMembers.add(new GroupMember().setMemberName("user.doe").setActive(true)
+                .setExpiration(twentyDaysExpiry));
+        inputMembers.add(new GroupMember().setMemberName("user.jane").setActive(true)
+                .setExpiration(tenDaysExpiry));
+        inputMembers.add(new GroupMember().setMemberName("sys.auth.zms").setActive(true)
+                .setExpiration(twentyDaysExpiry));
+
+        zms.putGroupReview(mockDomRsrcCtx, domainName, "group1", auditRef, inputGroup);
+
+        Group resGroup1 = zms.getGroup(mockDomRsrcCtx, domainName, "group1", false, false);
+
+        // john should be deleted and all others should stay as before - no changes
+
+        int userChecked = 0;
+        for (GroupMember groupMember : resGroup1.getGroupMembers()) {
+            switch (groupMember.getMemberName()) {
+                case "user.jane":
+                    assertTrue(groupMember.getApproved());
+                    assertNull(groupMember.getExpiration());
+                    userChecked += 1;
+                    break;
+                case "user.doe":
+                case "sys.auth.zms":
+                    assertTrue(groupMember.getApproved());
+                    assertEquals(groupMember.getExpiration(), tenDaysExpiry);
+                    userChecked += 1;
+                    break;
+                case "user.john":
+                    fail();
+                    break;
+            }
+        }
+        assertEquals(userChecked, 3);
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
@@ -151,4 +151,8 @@ public class ZMSTestUtils {
     public static Timestamp addDays(Timestamp date, int days) {
         return Timestamp.fromMillis(date.millis() + TimeUnit.MILLISECONDS.convert(days, TimeUnit.DAYS));
     }
+
+    public static boolean validateDueDate(long millis, long extMillis) {
+        return (millis > System.currentTimeMillis() + extMillis - 5000 && millis < System.currentTimeMillis() + extMillis + 5000);
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Principal;
@@ -351,5 +352,38 @@ public class ZMSUtilsTest {
 
         assertTrue(ZMSUtils.metaValueChanged(null, 10));
         assertFalse(ZMSUtils.metaValueChanged(10, null));
+    }
+
+    @Test
+    public void testConfiguredExpiryMillis() {
+
+        assertEquals(ZMSUtils.configuredDueDateMillis(null, null), 0);
+        assertEquals(ZMSUtils.configuredDueDateMillis(null, -3), 0);
+        assertEquals(ZMSUtils.configuredDueDateMillis(null, 0), 0);
+        assertEquals(ZMSUtils.configuredDueDateMillis(-3, null), 0);
+        assertEquals(ZMSUtils.configuredDueDateMillis(0, null), 0);
+        assertEquals(ZMSUtils.configuredDueDateMillis(-3, -3), 0);
+        assertEquals(ZMSUtils.configuredDueDateMillis(0, 0), 0);
+
+        long extMillis = TimeUnit.MILLISECONDS.convert(10, TimeUnit.DAYS);
+        long millis = ZMSUtils.configuredDueDateMillis(null, 10);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(null, 10);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(-1, 10);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(0, 10);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(5, 10);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(20, 10);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+
+        millis = ZMSUtils.configuredDueDateMillis(10, null);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(10, -1);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
+        millis = ZMSUtils.configuredDueDateMillis(10, 0);
+        assertTrue(ZMSTestUtils.validateDueDate(millis, extMillis));
     }
 }


### PR DESCRIPTION
initially we only allowed role review when the expiry settings were set either on domain and/or role. this limits the flexibility to enforce review of roles regardless of settings.

So now the role/group can be reviewed regardless if the role/domain/group have expiry/reminder settings configured. if the role/group has none of the settings configured, then the admin can only either delete the user or take no action, however, the role review date will be updated to satisfy audit requirements.

additionally, during the review, the reminder date extension is now support as well.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>