### PR TITLE
introduce backward compatible option for x.509 cert san values

### DIFF
--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -107,7 +107,7 @@ func GetRoleCertificate(ztsUrl, svcKeyFile, svcCertFile string, opts *options.Op
 			}
 		}
 
-		csr, err := util.GenerateRoleCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, opts.Services[0].Name, roleName, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains[0])
+		csr, err := util.GenerateRoleCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, opts.Services[0].Name, roleName, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains[0], opts.BackwardCompatible)
 		if err != nil {
 			logutil.LogInfo(sysLogger, "unable to generate CSR for %s, err: %v\n", roleName, err)
 			failures += 1
@@ -199,7 +199,7 @@ func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl 
 			return err
 		}
 	}
-	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard, opts.BackwardCompatible)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl s
 		logutil.LogInfo(sysLogger, "Unable to read private key from %s, err: %v\n", keyFile, err)
 		return err
 	}
-	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard, opts.BackwardCompatible)
 	if err != nil {
 		logutil.LogInfo(sysLogger, "Unable to generate CSR for %s, err: %v\n", opts.Name, err)
 		return err

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -137,6 +137,7 @@ type Options struct {
 	EC2Document          string                //EC2 instance identity document
 	EC2Signature         string                //EC2 instance identity document pkcs7 signature
 	EC2StartTime         *time.Time            //EC2 instance start time
+	BackwardCompatible   bool                  //support backward compatible option in generated certs
 }
 
 func GetAccountId(metaEndPoint string, useRegionalSTS bool, region string, sysLogger io.Writer) (string, error) {

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -254,7 +254,7 @@ func PrivateKeyFromFile(filename string) (*rsa.PrivateKey, error) {
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
 
-func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, service, commonName, instanceId, provider string, ztsDomains []string, wildCardDnsName bool) (string, error) {
+func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, service, commonName, instanceId, provider string, ztsDomains []string, wildCardDnsName, backwardCompatible bool) (string, error) {
 
 	//note: RFC 6125 states that if the SAN (Subject Alternative Name) exists,
 	//it is used, not the CN. So, we will always put the Athenz name in the CN
@@ -276,6 +276,11 @@ func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, servi
 			csrDetails.HostList = append(csrDetails.HostList, host)
 		}
 	}
+	// for backward compatibility a sanDNS entry with instance id in the hostname
+	if backwardCompatible {
+		instanceIdHost := fmt.Sprintf("%s.instanceid.athenz.%s", instanceId, ztsDomains[0])
+		csrDetails.HostList = append(csrDetails.HostList, instanceIdHost)
+	}
 
 	csrDetails.URIs = []*url.URL{}
 	// spiffe uri must always be the first one
@@ -289,7 +294,7 @@ func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, servi
 	return GenerateX509CSR(key, csrDetails)
 }
 
-func GenerateRoleCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, service, roleName, instanceId, provider, emailDomain string) (string, error) {
+func GenerateRoleCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, service, roleName, instanceId, provider, emailDomain string, backwardCompatible bool) (string, error) {
 
 	// for role certificates we're putting the role name in the CN
 	var csrDetails CertReqDetails
@@ -311,12 +316,15 @@ func GenerateRoleCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, serv
 	instanceIdUri := fmt.Sprintf("athenz://instanceid/%s/%s", provider, instanceId)
 	csrDetails.URIs = AppendUri(csrDetails.URIs, instanceIdUri)
 
-	// include an uri for athenz principal and for backward
-	// compatibility an email with the principal as the local part
+	// include an uri for athenz principal
 	principalUri := fmt.Sprintf("athenz://principal/%s.%s", domain, service)
 	csrDetails.URIs = AppendUri(csrDetails.URIs, principalUri)
-	email := fmt.Sprintf("%s.%s@%s", domain, service, emailDomain)
-	csrDetails.EmailList = []string{email}
+
+	// for backward compatibility an email with the principal as the local part
+	if backwardCompatible {
+		email := fmt.Sprintf("%s.%s@%s", domain, service, emailDomain)
+		csrDetails.EmailList = []string{email}
+	}
 
 	return GenerateX509CSR(key, csrDetails)
 }

--- a/libs/go/sia/util/util_test.go
+++ b/libs/go/sia/util/util_test.go
@@ -233,7 +233,7 @@ func TestGenerateSvcCertCSR(test *testing.T) {
 		return
 	}
 
