### PR TITLE
repository and validator interfaces for MSD static workload implementation

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/DomainChangePublisher.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/DomainChangePublisher.java
@@ -18,8 +18,15 @@
 
 package com.yahoo.athenz.common.messaging;
 
+/**
+ * Domain change publisher interface
+ */
 public interface DomainChangePublisher {
-    
+
+    /**
+     * Publishes a message to configured messaging system
+     * @param domainChangeMessage input object containing details to be published
+     */
     void publishMessage(DomainChangeMessage domainChangeMessage);
     
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/DomainChangePublisherFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/DomainChangePublisherFactory.java
@@ -38,6 +38,10 @@ public class DomainChangePublisherFactory {
         return instance;
     }
 
+    /**
+     * Creates the domain change publisher
+     * @return domain change publisher
+     */
     public static DomainChangePublisher create() {
         return createPublisher();
     }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/NoOpDomainChangePublisher.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/NoOpDomainChangePublisher.java
@@ -25,6 +25,6 @@ public class NoOpDomainChangePublisher implements DomainChangePublisher {
 
     @Override
     public void publishMessage(DomainChangeMessage domainChangeMessage) {
-        // do nothing ..        
+        // do nothing
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepository.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepository.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.common.server.msd.repository;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.common.server.dns.HostnameResolver;
+import com.yahoo.athenz.common.server.msd.MsdStore;
+
+public interface StaticWorkloadDataRepository<T> {
+    void initialize(PrivateKeyStore privateKeyStore, HostnameResolver hostnameResolver, MsdStore msdStore);
+    T getDataByKey(String key);
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepository.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepository.java
@@ -21,7 +21,24 @@ import com.yahoo.athenz.auth.PrivateKeyStore;
 import com.yahoo.athenz.common.server.dns.HostnameResolver;
 import com.yahoo.athenz.common.server.msd.MsdStore;
 
+/**
+ * StaticWorkloadDataRepository represents various data repositories corresponding to different types of static workloads.
+ * ( CloudLBRepository, CloudNATRepository etc.)
+ * @param <T> represents a generic Value Object used by various repository implementations
+ */
 public interface StaticWorkloadDataRepository<T> {
+    /**
+     * Initializes the repository object
+     * @param privateKeyStore used to fetch necessary secrets to initialize the repository
+     * @param hostnameResolver used to resolve hostnames to ip addresses
+     * @param msdStore used to fetch workload data from underlying storage
+     */
     void initialize(PrivateKeyStore privateKeyStore, HostnameResolver hostnameResolver, MsdStore msdStore);
+
+    /**
+     * Returns static workload data from the corresponding repository
+     * @param key map key to retrieve a specific Value Object from the repository
+     * @return a generic Value Object used by various repository implementations
+     */
     T getDataByKey(String key);
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepositoryFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepositoryFactory.java
@@ -22,7 +22,23 @@ import com.yahoo.athenz.common.server.dns.HostnameResolver;
 import com.yahoo.athenz.common.server.msd.MsdStore;
 import com.yahoo.athenz.msd.StaticWorkloadType;
 
+/**
+ * Factory to create various static workload data repositories
+ */
 public interface StaticWorkloadDataRepositoryFactory {
+
+    /**
+     * Creates the Repository objects
+     * @param privateKeyStore used to fetch necessary secrets to initialize the repository
+     * @param hostnameResolver used to resolve hostnames to ip addresses
+     * @param msdStore used to fetch workload data from underlying storage
+     */
     void create(final PrivateKeyStore privateKeyStore, final HostnameResolver hostnameResolver, final MsdStore msdStore);
+
+    /**
+     *
+     * @param type type of static workload to get appropriate repository from the factory implementation
+     * @return static workload data repository object
+     */
     StaticWorkloadDataRepository<?> getByType(StaticWorkloadType type);
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepositoryFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/repository/StaticWorkloadDataRepositoryFactory.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.common.server.msd.repository;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.common.server.dns.HostnameResolver;
+import com.yahoo.athenz.common.server.msd.MsdStore;
+import com.yahoo.athenz.msd.StaticWorkloadType;
+
+public interface StaticWorkloadDataRepositoryFactory {
+    void create(final PrivateKeyStore privateKeyStore, final HostnameResolver hostnameResolver, final MsdStore msdStore);
+    StaticWorkloadDataRepository<?> getByType(StaticWorkloadType type);
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/NoOpValidator.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/NoOpValidator.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.common.server.msd.validator;
+
+import com.yahoo.athenz.common.server.msd.repository.StaticWorkloadDataRepository;
+
+public class NoOpValidator implements StaticWorkloadValidator {
+    @Override
+    public void initialize(StaticWorkloadDataRepository<?> repository) {
+        // NO OP
+    }
+
+    @Override
+    public boolean validateWorkload(String domain, String service, String name) {
+        return true;
+    }
+
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/StaticWorkloadValidator.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/StaticWorkloadValidator.java
@@ -19,7 +19,23 @@ package com.yahoo.athenz.common.server.msd.validator;
 
 import com.yahoo.athenz.common.server.msd.repository.StaticWorkloadDataRepository;
 
+/**
+ * Static workload validator interface
+ */
 public interface StaticWorkloadValidator {
+
+    /**
+     * Initializes the validator
+     * @param repository static workload data repository used by the validator for source of truth data
+     */
     void initialize(StaticWorkloadDataRepository<?> repository);
+
+    /**
+     * Validates the static workload entry against the business rules and / or repository
+     * @param domain input domain of the static workload entry
+     * @param service input service of the static workload entry
+     * @param name static workload entry ( usually a Domain name like abc.example.com, but can be an IP address )
+     * @return validation status
+     */
     boolean validateWorkload(String domain, String service, String name);
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/StaticWorkloadValidator.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/StaticWorkloadValidator.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.common.server.msd.validator;
+
+import com.yahoo.athenz.common.server.msd.repository.StaticWorkloadDataRepository;
+
+public interface StaticWorkloadValidator {
+    void initialize(StaticWorkloadDataRepository<?> repository);
+    boolean validateWorkload(String domain, String service, String name);
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/StaticWorkloadValidatorFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/StaticWorkloadValidatorFactory.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.common.server.msd.validator;
+
+public interface StaticWorkloadValidatorFactory {
+    void create();
+    default StaticWorkloadValidator getByType(String type) {
+        return new NoOpValidator();
+    }
+}

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/NoOpValidatorTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/NoOpValidatorTest.java
@@ -12,27 +12,21 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package com.yahoo.athenz.common.server.msd.validator;
 
-/**
- * Factory to create various static workload validators
- */
-public interface StaticWorkloadValidatorFactory {
+import org.testng.annotations.Test;
 
-    /**
-     * Creates the static workload validators
-     */
-    void create();
+import static org.testng.Assert.*;
 
-    /**
-     * Get an appropriate static workload validator based on the type parameter
-     * @param type static workload type {@link com.yahoo.athenz.msd.StaticWorkloadType}
-     * @return static workload validator
-     */
-    default StaticWorkloadValidator getByType(String type) {
-        return new NoOpValidator();
+public class NoOpValidatorTest {
+
+    @Test
+    public void testNoOpValidator() {
+        StaticWorkloadValidatorFactory factory = () -> {};
+        StaticWorkloadValidator validator = factory.getByType("abc");
+        assertTrue(validator instanceof NoOpValidator);
+        assertTrue(validator.validateWorkload("mydom", "mysvc", "xyz.athenz.io"));
     }
 }


### PR DESCRIPTION
StaticWorkloadDataRepository represents various data repositories corresponding to different types of static workloads. ( CloudLBRepository, CloudNATRepository etc.)

StaticWorkloadValidator represents various validators corresponding to different types of static workloads. The validators use corresponding repository objects to validate against them.

Signed-off-by: Abhijeet V <31417623+abvaidya@users.noreply.github.com>