### PR TITLE
multi version policy support: make zms signature check configurable

### DIFF
--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeConsts.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeConsts.java
@@ -50,20 +50,21 @@ public final class ZpeConsts {
     public static final String ZPE_METRIC_LOAD_DOM_GOOD         = DomainMetricType.LOAD_DOMAIN_GOOD.toString();
     
     // properties
-    public static final String ZPE_PROP_ATHENZ_CONF           = "athenz.athenz_conf";
+    public static final String ZPE_PROP_ATHENZ_CONF               = "athenz.athenz_conf";
 
-    public static final String ZPE_PROP_STATS_ENABLED         = "athenz.zpe.enable_stats";
-    public static final String ZPE_PROP_METRIC_CLASS          = "athenz.zpe.metric_factory_class";
-    public static final String ZPE_PROP_PUBLIC_KEY_CLASS      = "athenz.zpe.public_key_class";
-    public static final String ZPE_PROP_CLIENT_IMPL           = "athenz.zpe.updater_class";
-    public static final String ZPE_PROP_TOKEN_OFFSET          = "athenz.zpe.token_allowed_offset";
-    public static final String ZPE_PROP_METRIC_WRITE_INTERVAL = "athenz.zpe.metric_write_interval";
-    public static final String ZPE_PROP_METRIC_FILE_PATH      = "athenz.zpe.metric_file_path";
-    public static final String ZPE_PROP_MON_TIMEOUT           = "athenz.zpe.monitor_timeout_secs";
-    public static final String ZPE_PROP_MON_CLEANUP_TOKENS    = "athenz.zpe.cleanup_tokens_secs";
-    public static final String ZPE_PROP_POLICY_DIR            = "athenz.zpe.policy_dir";
-    public static final String ZPE_PROP_SKIP_POLICY_DIR_CHECK = "athenz.zpe.skip_policy_dir_check";
+    public static final String ZPE_PROP_STATS_ENABLED              = "athenz.zpe.enable_stats";
+    public static final String ZPE_PROP_METRIC_CLASS               = "athenz.zpe.metric_factory_class";
+    public static final String ZPE_PROP_PUBLIC_KEY_CLASS           = "athenz.zpe.public_key_class";
+    public static final String ZPE_PROP_CLIENT_IMPL                = "athenz.zpe.updater_class";
+    public static final String ZPE_PROP_TOKEN_OFFSET               = "athenz.zpe.token_allowed_offset";
+    public static final String ZPE_PROP_METRIC_WRITE_INTERVAL      = "athenz.zpe.metric_write_interval";
+    public static final String ZPE_PROP_METRIC_FILE_PATH           = "athenz.zpe.metric_file_path";
+    public static final String ZPE_PROP_MON_TIMEOUT                = "athenz.zpe.monitor_timeout_secs";
+    public static final String ZPE_PROP_MON_CLEANUP_TOKENS         = "athenz.zpe.cleanup_tokens_secs";
+    public static final String ZPE_PROP_POLICY_DIR                 = "athenz.zpe.policy_dir";
+    public static final String ZPE_PROP_SKIP_POLICY_DIR_CHECK      = "athenz.zpe.skip_policy_dir_check";
+    public static final String ZPE_PROP_CHECK_POLICY_ZMS_SIGNATURE = "athenz.zpe.check_policy_zms_signature";
 
-    public static final String ZPE_PROP_X509_CA_ISSUERS       = "athenz.zpe.x509.ca.issuers";
+    public static final String ZPE_PROP_X509_CA_ISSUERS           = "athenz.zpe.x509.ca.issuers";
 
 }