-	csr, err := GenerateSvcCertCSR(key, "US", "", "domain", "service", "domain.service", "instance001", "Athenz", []string{"athenz.cloud"}, false)
+	csr, err := GenerateSvcCertCSR(key, "US", "", "domain", "service", "domain.service", "instance001", "Athenz", []string{"athenz.cloud"}, false, false)
 	if err != nil {
 		test.Errorf("Cannot create CSR: %v", err)
 		return
@@ -296,7 +296,7 @@ func TestGenerateRoleCertCSR(test *testing.T) {
 		return
 	}
 
-	csr, err := GenerateRoleCertCSR(key, "US", "", "domain", "service", "athenz:role.readers", "instance001", "Athenz", "athenz.cloud")
+	csr, err := GenerateRoleCertCSR(key, "US", "", "domain", "service", "athenz:role.readers", "instance001", "Athenz", "athenz.cloud", true)
 	if err != nil {
 		test.Errorf("Cannot create CSR: %v", err)
 		return
@@ -354,7 +354,7 @@ func TestGenerateWithWildCardHostname(test *testing.T) {
 		test.Errorf("Cannot generate private key: %v", err)
 		return
 	}
-	csr, err := GenerateSvcCertCSR(key, "US", "", "domain", "service", "domain.service", "", "Athenz", []string{"athenz.cloud"}, true)
+	csr, err := GenerateSvcCertCSR(key, "US", "", "domain", "service", "domain.service", "", "Athenz", []string{"athenz.cloud"}, true, false)
 	if err != nil {
 		test.Errorf("Cannot create CSR: %v", err)
 		return
@@ -389,7 +389,7 @@ func TestGenerateCSRWithMultipleHostname(test *testing.T) {
 	}
 	ztsDomains := []string{"athenz1.cloud"}
 	ztsDomains = append(ztsDomains, "athenz2.cloud")
-	csr, err := GenerateSvcCertCSR(key, "US", "", "domain", "service", "domain.service", "", "Athenz", ztsDomains, true)
+	csr, err := GenerateSvcCertCSR(key, "US", "", "domain", "service", "domain.service", "", "Athenz", ztsDomains, true, false)
 	if err != nil {
 		test.Errorf("Cannot create CSR: %v", err)
 		return

--- a/provider/azure/sia-vm/authn.go
+++ b/provider/azure/sia-vm/authn.go
@@ -84,7 +84,7 @@ func GetRoleCertificate(ztsUrl, svcKeyFile, svcCertFile string, opts *options.Op
 	var roleRequest = new(zts.RoleCertificateRequest)
 	for roleName, role := range opts.Roles {
 		certFilePem := util.GetRoleCertFileName(mkDirPath(opts.CertDir), role.Filename, roleName)
-		csr, err := util.GenerateRoleCertCSR(key, opts.CountryName, "", opts.Domain, opts.Services[0].Name, roleName, opts.Services[0].Name, provider, opts.ZTSAzureDomains[0])
+		csr, err := util.GenerateRoleCertCSR(key, opts.CountryName, "", opts.Domain, opts.Services[0].Name, roleName, opts.Services[0].Name, provider, opts.ZTSAzureDomains[0], false)
 		if err != nil {
 			logutil.LogInfo(sysLogger, "unable to generate CSR for %s, err: %v\n", roleName, err)
 			failures += 1
@@ -145,7 +145,7 @@ func registerSvc(svc options.Service, data *attestation.Data, ztsUrl string, ide
 
 	provider := getProviderName(opts.Provider, identityDocument.Location)
 	commonName := fmt.Sprintf("%s.%s", opts.Domain, svc.Name)
-	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard, false)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func refreshSvc(svc options.Service, data *attestation.Data, ztsUrl string, iden
 	}
 	provider := getProviderName(opts.Provider, identityDocument.Location)
 	commonName := fmt.Sprintf("%s.%s", opts.Domain, svc.Name)
-	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard, false)
 	if err != nil {
 		logutil.LogInfo(sysLogger, "Unable to generate CSR for %s, err: %v\n", opts.Name, err)
 		return err


### PR DESCRIPTION
if enabled:
a) service cert - include instanceid-id.instanceid.aws-dns-zone value in the sanDNS entry (replaced by athenz://instanceid/provider/instance-id value
b) role cert - include domain.service@aws-dns-zone email (replaced by athenz://principal/domain.service)

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>