### PR TITLE
correctly support new config manager library that returns empty values instead of nulls

### DIFF
--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -55,6 +55,7 @@ import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.ssl.KeyStoreScanner;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -96,7 +97,7 @@ public class AthenzJettyContainer {
     static String getServerHostName() {
         
         String serverHostName = System.getProperty(AthenzConsts.ATHENZ_PROP_HOSTNAME);
-        if (serverHostName == null || serverHostName.isEmpty()) {
+        if (StringUtil.isEmpty(serverHostName)) {
             try {
                 InetAddress localhost = java.net.InetAddress.getLocalHost();
                 serverHostName = localhost.getCanonicalHostName();
@@ -130,7 +131,7 @@ public class AthenzJettyContainer {
         // our audit logger to keep track of unauthenticated requests
         
         String accessSlf4jLogger = System.getProperty(AthenzConsts.ATHENZ_PROP_ACCESS_SLF4J_LOGGER);
-        if (accessSlf4jLogger != null && !accessSlf4jLogger.isEmpty()) {
+        if (!StringUtil.isEmpty(accessSlf4jLogger)) {
             
             Slf4jRequestLog requestLog = new Slf4jRequestLog();
             requestLog.setLoggerName(accessSlf4jLogger);
@@ -187,8 +188,8 @@ public class AthenzJettyContainer {
         
         // Add response-headers, according to configuration
 
-        String responseHeadersJson = System.getProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON, "");
-        if (!responseHeadersJson.isEmpty()) {
+        final String responseHeadersJson = System.getProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON);
+        if (!StringUtil.isEmpty(responseHeadersJson)) {
             HashMap<String, String> responseHeaders;
             try {
                 responseHeaders = new ObjectMapper().readValue(responseHeadersJson, new TypeReference<HashMap<String, String>>() {
@@ -265,7 +266,7 @@ public class AthenzJettyContainer {
 
         final String checkList = System.getProperty(AthenzConsts.ATHENZ_PROP_HEALTH_CHECK_URI_LIST);
 
-        if (checkList != null && !checkList.isEmpty()) {
+        if (!StringUtil.isEmpty(checkList)) {
             String[] checkUriArray = checkList.split(",");
             for (String checkUri : checkUriArray) {
                 servletCtxHandler.addFilter(filterHolder, checkUri.trim(), EnumSet.of(DispatcherType.REQUEST));
@@ -374,33 +375,33 @@ public class AthenzJettyContainer {
         SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setEndpointIdentificationAlgorithm(null);
 
-        if (keyStorePath != null) {
+        if (!StringUtil.isEmpty(keyStorePath)) {
             LOG.info("Using SSL KeyStore path: {}", keyStorePath);
             sslContextFactory.setKeyStorePath(keyStorePath);
         }
-        if (keyStorePassword != null) {
+        if (!StringUtil.isEmpty(keyStorePassword)) {
             //default implementation should just return the same
             sslContextFactory.setKeyStorePassword(this.privateKeyStore.getApplicationSecret(keyStorePasswordAppName, keyStorePassword));
         }
         sslContextFactory.setKeyStoreType(keyStoreType);
 
-        if (keyManagerPassword != null) {
+        if (!StringUtil.isEmpty(keyManagerPassword)) {
             sslContextFactory.setKeyManagerPassword(this.privateKeyStore.getApplicationSecret(keyManagerPasswordAppName, keyManagerPassword));
         }
-        if (trustStorePath != null) {
+        if (!StringUtil.isEmpty(trustStorePath)) {
             LOG.info("Using SSL TrustStore path: {}", trustStorePath);
             sslContextFactory.setTrustStorePath(trustStorePath);
         }
-        if (trustStorePassword != null) {
+        if (!StringUtil.isEmpty(trustStorePassword)) {
             sslContextFactory.setTrustStorePassword(this.privateKeyStore.getApplicationSecret(trustStorePasswordAppName, trustStorePassword));
         }
         sslContextFactory.setTrustStoreType(trustStoreType);
 
-        if (includedCipherSuites != null && !includedCipherSuites.isEmpty()) {
+        if (!StringUtil.isEmpty(includedCipherSuites)) {
             sslContextFactory.setIncludeCipherSuites(includedCipherSuites.split(","));
         }
         
-        if (excludedCipherSuites != null && !excludedCipherSuites.isEmpty()) {
+        if (!StringUtil.isEmpty(excludedCipherSuites)) {
             sslContextFactory.setExcludeCipherSuites(excludedCipherSuites.split(","));
         }
         
@@ -429,7 +430,7 @@ public class AthenzJettyContainer {
         } else {
             connector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
         }
-        if (listenHost != null) {
+        if (!StringUtil.isEmpty(listenHost)) {
             connector.setHost(listenHost);
         }
         connector.setPort(httpPort);

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/HealthCheckFilter.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/HealthCheckFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,8 +60,7 @@ public class HealthCheckFilter implements javax.servlet.Filter {
 
         uriList = new HashMap<>();
         final String list = System.getProperty(AthenzConsts.ATHENZ_PROP_HEALTH_CHECK_URI_LIST);
-
-        if (list == null || list.isEmpty()) {
+        if (StringUtil.isEmpty(list)) {
             return;
         }
         

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/KerberosAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/KerberosAuthority.java
@@ -148,7 +148,7 @@ public class KerberosAuthority implements Authority {
             // qualified class name of a default handler implementation
             LoginContext    loginContext;
             CallbackHandler loginHandler = null;
-            if (loginCallbackHandler != null) {
+            if (loginCallbackHandler != null && !loginCallbackHandler.isEmpty()) {
                 Class cbhandlerClass = Class.forName(loginCallbackHandler);
                 loginHandler = (CallbackHandler) cbhandlerClass.getConstructor(String.class, String.class).newInstance(servicePrincipal, null);
             }
@@ -343,7 +343,7 @@ public class KerberosAuthority implements Authority {
                 } else {
                     ///CLOVER:ON
                     ticketCacheName = System.getProperty(KRB_PROP_LOGIN_TKT_CACHE_NAME);
-                    if (ticketCacheName != null) {
+                    if (ticketCacheName != null && !ticketCacheName.isEmpty()) {
                         options.put("ticketCache", ticketCacheName);
                     }
                 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/KerberosToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/KerberosToken.java
@@ -68,11 +68,11 @@ public class KerberosToken extends Token {
         PrivilegedExceptionAction<String> privExcAction;
         try {
             byte[] kerberosTicket = Base64.decode(unsignedToken.getBytes(StandardCharsets.UTF_8));
-            if (krbPrivActionClass == null) {
-                privExcAction = new KerberosValidateAction(kerberosTicket);
-            } else {
+            if (krbPrivActionClass != null && !krbPrivActionClass.isEmpty()) {
                 Class privActionClass = Class.forName(krbPrivActionClass);
                 privExcAction = (PrivilegedExceptionAction<String>) privActionClass.getConstructor(byte[].class).newInstance((Object) kerberosTicket);
+            } else {
+                privExcAction = new KerberosValidateAction(kerberosTicket);
             }
             userName = Subject.doAs(serviceSubject, privExcAction);
             int index = userName.indexOf('@');

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/ZMSFileChangeLogStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/ZMSFileChangeLogStore.java
@@ -22,6 +22,7 @@ import com.yahoo.athenz.auth.impl.SimplePrincipal;
 import com.yahoo.athenz.auth.token.PrincipalToken;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
 import com.yahoo.athenz.zms.*;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,8 @@ public class ZMSFileChangeLogStore implements ChangeLogStore {
 
         // check to see if we need to override the ZMS url from the config file
 
-        zmsUrl = System.getProperty(ZTS_PROP_ZMS_URL_OVERRIDE);
+        final String overrideUrl = System.getProperty(ZTS_PROP_ZMS_URL_OVERRIDE);
+        zmsUrl = (StringUtil.isEmpty(overrideUrl)) ? null : overrideUrl;
 
         // create our common logic object
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/ZMSFileMTLSChangeLogStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/ZMSFileMTLSChangeLogStore.java
@@ -21,6 +21,7 @@ import com.oath.auth.KeyRefresherException;
 import com.oath.auth.Utils;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
 import com.yahoo.athenz.zms.*;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +44,8 @@ public class ZMSFileMTLSChangeLogStore implements ChangeLogStore {
 
         // check to see if we need to override the ZMS url from the config file
 
-        final String zmsUrl = System.getProperty(ZTS_PROP_ZMS_URL_OVERRIDE);
+        final String overrideUrl = System.getProperty(ZTS_PROP_ZMS_URL_OVERRIDE);
+        final String zmsUrl = (StringUtil.isEmpty(overrideUrl)) ? null : overrideUrl;
 
         // setup our mtls client first to make sure our settings are correct
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -700,12 +700,12 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         userDomainPrefix = userDomain + ".";
 
         userDomainAlias = System.getProperty(ZMSConsts.ZMS_PROP_USER_DOMAIN_ALIAS);
-        if (userDomainAlias != null) {
+        if (!StringUtil.isEmpty(userDomainAlias)) {
             userDomainAliasPrefix = userDomainAlias + ".";
         }
 
         final String addlUserCheckDomains = System.getProperty(ZMSConsts.ZMS_PROP_ADDL_USER_CHECK_DOMAINS);
-        if (addlUserCheckDomains != null && !addlUserCheckDomains.isEmpty()) {
+        if (!StringUtil.isEmpty(addlUserCheckDomains)) {
             String[] checkDomains = addlUserCheckDomains.split(",");
             addlUserCheckDomainSet = new HashSet<>();
             addlUserCheckDomainPrefixList = new ArrayList<>();
@@ -753,7 +753,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // get the list of valid provider endpoints
 
         final String endPoints = System.getProperty(ZMSConsts.ZMS_PROP_PROVIDER_ENDPOINTS);
-        if (endPoints != null) {
+        if (!StringUtil.isEmpty(endPoints)) {
             providerEndpoints = Arrays.asList(endPoints.split(","));
         }
 
@@ -795,7 +795,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // get the list of uris that we want to allow an-authenticated access
 
         final String uriList = System.getProperty(ZMSConsts.ZMS_PROP_NOAUTH_URI_LIST);
-        if (uriList != null) {
+        if (!StringUtil.isEmpty(uriList)) {
             authFreeUriSet = new HashSet<>();
             authFreeUriList = new ArrayList<>();
             String[] list = uriList.split(",");
@@ -811,7 +811,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // get the list of allowed origin values for cors requests
 
         final String originList = System.getProperty(ZMSConsts.ZMS_PROP_CORS_ORIGIN_LIST);
-        if (originList != null) {
+        if (!StringUtil.isEmpty(originList)) {
             corsOriginList = new HashSet<>(Arrays.asList(originList.split(",")));
         }
 
@@ -847,7 +847,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // setup our health check file
 
         final String healthCheckPath = System.getProperty(ZMSConsts.ZMS_PROP_HEALTH_CHECK_PATH);
-        if (healthCheckPath != null && !healthCheckPath.isEmpty()) {
+        if (!StringUtil.isEmpty(healthCheckPath)) {
             healthCheckFile = new File(healthCheckPath);
         }
 
@@ -1006,7 +1006,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         final String auditRefValidatorClass = System.getProperty(ZMSConsts.ZMS_PROP_AUDIT_REF_VALIDATOR_FACTORY_CLASS);
         AuditReferenceValidatorFactory auditReferenceValidatorFactory;
 
-        if (auditRefValidatorClass != null && !auditRefValidatorClass.isEmpty()) {
+        if (!StringUtil.isEmpty(auditRefValidatorClass)) {
 
             try {
                 auditReferenceValidatorFactory = (AuditReferenceValidatorFactory) Class.forName(auditRefValidatorClass).newInstance();
@@ -1062,7 +1062,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         try {
             serverSolutionTemplates = JSON.fromBytes(Files.readAllBytes(path), SolutionTemplates.class);
         } catch (IOException ex) {
-            LOG.error("Unable to parse service templates file {}: {}",
+            LOG.error("Unable to parse solution templates file {}: {}",
                     solutionTemplatesFname, ex.getMessage());
         }
 
@@ -1117,7 +1117,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         final String statusCheckerFactoryClass = System.getProperty(ZMSConsts.ZMS_PROP_STATUS_CHECKER_FACTORY_CLASS);
         StatusCheckerFactory statusCheckerFactory;
 
-        if (statusCheckerFactoryClass != null && !statusCheckerFactoryClass.isEmpty()) {
+        if (!StringUtil.isEmpty(statusCheckerFactoryClass)) {
 
             try {
                 statusCheckerFactory = (StatusCheckerFactory) Class.forName(statusCheckerFactoryClass).newInstance();
@@ -1141,8 +1141,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             return;
         }
 
-        String adminUserList = System.getProperty(ZMSConsts.ZMS_PROP_DOMAIN_ADMIN);
-        if (adminUserList == null) {
+        final String adminUserList = System.getProperty(ZMSConsts.ZMS_PROP_DOMAIN_ADMIN);
+        if (StringUtil.isEmpty(adminUserList)) {
             throw ZMSUtils.internalServerError("init: No ZMS admin user specified", caller);
         }
 
@@ -7983,7 +7983,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     static String getServerHostName() {
 
         String serverHostName = System.getProperty(ZMSConsts.ZMS_PROP_HOSTNAME);
-        if (serverHostName == null || serverHostName.isEmpty()) {
+        if (StringUtil.isEmpty(serverHostName)) {
             try {
                 InetAddress localhost = java.net.InetAddress.getLocalHost();
                 serverHostName = localhost.getCanonicalHostName();

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/ZMSNotificationTaskFactory.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/ZMSNotificationTaskFactory.java
@@ -41,7 +41,7 @@ public class ZMSNotificationTaskFactory implements NotificationTaskFactory {
     public List<NotificationTask> getNotificationTasks() {
         List<NotificationTask> notificationTasks = new ArrayList<>();
         int pendingRoleMemberLifespan = Integer.parseInt(System.getProperty(ZMSConsts.ZMS_PROP_PENDING_ROLE_MEMBER_LIFESPAN, ZMSConsts.ZMS_PENDING_ROLE_MEMBER_LIFESPAN_DEFAULT));
-        String monitorIdentity = System.getProperty(ZMSConsts.ZMS_PROP_MONITOR_IDENTITY, ZMSConsts.SYS_AUTH_MONITOR);
+        final String monitorIdentity = System.getProperty(ZMSConsts.ZMS_PROP_MONITOR_IDENTITY, ZMSConsts.SYS_AUTH_MONITOR);
         notificationTasks.add(new PendingRoleMembershipApprovalNotificationTask(dbService, pendingRoleMemberLifespan, monitorIdentity, userDomainPrefix, notificationToEmailConverterCommon));
         notificationTasks.add(new PendingGroupMembershipApprovalNotificationTask(dbService, pendingRoleMemberLifespan, monitorIdentity, userDomainPrefix, notificationToEmailConverterCommon));
         notificationTasks.add(new RoleMemberExpiryNotificationTask(dbService, userDomainPrefix, notificationToEmailConverterCommon));

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBClientFetcherImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBClientFetcherImpl.java
@@ -98,9 +98,9 @@ public class DynamoDBClientFetcherImpl implements DynamoDBClientFetcher {
             SSLContext sslContext = Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(),
                     keyRefresher.getTrustManagerProxy());
 
-            String externalId = System.getProperty(ZTS_PROP_DYNAMODB_EXTERNAL_ID, null);
-            String minExpiryTimeStr = System.getProperty(ZTS_PROP_DYNAMODB_MIN_EXPIRY_TIME, "");
-            String maxExpiryTimeStr = System.getProperty(ZTS_PROP_DYNAMODB_MAX_EXPIRY_TIME, "");
+            final String externalId = System.getProperty(ZTS_PROP_DYNAMODB_EXTERNAL_ID);
+            final String minExpiryTimeStr = System.getProperty(ZTS_PROP_DYNAMODB_MIN_EXPIRY_TIME, "");
+            final String maxExpiryTimeStr = System.getProperty(ZTS_PROP_DYNAMODB_MAX_EXPIRY_TIME, "");
             Integer minExpiryTime = minExpiryTimeStr.isEmpty() ? null : Integer.parseInt(minExpiryTimeStr);
             Integer maxExpiryTime = maxExpiryTimeStr.isEmpty() ? null : Integer.parseInt(maxExpiryTimeStr);
 
@@ -109,7 +109,7 @@ public class DynamoDBClientFetcherImpl implements DynamoDBClientFetcher {
                     sslContext,
                     dynamoDBClientSettings.getDomainName(),
                     dynamoDBClientSettings.getRoleName(),
-                    externalId,
+                    StringUtil.isEmpty(externalId) ? null : externalId,
                     minExpiryTime,
                     maxExpiryTime,
                     ztsClientNotificationSender);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerFactory.java
@@ -15,6 +15,7 @@
  */
 package com.yahoo.athenz.zts.cert.impl;
 
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,7 @@ public class SelfCertSignerFactory implements CertSignerFactory {
         final String csrDn = System.getProperty(ZTSConsts.ZTS_PROP_SELF_SIGNER_CERT_DN,
                 "cn=Self Signed Athenz CA,o=Athenz,c=US");
 
-        if (pKeyFileName == null) {
+        if (StringUtil.isEmpty(pKeyFileName)) {
             LOGGER.error("No private key path available for Self Cert Signer Factory");
             return null;
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import com.oath.auth.KeyRefresher;
 import com.oath.auth.Utils;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,27 +101,27 @@ public class ZTSUtils {
         boolean wantClientAuth = Boolean.parseBoolean(System.getProperty(ZTSConsts.ZTS_PROP_WANT_CLIENT_CERT, "false"));
         
         SslContextFactory sslContextFactory = new SslContextFactory();
-        if (keyStorePath != null) {
+        if (!StringUtil.isEmpty(keyStorePath)) {
             LOGGER.info("createSSLContextObject: using SSL KeyStore path: {}", keyStorePath);
             sslContextFactory.setKeyStorePath(keyStorePath);
         }
         
-        if (keyStorePassword != null) {
+        if (!StringUtil.isEmpty(keyStorePassword)) {
             keyStorePassword = getApplicationSecret(privateKeyStore, keyStorePasswordAppName, keyStorePassword);
             sslContextFactory.setKeyStorePassword(keyStorePassword);
         }
         sslContextFactory.setKeyStoreType(keyStoreType);
 
-        if (keyManagerPassword != null) {
+        if (!StringUtil.isEmpty(keyManagerPassword)) {
             keyManagerPassword = getApplicationSecret(privateKeyStore, keyManagerPasswordAppName, keyManagerPassword);
             sslContextFactory.setKeyManagerPassword(keyManagerPassword);
         }
         
-        if (trustStorePath != null) {
+        if (!StringUtil.isEmpty(trustStorePath)) {
             LOGGER.info("createSSLContextObject: using SSL TrustStore path: {}", trustStorePath);
             sslContextFactory.setTrustStorePath(trustStorePath);
         }
-        if (trustStorePassword != null) {
+        if (!StringUtil.isEmpty(trustStorePassword)) {
             trustStorePassword = getApplicationSecret(privateKeyStore, trustStorePasswordAppName, trustStorePassword);
             sslContextFactory.setTrustStorePassword(trustStorePassword);
         }


### PR DESCRIPTION
The old config manager would treat values like "property=" as null value for the property. The new config manager follows the java command line behavior where "-Dproperty=" would return an empty string. So the code has been updated to correctly handle cases where empty string are returned instead of nulls.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>