--- a/utils/zpe-updater/zpu_client.go
+++ b/utils/zpe-updater/zpu_client.go
@@ -13,22 +13,22 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ardielle/ardielle-go/rdl"
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/athenz/libs/go/athenzutils"
 	"github.com/AthenZ/athenz/libs/go/zmssvctoken"
 	"github.com/AthenZ/athenz/utils/zpe-updater/util"
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 func PolicyUpdater(config *ZpuConfiguration) error {
 	if config == nil {
-		return errors.New("Nil configuration")
+		return errors.New("nil configuration")
 	}
 	if config.DomainList == "" {
-		return errors.New("No domain list to process from configuration")
+		return errors.New("no domain list to process from configuration")
 	}
 	if config.Zts == "" {
-		return errors.New("Empty Zts url in configuration")
+		return errors.New("empty Zts url in configuration")
 	}
 	success := true
 	domains := strings.Split(config.DomainList, ",")
@@ -38,13 +38,13 @@ func PolicyUpdater(config *ZpuConfiguration) error {
 	if config.PrivateKeyFile != "" && config.CertFile != "" {
 		ztsCli, err := athenzutils.ZtsClient(ztsURL, config.PrivateKeyFile, config.CertFile, config.CaCertFile, config.Proxy)
 		if err != nil {
-			return fmt.Errorf("Failed to create Zts Client, Error:%v", err)
+			return fmt.Errorf("failed to create Zts Client, Error:%v", err)
 		}
 		ztsClient = *ztsCli
 	} else if config.PrivateKeyFile == "" && config.CertFile != "" {
-		return errors.New("Both private key and cert file are required, missing private key file")
+		return errors.New("both private key and cert file are required, missing private key file")
 	} else if config.PrivateKeyFile != "" && config.CertFile == "" {
-		return errors.New("Both private key and cert file are required, missing certificate file")
+		return errors.New("both private key and cert file are required, missing certificate file")
 	} else {
 		ztsClient = zts.NewClient(ztsURL, nil)
 	}
@@ -61,11 +61,11 @@ func PolicyUpdater(config *ZpuConfiguration) error {
 			failedDomains += `"`
 			failedDomains += domain
 			failedDomains += `" `
-			log.Printf("Failed to get policies for domain: %v, Error:%v", domain, err)
+			log.Printf("failed to get policies for domain: %v, Error:%v", domain, err)
 		}
 	}
 	if !success {
-		return fmt.Errorf("Failed to get policies for domains: %v", failedDomains)
+		return fmt.Errorf("failed to get policies for domains: %v", failedDomains)
 	}
 	return nil
 }
