### PR TITLE
Updated mariadb to 10.5.13

### DIFF
--- a/docker/db/zms/Dockerfile
+++ b/docker/db/zms/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.5.2
+FROM mariadb:10.5.13
 # date -u +'%Y-%m-%dT%H:%M:%SZ'
 ARG BUILD_DATE
 # git rev-parse --short HEAD

--- a/docker/db/zts/Dockerfile
+++ b/docker/db/zts/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.5.2
+FROM mariadb:10.5.13
 # date -u +'%Y-%m-%dT%H:%M:%SZ'
 ARG BUILD_DATE
 # git rev-parse --short HEAD


### PR DESCRIPTION
Upgrade mariadb version in docker images from 10.5.2  to 10.5.13 to solve issue with critical security issue CVE-2021-27928.

https://www.cvedetails.com/cve/CVE-2021-27928/

Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>