### PR TITLE
go/athenzutils: address golint issues

### DIFF
--- a/libs/go/athenzutils/cert.go
+++ b/libs/go/athenzutils/cert.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 )
 
+// LoadX509Certificate reads and parses the x509.Certificate from the specified file.
 func LoadX509Certificate(certFile string) (*x509.Certificate, error) {
 	pemBytes, err := ioutil.ReadFile(certFile)
 	if err != nil {

--- a/libs/go/athenzutils/instance_test.go
+++ b/libs/go/athenzutils/instance_test.go
@@ -32,8 +32,8 @@ func TestExtractInstanceIdValid(test *testing.T) {
 func TestExtractInstanceIdInValid(test *testing.T) {
 
 	tests := []struct {
-		name      string
-		certFile  string
+		name     string
+		certFile string
 	}{
 		{"id1", "data/service_identity1.cert"},
 		{"id2", "data/service_identity2.cert"},

--- a/libs/go/athenzutils/principal.go
+++ b/libs/go/athenzutils/principal.go
@@ -9,11 +9,10 @@ import (
 	"strings"
 )
 
-// Return the Athenz Service principal for the given certificate which
-// could be either a service certificate or a role certificate.
+// ExtractServicePrincipal returns the Athenz Service principal for the given
+// certificate which could be either a service certificate or a role certificate.
 // If the certificate does not have the Athenz expected name format
-// the method will an appropriate error
-
+// the method will an appropriate error.
 func ExtractServicePrincipal(x509Cert x509.Certificate) (string, error) {
 
 	// let's first get the common name of the certificate

--- a/libs/go/athenzutils/principal_test.go
+++ b/libs/go/athenzutils/principal_test.go
@@ -32,8 +32,8 @@ func TestExtractServicePrincipalValid(test *testing.T) {
 func TestExtractServicePrincipalInValid(test *testing.T) {
 
 	tests := []struct {
-		name      string
-		certFile  string
+		name     string
+		certFile string
 	}{
 		{"nocn", "data/no_cn_x509.cert"},
 		{"invalidemail", "data/invalid_email_x509.cert"},

--- a/libs/go/athenzutils/ztsclient.go
+++ b/libs/go/athenzutils/ztsclient.go
@@ -15,7 +15,8 @@ import (
 	"github.com/AthenZ/athenz/clients/go/zts"
 )
 
-func ZtsClient(ztsUrl, keyFile, certFile, caCertFile string, proxy bool) (*zts.ZTSClient, error) {
+// ZtsClient creates and returns a ZTS client instance.
+func ZtsClient(ztsURL, keyFile, certFile, caCertFile string, proxy bool) (*zts.ZTSClient, error) {
 	keypem, err := ioutil.ReadFile(keyFile)
 	if err != nil {
 		return nil, err
@@ -41,7 +42,7 @@ func ZtsClient(ztsUrl, keyFile, certFile, caCertFile string, proxy bool) (*zts.Z
 	if proxy {
 		tr.Proxy = http.ProxyFromEnvironment
 	}
-	client := zts.NewClient(ztsUrl, tr)
+	client := zts.NewClient(ztsURL, tr)
 	return &client, nil
 }
 
@@ -63,6 +64,7 @@ func tlsConfiguration(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
 	return config, nil
 }
 
+// GenerateAccessTokenRequestString generates and urlencodes an access token string.
 func GenerateAccessTokenRequestString(domain, service, roles, authzDetails, proxyPrincipalSpiffeUris string, expiryTime int) string {
 
 	params := url.Values{}


### PR DESCRIPTION
PR addresses several golint issues in libs/go/athenzutils (all except those related to the names being `...Id` instead of `...ID`).