@@ -75,7 +75,7 @@ func GetPolicies(config *ZpuConfiguration, ztsClient zts.ZTSClient, policyFileDi
 	etag := GetEtagForExistingPolicy(config, ztsClient, domain, policyFileDir)
 	data, _, err := ztsClient.GetDomainSignedPolicyData(zts.DomainName(domain), etag)
 	if err != nil {
-		return fmt.Errorf("Failed to get domain signed policy data for domain: %v, Error:%v", domain, err)
+		return fmt.Errorf("failed to get domain signed policy data for domain: %v, Error:%v", domain, err)
 	}
 
 	if data == nil {
@@ -83,16 +83,16 @@ func GetPolicies(config *ZpuConfiguration, ztsClient zts.ZTSClient, policyFileDi
 			log.Printf("Policies not updated since last fetch for domain: %v", domain)
 			return nil
 		}
-		return fmt.Errorf("Empty policies data returned for domain: %v", domain)
+		return fmt.Errorf("empty policies data returned for domain: %v", domain)
 	}
 	// validate data using zts public key and signature
 	bytes, err := ValidateSignedPolicies(config, ztsClient, data)
 	if err != nil {
-		return fmt.Errorf("Failed to validate policy data for domain: %v, Error: %v", domain, err)
+		return fmt.Errorf("failed to validate policy data for domain: %v, Error: %v", domain, err)
 	}
 	err = WritePolicies(config, bytes, domain, policyFileDir)
 	if err != nil {
-		return fmt.Errorf("Unable to write Policies for domain:\"%v\" to file, Error:%v", domain, err)
+		return fmt.Errorf("unable to write Policies for domain:\"%v\" to file, Error:%v", domain, err)
 	}
 	log.Printf("Policies for domain: %v successfully written", domain)
 	return nil
@@ -105,7 +105,7 @@ func GetEtagForExistingPolicy(config *ZpuConfiguration, ztsClient zts.ZTSClient,
 	policyFile := fmt.Sprintf("%s/%s.pol", policyFileDir, domain)
 
 	// If Policies file is not found, return empty etag the first time.
-	// Otherwise load the file contents, if data has expired return empty etag,
+	// Otherwise, load the file contents, if data has expired return empty etag,
 	// else construct etag from modified field in JSON.
 	exists := util.Exists(policyFile)
 	if !exists {
@@ -113,10 +113,11 @@ func GetEtagForExistingPolicy(config *ZpuConfiguration, ztsClient zts.ZTSClient,
 	}
 
 	readFile, err := os.OpenFile(policyFile, os.O_RDONLY, 0444)
-	defer readFile.Close()
 	if err != nil {
 		return ""
 	}
+	defer readFile.Close()
+
 	err = json.NewDecoder(readFile).Decode(&domainSignedPolicyData)
 	if err != nil {
 		return ""
@@ -144,7 +145,7 @@ func GetEtagForExistingPolicy(config *ZpuConfiguration, ztsClient zts.ZTSClient,
 func ValidateSignedPolicies(config *ZpuConfiguration, ztsClient zts.ZTSClient, data *zts.DomainSignedPolicyData) ([]byte, error) {
 	expires := data.SignedPolicyData.Expires
 	if expired(expires, 0) {
-		return nil, fmt.Errorf("The policy data is expired on %v", expires)
+		return nil, fmt.Errorf("policy data is expired on %v", expires)
 	}
 	signedPolicyData := data.SignedPolicyData
 	ztsSignature := data.Signature
@@ -154,11 +155,11 @@ func ValidateSignedPolicies(config *ZpuConfiguration, ztsClient zts.ZTSClient, d
 	if ztsPublicKey == "" {
 		key, err := ztsClient.GetPublicKeyEntry("sys.auth", "zts", ztsKeyID)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to get the Zts public key with id:\"%v\" to verify data", ztsKeyID)
+			return nil, fmt.Errorf("unable to get the Zts public key with id:\"%v\" to verify data", ztsKeyID)
 		}
 		decodedKey, err := new(zmssvctoken.YBase64).DecodeString(key.Key)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to decode the Zts public key with id:\"%v\" to verify data", ztsKeyID)
+			return nil, fmt.Errorf("unable to decode the Zts public key with id:\"%v\" to verify data", ztsKeyID)
 		}
 		ztsPublicKey = string(decodedKey)
 	}
@@ -168,34 +169,36 @@ func ValidateSignedPolicies(config *ZpuConfiguration, ztsClient zts.ZTSClient, d
 	}
 	err = verify(input, ztsSignature, ztsPublicKey)
 	if err != nil {
-		return nil, fmt.Errorf("Verification of data with zts key having id:\"%v\" failed, Error :%v", ztsKeyID, err)
+		return nil, fmt.Errorf("verification of data with zts key having id:\"%v\" failed, Error :%v", ztsKeyID, err)
 	}
 	//generate canonical json output so that properties
 	//can validate the signatures if not using athenz
 	//provided libraries for authorization
 	bytes := []byte("{\"signedPolicyData\":" + input + ",\"keyId\":\"" + ztsKeyID + "\",\"signature\":\"" + ztsSignature + "\"}")
-	zmsSignature := data.SignedPolicyData.ZmsSignature
-	zmsKeyID := data.SignedPolicyData.ZmsKeyId
-	zmsPublicKey := config.GetZmsPublicKey(zmsKeyID)
-	if zmsPublicKey == "" {
-		key, err := ztsClient.GetPublicKeyEntry("sys.auth", "zms", zmsKeyID)
-		if err != nil {
-			return nil, fmt.Errorf("Unable to get the Zms public key with id:\"%v\" to verify data", zmsKeyID)
+	if config.CheckZMSSignature {
+		zmsSignature := data.SignedPolicyData.ZmsSignature
+		zmsKeyID := data.SignedPolicyData.ZmsKeyId
+		zmsPublicKey := config.GetZmsPublicKey(zmsKeyID)
+		if zmsPublicKey == "" {
+			key, err := ztsClient.GetPublicKeyEntry("sys.auth", "zms", zmsKeyID)
+			if err != nil {
+				return nil, fmt.Errorf("unable to get the Zms public key with id:\"%v\" to verify data", zmsKeyID)
+			}
+			decodedKey, err := new(zmssvctoken.YBase64).DecodeString(key.Key)
+			if err != nil {
+				return nil, fmt.Errorf("unable to decode the Zms public key with id:\"%v\" to verify data", zmsKeyID)
+			}
+			zmsPublicKey = string(decodedKey)
 		}
-		decodedKey, err := new(zmssvctoken.YBase64).DecodeString(key.Key)
+		policyData := data.SignedPolicyData.PolicyData
+		input, err = util.ToCanonicalString(policyData)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to decode the Zms public key with id:\"%v\" to verify data", zmsKeyID)
+			return nil, err
 		}
-		zmsPublicKey = string(decodedKey)
-	}
-	policyData := data.SignedPolicyData.PolicyData
-	input, err = util.ToCanonicalString(policyData)
-	if err != nil {
-		return nil, err
-	}
-	err = verify(input, zmsSignature, zmsPublicKey)
-	if err != nil {
-		return nil, fmt.Errorf("Verification of data with zms key with id:\"%v\" failed, Error :%v", zmsKeyID, err)
+		err = verify(input, zmsSignature, zmsPublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("verification of data with zms key with id:\"%v\" failed, Error :%v", zmsKeyID, err)
+		}
 	}
 	return bytes, nil
 }
@@ -214,12 +217,12 @@ func expired(expires rdl.Timestamp, offset int) bool {
 	return rdl.TimestampNow().Millis() > expiryCheck.Millis()
 }
 
-// If domain policy file is not found, create the policy file and write policies in it.
+// WritePolicies If domain policy file is not found, create the policy file and write policies in it.
 // Else delete the existing file and write the modified policies to new file.
 func WritePolicies(config *ZpuConfiguration, bytes []byte, domain, policyFileDir string) error {
 	tempPolicyFileDir := config.TempPolicyFileDir
 	if tempPolicyFileDir == "" || bytes == nil {
-		return errors.New("Empty parameters are not valid arguments")
+		return errors.New("empty parameters are not valid arguments")
 	}
 	policyFile := fmt.Sprintf("%s/%s.pol", policyFileDir, domain)
 	tempPolicyFile := fmt.Sprintf("%s/%s.tmp", tempPolicyFileDir, domain)

--- a/utils/zpe-updater/zpu_config.go
+++ b/utils/zpe-updater/zpu_config.go
@@ -42,6 +42,7 @@ type ZpuConfiguration struct {
 	CertFile          string
 	CaCertFile        string
 	Proxy             bool
+	CheckZMSSignature bool
 }
 
 type AthenzConf struct {
@@ -58,20 +59,21 @@ type AthenzConf struct {
 }
 
 type ZpuConf struct {
-	Domains       string `json:"domains"`
-	User          string `json:"user"`
-	PolicyDir     string `json:"policyDir"`
-	TempPolicyDir string `json:"tempPolicyDir"`
-	MetricsDir    string `json:"metricsDir"`
-	LogMaxSize    int    `json:"logMaxsize"`
-	LogMaxAge     int    `json:"logMaxage"`
-	LogMaxBackups int    `json:"logMaxbackups"`
-	LogCompress   bool   `json:"logCompress"`
-	PrivateKey    string `json:"privateKeyFile"`
-	CertFile      string `json:"certFile"`
-	CaCertFile    string `json:"caCertFile"`
-	Proxy         bool   `json:"proxy"`
-	ExpiryCheck   int    `json:"expiryCheck"`
+	Domains           string `json:"domains"`
+	User              string `json:"user"`
+	PolicyDir         string `json:"policyDir"`
+	TempPolicyDir     string `json:"tempPolicyDir"`
+	MetricsDir        string `json:"metricsDir"`
+	LogMaxSize        int    `json:"logMaxsize"`
+	LogMaxAge         int    `json:"logMaxage"`
+	LogMaxBackups     int    `json:"logMaxbackups"`
+	LogCompress       bool   `json:"logCompress"`
+	PrivateKey        string `json:"privateKeyFile"`
+	CertFile          string `json:"certFile"`
+	CaCertFile        string `json:"caCertFile"`
+	Proxy             bool   `json:"proxy"`
+	ExpiryCheck       int    `json:"expiryCheck"`
+	CheckZMSSignature bool   `json:"checkZMSSignature"`
 }
 
 func NewZpuConfiguration(root, athensConfFile, zpuConfFile string) (*ZpuConfiguration, error) {
@@ -92,7 +94,7 @@ func NewZpuConfiguration(root, athensConfFile, zpuConfFile string) (*ZpuConfigur
 		}
 		key, err := new(zmssvctoken.YBase64).DecodeString(publicKey.Key)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to decode Zts public Key with id: %v, Error: %v", publicKey.Id, err)
+			return nil, fmt.Errorf("unable to decode Zts public Key with id: %v, Error: %v", publicKey.Id, err)
 		}
 		ztsKeysmap[publicKey.Id] = string(key)
 	}
@@ -103,7 +105,7 @@ func NewZpuConfiguration(root, athensConfFile, zpuConfFile string) (*ZpuConfigur
 		}
 		key, err := new(zmssvctoken.YBase64).DecodeString(publicKey.Key)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to decode Zms public Key with id: %v, Error: %v", publicKey.Id, err)
+			return nil, fmt.Errorf("unable to decode Zms public Key with id: %v, Error: %v", publicKey.Id, err)
 		}
 		zmsKeysmap[publicKey.Id] = string(key)
 	}
@@ -113,7 +115,7 @@ func NewZpuConfiguration(root, athensConfFile, zpuConfFile string) (*ZpuConfigur
 	if startupDelayString != "" {
 		startupDelay, err = strconv.Atoi(startupDelayString)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to set start up delay, Error: %v", err)
+			return nil, fmt.Errorf("unable to set start up delay, Error: %v", err)
 		}
 	}
 	if startupDelay < 0 {
@@ -172,22 +174,23 @@ func NewZpuConfiguration(root, athensConfFile, zpuConfFile string) (*ZpuConfigur
 		CaCertFile:        zpuConf.CaCertFile,
 		CertFile:          zpuConf.CertFile,
 		Proxy:             zpuConf.Proxy,
+		CheckZMSSignature: zpuConf.CheckZMSSignature,
 	}, nil
 }
 
 func ReadAthenzConf(athenzConf string) (*AthenzConf, error) {
 	var aConf *AthenzConf
 	if !util.Exists(athenzConf) {
-		return nil, fmt.Errorf("The Athenz configuration file does not exist at path: %v", athenzConf)
+		return nil, fmt.Errorf("athenz configuration file does not exist at path: %v", athenzConf)
 	}
 
 	data, err := ioutil.ReadFile(athenzConf)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read the Athenz configuration file, Error:%v", err)
+		return nil, fmt.Errorf("failed to read the Athenz configuration file, Error:%v", err)
 	}
 	err = json.Unmarshal(data, &aConf)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse the Athenz configuration file, Error:%v", err)
+		return nil, fmt.Errorf("failed to parse the Athenz configuration file, Error:%v", err)
 	}
 	return aConf, nil
 }
