### PR TITLE
update ssl context protol to 1.3 for cert refresher

### DIFF
--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/CaCertKeyStoreProvider.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/CaCertKeyStoreProvider.java
@@ -16,7 +16,6 @@
 package com.oath.auth;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
@@ -33,8 +32,8 @@ class CaCertKeyStoreProvider implements KeyStoreProvider {
     }
 
     @Override
-    public KeyStore provide() throws KeyRefresherException, FileNotFoundException, IOException {
-        KeyStore keyStore = null;
+    public KeyStore provide() throws KeyRefresherException, IOException {
+        KeyStore keyStore;
         try (InputStream inputStream = new FileInputStream(caCertFilePath)) {
             keyStore = Utils.generateTrustStore(inputStream);
         }

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/JavaKeyStoreProvider.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/JavaKeyStoreProvider.java
@@ -15,7 +15,6 @@
  */
 package com.oath.auth;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.KeyStore;
 
@@ -34,7 +33,7 @@ class JavaKeyStoreProvider implements KeyStoreProvider {
     }
 
     @Override
-    public KeyStore provide() throws FileNotFoundException, IOException, KeyRefresherException {
+    public KeyStore provide() throws IOException, KeyRefresherException {
         return Utils.getKeyStore(jksFilePath, password);
     }
 }

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
@@ -81,7 +81,6 @@ public class KeyRefresher {
     public KeyRefresher(final String athenzPublicCert, final String athenzPrivateKey, final TrustStore trustStore,
             final KeyManagerProxy keyManagerProxy, final TrustManagerProxy trustManagerProxy) throws NoSuchAlgorithmException {
         this(athenzPublicCert, athenzPrivateKey, trustStore, keyManagerProxy, trustManagerProxy, null);
-        
     }
     
     /**
@@ -224,7 +223,7 @@ public class KeyRefresher {
                 // do nothing, just read until the EoF
             }
         } catch (IOException ex) {
-            //this is best effort, if we couldn't read the file, assume its the same
+            //this is best effort, if we couldn't read the file, assume it's the same
             LOGGER.warn("Error reading file {}", filePath, ex);
             return false;
         }

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresherListener.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresherListener.java
@@ -17,11 +17,14 @@
 package com.oath.auth;
 
 /**
- * 
- * @author charlesk
- *
+ * Listener interface for any key/cert changes.
  */
 public interface KeyRefresherListener {
 
-    public void onKeyChangeEvent(); 
+    /**
+     * method is called whenever the KeyRefresher detects a change
+     * either in the private key or x.509 certificate files and
+     * updates the ssl context with the new content.
+     */
+    void onKeyChangeEvent();
 }

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyStoreProvider.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyStoreProvider.java
@@ -15,7 +15,6 @@
  */
 package com.oath.auth;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.KeyStore;
 
@@ -26,6 +25,13 @@ import java.security.KeyStore;
  */
 public interface KeyStoreProvider {
 
-    KeyStore provide() throws KeyRefresherException, FileNotFoundException, IOException;
+    /**
+     * provide a KeyStore object which could be either a PrivateKey/Certificate
+     * key pair store or a Trust CA Certificate store
+     * @return keystore object
+     * @throws KeyRefresherException in case of any key refresher errors processing the request
+     * @throws IOException in case of any errors with reading files
+     */
+    KeyStore provide() throws KeyRefresherException, IOException;
 }
 

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/TrustStore.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/TrustStore.java
@@ -15,7 +15,6 @@
  */
 package com.oath.auth;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -37,7 +36,7 @@ class TrustStore {
         this.keyStoreProvider = keyStoreProvider;
     }
 
-    public TrustManager[] getTrustManagers() throws FileNotFoundException, KeyRefresherException, IOException  {
+    public TrustManager[] getTrustManagers() throws KeyRefresherException, IOException  {
         final KeyStore keystore = keyStoreProvider.provide();
 
         TrustManagerFactory trustManagerFactory;

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/SocketTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/SocketTest.java
@@ -40,6 +40,8 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.testng.Assert.assertTrue;
 
 /**
  * this test validates that when the server changes the keyManager on the fly, no existing connections are broken
@@ -119,6 +121,15 @@ public class SocketTest {
                 return null;
             }
         };
+
+        // create ssl context with unknown protocol
+
+        try {
+            Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(), keyRefresher.getTrustManagerProxy(), "TLS2.0");
+            fail();
+        } catch (KeyRefresherException ex) {
+            assertTrue(ex.getMessage().contains("No Provider supports a SSLContextSpi implementation"));
+        }
 
         //setup socket for first call
         SSLContext sslContext = Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(),


### PR DESCRIPTION
1) changed default to TLSv1.3. If the application wants to stick with 1.2, then they can either set the system property "athenz.cert_refresher.tls_algorithm" to "TLSv1.2" or use the buildSSLContext method that now provides a protocol argument
2) removed non-needed FileNotFound exceptions from signatures since they already throw more general IOExceptions