### PR TITLE
proper handling of disabled domains from zms to zts

### DIFF
--- a/servers/zms/pom.xml
+++ b/servers/zms/pom.xml
@@ -155,12 +155,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.wix</groupId>
-      <artifactId>wix-embedded-mysql</artifactId>
-      <version>4.6.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-jaxrs2</artifactId>
       <version>${swagger.version}</version>
@@ -169,6 +163,18 @@
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-jaxrs2-servlet-initializer</artifactId>
       <version>${swagger.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.wix</groupId>
+      <artifactId>wix-embedded-mysql</artifactId>
+      <version>4.6.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>9.11.1</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -64,9 +64,9 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "SET modified=CURRENT_TIMESTAMP(3) WHERE name=?;";
     private static final String SQL_GET_DOMAIN_MOD_TIMESTAMP = "SELECT modified FROM domain WHERE name=?;";
     private static final String SQL_LIST_DOMAIN = "SELECT * FROM domain;";
-    private static final String SQL_LIST_DOMAIN_PREFIX = "SELECT name, modified FROM domain WHERE name>=? AND name<?;";
+    private static final String SQL_LIST_DOMAIN_PREFIX = "SELECT name, modified, enabled FROM domain WHERE name>=? AND name<?;";
     private static final String SQL_LIST_DOMAIN_MODIFIED = "SELECT * FROM domain WHERE modified>?;";
-    private static final String SQL_LIST_DOMAIN_PREFIX_MODIFIED = "SELECT name, modified FROM domain "
+    private static final String SQL_LIST_DOMAIN_PREFIX_MODIFIED = "SELECT name, modified, enabled FROM domain "
             + "WHERE name>=? AND name<? AND modified>?;";
     private static final String SQL_LIST_DOMAIN_ROLE_NAME_MEMBER = "SELECT domain.name FROM domain "
             + "JOIN role ON role.domain_id=domain.domain_id "

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
@@ -4460,4 +4460,32 @@ public class DataStoreTest {
         store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
         assertTrue(accessibleRoles.isEmpty());
     }
+
+    @Test
+    public void testProcessDomainCheck() {
+
+        ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                pkey, "0");
+        DataStore store = new DataStore(clogStore, null, ztsMetric);
+
+        DomainData domainData = new DomainData();
+        assertTrue(store.processDomainCheck(null, domainData));
+
+        domainData.setEnabled(Boolean.TRUE);
+        assertTrue(store.processDomainCheck(null, domainData));
+
+        domainData.setEnabled(false);
+        assertFalse(store.processDomainCheck(null, domainData));
+
+        DomainData localData = new DomainData();
+        assertTrue(store.processDomainCheck(localData, domainData));
+
+        domainData.setEnabled(true);
+        localData.setModified(Timestamp.fromMillis(100));
+        domainData.setModified(Timestamp.fromMillis(200));
+        assertTrue(store.processDomainCheck(localData, domainData));
+
+        localData.setModified(Timestamp.fromMillis(201));
+        assertFalse(store.processDomainCheck(localData, domainData));
+    }
 }


### PR DESCRIPTION
1) when returning domain modified list from zms to zts we also now retrieve the enabled flag from DB and pass it along to ZTS to it can handle domains accordingly
2) updated zts domain sync operation to correctly handle disabled domains
3) also updated unit tests for zms to verify the jws domains with an external jws library (test usage only) to verify that our jws document is valid according to the rfc.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>