@@ -195,16 +198,16 @@ func ReadAthenzConf(athenzConf string) (*AthenzConf, error) {
 func ReadZpuConf(zpuConf string) (*ZpuConf, error) {
 	var zConf *ZpuConf
 	if !util.Exists(zpuConf) {
-		return nil, fmt.Errorf("The ZPU configuration file does not exist at the given path: %v", zpuConf)
+		return nil, fmt.Errorf("zpu configuration file does not exist at the given path: %v", zpuConf)
 	}
 
 	data, err := ioutil.ReadFile(zpuConf)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read the Zpu configuration file, Error:%v", err)
+		return nil, fmt.Errorf("failed to read the Zpu configuration file, Error:%v", err)
 	}
 	err = json.Unmarshal(data, &zConf)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse the Zpu configuration file, Error:%v", err)
+		return nil, fmt.Errorf("failed to parse the Zpu configuration file, Error:%v", err)
 	}
 	return zConf, nil
 }


### PR DESCRIPTION
once we add multi-version policy support, we can no longer return the zms signature over the policy data since zms is not involved when zpu asks for the policy data from zts and it could ask for the latest version of the policy assertions and not the active ones. while zms signature provided extra protection in case zts private key was compromised, in really it doesn't really protect the application since if the user has access to the private key, it can also just issue access tokens including any roles it needs to satisfy the policy.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>