### PR TITLE
migrate from logutil to std log package

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/libs/go/sia/access/tokens/tokens_test.go
+++ b/libs/go/sia/access/tokens/tokens_test.go
@@ -88,7 +88,7 @@ func TestToBeRefreshed(t *testing.T) {
 	require.Nilf(t, err, "should be able to create a temp directory")
 	//defer os.RemoveAll(tokenDir)
 
-	log.Printf("temp dir: %s", tokenDir)
+	log.Printf("temp dir: %s\n", tokenDir)
 	domain := "athenz.examples"
 	service := "httpd"
 
@@ -136,36 +136,36 @@ func TestToBeRefreshed(t *testing.T) {
 	require.Nilf(t, err, fmt.Sprintf("should be able to create directory: %s", domainDir))
 
 	tpath := filepath.Join(tokenDir, domain, "reader")
-	log.Printf("Creating a token at: %s", tpath)
+	log.Printf("Creating a token at: %s\n", tpath)
 	err = ioutil.WriteFile(tpath, token(3600), 0400)
 	require.Nilf(t, err, fmt.Sprintf("should be able to create token: %s", tpath))
 
 	tpath = filepath.Join(tokenDir, domain, "reader-aged")
-	log.Printf("Creating a token at: %s", tpath)
+	log.Printf("Creating a token at: %s\n", tpath)
 	err = ioutil.WriteFile(tpath, token(3600), 0400)
 	require.Nilf(t, err, fmt.Sprintf("should be able to create token: %s", tpath))
 	err = os.Chtimes(tpath, time.Now(), time.Now().Add(-time.Minute*90))
 
 	tpath = filepath.Join(tokenDir, domain, "reader-fail1")
-	log.Printf("Creating a token at: %s", tpath)
+	log.Printf("Creating a token at: %s\n", tpath)
 	err = ioutil.WriteFile(tpath, []byte("{}"), 0000)
 	require.Nilf(t, err, fmt.Sprintf("should be able to create token: %s", tpath))
 
 	tpath = filepath.Join(tokenDir, domain, "reader-fail2")
-	log.Printf("Creating a token at: %s", tpath)
+	log.Printf("Creating a token at: %s\n", tpath)
 	err = ioutil.WriteFile(tpath, []byte("asdf"), 0400)
 	require.Nilf(t, err, fmt.Sprintf("should be able to create token: %s", tpath))
 
 	tpath = filepath.Join(tokenDir, domain, "reader-fail3")
-	log.Printf("Creating a token at: %s", tpath)
+	log.Printf("Creating a token at: %s\n", tpath)
 	err = ioutil.WriteFile(tpath, []byte(fmt.Sprintf("{%q: %q, %q: %q}", "access_token", "signed-string", "token_type", "Bearer")), 0400)
 	require.Nilf(t, err, fmt.Sprintf("should be able to create token: %s", tpath))
 
 	toRefresh, errors := ToBeRefreshed(tokenDir, tokens)
 	assert.True(t, len(errors) == 3, fmt.Sprintf("there shoud be errors in fetching ToBeRefreshed tokend, err: %v", err))
-	log.Printf("errors so far: %+v", errors)
+	log.Printf("errors so far: %+v\n", errors)
 
-	log.Printf("toRefresh: %#v", toRefresh)
+	log.Printf("toRefresh: %#v\n", toRefresh)
 	assert.NotNil(t, toRefresh, "list of tokens to be refreshed should not be empty")
 	assert.True(t, len(toRefresh) == 2, "there should be one token to be refreshed")
 	assert.Equalf(t, toRefresh[0].FileName, "writer", fmt.Sprintf("first item: %+v should be %q", toRefresh[0], "writer"))
@@ -211,7 +211,7 @@ func TestAccessTokensSuccess(t *testing.T) {
 
 	// Mock Access Tokens
 	ztsRouter.POST("/zts/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /zts/v1/instance")
+		log.Println("Called /zts/v1/instance")
 		io.WriteString(w, makeAccessToken(r, eckey))
 	})
 
@@ -235,7 +235,7 @@ func TestAccessTokensSuccess(t *testing.T) {
 		ZtsUrl: ztsServer.baseUrl("zts/v1"),
 	}
 
-	log.Printf("Options fed are: %+v", opts)
+	log.Printf("Options fed are: %+v\n", opts)
 
 	makeSiaDirs(t, opts)
 	makeIdentity(t, opts)
@@ -258,7 +258,7 @@ func TestAccessTokensSuccess(t *testing.T) {
 
 	errs = Fetch(opts)
 	assert.Lenf(t, errs, 1, "should be one error related to token1, errs: %v", err)
-	log.Printf("errors; %+v", errs)
+	log.Printf("errors; %+v\n", errs)
 }
 
 // TestAccessTokensRerun verifies that access tokens are being fetched
@@ -273,7 +273,7 @@ func TestAccessTokensRerun(t *testing.T) {
 
 	// Mock Access Tokens
 	ztsRouter.POST("/zts/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /zts/v1/instance")
+		log.Println("Called /zts/v1/instance")
 		io.WriteString(w, makeAccessToken(r, eckey))
 	})
 
@@ -293,7 +293,7 @@ func TestAccessTokensRerun(t *testing.T) {
 		ZtsUrl: ztsServer.baseUrl("zts/v1"),
 	}
 
-	log.Printf("Options fed are: %+v", opts)
+	log.Printf("Options fed are: %+v\n", opts)
 
 	makeSiaDirs(t, opts)
 	makeIdentity(t, opts)
@@ -350,7 +350,7 @@ func TestAccessTokensUserAgent(t *testing.T) {
 
 	// Mock Access Tokens
 	ztsRouter.POST("/zts/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /zts/v1/instance")
+		log.Println("Called /zts/v1/instance")
 		if r.Header.Get(USER_AGENT) != userAgent {
 			panic("User-Agent is not set")
 		}
@@ -374,7 +374,7 @@ func TestAccessTokensUserAgent(t *testing.T) {
 		UserAgent: userAgent,
 	}
 
-	log.Printf("Options fed are: %+v", opts)
+	log.Printf("Options fed are: %+v\n", opts)
 
 	makeSiaDirs(t, opts)
 	makeIdentity(t, opts)
@@ -397,7 +397,7 @@ func TestAccessTokensMixedTokenErrors(t *testing.T) {
 
 	// Mock Access Tokens
 	ztsRouter.POST("/zts/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /zts/v1/instance")
+		log.Println("Called /zts/v1/instance")
 		io.WriteString(w, makeAccessToken(r, eckey))
 	})
 
@@ -418,7 +418,7 @@ func TestAccessTokensMixedTokenErrors(t *testing.T) {
 		ZtsUrl: ztsServer.baseUrl("zts/v1"),
 	}
 
-	log.Printf("Options fed are: %+v", opts)
+	log.Printf("Options fed are: %+v\n", opts)
 
 	makeSiaDirs(t, opts)
 	makeIdentity(t, opts)
@@ -440,7 +440,7 @@ func TestAccessTokensMixedTokenErrors(t *testing.T) {
 
 	errs = Fetch(opts)
 	assert.Lenf(t, errs, 1, "should be one error related to token2, err: %v", errs)
-	log.Printf("tokens error: %v", errs)
+	log.Printf("tokens error: %v\n", errs)
 
 	// Make sure token1 is updated
 	tpath = filepath.Join(opts.TokenDir, "athenz.demo", "token1")
@@ -462,7 +462,7 @@ func TestAccessTokensApiErrors(t *testing.T) {
 	// Mock Access Tokens
 	c := 0
 	ztsRouter.POST("/zts/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /zts/v1/token")
+		log.Println("Called /zts/v1/token")
 		// Success the first time, api error second time, json error the third time
 		switch c {
 		case 0:
@@ -493,7 +493,7 @@ func TestAccessTokensApiErrors(t *testing.T) {
 		ZtsUrl: ztsServer.baseUrl("zts/v1"),
 	}
 
-	log.Printf("Options fed are: %+v", opts)
+	log.Printf("Options fed are: %+v\n", opts)
 
 	makeSiaDirs(t, opts)
 	makeIdentity(t, opts)
@@ -512,7 +512,7 @@ func TestAccessTokensApiErrors(t *testing.T) {
 
 	errs = Fetch(opts)
 	assert.Lenf(t, errs, 1, "should be one error related to token1, err: %v", errs)
-	log.Printf("tokens error: %v", err)
+	log.Printf("tokens error: %v\n", err)
 
 	// Make sure token1 is not updated, since ZTS is giving an api error
 	after, err := os.Stat(tpath)
@@ -522,7 +522,7 @@ func TestAccessTokensApiErrors(t *testing.T) {
 	// Handling ZTS returning bad content
 	errs = Fetch(opts)
 	assert.Lenf(t, errs, 1, "should be one error related to token1, err: %v", errs)
-	log.Printf("tokens error: %v", err)
+	log.Printf("tokens error: %v\n", err)
 
 	// Make sure token1 is not updated, since ZTS is giving an api error
 	after, err = os.Stat(tpath)
@@ -554,14 +554,14 @@ func TestAccessTokensBadCerts(t *testing.T) {
 		ZtsUrl: "http://testurl.invalid",
 	}
 
-	log.Printf("Options fed are: %+v", opts)
+	log.Printf("Options fed are: %+v\n", opts)
 
 	makeSiaDirs(t, opts)
 
 	// Fetch Tokens should return errors, since identity svc certs are not present
 	errs := Fetch(opts)
 	assert.Lenf(t, errs, 3, "there should be 2 errors, errs: %+v", errs)
-	log.Printf("Errors: %+v", errs)
+	log.Printf("Errors: %+v\n", errs)
 }
 
 func token(expiry int) []byte {
@@ -585,7 +585,7 @@ func makeSiaDirs(t *testing.T, opts *config.TokenOptions) {
 	dirs = append(dirs, TokenDirs(opts.TokenDir, opts.Tokens)...)
 	for _, d := range dirs {
 		if e := os.MkdirAll(d, 0755); e != nil {
-			log.Printf("unable to create folder: %s, err: %v", d, e)
+			log.Printf("unable to create folder: %s, err: %v\n", d, e)
 			t.FailNow()
 		}
 	}
@@ -631,13 +631,13 @@ func makeAccessToken(r *http.Request, key crypto.PrivateKey) string {
 		panic(err)
 	}
 
-	log.Printf("Body: %q", string(body))
+	log.Printf("Body: %q\n", string(body))
 	values, err := url.ParseQuery(string(body))
 	if err != nil {
 		panic(err)
 	}
 
-	log.Printf("Scopes: %+v", values.Get("scope"))
+	log.Printf("Scopes: %+v\n", values.Get("scope"))
 	audience, roles := audScopes(values.Get("scope"))
 
 	expiry, err := strconv.Atoi(values.Get("expires_in"))

--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -48,14 +48,12 @@ func TestMain(m *testing.M) {
 
 func TestUpdateFileNew(test *testing.T) {
 
-	sysLogger := os.Stdout
-
 	//make sure our temp file does not exist
 	timeNano := time.Now().UnixNano()
 	fileName := fmt.Sprintf("sia-test.tmp%d", timeNano)
 	_ = os.Remove(fileName)
 	testContents := "sia-unit-test"
-	err := util.UpdateFile(fileName, []byte(testContents), 0, 0, 0644, sysLogger)
+	err := util.UpdateFile(fileName, []byte(testContents), 0, 0, 0644)
 	if err != nil {
 		test.Errorf("Cannot create new file: %v", err)
 		return
@@ -76,8 +74,6 @@ func TestUpdateFileNew(test *testing.T) {
 
 func TestUpdateFileExisting(test *testing.T) {
 
-	sysLogger := os.Stdout
-
 	//create our temporary file
 	timeNano := time.Now().UnixNano()
 	fileName := fmt.Sprintf("sia-test.tmp%d", timeNano)
@@ -88,7 +84,7 @@ func TestUpdateFileExisting(test *testing.T) {
 		return
 	}
 	testNewContents := "sia-unit"
-	err = util.UpdateFile(fileName, []byte(testNewContents), 0, 0, 0644, sysLogger)
+	err = util.UpdateFile(fileName, []byte(testNewContents), 0, 0, 0644)
 	if err != nil {
 		test.Errorf("Cannot create new file: %v", err)
 		return
@@ -139,7 +135,7 @@ func TestRegisterInstance(test *testing.T) {
 		Role: "athenz.hockey",
 	}
 
-	err = RegisterInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5081/zts/v1", opts, false, os.Stdout)
+	err = RegisterInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5081/zts/v1", opts, false)
 	assert.Nil(test, err, "unable to register instance")
 
 	if err != nil {
@@ -214,7 +210,7 @@ func TestRefreshInstance(test *testing.T) {
 		Role: "athenz.hockey",
 	}
 
-	err = RefreshInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5081/zts/v1", opts, os.Stdout)
+	err = RefreshInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5081/zts/v1", opts)
 	assert.Nil(test, err, fmt.Sprintf("unable to refresh instance: %v", err))
 
 	oldCert, _ := ioutil.ReadFile("devel/data/cert.pem")
@@ -271,7 +267,7 @@ func TestRoleCertificateRequest(test *testing.T) {
 		Provider:         "athenz.aws.us-west-2",
 	}
 
-	result := GetRoleCertificate("http://127.0.0.1:5081/zts/v1", keyFile, certFile, opts, os.Stdout)
+	result := GetRoleCertificate("http://127.0.0.1:5081/zts/v1", keyFile, certFile, opts)
 	if !result {
 		test.Errorf("Unable to get role certificate: %v", err)
 		return
@@ -293,16 +289,15 @@ func TestShouldSkipRegister(test *testing.T) {
 		test.Errorf("Current time is considered expired incorrectly")
 	}
 	//generate time stamp 29 mins ago - valid
-	startTime = time.Now().Add(time.Minute*29*-1)
+	startTime = time.Now().Add(time.Minute * 29 * -1)
 	opts.EC2StartTime = &startTime
 	if shouldSkipRegister(opts) {
 		test.Errorf("29 mins ago time is considered expired incorrectly")
 	}
 	//generate time stamp 31 mins ago - expired
-	startTime = time.Now().Add(time.Minute*31*-1)
+	startTime = time.Now().Add(time.Minute * 31 * -1)
 	opts.EC2StartTime = &startTime
 	if !shouldSkipRegister(opts) {
 		test.Errorf("31 mins ago time is considered not expired incorrectly")
 	}
 }
-

--- a/libs/go/sia/aws/agent/devel/ztsmock/zts.go
+++ b/libs/go/sia/aws/agent/devel/ztsmock/zts.go
@@ -44,7 +44,7 @@ func SetupCA() (string, string) {
 
 	key, err := generateKeyPair()
 	if err != nil {
-		log.Fatalf("Cannot generate private key: %v", err)
+		log.Fatalf("Cannot generate private key: %v\n", err)
 	}
 
 	//create self-signed cert
@@ -56,7 +56,7 @@ func SetupCA() (string, string) {
 	name := "Troy CA"
 	certPem, err := createCACert(key, country, locality, province, org, unit, name, nil, nil)
 	if err != nil {
-		log.Fatalf("Cannot create CA Cert: %v", err)
+		log.Fatalf("Cannot create CA Cert: %v\n", err)
 	}
 
 	return privatePem(key), certPem
@@ -66,33 +66,33 @@ func StartZtsServer(endPoint string) {
 	router := mux.NewRouter()
 
 	router.HandleFunc("/zts/v1/instance", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("/instance is called")
+		log.Println("/instance is called")
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Fatalf("Could not read the body")
+			log.Fatalln("Could not read the body")
 		}
 
 		var data *zts.InstanceRegisterInformation
 		err = json.Unmarshal(body, &data)
 		if err != nil {
-			log.Fatalf("Could not parse the body into zts.InstanceRegisterInformation")
+			log.Fatalln("Could not parse the body into zts.InstanceRegisterInformation")
 		}
 
 		caKey, err := privateKeyFromPem(caKeyStr)
 		if err != nil {
-			log.Fatalf("Could not generate caKey from string")
+			log.Fatalln("Could not generate caKey from string")
 		}
 
 		caCert, err := certFromPEM(caCertStr)
 		if err != nil {
-			log.Fatalf("Could not generate caCert from string")
+			log.Fatalln("Could not generate caCert from string")
 		}
 
 		service := fmt.Sprintf("%s.%s", data.Domain, data.Service)
 		cert, err := generateCertInMemory(data.Csr, caKey, caCert, service)
 		if err != nil {
-			log.Fatalf("Could not generate cert in memory: %v", err)
+			log.Fatalf("Could not generate cert in memory: %v\n", err)
 		}
 
 		identity := &zts.InstanceIdentity{
@@ -106,36 +106,36 @@ func StartZtsServer(endPoint string) {
 		if err == nil {
 			w.WriteHeader(201)
 			io.WriteString(w, string(identityBytes))
-			log.Printf("Successfully processed register instance request")
+			log.Println("Successfully processed register instance request")
 		}
 	}).Methods("POST")
 
 	router.HandleFunc("/zts/v1/instance/athenz.aws.us-west-2/athenz/hockey/pod-1234", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("instance refresh handler called")
+		log.Println("instance refresh handler called")
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Fatalf("Could not read the body")
+			log.Fatalln("Could not read the body")
 		}
 		var data *zts.InstanceRefreshInformation
 		err = json.Unmarshal(body, &data)
 		if err != nil {
-			log.Fatalf("Could not parse the body into zts.InstanceRefreshInformation")
+			log.Fatalln("Could not parse the body into zts.InstanceRefreshInformation")
 		}
 
 		caKey, err := privateKeyFromPem(caKeyStr)
 		if err != nil {
-			log.Fatalf("Could not generate caKey from string")
+			log.Fatalln("Could not generate caKey from string")
 		}
 
 		caCert, err := certFromPEM(caCertStr)
 		if err != nil {
-			log.Fatalf("Could not generate caCert from string")
+			log.Fatalln("Could not generate caCert from string")
 		}
 
 		cert, err := generateCertInMemory(data.Csr, caKey, caCert, "athenz.hockey")
 		if err != nil {
-			log.Fatalf("Could not generate cert in memory: %v", err)
+			log.Fatalf("Could not generate cert in memory: %v\n", err)
 		}
 
 		identity := &zts.InstanceIdentity{
@@ -148,36 +148,36 @@ func StartZtsServer(endPoint string) {
 		identityBytes, err := json.Marshal(identity)
 		if err == nil {
 			io.WriteString(w, string(identityBytes))
-			log.Printf("Successfully processed refresh instance request")
+			log.Println("Successfully processed refresh instance request")
 		}
 	}).Methods("POST")
 
 	router.HandleFunc("/zts/v1/rolecert", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("role certificate handler called")
+		log.Println("role certificate handler called")
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Fatalf("Could not read the body")
+			log.Fatalln("Could not read the body")
 		}
 		var data *zts.RoleCertificateRequest
 		err = json.Unmarshal(body, &data)
 		if err != nil {
-			log.Fatalf("Could not parse the body into zts.RoleCertificateRequest")
+			log.Fatalln("Could not parse the body into zts.RoleCertificateRequest")
 		}
 
 		caKey, err := privateKeyFromPem(caKeyStr)
 		if err != nil {
-			log.Fatalf("Could not generate caKey from string")
+			log.Fatalln("Could not generate caKey from string")
 		}
 
 		caCert, err := certFromPEM(caCertStr)
 		if err != nil {
-			log.Fatalf("Could not generate caCert from string")
+			log.Fatalln("Could not generate caCert from string")
 		}
 
 		cert, err := generateCertInMemory(data.Csr, caKey, caCert, "athenz:role.writers")
 		if err != nil {
-			log.Fatalf("Could not generate cert in memory: %v", err)
+			log.Fatalf("Could not generate cert in memory: %v\n", err)
 		}
 
 		identity := &zts.RoleCertificate{
@@ -186,7 +186,7 @@ func StartZtsServer(endPoint string) {
 		identityBytes, err := json.Marshal(identity)
 		if err == nil {
 			io.WriteString(w, string(identityBytes))
-			log.Printf("Successfully processed role certificate request")
+			log.Println("Successfully processed role certificate request")
 		}
 	}).Methods("POST")
 

--- a/libs/go/sia/aws/lambda/lambda.go
+++ b/libs/go/sia/aws/lambda/lambda.go
@@ -89,7 +89,7 @@ func GetAWSLambdaServiceCertificate(ztsUrl, provider, domain, service, account s
 		return tls.Certificate{}, err
 	}
 
-	client, err := util.ZtsClient(ztsUrl, "", "", "", "", nil)
+	client, err := util.ZtsClient(ztsUrl, "", "", "", "")
 	if err != nil {
 		return tls.Certificate{}, err
 	}

--- a/libs/go/sia/aws/meta/meta.go
+++ b/libs/go/sia/aws/meta/meta.go
@@ -18,9 +18,8 @@ package meta
 import (
 	"fmt"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/doc"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
-	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"time"
@@ -50,19 +49,19 @@ func GetData(base, path string) ([]byte, error) {
 }
 
 // GetRegion get current region from identity document
-func GetRegion(metaEndPoint string, sysLogger io.Writer) string {
+func GetRegion(metaEndPoint string) string {
 	var region string
 	document, err := GetData(metaEndPoint, "/latest/dynamic/instance-identity/document")
 	if err == nil {
-		logutil.LogInfo(sysLogger, "Trying to determine region from identity document ...\n")
+		log.Println("Trying to determine region from identity document ...")
 		region, _ = doc.GetDocumentEntry(document, "region")
 	}
 	if region == "" {
-		logutil.LogInfo(sysLogger, "Trying to determine region from AWS_REGION environment variable...\n")
+		log.Println("Trying to determine region from AWS_REGION environment variable...")
 		region = os.Getenv("AWS_REGION")
 	}
 	if region == "" {
-		logutil.LogInfo(sysLogger, "No region information available. Defaulting to us-west-2\n")
+		log.Println("No region information available. Defaulting to us-west-2")
 		region = "us-west-2"
 	}
 	return region

--- a/libs/go/sia/aws/meta/meta_test.go
+++ b/libs/go/sia/aws/meta/meta_test.go
@@ -58,12 +58,12 @@ func TestGetMetadata(test *testing.T) {
 	// Mock the metadata endpoints
 	router := httptreemux.New()
 	router.GET("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /latest/dynamic/instance-identity/document")
+		log.Println("Called /latest/dynamic/instance-identity/document")
 		io.WriteString(w, "{ \"test\": \"document\" }")
 	})
 
 	router.GET("/latest/dynamic/instance-identity/pkcs7", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /latest/dynamic/instance-identity/pkcs7")
+		log.Println("Called /latest/dynamic/instance-identity/pkcs7")
 		io.WriteString(w, "{ \"test\": \"pkcs7\"}")
 	})
 
@@ -88,7 +88,7 @@ func TestGetRegionFromDoc(test *testing.T) {
 	// Mock the metadata endpoints
 	router := httptreemux.New()
 	router.GET("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /latest/dynamic/instance-identity/document")
+		log.Println("Called /latest/dynamic/instance-identity/document")
 		io.WriteString(w, "{ \"test\": \"document\", \"region\": \"us-west-1\"}")
 	})
 
@@ -96,7 +96,7 @@ func TestGetRegionFromDoc(test *testing.T) {
 	metaServer.start(router)
 	defer metaServer.stop()
 
-	region := GetRegion(metaServer.httpUrl(), os.Stdout)
+	region := GetRegion(metaServer.httpUrl())
 	if region != "us-west-1" {
 		test.Errorf("Unable to expected region: %s", region)
 	}
@@ -108,7 +108,7 @@ func TestGetRegionFromEnv(test *testing.T) {
 	// Mock the metadata endpoints
 	router := httptreemux.New()
 	router.GET("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /latest/dynamic/instance-identity/document")
+		log.Println("Called /latest/dynamic/instance-identity/document")
 		io.WriteString(w, "{ \"test\": \"document\"}")
 	})
 
@@ -116,14 +116,14 @@ func TestGetRegionFromEnv(test *testing.T) {
 	metaServer.start(router)
 	defer metaServer.stop()
 
-	region := GetRegion(metaServer.httpUrl(), os.Stdout)
+	region := GetRegion(metaServer.httpUrl())
 	if region != "us-east-1" {
 		test.Errorf("Unable to expected region: %s", region)
 	}
 	os.Setenv("AWS_REGION", "")
 
 	//without doc/env we should default to us-west-2
-	region = GetRegion(metaServer.httpUrl(), os.Stdout)
+	region = GetRegion(metaServer.httpUrl())
 	if region != "us-west-2" {
 		test.Errorf("Unable to expected region: %s", region)
 	}

--- a/libs/go/sia/aws/sds/handler.go
+++ b/libs/go/sia/aws/sds/handler.go
@@ -148,7 +148,7 @@ func (handler *ServerHandler) DeltaSecrets(envoySecret.SecretDiscoveryService_De
 func (handler *ServerHandler) FetchSecrets(ctx context.Context, req *envoyDiscovery.DiscoveryRequest) (*envoyDiscovery.DiscoveryResponse, error) {
 
 	clientInfo := ClientInfoFromContext(ctx)
-	log.Printf("FetchSecrets: client info - %v\n", clientInfo)
+	log.Printf("FetchSecrets: client info: %v\n", clientInfo)
 
 	resp, err := handler.getFetchResponse(clientInfo, req)
 	if err != nil {
@@ -230,7 +230,7 @@ func (handler *ServerHandler) getResponse(req *envoyDiscovery.DiscoveryRequest, 
 		} else {
 			domain, service := util.ParseServiceSpiffeUri(spiffeUri)
 			if domain == "" || service == "" {
-				log.Printf("Response: %s: unable to parse spiffe uri: %s", subId, spiffeUri)
+				log.Printf("Response: %s: unable to parse spiffe uri: %s\n", subId, spiffeUri)
 				continue
 			}
 			// authenticate the request

--- a/libs/go/sia/aws/sds/sds.go
+++ b/libs/go/sia/aws/sds/sds.go
@@ -50,7 +50,7 @@ func StartGrpcServer(opts *options.Options, certUpdates chan bool) error {
 
 	select {
 	case err = <-errChan:
-		log.Printf("Stopping GRPC SDS server...")
+		log.Println("Stopping GRPC SDS server...")
 		grpcServer.Stop()
 		if _, err := os.Stat(opts.SDSUdsPath); err == nil {
 			os.Remove(opts.SDSUdsPath)

--- a/libs/go/sia/aws/sds/uds.go
+++ b/libs/go/sia/aws/sds/uds.go
@@ -18,8 +18,8 @@ package sds
 
 import (
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/athenz-common/log"
 	"inet.af/peercred"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -102,7 +102,7 @@ func getUdsUserDetails(connection net.Conn) ClientInfo {
 	}
 	userId, ok := credentials.UserID()
 	if !ok {
-		log.Printf("unable to obtain connection user id\n")
+		log.Println("unable to obtain connection user id")
 	} else {
 		uid, err := strconv.Atoi(userId)
 		if err != nil {
@@ -113,7 +113,7 @@ func getUdsUserDetails(connection net.Conn) ClientInfo {
 	}
 	clientInfo.PID, ok = credentials.PID()
 	if !ok {
-		log.Printf("unable to obtain connection pid\n")
+		log.Println("unable to obtain connection pid")
 	}
 	return clientInfo
 }

--- a/libs/go/sia/aws/stssession/stssession.go
+++ b/libs/go/sia/aws/stssession/stssession.go
@@ -18,18 +18,17 @@ package stssession
 
 import (
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"io"
+	"log"
 )
 
-func New(useRegionalSTS bool, region string, sysLogger io.Writer) (*session.Session, error) {
+func New(useRegionalSTS bool, region string) (*session.Session, error) {
 	if useRegionalSTS {
 		stsUrl := "sts." + region + ".amazonaws.com"
-		logutil.LogInfo(sysLogger, "Creating session to regional STS endpoint: %s\n", stsUrl)
+		log.Printf("Creating session to regional STS endpoint: %s\n", stsUrl)
 		return session.NewSessionWithOptions(session.Options{
 			Config: aws.Config{
 				Endpoint: aws.String(stsUrl),
@@ -37,13 +36,13 @@ func New(useRegionalSTS bool, region string, sysLogger io.Writer) (*session.Sess
 			},
 		})
 	} else {
-		logutil.LogInfo(sysLogger, "Creating session to global STS endpoint\n")
+		log.Print("Creating session to global STS endpoint\n")
 		return session.NewSession()
 	}
 }
 
-func GetMetaDetailsFromCreds(serviceSuffix string, useRegionalSTS bool, region string, sysLogger io.Writer) (string, string, string, error) {
-	stsSession, err := New(useRegionalSTS, region, sysLogger)
+func GetMetaDetailsFromCreds(serviceSuffix string, useRegionalSTS bool, region string) (string, string, string, error) {
+	stsSession, err := New(useRegionalSTS, region)
 	if err != nil {
 		return "", "", "", fmt.Errorf("unable to create new session: %v", err)
 	}

--- a/libs/go/sia/file/file.go
+++ b/libs/go/sia/file/file.go
@@ -35,7 +35,7 @@ func Update(fileName string, contents []byte, uid, gid int, perm os.FileMode, vf
 			}
 		} else {
 			// Unknown stat error
-			log.Printf("Unable to stat file: %q", fileName)
+			log.Printf("Unable to stat file: %q\n", fileName)
 			return err
 		}
 	} else {
@@ -66,7 +66,7 @@ func Update(fileName string, contents []byte, uid, gid int, perm os.FileMode, vf
 			return err
 		}
 	} else {
-		log.Printf("Not changing the file ownership, file: %q, uid: %d, gid: %d", fileName, uid, gid)
+		log.Printf("Not changing the file ownership, file: %q, uid: %d, gid: %d\n", fileName, uid, gid)
 	}
 	return nil
 }
@@ -87,7 +87,7 @@ func overrideFile(fileName string, err error, contents []byte, perm os.FileMode,
 	if vfn != nil {
 		err = vfn(fileName, newFileName)
 		if err != nil {
-			log.Printf("invalid content: %q, error: %v", newFileName, err)
+			log.Printf("invalid content: %q, error: %v\n", newFileName, err)
 			return err
 		}
 	}
@@ -119,12 +119,12 @@ func Copy(sourceFile, destFile string, perm os.FileMode) error {
 	if Exists(sourceFile) {
 		sourceBytes, err := ioutil.ReadFile(sourceFile)
 		if err != nil {
-			log.Printf("unable to read file %s", sourceFile)
+			log.Printf("unable to read file %s\n", sourceFile)
 			return err
 		}
 		err = ioutil.WriteFile(destFile, sourceBytes, perm)
 		if err != nil {
-			log.Printf("unable to write to file %s", destFile)
+			log.Printf("unable to write to file %s\n", destFile)
 			return err
 		}
 	}
@@ -156,11 +156,11 @@ func WriteFile(content interface{}, ipFile string) error {
 	if err == nil {
 		err = ioutil.WriteFile(ipFile, file, 0644)
 		if err != nil {
-			log.Printf("Failed to write file, Error: %v", err)
+			log.Printf("Failed to write file, Error: %v\n", err)
 			return err
 		}
 	} else {
-		log.Printf("Failed marshal struct, Error: %v", err)
+		log.Printf("Failed marshal struct, Error: %v\n", err)
 		return err
 	}
 	return nil
@@ -170,13 +170,13 @@ func ReadFile(filePath string, value interface{}) error {
 
 	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		log.Printf("Failed to read file: %v", err)
+		log.Printf("Failed to read file: %v\n", err)
 		return err
 	}
 
 	err = json.Unmarshal(file, value)
 	if err != nil {
-		log.Printf("Failed to unmarshal file: %v", err)
+		log.Printf("Failed to unmarshal file: %v\n", err)
 		return err
 	}
 	return nil

--- a/libs/go/sia/util/os_util_darwin.go
+++ b/libs/go/sia/util/os_util_darwin.go
@@ -2,9 +2,9 @@ package util
 
 import (
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"io"
 	"io/ioutil"
+	"log"
 	"log/syslog"
 	"os"
 	"os/exec"
@@ -20,11 +20,11 @@ func NewSysLogger() (io.Writer, error) {
 	return syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
 }
 
-func UpdateFile(fileName string, contents []byte, uid, gid int, perm os.FileMode, sysLogger io.Writer) error {
+func UpdateFile(fileName string, contents []byte, uid, gid int, perm os.FileMode) error {
 	// verify we have valid contents otherwise we're just
 	// going to skip and return success without doing anything
 	if len(contents) == 0 {
-		logutil.LogInfo(sysLogger, "Contents is empty. Skipping writing to file %s\n", fileName)
+		log.Printf("Contents is empty. Skipping writing to file %s\n", fileName)
 		return nil
 	}
 	// if the original file does not exists then we
@@ -32,69 +32,69 @@ func UpdateFile(fileName string, contents []byte, uid, gid int, perm os.FileMode
 	// directly
 	_, err := os.Stat(fileName)
 	if err != nil && os.IsNotExist(err) {
-		logutil.LogInfo(sysLogger, "Updating file %s...\n", fileName)
+		log.Printf("Updating file %s...\n", fileName)
 		err = ioutil.WriteFile(fileName, contents, perm)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to write new file %s, err: %v\n", fileName, err)
+			log.Printf("Unable to write new file %s, err: %v\n", fileName, err)
 			return err
 		}
 	} else {
 		timeNano := time.Now().UnixNano()
 		// write the new contents to a temporary file
 		newFileName := fmt.Sprintf("%s.tmp%d", fileName, timeNano)
-		logutil.LogInfo(sysLogger, "Writing contents to temporary file %s...\n", newFileName)
+		log.Printf("Writing contents to temporary file %s...\n", newFileName)
 		err = ioutil.WriteFile(newFileName, contents, perm)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to write new file %s, err: %v\n", newFileName, err)
+			log.Printf("Unable to write new file %s, err: %v\n", newFileName, err)
 			return err
 		}
 		// move the contents of the old file to a backup file
 		bakFileName := fmt.Sprintf("%s.bak%d", fileName, timeNano)
-		logutil.LogInfo(sysLogger, "Renaming original file %s to backup file %s...\n", fileName, bakFileName)
+		log.Printf("Renaming original file %s to backup file %s...\n", fileName, bakFileName)
 		err = os.Rename(fileName, bakFileName)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to rename file %s to %s, err: %v\n", fileName, bakFileName, err)
+			log.Printf("Unable to rename file %s to %s, err: %v\n", fileName, bakFileName, err)
 			return err
 		}
 		// move the new contents to the original location
-		logutil.LogInfo(sysLogger, "Renaming temporary file %s to requested file %s...\n", newFileName, fileName)
+		log.Printf("Renaming temporary file %s to requested file %s...\n", newFileName, fileName)
 		err = os.Rename(newFileName, fileName)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to rename file %s to %s, err: %v\n", newFileName, fileName, err)
+			log.Printf("Unable to rename file %s to %s, err: %v\n", newFileName, fileName, err)
 			// before returning try to restore the original file
 			os.Rename(bakFileName, fileName)
 			return err
 		}
 		// remove the temporary backup file
-		logutil.LogInfo(sysLogger, "Removing backup file %s...\n", bakFileName)
+		log.Printf("Removing backup file %s...\n", bakFileName)
 		os.Remove(bakFileName)
 	}
 	if uid != 0 || gid != 0 {
-		logutil.LogInfo(sysLogger, "Changing file %s ownership to %d:%d...\n", fileName, uid, gid)
+		log.Printf("Changing file %s ownership to %d:%d...\n", fileName, uid, gid)
 		err = os.Chown(fileName, uid, gid)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Cannot chown file %s to %d:%d, err: %v\n", fileName, uid, gid, err)
+			log.Printf("Cannot chown file %s to %d:%d, err: %v\n", fileName, uid, gid, err)
 			return err
 		}
 	}
 	return nil
 }
 
-func SvcAttrs(username, groupname string, sysLogger io.Writer) (int, int, int) {
+func SvcAttrs(username, groupname string) (int, int, int) {
 	// Default file mode for service key
 	fileMode := 0400
 	// Get uid and gid for the username.
-	uid, gid := uidGidForUser(username, sysLogger)
+	uid, gid := uidGidForUser(username)
 
 	// Override the group id if user explicitly specified the group.
 	ggid := -1
 	if groupname != "" {
-		ggid = gidForGroup(groupname, sysLogger)
+		ggid = gidForGroup(groupname)
 	}
 	// if the group is not specified or invalid then we'll default
 	// to our unix group name called athenz
 	if ggid == -1 {
-		ggid = gidForGroup(siaUnixGroup, sysLogger)
+		ggid = gidForGroup(siaUnixGroup)
 	}
 	// if we have a valid value then update the gid
 	// otherwise use the user group id value
@@ -107,19 +107,19 @@ func SvcAttrs(username, groupname string, sysLogger io.Writer) (int, int, int) {
 	return uid, gid, fileMode
 }
 
-func UidGidForUserGroup(username, groupname string, sysLogger io.Writer) (int, int) {
+func UidGidForUserGroup(username, groupname string) (int, int) {
 	// Get uid and gid for the username.
-	uid, gid := uidGidForUser(username, sysLogger)
+	uid, gid := uidGidForUser(username)
 
 	// Override the group id if user explicitly specified the group.
 	ggid := -1
 	if groupname != "" {
-		ggid = gidForGroup(groupname, sysLogger)
+		ggid = gidForGroup(groupname)
 	}
 	// if the group is not specified or invalid then we'll default
 	// to our unix group name called athenz
 	if ggid == -1 {
-		ggid = gidForGroup(siaUnixGroup, sysLogger)
+		ggid = gidForGroup(siaUnixGroup)
 	}
 	// if we have a valid value then update the gid
 	// otherwise use the user group id value
@@ -129,56 +129,56 @@ func UidGidForUserGroup(username, groupname string, sysLogger io.Writer) (int, i
 	return uid, gid
 }
 
-func gidForGroup(groupname string, sysLogger io.Writer) int {
+func gidForGroup(groupname string) int {
 	//shelling out to id is used here because the os/user package
 	//requires cgo, which doesn't cross-compile. we can use getent group
 	//command but instead we opted for a simple grep for /etc/group
 	cmdStr := fmt.Sprintf("^%s:", groupname)
 	out, err := exec.Command("/usr/bin/grep", cmdStr, "/etc/group").Output()
 	if err != nil {
-		logutil.LogInfo(sysLogger, "Cannot exec '/usr/bin/grep %s '/etc/group': %v\n", groupname, err)
+		log.Printf("Cannot exec '/usr/bin/grep %s '/etc/group': %v\n", groupname, err)
 		return -1
 	}
 	s := strings.Trim(string(out), "\n\r ")
 	comps := strings.Split(string(out), ":")
 	if len(comps) < 3 {
-		logutil.LogInfo(sysLogger, "Invalid response from grep group command: %s\n", s)
+		log.Printf("Invalid response from grep group command: %s\n", s)
 		return -1
 	}
 	//the group id should be the third value: 'group_name:password:group_id:group_list'
 	id, err := strconv.Atoi(comps[2])
 	if err != nil {
-		logutil.LogInfo(sysLogger, "Invalid response from getent group command: %s\n", s)
+		log.Printf("Invalid response from getent group command: %s\n", s)
 		return -1
 	}
 	return id
 }
 
-func idCommand(username, arg string, sysLogger io.Writer) int {
+func idCommand(username, arg string) int {
 	//shelling out to id is used here because the os/user package
 	//requires cgo, which doesn't cross-compile
 	out, err := exec.Command("id", arg, username).Output()
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Cannot exec 'id %s %s': %v\n", arg, username, err)
+		log.Fatalf("Cannot exec 'id %s %s': %v\n", arg, username, err)
 	}
 	s := strings.Trim(string(out), "\n\r ")
 	id, err := strconv.Atoi(s)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unexpected UID/GID format in user record: %s\n", string(out))
+		log.Fatalf("Unexpected UID/GID format in user record: %s\n", string(out))
 	}
 	return id
 }
 
-func uidGidForUser(username string, sysLogger io.Writer) (int, int) {
+func uidGidForUser(username string) (int, int) {
 	if username == "" {
 		return 0, 0
 	}
-	uid := idCommand(username, "-u", sysLogger)
-	gid := idCommand(username, "-g", sysLogger)
+	uid := idCommand(username, "-u")
+	gid := idCommand(username, "-g")
 	return uid, gid
 }
 
-func SetupSIADirs(siaMainDir, siaLinkDir string, sysLogger io.Writer) error {
+func SetupSIADirs(siaMainDir, siaLinkDir string) error {
 	// Create the certs directory, if it doesn't exist
 	certDir := fmt.Sprintf("%s/certs", siaMainDir)
 	if !FileExists(certDir) {
@@ -201,7 +201,7 @@ func SetupSIADirs(siaMainDir, siaLinkDir string, sysLogger io.Writer) error {
 	if siaLinkDir != "" && !FileExists(siaLinkDir) {
 		err := os.Symlink(siaMainDir, siaLinkDir)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to symlink SIA directory '%s': %v\n", siaLinkDir, err)
+			log.Printf("Unable to symlink SIA directory '%s': %v\n", siaLinkDir, err)
 			return nil
 		}
 	}

--- a/libs/go/sia/util/os_util_linux.go
+++ b/libs/go/sia/util/os_util_linux.go
@@ -2,9 +2,9 @@ package util
 
 import (
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"io"
 	"io/ioutil"
+	"log"
 	"log/syslog"
 	"os"
 	"os/exec"
@@ -20,11 +20,11 @@ func NewSysLogger() (io.Writer, error) {
 	return syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
 }
 
-func UpdateFile(fileName string, contents []byte, uid, gid int, perm os.FileMode, sysLogger io.Writer) error {
+func UpdateFile(fileName string, contents []byte, uid, gid int, perm os.FileMode) error {
 	// verify we have valid contents otherwise we're just
 	// going to skip and return success without doing anything
 	if len(contents) == 0 {
-		logutil.LogInfo(sysLogger, "Contents is empty. Skipping writing to file %s\n", fileName)
+		log.Printf("Contents is empty. Skipping writing to file %s\n", fileName)
 		return nil
 	}
 	// if the original file does not exists then we
@@ -32,69 +32,69 @@ func UpdateFile(fileName string, contents []byte, uid, gid int, perm os.FileMode
 	// directly
 	_, err := os.Stat(fileName)
 	if err != nil && os.IsNotExist(err) {
-		logutil.LogInfo(sysLogger, "Updating file %s...\n", fileName)
+		log.Printf("Updating file %s...\n", fileName)
 		err = ioutil.WriteFile(fileName, contents, perm)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to write new file %s, err: %v\n", fileName, err)
+			log.Printf("Unable to write new file %s, err: %v\n", fileName, err)
 			return err
 		}
 	} else {
 		timeNano := time.Now().UnixNano()
 		// write the new contents to a temporary file
 		newFileName := fmt.Sprintf("%s.tmp%d", fileName, timeNano)
-		logutil.LogInfo(sysLogger, "Writing contents to temporary file %s...\n", newFileName)
+		log.Printf("Writing contents to temporary file %s...\n", newFileName)
 		err = ioutil.WriteFile(newFileName, contents, perm)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to write new file %s, err: %v\n", newFileName, err)
+			log.Printf("Unable to write new file %s, err: %v\n", newFileName, err)
 			return err
 		}
 		// move the contents of the old file to a backup file
 		bakFileName := fmt.Sprintf("%s.bak%d", fileName, timeNano)
-		logutil.LogInfo(sysLogger, "Renaming original file %s to backup file %s...\n", fileName, bakFileName)
+		log.Printf("Renaming original file %s to backup file %s...\n", fileName, bakFileName)
 		err = os.Rename(fileName, bakFileName)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to rename file %s to %s, err: %v\n", fileName, bakFileName, err)
+			log.Printf("Unable to rename file %s to %s, err: %v\n", fileName, bakFileName, err)
 			return err
 		}
 		// move the new contents to the original location
-		logutil.LogInfo(sysLogger, "Renaming temporary file %s to requested file %s...\n", newFileName, fileName)
+		log.Printf("Renaming temporary file %s to requested file %s...\n", newFileName, fileName)
 		err = os.Rename(newFileName, fileName)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to rename file %s to %s, err: %v\n", newFileName, fileName, err)
+			log.Printf("Unable to rename file %s to %s, err: %v\n", newFileName, fileName, err)
 			// before returning try to restore the original file
 			os.Rename(bakFileName, fileName)
 			return err
 		}
 		// remove the temporary backup file
-		logutil.LogInfo(sysLogger, "Removing backup file %s...\n", bakFileName)
+		log.Printf("Removing backup file %s...\n", bakFileName)
 		os.Remove(bakFileName)
 	}
 	if uid != 0 || gid != 0 {
-		logutil.LogInfo(sysLogger, "Changing file %s ownership to %d:%d...\n", fileName, uid, gid)
+		log.Printf("Changing file %s ownership to %d:%d...\n", fileName, uid, gid)
 		err = os.Chown(fileName, uid, gid)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Cannot chown file %s to %d:%d, err: %v\n", fileName, uid, gid, err)
+			log.Printf("Cannot chown file %s to %d:%d, err: %v\n", fileName, uid, gid, err)
 			return err
 		}
 	}
 	return nil
 }
 
-func SvcAttrs(username, groupname string, sysLogger io.Writer) (int, int, int) {
+func SvcAttrs(username, groupname string) (int, int, int) {
 	// Default file mode for service key
 	fileMode := 0400
 	// Get uid and gid for the username.
-	uid, gid := uidGidForUser(username, sysLogger)
+	uid, gid := uidGidForUser(username)
 
 	// Override the group id if user explicitly specified the group.
 	ggid := -1
 	if groupname != "" {
-		ggid = gidForGroup(groupname, sysLogger)
+		ggid = gidForGroup(groupname)
 	}
 	// if the group is not specified or invalid then we'll default
 	// to our unix group name called athenz
 	if ggid == -1 {
-		ggid = gidForGroup(siaUnixGroup, sysLogger)
+		ggid = gidForGroup(siaUnixGroup)
 	}
 	// if we have a valid value then update the gid
 	// otherwise use the user group id value
@@ -107,19 +107,19 @@ func SvcAttrs(username, groupname string, sysLogger io.Writer) (int, int, int) {
 	return uid, gid, fileMode
 }
 
-func UidGidForUserGroup(username, groupname string, sysLogger io.Writer) (int, int) {
+func UidGidForUserGroup(username, groupname string) (int, int) {
 	// Get uid and gid for the username.
-	uid, gid := uidGidForUser(username, sysLogger)
+	uid, gid := uidGidForUser(username)
 
 	// Override the group id if user explicitly specified the group.
 	ggid := -1
 	if groupname != "" {
-		ggid = gidForGroup(groupname, sysLogger)
+		ggid = gidForGroup(groupname)
 	}
 	// if the group is not specified or invalid then we'll default
 	// to our unix group name called athenz
 	if ggid == -1 {
-		ggid = gidForGroup(siaUnixGroup, sysLogger)
+		ggid = gidForGroup(siaUnixGroup)
 	}
 	// if we have a valid value then update the gid
 	// otherwise use the user group id value
@@ -129,57 +129,57 @@ func UidGidForUserGroup(username, groupname string, sysLogger io.Writer) (int, i
 	return uid, gid
 }
 
-func gidForGroup(groupname string, sysLogger io.Writer) int {
+func gidForGroup(groupname string) int {
 	//shelling out to id is used here because the os/user package
 	//requires cgo, which doesn't cross-compile. we can use getent group
 	//command but instead we opted for a simple grep for /etc/group
 	cmdStr := fmt.Sprintf("^%s:", groupname)
 	out, err := exec.Command("/usr/bin/grep", cmdStr, "/etc/group").Output()
 	if err != nil {
-		logutil.LogInfo(sysLogger, "Cannot exec '/usr/bin/grep %s /etc/group': %v\n", groupname, err)
+		log.Printf("Cannot exec '/usr/bin/grep %s /etc/group': %v\n", groupname, err)
 		return -1
 	}
 	s := strings.Trim(string(out), "\n\r ")
 	comps := strings.Split(string(out), ":")
 	if len(comps) < 3 {
-		logutil.LogInfo(sysLogger, "Invalid response from grep group command: %s\n", s)
+		log.Printf("Invalid response from grep group command: %s\n", s)
 		return -1
 	}
 	//the group id should be the third value: 'group_name:password:group_id:group_list'
 	id, err := strconv.Atoi(comps[2])
 	if err != nil {
-		logutil.LogInfo(sysLogger, "Invalid response from getent group command: %s\n", s)
+		log.Printf("Invalid response from getent group command: %s\n", s)
 		return -1
 	}
-	logutil.LogInfo(sysLogger, "Group %s id: %d\n", groupname, id)
+	log.Printf("Group %s id: %d\n", groupname, id)
 	return id
 }
 
-func idCommand(username, arg string, sysLogger io.Writer) int {
+func idCommand(username, arg string) int {
 	//shelling out to id is used here because the os/user package
 	//requires cgo, which doesn't cross-compile
 	out, err := exec.Command("id", arg, username).Output()
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Cannot exec 'id %s %s': %v\n", arg, username, err)
+		log.Fatalf("Cannot exec 'id %s %s': %v\n", arg, username, err)
 	}
 	s := strings.Trim(string(out), "\n\r ")
 	id, err := strconv.Atoi(s)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unexpected UID/GID format in user record: %s\n", string(out))
+		log.Fatalf("Unexpected UID/GID format in user record: %s\n", string(out))
 	}
 	return id
 }
 
-func uidGidForUser(username string, sysLogger io.Writer) (int, int) {
+func uidGidForUser(username string) (int, int) {
 	if username == "" {
 		return 0, 0
 	}
-	uid := idCommand(username, "-u", sysLogger)
-	gid := idCommand(username, "-g", sysLogger)
+	uid := idCommand(username, "-u")
+	gid := idCommand(username, "-g")
 	return uid, gid
 }
 
-func SetupSIADirs(siaMainDir, siaLinkDir string, sysLogger io.Writer) error {
+func SetupSIADirs(siaMainDir, siaLinkDir string) error {
 	// Create the certs directory, if it doesn't exist
 	certDir := fmt.Sprintf("%s/certs", siaMainDir)
 	if !FileExists(certDir) {
@@ -202,7 +202,7 @@ func SetupSIADirs(siaMainDir, siaLinkDir string, sysLogger io.Writer) error {
 	if siaLinkDir != "" && !FileExists(siaLinkDir) {
 		err := os.Symlink(siaMainDir, siaLinkDir)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to symlink SIA directory '%s': %v\n", siaLinkDir, err)
+			log.Printf("Unable to symlink SIA directory '%s': %v\n", siaLinkDir, err)
 			return nil
 		}
 	}

--- a/libs/go/sia/util/util_test.go
+++ b/libs/go/sia/util/util_test.go
@@ -126,15 +126,12 @@ func TestZtsHostName(test *testing.T) {
 }
 
 func TestUpdateFileNew(test *testing.T) {
-
-	sysLogger := os.Stdout
-
 	//make sure our temp file does not exist
 	timeNano := time.Now().UnixNano()
 	fileName := fmt.Sprintf("sia-test.tmp%d", timeNano)
 	os.Remove(fileName)
 	testContents := "sia-unit-test"
-	err := UpdateFile(fileName, []byte(testContents), 0, 0, 0644, sysLogger)
+	err := UpdateFile(fileName, []byte(testContents), 0, 0, 0644)
 	if err != nil {
 		test.Errorf("Cannot create new file: %v", err)
 		return
@@ -154,9 +151,6 @@ func TestUpdateFileNew(test *testing.T) {
 }
 
 func TestUpdateFileExisting(test *testing.T) {
-
-	sysLogger := os.Stdout
-
 	//create our temporary file
 	timeNano := time.Now().UnixNano()
 	fileName := fmt.Sprintf("sia-test.tmp%d", timeNano)
@@ -167,7 +161,7 @@ func TestUpdateFileExisting(test *testing.T) {
 		return
 	}
 	testNewContents := "sia-unit"
-	err = UpdateFile(fileName, []byte(testNewContents), 0, 0, 0644, sysLogger)
+	err = UpdateFile(fileName, []byte(testNewContents), 0, 0, 0644)
 	if err != nil {
 		test.Errorf("Cannot create new file: %v", err)
 		return
@@ -187,9 +181,6 @@ func TestUpdateFileExisting(test *testing.T) {
 }
 
 func TestPrivateKeySupport(test *testing.T) {
-
-	sysLogger := os.Stdout
-
 	key, err := GenerateKeyPair(2048)
 	if err != nil {
 		test.Errorf("Unable to generate private key pair %v", err)
@@ -199,7 +190,7 @@ func TestPrivateKeySupport(test *testing.T) {
 	fileName := fmt.Sprintf("sia-test.tmp%d", timeNano)
 	uid := localIdCommand("-u")
 	gid := localIdCommand("-g")
-	err = UpdateFile(fileName, []byte(PrivatePem(key)), uid, gid, 0644, sysLogger)
+	err = UpdateFile(fileName, []byte(PrivatePem(key)), uid, gid, 0644)
 	if err != nil {
 		test.Errorf("Unable to save private key file - %v", err)
 		return

--- a/libs/go/sia/util/util_test_darwin.go
+++ b/libs/go/sia/util/util_test_darwin.go
@@ -17,10 +17,6 @@
 package util
 
 import (
-	"io"
-	"log"
-	"log/syslog"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -28,12 +24,6 @@ import (
 )
 
 func TestGidForGroupCommand(t *testing.T) {
-	var sysLogger io.Writer
-	sysLogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-	if err != nil {
-		log.Printf("Unable to create sys logger: %v\n", err)
-		sysLogger = os.Stdout
-	}
 
 	// Get current group name.
 	grp, err := exec.Command("id", "-gn").Output()
@@ -55,7 +45,7 @@ func TestGidForGroupCommand(t *testing.T) {
 	}
 
 	// Test if function returns expected gid.
-	actualGid := gidForGroup(group, sysLogger)
+	actualGid := gidForGroup(group)
 	if actualGid != gid {
 		t.Errorf("Unexpected group id: group=%s, expected=%d, got=%d", group, gid, actualGid)
 		return
@@ -63,15 +53,9 @@ func TestGidForGroupCommand(t *testing.T) {
 }
 
 func TestGidForInvalidGroupCommand(t *testing.T) {
-	var sysLogger io.Writer
-	sysLogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-	if err != nil {
-		log.Printf("Unable to create sys logger: %v\n", err)
-		sysLogger = os.Stdout
-	}
 
 	// Test if function returns -1
-	gid := gidForGroup("invalid-group-name", sysLogger)
+	gid := gidForGroup("invalid-group-name")
 	if gid != -1 {
 		t.Errorf("Did not get expected -1 for gid, got=%d", gid)
 		return
@@ -79,12 +63,6 @@ func TestGidForInvalidGroupCommand(t *testing.T) {
 }
 
 func TestUidGidForUserGroupCommand(t *testing.T) {
-	var sysLogger io.Writer
-	sysLogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-	if err != nil {
-		log.Printf("Unable to create sys logger: %v\n", err)
-		sysLogger = os.Stdout
-	}
 
 	// Get current user id
 	usr, err := exec.Command("id", "-un").Output()
@@ -116,14 +94,14 @@ func TestUidGidForUserGroupCommand(t *testing.T) {
 		t.Errorf("Unexpected GID format in user record: %s", string(gidBytes))
 	}
 
-	testUid, testGid := uidGidForUser(user, sysLogger)
+	testUid, testGid := uidGidForUser(user)
 	if testUid != uid {
 		t.Errorf("Unexpected uid value returned: %d, expected: %d", testUid, uid)
 	}
 	if testGid != gid {
 		t.Errorf("Unexpected gid value returned: %d, expected: %d", testGid, gid)
 	}
-	testUid, testGid = uidGidForUser("root", sysLogger)
+	testUid, testGid = uidGidForUser("root")
 	if testUid != 0 {
 		t.Errorf("Unexpected uid value returned: %d, expected: 0", testUid)
 	}

--- a/libs/go/sia/util/util_test_linux.go
+++ b/libs/go/sia/util/util_test_linux.go
@@ -17,10 +17,6 @@
 package util
 
 import (
-	"io"
-	"log"
-	"log/syslog"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -28,13 +24,6 @@ import (
 )
 
 func TestGidForGroupCommand(t *testing.T) {
-	var sysLogger io.Writer
-	sysLogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-	if err != nil {
-		log.Printf("Unable to create sys logger: %v\n", err)
-		sysLogger = os.Stdout
-	}
-
 	// Get current group name.
 	grp, err := exec.Command("id", "-gn").Output()
 	if err != nil {
@@ -55,7 +44,7 @@ func TestGidForGroupCommand(t *testing.T) {
 	}
 
 	// Test if function returns expected gid.
-	actualGid := gidForGroup(group, sysLogger)
+	actualGid := gidForGroup(group)
 	if actualGid != gid {
 		t.Errorf("Unexpected group id: group=%s, expected=%d, got=%d", group, gid, actualGid)
 		return
@@ -63,15 +52,8 @@ func TestGidForGroupCommand(t *testing.T) {
 }
 
 func TestGidForInvalidGroupCommand(t *testing.T) {
-	var sysLogger io.Writer
-	sysLogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-	if err != nil {
-		log.Printf("Unable to create sys logger: %v\n", err)
-		sysLogger = os.Stdout
-	}
-
 	// Test if function returns -1
-	gid := gidForGroup("invalid-group-name", sysLogger)
+	gid := gidForGroup("invalid-group-name")
 	if gid != -1 {
 		t.Errorf("Did not get expected -1 for gid, got=%d", gid)
 		return
@@ -79,13 +61,6 @@ func TestGidForInvalidGroupCommand(t *testing.T) {
 }
 
 func TestUidGidForUserGroupCommand(t *testing.T) {
-	var sysLogger io.Writer
-	sysLogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-	if err != nil {
-		log.Printf("Unable to create sys logger: %v\n", err)
-		sysLogger = os.Stdout
-	}
-
 	// Get current user id
 	usr, err := exec.Command("id", "-un").Output()
 	if err != nil {
@@ -116,14 +91,14 @@ func TestUidGidForUserGroupCommand(t *testing.T) {
 		t.Errorf("Unexpected GID format in user record: %s", string(gidBytes))
 	}
 
-	testUid, testGid := uidGidForUser(user, sysLogger)
+	testUid, testGid := uidGidForUser(user)
 	if testUid != uid {
 		t.Errorf("Unexpected uid value returned: %d, expected: %d", testUid, uid)
 	}
 	if testGid != gid {
 		t.Errorf("Unexpected gid value returned: %d, expected: %d", testGid, gid)
 	}
-	testUid, testGid = uidGidForUser("root", sysLogger)
+	testUid, testGid = uidGidForUser("root")
 	if testUid != 0 {
 		t.Errorf("Unexpected uid value returned: %d, expected: 0", testUid)
 	}

--- a/provider/aws/sia-ec2/authn_test.go
+++ b/provider/aws/sia-ec2/authn_test.go
@@ -38,15 +38,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetECSonEC2TaskId(t *testing.T) {
-	sysLogger := os.Stdout
 	os.Setenv("ECS_CONTAINER_METADATA_FILE", "devel/data/ecs.json")
-	assert.True(t, GetECSOnEC2TaskId(sysLogger) == "1234")
+	assert.True(t, GetECSOnEC2TaskId() == "1234")
 	os.Setenv("ECS_CONTAINER_METADATA_FILE", "devel/data/ecs-old.json")
-	assert.True(t, GetECSOnEC2TaskId(sysLogger) == "3456")
+	assert.True(t, GetECSOnEC2TaskId() == "3456")
 	os.Setenv("ECS_CONTAINER_METADATA_FILE", "devel/data/ecs-notask.json")
-	assert.True(t, GetECSOnEC2TaskId(sysLogger) == "")
+	assert.True(t, GetECSOnEC2TaskId() == "")
 	os.Setenv("ECS_CONTAINER_METADATA_FILE", "devel/data/ecs-invalid.json")
-	assert.True(t, GetECSOnEC2TaskId(sysLogger) == "")
+	assert.True(t, GetECSOnEC2TaskId() == "")
 }
 
 func TestGetEC2DocumentDetails(t *testing.T) {

--- a/provider/aws/sia-ec2/devel/metamock/meta.go
+++ b/provider/aws/sia-ec2/devel/metamock/meta.go
@@ -64,6 +64,6 @@ func StartMetaServer(EndPoint string) {
 	log.Println("Starting Meta Mock listening on: " + EndPoint)
 	err := http.ListenAndServe(EndPoint, nil)
 	if err != nil {
-		log.Fatal("ListenAndServe: ", err)
+		log.Fatalf("ListenAndServe: %v\n", err)
 	}
 }

--- a/provider/aws/sia-eks/authn.go
+++ b/provider/aws/sia-eks/authn.go
@@ -17,11 +17,10 @@
 package sia
 
 import (
-	"io"
+	"log"
 	"os"
 
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 )
 
 func GetEKSPodId() string {
@@ -32,25 +31,25 @@ func GetEKSPodId() string {
 	return podId
 }
 
-func GetEKSConfig(configFile, metaEndpoint string, useRegionalSTS bool, region string, sysLogger io.Writer) (*options.Config, *options.ConfigAccount, error) {
+func GetEKSConfig(configFile, metaEndpoint string, useRegionalSTS bool, region string) (*options.Config, *options.ConfigAccount, error) {
 
-	config, configAccount, err := options.InitFileConfig(configFile, metaEndpoint, useRegionalSTS, region, "", sysLogger)
+	config, configAccount, err := options.InitFileConfig(configFile, metaEndpoint, useRegionalSTS, region, "")
 	if err != nil {
-		logutil.LogInfo(sysLogger, "Unable to process configuration file '%s': %v\n", configFile, err)
-		logutil.LogInfo(sysLogger, "Trying to determine service details from the environment variables...\n")
+		log.Printf("Unable to process configuration file '%s': %v\n", configFile, err)
+		log.Println("Trying to determine service details from the environment variables...")
 		config, configAccount, err = options.InitEnvConfig(config)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to process environment settings: %v\n", err)
+			log.Printf("Unable to process environment settings: %v\n", err)
 			// if we do not have settings in our environment, we're going
 			// to use fallback to <domain>.<service>-service naming structure
-			logutil.LogInfo(sysLogger, "Trying to determine service name security credentials...\n")
-			configAccount, err = options.InitCredsConfig("-service", useRegionalSTS, region, sysLogger)
+			log.Println("Trying to determine service name security credentials...")
+			configAccount, err = options.InitCredsConfig("-service", useRegionalSTS, region)
 			if err != nil {
-				logutil.LogInfo(sysLogger, "Unable to process security credentials: %v\n", err)
-				logutil.LogInfo(sysLogger, "Trying to determine service name from profile arn...\n")
+				log.Printf("Unable to process security credentials: %v\n", err)
+				log.Println("Trying to determine service name from profile arn...")
 				configAccount, err = options.InitProfileConfig(metaEndpoint, "-service")
 				if err != nil {
-					logutil.LogInfo(sysLogger, "Unable to determine service name: %v\n", err)
+					log.Printf("Unable to determine service name: %v\n", err)
 					return config, nil, err
 				}
 			}

--- a/provider/aws/sia-eks/authn_test.go
+++ b/provider/aws/sia-eks/authn_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 
 // TestGetConfigNoConfig tests the scenario when there is no /etc/sia/sia_config, the system uses profile arn
 func TestGetConfigNoConfig(t *testing.T) {
-	config, configAccount, err := GetEKSConfig("devel/data/sia_empty_config", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, configAccount, err := GetEKSConfig("devel/data/sia_empty_config", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nil(t, err)
 	require.NotNil(t, config)
 	require.NotNil(t, configAccount)
@@ -52,7 +52,7 @@ func TestGetConfigNoConfig(t *testing.T) {
 
 // TestGetConfigWithConfig test the scenario when /etc/sia/sia_config is present
 func TestGetConfigWithConfig(t *testing.T) {
-	config, configAccount, err := GetEKSConfig("devel/data/sia_config", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, configAccount, err := GetEKSConfig("devel/data/sia_config", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nilf(t, err, "error should be empty, error: %v", err)
 	require.NotNil(t, config, "should be able to get config")
 	require.NotNil(t, configAccount, "should be able to get config")
@@ -65,11 +65,11 @@ func TestGetConfigWithConfig(t *testing.T) {
 
 // TestGetConfigNoService test the scenario when /etc/sia/sia_config is present, but service is not repeated in services
 func TestGetConfigNoService(t *testing.T) {
-	config, _, err := GetEKSConfig("devel/data/sia_no_service", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, _, err := GetEKSConfig("devel/data/sia_no_service", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nilf(t, err, "error should not be thrown, error: %v", err)
 	assert.True(t, len(config.Services) == 2)
 
-	config, _, err = GetEKSConfig("devel/data/sia_no_service2", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, _, err = GetEKSConfig("devel/data/sia_no_service2", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nilf(t, err, "error should not be thrown, error: %v", err)
 	assert.True(t, config.Service == "api")
 	assert.True(t, len(config.Services) == 1)
@@ -78,7 +78,7 @@ func TestGetConfigNoService(t *testing.T) {
 
 // TestGetConfigNoServices test the scenario when only "service" is mentioned and there are no multiple "services"
 func TestGetConfigNoServices(t *testing.T) {
-	config, configAccount, err := GetEKSConfig("devel/data/sia_no_services", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, configAccount, err := GetEKSConfig("devel/data/sia_no_services", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nilf(t, err, "error should not be thrown, error: %v", err)
 
 	// Make sure one service is set
@@ -89,13 +89,13 @@ func TestGetConfigNoServices(t *testing.T) {
 }
 
 func TestGetConfigWithGenerateRoleKeyConfig(t *testing.T) {
-	config, _, err := GetEKSConfig("devel/data/sia_generate_role_key", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, _, err := GetEKSConfig("devel/data/sia_generate_role_key", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nilf(t, err, "error should not be thrown, error: %v", err)
 	assert.True(t, config.GenerateRoleKey == true)
 }
 
 func TestGetConfigWithRotateKeyConfig(t *testing.T) {
-	config, _, err := GetEKSConfig("devel/data/sia_rotate_key", "http://127.0.0.1:5082", false, "us-west-2", os.Stdout)
+	config, _, err := GetEKSConfig("devel/data/sia_rotate_key", "http://127.0.0.1:5082", false, "us-west-2")
 	require.Nilf(t, err, "error should not be thrown, error: %v", err)
 	assert.True(t, config.RotateKey == true)
 }

--- a/provider/aws/sia-eks/cmd/siad/main.go
+++ b/provider/aws/sia-eks/cmd/siad/main.go
@@ -19,13 +19,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
 	"github.com/AthenZ/athenz/libs/go/sia/aws/agent"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/meta"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"github.com/AthenZ/athenz/provider/aws/sia-eks"
 )
 
@@ -56,31 +56,31 @@ func main() {
 		os.Exit(0)
 	}
 
+	log.SetFlags(log.LstdFlags)
+
 	if *ztsEndPoint == "" {
-		logutil.LogFatal(os.Stderr, "missing zts argument\n")
+		log.Fatalln("missing zts argument")
 	}
 	ztsUrl := fmt.Sprintf("https://%s:%d/zts/v1", *ztsEndPoint, *ztsPort)
 
 	if *dnsDomains == "" {
-		logutil.LogFatal(os.Stderr, "missing dnsdomains argument\n")
+		log.Fatalln("missing dnsdomains argument")
 	}
 
 	if *providerPrefix == "" {
-		logutil.LogFatal(os.Stderr, "missing providerprefix argument\n")
+		log.Fatalln("missing providerprefix argument")
 	}
 
-	sysLogger := os.Stderr
+	region := meta.GetRegion(*eksMetaEndPoint)
 
-	region := meta.GetRegion(*eksMetaEndPoint, sysLogger)
-
-	config, configAccount, err := sia.GetEKSConfig(*pConf, *eksMetaEndPoint, *useRegionalSTS, region, sysLogger)
+	config, configAccount, err := sia.GetEKSConfig(*pConf, *eksMetaEndPoint, *useRegionalSTS, region)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to formulate configuration objects, error: %v", err)
+		log.Fatalf("Unable to formulate configuration objects, error: %v\n", err)
 	}
 
-	opts, err := options.NewOptions(config, configAccount, siaMainDir, Version, *useRegionalSTS, region, sysLogger)
+	opts, err := options.NewOptions(config, configAccount, siaMainDir, Version, *useRegionalSTS, region)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to formulate options, error: %v", err)
+		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
 	opts.Ssh = false
@@ -94,5 +94,5 @@ func main() {
 		opts.SDSUdsPath = *udsPath
 	}
 
-	agent.RunAgent(*cmd, siaMainDir, ztsUrl, opts, sysLogger)
+	agent.RunAgent(*cmd, siaMainDir, ztsUrl, opts)
 }

--- a/provider/aws/sia-eks/devel/metamock/meta.go
+++ b/provider/aws/sia-eks/devel/metamock/meta.go
@@ -77,6 +77,6 @@ func StartMetaServer(EndPoint string) {
 	log.Println("Starting Meta Mock listening on: " + EndPoint)
 	err := http.ListenAndServe(EndPoint, nil)
 	if err != nil {
-		log.Fatal("ListenAndServe: ", err)
+		log.Fatalf("ListenAndServe: %v\n", err)
 	}
 }

--- a/provider/aws/sia-fargate/authn.go
+++ b/provider/aws/sia-fargate/authn.go
@@ -18,13 +18,12 @@ package sia
 
 import (
 	"fmt"
-	"io"
+	"log"
 	"os"
 
 	"github.com/AthenZ/athenz/libs/go/sia/aws/doc"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/meta"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 )
 
@@ -85,21 +84,21 @@ func initTaskConfig(config *options.Config, metaEndpoint string) (*options.Confi
 	}, nil
 }
 
-func GetFargateConfig(configFile, metaEndpoint string, useRegionalSTS bool, account, region string, sysLogger io.Writer) (*options.Config, *options.ConfigAccount, error) {
+func GetFargateConfig(configFile, metaEndpoint string, useRegionalSTS bool, account, region string) (*options.Config, *options.ConfigAccount, error) {
 
-	config, configAccount, err := options.InitFileConfig(configFile, metaEndpoint, useRegionalSTS, account, region, sysLogger)
+	config, configAccount, err := options.InitFileConfig(configFile, metaEndpoint, useRegionalSTS, account, region)
 	if err != nil {
-		logutil.LogInfo(sysLogger, "Unable to process configuration file '%s': %v\n", configFile, err)
-		logutil.LogInfo(sysLogger, "Trying to determine service details from the environment variables...\n")
+		log.Printf("Unable to process configuration file '%s': %v\n", configFile, err)
+		log.Println("Trying to determine service details from the environment variables...")
 		config, configAccount, err = options.InitEnvConfig(config)
 		if err != nil {
-			logutil.LogInfo(sysLogger, "Unable to process environment settings: %v\n", err)
+			log.Printf("Unable to process environment settings: %v\n", err)
 			// if we do not have settings in our environment, we're going
 			// to use fallback to <domain>.<service>-service naming structure
-			logutil.LogInfo(sysLogger, "Trying to determine service name from task role arn...\n")
+			log.Println("Trying to determine service name from task role arn...")
 			config, configAccount, err = initTaskConfig(config, metaEndpoint)
 			if err != nil {
-				logutil.LogInfo(sysLogger, "Unable to determine service name: %v\n", err)
+				log.Printf("Unable to determine service name: %v\n", err)
 				return config, nil, err
 			}
 		}

--- a/provider/aws/sia-fargate/cmd/siad/main.go
+++ b/provider/aws/sia-fargate/cmd/siad/main.go
@@ -19,12 +19,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
 	"github.com/AthenZ/athenz/libs/go/sia/aws/agent"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"github.com/AthenZ/athenz/provider/aws/sia-fargate"
 )
 
@@ -55,34 +55,34 @@ func main() {
 		os.Exit(0)
 	}
 
-	sysLogger := os.Stderr
+	log.SetFlags(log.LstdFlags)
 
 	if *ztsEndPoint == "" {
-		logutil.LogFatal(os.Stderr, "missing zts argument\n")
+		log.Fatalln("missing zts argument")
 	}
 	ztsUrl := fmt.Sprintf("https://%s:%d/zts/v1", *ztsEndPoint, *ztsPort)
 
 	if *dnsDomains == "" {
-		logutil.LogFatal(os.Stderr, "missing dnsdomains argument\n")
+		log.Fatalln("missing dnsdomains argument")
 	}
 
 	if *providerPrefix == "" {
-		logutil.LogFatal(os.Stderr, "missing providerprefix argument\n")
+		log.Fatalln("missing providerprefix argument")
 	}
 
 	account, taskId, region, err := sia.GetFargateData(*ecsMetaEndPoint)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to extract fargate task details: %v", err)
+		log.Fatalf("Unable to extract fargate task details: %v\n", err)
 	}
 
-	config, configAccount, err := sia.GetFargateConfig(*pConf, *ecsMetaEndPoint, *useRegionalSTS, account, region, sysLogger)
+	config, configAccount, err := sia.GetFargateConfig(*pConf, *ecsMetaEndPoint, *useRegionalSTS, account, region)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to formulate configuration objects, error: %v", err)
+		log.Fatalf("Unable to formulate configuration objects, error: %v\n", err)
 	}
 
-	opts, err := options.NewOptions(config, configAccount, siaMainDir, Version, *useRegionalSTS, region, sysLogger)
+	opts, err := options.NewOptions(config, configAccount, siaMainDir, Version, *useRegionalSTS, region)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to formulate options, error: %v", err)
+		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
 	opts.Ssh = false
@@ -96,5 +96,5 @@ func main() {
 		opts.SDSUdsPath = *udsPath
 	}
 
-	agent.RunAgent(*cmd, siaMainDir, ztsUrl, opts, sysLogger)
+	agent.RunAgent(*cmd, siaMainDir, ztsUrl, opts)
 }

--- a/provider/aws/sia-fargate/devel/metamock/meta.go
+++ b/provider/aws/sia-fargate/devel/metamock/meta.go
@@ -41,6 +41,6 @@ func StartMetaServer(EndPoint string) {
 	log.Println("Starting Meta Mock listening on: " + EndPoint)
 	err := http.ListenAndServe(EndPoint, nil)
 	if err != nil {
-		log.Fatal("ListenAndServe: ", err)
+		log.Fatalf("ListenAndServe: %v\n", err)
 	}
 }

--- a/provider/azure/sia-vm/authn_test.go
+++ b/provider/azure/sia-vm/authn_test.go
@@ -100,7 +100,7 @@ func TestRegisterInstance(test *testing.T) {
 		Document:          nil,
 	}
 
-	err = RegisterInstance([]*attestation.Data{a}, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts, os.Stdout)
+	err = RegisterInstance([]*attestation.Data{a}, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts)
 	assert.Nil(test, err, "unable to regster instance")
 
 	_, err = os.Stat(keyFile)
@@ -152,7 +152,7 @@ func TestRegisterInstanceMultiple(test *testing.T) {
 		Document:          nil,
 	}
 
-	err = RegisterInstance(data, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts, os.Stdout)
+	err = RegisterInstance(data, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts)
 	assert.Nil(test, err, "unable to regster instance")
 
 	// Verify the first service
@@ -235,7 +235,7 @@ func TestRefreshInstance(test *testing.T) {
 		Document:          nil,
 	}
 
-	err = RefreshInstance([]*attestation.Data{a}, "http://127.0.0.1:5081/zts/v1", &identityDocument, &opts, os.Stdout)
+	err = RefreshInstance([]*attestation.Data{a}, "http://127.0.0.1:5081/zts/v1", &identityDocument, &opts)
 	assert.Nil(test, err, fmt.Sprintf("unable to refresh instance: %v", err))
 
 	oldCert, _ := ioutil.ReadFile("devel/data/cert.pem")
@@ -283,7 +283,7 @@ func TestRoleCertificateRequest(test *testing.T) {
 		ZTSAzureDomains:  []string{"zts-azure-domain"},
 	}
 
-	result := GetRoleCertificate("http://127.0.0.1:5081/zts/v1", keyFile, certFile, opts, os.Stdout)
+	result := GetRoleCertificate("http://127.0.0.1:5081/zts/v1", keyFile, certFile, opts)
 	if !result {
 		test.Errorf("Unable to get role certificate: %v", err)
 		return

--- a/provider/azure/sia-vm/cmd/siad/main.go
+++ b/provider/azure/sia-vm/cmd/siad/main.go
@@ -19,15 +19,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm/data/attestation"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm/options"
-	"io"
 	"io/ioutil"
 	"log"
-	"log/syslog"
 	"os"
 	"os/signal"
 	"strings"
@@ -57,49 +54,49 @@ func main() {
 
 	flag.Parse()
 
-	var sysLogger io.Writer
-	if *noSysLog {
-		sysLogger = os.Stdout
-	} else {
-		var err error
-		sysLogger, err = syslog.New(syslog.LOG_INFO|syslog.LOG_DAEMON, "siad")
-		if err != nil {
+	if !*noSysLog {
+		sysLogger, err := util.NewSysLogger()
+		if err == nil {
+			log.SetOutput(sysLogger)
+		} else {
+			log.SetFlags(log.LstdFlags)
 			log.Printf("Unable to create sys logger: %v\n", err)
-			sysLogger = os.Stdout
 		}
+	} else {
+		log.SetFlags(log.LstdFlags)
 	}
 
 	if *ztsEndPoint == "" {
-		logutil.LogFatal(sysLogger, "ztsEndPoint argument must be specified\n")
+		log.Fatalf("ztsEndPoint argument must be specified\n")
 	}
 	if *ztsAzureDomains == "" {
-		logutil.LogFatal(sysLogger, "ztsazuredomain argument must be specified\n")
+		log.Fatalf("ztsazuredomain argument must be specified\n")
 	}
 	ztsAzureDomainList := strings.Split(*ztsAzureDomains, ",")
 
 	if *ztsResourceUri == "" {
-		logutil.LogFatal(sysLogger, "ztsresourceuri argument must be specified\n")
+		log.Fatalf("ztsresourceuri argument must be specified\n")
 	}
 	if *metaEndPoint != "" {
 		MetaEndPoint = *metaEndPoint
 	}
 
-	identityDocument, err := attestation.GetIdentityDocument(MetaEndPoint, ApiVersion, sysLogger)
+	identityDocument, err := attestation.GetIdentityDocument(MetaEndPoint, ApiVersion)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to get the instance identity document, error: %v\n", err)
+		log.Fatalf("Unable to get the instance identity document, error: %v\n", err)
 	}
 
 	confBytes, _ := ioutil.ReadFile(*pConf)
-	opts, err := options.NewOptions(confBytes, identityDocument, siaMainDir, siaVersion, *ztsCACert, *ztsServerName, ztsAzureDomainList, *countryName, *azureProvider, sysLogger)
+	opts, err := options.NewOptions(confBytes, identityDocument, siaMainDir, siaVersion, *ztsCACert, *ztsServerName, ztsAzureDomainList, *countryName, *azureProvider)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to formulate options, error: %v\n", err)
+		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
-	logutil.LogInfo(sysLogger, "options: %+v\n", opts)
+	log.Printf("options: %+v\n", opts)
 
-	data, err := getAttestationData(*ztsResourceUri, identityDocument, opts, sysLogger)
+	data, err := getAttestationData(*ztsResourceUri, identityDocument, opts)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to formulate attestation data, error: %v\n", err)
+		log.Fatalf("Unable to formulate attestation data, error: %v\n", err)
 	}
 
 	// for now we're going to rotate once every day
@@ -109,12 +106,12 @@ func main() {
 
 	ztsUrl := fmt.Sprintf("https://%s:4443/zts/v1", *ztsEndPoint)
 
-	err = util.SetupSIADirs(siaMainDir, siaLinkDir, sysLogger)
+	err = util.SetupSIADirs(siaMainDir, siaLinkDir)
 	if err != nil {
-		logutil.LogFatal(sysLogger, "Unable to setup sia directories, error: %v\n", err)
+		log.Fatalf("Unable to setup sia directories, error: %v\n", err)
 	}
 
-	logutil.LogInfo(sysLogger, "Request SSH Certificates: %t\n", opts.Ssh)
+	log.Printf("Request SSH Certificates: %t\n", opts.Ssh)
 
 	svcs := options.GetSvcNames(opts.Services)
 
@@ -124,20 +121,19 @@ func main() {
 			fmt.Sprintf("%s/%s.%s.key.pem", opts.KeyDir, opts.Domain, opts.Services[0].Name),
 			fmt.Sprintf("%s/%s.%s.cert.pem", opts.CertDir, opts.Domain, opts.Services[0].Name),
 			opts,
-			sysLogger,
 		)
 	case "post":
-		err := sia.RegisterInstance(data, ztsUrl, identityDocument, opts, sysLogger)
+		err := sia.RegisterInstance(data, ztsUrl, identityDocument, opts)
 		if err != nil {
-			logutil.LogFatal(sysLogger, "Register identity failed, err: %v\n", err)
+			log.Fatalf("Register identity failed, err: %v\n", err)
 		}
-		logutil.LogInfo(sysLogger, "identity registered for services: %s\n", svcs)
+		log.Printf("identity registered for services: %s\n", svcs)
 	case "rotate":
-		err = sia.RefreshInstance(data, ztsUrl, identityDocument, opts, sysLogger)
+		err = sia.RefreshInstance(data, ztsUrl, identityDocument, opts)
 		if err != nil {
-			logutil.LogFatal(sysLogger, "Refresh identity failed, err: %v\n", err)
+			log.Fatalf("Refresh identity failed, err: %v\n", err)
 		}
-		logutil.LogInfo(sysLogger, "Identity successfully refreshed for services: %s\n", svcs)
+		log.Printf("Identity successfully refreshed for services: %s\n", svcs)
 	default:
 		// if we already have a cert file then we're not going to
 		// prove our identity since most likely it will not succeed
@@ -147,39 +143,39 @@ func main() {
 
 		initialSetup := true
 		if files, err := ioutil.ReadDir(opts.CertDir); err != nil || len(files) <= 0 {
-			err := sia.RegisterInstance(data, ztsUrl, identityDocument, opts, sysLogger)
+			err := sia.RegisterInstance(data, ztsUrl, identityDocument, opts)
 			if err != nil {
-				logutil.LogFatal(sysLogger, "Register identity failed, error: %v\n", err)
+				log.Fatalf("Register identity failed, error: %v\n", err)
 			}
 		} else {
 			initialSetup = false
-			logutil.LogInfo(sysLogger, "Identity certificate file already exists. Retrieving identity details...\n")
+			log.Println("Identity certificate file already exists. Retrieving identity details...")
 		}
-		logutil.LogInfo(sysLogger, "Identity established for services: %s\n", svcs)
+		log.Printf("Identity established for services: %s\n", svcs)
 
 		stop := make(chan bool, 1)
 		errors := make(chan error, 1)
 
 		go func() {
 			for {
-				logutil.LogInfo(sysLogger, "Identity being used: %s\n", opts.Name)
+				log.Printf("Identity being used: %s\n", opts.Name)
 
 				// if we just did our initial setup there is no point
 				// to refresh the certs again. so we are going to skip
 				// this time around and refresh certs next time
 
 				if !initialSetup {
-					data, err := getAttestationData(*ztsResourceUri, identityDocument, opts, sysLogger)
+					data, err := getAttestationData(*ztsResourceUri, identityDocument, opts)
 					if err != nil {
 						errors <- fmt.Errorf("Cannot get attestation data: %v\n", err)
 						return
 					}
-					err = sia.RefreshInstance(data, ztsUrl, identityDocument, opts, sysLogger)
+					err = sia.RefreshInstance(data, ztsUrl, identityDocument, opts)
 					if err != nil {
 						errors <- fmt.Errorf("refresh identity failed, error: %v", err)
 						return
 					}
-					logutil.LogInfo(sysLogger, "identity successfully refreshed for services: %s\n", svcs)
+					log.Printf("identity successfully refreshed for services: %s\n", svcs)
 				} else {
 					initialSetup = false
 				}
@@ -187,7 +183,6 @@ func main() {
 					fmt.Sprintf("%s/%s.%s.key.pem", opts.KeyDir, opts.Domain, opts.Services[0].Name),
 					fmt.Sprintf("%s/%s.%s.cert.pem", opts.CertDir, opts.Domain, opts.Services[0].Name),
 					opts,
-					sysLogger,
 				)
 				select {
 				case <-stop:
@@ -203,23 +198,23 @@ func main() {
 			signals := make(chan os.Signal, 2)
 			signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 			sig := <-signals
-			logutil.LogInfo(sysLogger, "Received signal %v, stopping rotation\n", sig)
+			log.Printf("Received signal %v, stopping rotation\n", sig)
 			stop <- true
 		}()
 
 		err = <-errors
 		if err != nil {
-			logutil.LogInfo(sysLogger, "%v\n", err)
+			log.Printf("%v\n", err)
 		}
 	}
 	os.Exit(0)
 }
 
 // getAttestationData fetches attestation data for all the services mentioned in the config file
-func getAttestationData(resourceUri string, identityDocument *attestation.IdentityDocument, opts *options.Options, sysLogger io.Writer) ([]*attestation.Data, error) {
+func getAttestationData(resourceUri string, identityDocument *attestation.IdentityDocument, opts *options.Options) ([]*attestation.Data, error) {
 	var data []*attestation.Data
 	for _, svc := range opts.Services {
-		a, err := attestation.New(opts.Domain, svc.Name, MetaEndPoint, ApiVersion, resourceUri, identityDocument, sysLogger)
+		a, err := attestation.New(opts.Domain, svc.Name, MetaEndPoint, ApiVersion, resourceUri, identityDocument)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/azure/sia-vm/data/attestation/attestation_test.go
+++ b/provider/azure/sia-vm/data/attestation/attestation_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetIdentityDocument(test *testing.T) {
-	identityDocument, err := GetIdentityDocument(MetaEndPoint, ApiVersion, os.Stdout)
+	identityDocument, err := GetIdentityDocument(MetaEndPoint, ApiVersion)
 	require.Nilf(test, err, "error for get identity document should be empty, error: %v", err)
 
 	assert.True(test, identityDocument.Name == "athenz-client")
@@ -72,7 +72,7 @@ func TestGetAccessToken(test *testing.T) {
 		Document:          nil,
 	}
 
-	attestData, err := New("athenz", "backend", MetaEndPoint, ApiVersion, "https://test.athenz.io/", &identityDocument, os.Stdout)
+	attestData, err := New("athenz", "backend", MetaEndPoint, ApiVersion, "https://test.athenz.io/", &identityDocument)
 	require.Nilf(test, err, "error for get attestation data should be empty, error: %v", err)
 
 	assert.True(test, attestData.Name == "athenz-client")

--- a/provider/azure/sia-vm/data/meta/meta_test.go
+++ b/provider/azure/sia-vm/data/meta/meta_test.go
@@ -57,7 +57,7 @@ func TestGetMetadata(test *testing.T) {
 	// Mock the metadata endpoints
 	router := httptreemux.New()
 	router.GET("/metadata/instance", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
-		log.Printf("Called /metadata/instance?api-version=2020-06-01")
+		log.Println("Called /metadata/instance?api-version=2020-06-01")
 		io.WriteString(w, "{ \"test\": \"document\"}")
 	})
 

--- a/provider/azure/sia-vm/devel/metamock/meta.go
+++ b/provider/azure/sia-vm/devel/metamock/meta.go
@@ -72,6 +72,6 @@ func StartMetaServer(EndPoint string) {
 	log.Println("Starting Meta Mock listening on: " + EndPoint)
 	err := http.ListenAndServe(EndPoint, nil)
 	if err != nil {
-		log.Fatal("ListenAndServe: ", err)
+		log.Fatalf("ListenAndServe: %v\n", err)
 	}
 }

--- a/provider/azure/sia-vm/devel/ztsmock/zts.go
+++ b/provider/azure/sia-vm/devel/ztsmock/zts.go
@@ -44,7 +44,7 @@ func SetupCA() (string, string) {
 
 	key, err := generateKeyPair()
 	if err != nil {
-		log.Fatalf("Cannot generate private key: %v", err)
+		log.Fatalf("Cannot generate private key: %v\n", err)
 	}
 
 	//create self-signed cert
@@ -56,7 +56,7 @@ func SetupCA() (string, string) {
 	name := "Troy CA"
 	certPem, err := createCACert(key, country, locality, province, org, unit, name, nil, nil)
 	if err != nil {
-		log.Fatalf("Cannot create CA Cert: %v", err)
+		log.Fatalf("Cannot create CA Cert: %v\n", err)
 	}
 
 	return privatePem(key), certPem
@@ -66,33 +66,33 @@ func StartZtsServer(endPoint string) {
 	router := mux.NewRouter()
 
 	router.HandleFunc("/zts/v1/instance", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("/instance is called")
+		log.Println("/instance is called")
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Fatalf("Could not read the body")
+			log.Fatalln("Could not read the body")
 		}
 
 		var data *zts.InstanceRegisterInformation
 		err = json.Unmarshal(body, &data)
 		if err != nil {
-			log.Fatalf("Could not parse the body into zts.InstanceRegisterInformation")
+			log.Fatalln("Could not parse the body into zts.InstanceRegisterInformation")
 		}
 
 		caKey, err := privateKeyFromPem(caKeyStr)
 		if err != nil {
-			log.Fatalf("Could not generate caKey from string")
+			log.Fatalln("Could not generate caKey from string")
 		}
 
 		caCert, err := certFromPEM(caCertStr)
 		if err != nil {
-			log.Fatalf("Could not generate caCert from string")
+			log.Fatalln("Could not generate caCert from string")
 		}
 
 		service := fmt.Sprintf("%s.%s", data.Domain, data.Service)
 		cert, err := generateCertInMemory(data.Csr, caKey, caCert, service)
 		if err != nil {
-			log.Fatalf("Could not generate cert in memory: %v", err)
+			log.Fatalf("Could not generate cert in memory: %v\n", err)
 		}
 
 		identity := &zts.InstanceIdentity{
@@ -106,36 +106,36 @@ func StartZtsServer(endPoint string) {
 		if err == nil {
 			w.WriteHeader(201)
 			io.WriteString(w, string(identityBytes))
-			log.Printf("Successfully processed register instance request")
+			log.Println("Successfully processed register instance request")
 		}
 	}).Methods("POST")
 
 	router.HandleFunc("/zts/v1/instance/athenz.azure.west2/athenz/hockey/123456789012-vmid", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("instance refresh handler called")
+		log.Println("instance refresh handler called")
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Fatalf("Could not read the body")
+			log.Fatalln("Could not read the body")
 		}
 		var data *zts.InstanceRefreshInformation
 		err = json.Unmarshal(body, &data)
 		if err != nil {
-			log.Fatalf("Could not parse the body into zts.InstanceRefreshInformation")
+			log.Fatalln("Could not parse the body into zts.InstanceRefreshInformation")
 		}
 
 		caKey, err := privateKeyFromPem(caKeyStr)
 		if err != nil {
-			log.Fatalf("Could not generate caKey from string")
+			log.Fatalln("Could not generate caKey from string")
 		}
 
 		caCert, err := certFromPEM(caCertStr)
 		if err != nil {
-			log.Fatalf("Could not generate caCert from string")
+			log.Fatalln("Could not generate caCert from string")
 		}
 
 		cert, err := generateCertInMemory(data.Csr, caKey, caCert, "athenz.hockey")
 		if err != nil {
-			log.Fatalf("Could not generate cert in memory: %v", err)
+			log.Fatalf("Could not generate cert in memory: %v\n", err)
 		}
 
 		identity := &zts.InstanceIdentity{
@@ -148,36 +148,36 @@ func StartZtsServer(endPoint string) {
 		identityBytes, err := json.Marshal(identity)
 		if err == nil {
 			io.WriteString(w, string(identityBytes))
-			log.Printf("Successfully processed refresh instance request")
+			log.Println("Successfully processed refresh instance request")
 		}
 	}).Methods("POST")
 
 	router.HandleFunc("/zts/v1/rolecert", func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("role certificate handler called")
+		log.Println("role certificate handler called")
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			log.Fatalf("Could not read the body")
+			log.Fatalln("Could not read the body")
 		}
 		var data *zts.RoleCertificateRequest
 		err = json.Unmarshal(body, &data)
 		if err != nil {
-			log.Fatalf("Could not parse the body into zts.RoleCertificateRequest")
+			log.Fatalln("Could not parse the body into zts.RoleCertificateRequest")
 		}
 
 		caKey, err := privateKeyFromPem(caKeyStr)
 		if err != nil {
-			log.Fatalf("Could not generate caKey from string")
+			log.Fatalln("Could not generate caKey from string")
 		}
 
 		caCert, err := certFromPEM(caCertStr)
 		if err != nil {
-			log.Fatalf("Could not generate caCert from string")
+			log.Fatalln("Could not generate caCert from string")
 		}
 
 		cert, err := generateCertInMemory(data.Csr, caKey, caCert, "athenz:role.writers")
 		if err != nil {
-			log.Fatalf("Could not generate cert in memory: %v", err)
+			log.Fatalf("Could not generate cert in memory: %v\n", err)
 		}
 
 		identity := &zts.RoleCertificate{
@@ -186,13 +186,13 @@ func StartZtsServer(endPoint string) {
 		identityBytes, err := json.Marshal(identity)
 		if err == nil {
 			io.WriteString(w, string(identityBytes))
-			log.Printf("Successfully processed role certificate request")
+			log.Println("Successfully processed role certificate request")
 		}
 	}).Methods("POST")
 
 	err := http.ListenAndServe(endPoint, router)
 	if err != nil {
-		log.Fatal("ListenAndServe: ", err)
+		log.Fatalf("ListenAndServe: %v\n", err)
 	}
 
 }

--- a/provider/azure/sia-vm/options/options.go
+++ b/provider/azure/sia-vm/options/options.go
@@ -23,11 +23,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/logutil"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm/data/attestation"
 	vmutil "github.com/AthenZ/athenz/provider/azure/sia-vm/util"
-	"io"
+	"log"
 	"strings"
 )
 
@@ -158,12 +157,12 @@ func initFileConfig(bytes []byte, identityDocument *attestation.IdentityDocument
 
 // NewOptions takes in sia_config bytes and returns a pointer to Options after parsing and initializing the defaults
 // It uses identity document defaults when sia_config is empty or non-parsable. It populates "services" array
-func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, siaDir, version, ztsCaCert, ztsServerName string, ztsAzureDomains []string, countryName, azureProvider string, sysLogger io.Writer) (*Options, error) {
+func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, siaDir, version, ztsCaCert, ztsServerName string, ztsAzureDomains []string, countryName, azureProvider string) (*Options, error) {
 	// Parse config bytes first, and if that fails, load values from Identity document
 	config, account, err := initFileConfig(bytes, identityDocument)
 	if err != nil {
-		logutil.LogInfo(sysLogger, "unable to parse configuration file, error: %v\n", err)
-		logutil.LogInfo(sysLogger, "trying to determine service name from identity document tags...\n")
+		log.Printf("unable to parse configuration file, error: %v\n", err)
+		log.Println("trying to determine service name from identity document tags...")
 		account, err = initProfileConfig(identityDocument)
 		if err != nil {
 			return nil, fmt.Errorf("config non-parsable and unable to determine service name from identity tags, error: %v", err)
@@ -188,7 +187,7 @@ func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, si
 			Filename: account.Filename,
 			User:     account.User,
 		}
-		s.Uid, s.Gid = util.UidGidForUserGroup(account.User, account.Group, sysLogger)
+		s.Uid, s.Gid = util.UidGidForUserGroup(account.User, account.Group)
 		services = append(services, s)
 	} else {
 		// sia_config and services are found
@@ -215,7 +214,7 @@ func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, si
 				if first.Group == "" {
 					first.Group = account.Group
 				}
-				first.Uid, first.Gid = util.UidGidForUserGroup(first.User, first.Group, sysLogger)
+				first.Uid, first.Gid = util.UidGidForUserGroup(first.User, first.Group)
 			} else {
 				ts := Service{
 					Name:     name,
@@ -223,7 +222,7 @@ func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, si
 					User:     s.User,
 					Group:    s.Group,
 				}
-				ts.Uid, ts.Gid = util.UidGidForUserGroup(s.User, s.Group, sysLogger)
+				ts.Uid, ts.Gid = util.UidGidForUserGroup(s.User, s.Group)
 				tail = append(tail, ts)
 			}
 		}

--- a/provider/azure/sia-vm/options/options_test.go
+++ b/provider/azure/sia-vm/options/options_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"log"
-	"os"
 	"os/user"
 	"strconv"
 	"strings"
@@ -60,7 +59,7 @@ func TestOptionsNoConfig(t *testing.T) {
 	}
 
 	ztsAzureDomains := []string{"zts-azure-domain"}
-	opts, e := NewOptions([]byte{}, &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider", os.Stdout)
+	opts, e := NewOptions([]byte{}, &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider")
 	require.Nilf(t, e, "error should be empty, error: %v", e)
 	require.NotNil(t, opts, "should be able to get Options")
 
@@ -107,7 +106,7 @@ func TestOptionsWithConfig(t *testing.T) {
 	}
 
 	ztsAzureDomains := []string{"zts-azure-domain"}
-	opts, e := NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider", os.Stdout)
+	opts, e := NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider")
 	require.Nilf(t, e, "error should be empty, error: %v", e)
 	require.NotNil(t, opts, "should be able to get Options")
 
@@ -153,7 +152,7 @@ func TestOptionsNoService(t *testing.T) {
 	}
 
 	ztsAzureDomains := []string{"zts-azure-domain"}
-	_, e := NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider", os.Stdout)
+	_, e := NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider")
 	require.NotNilf(t, e, "error should be thrown, error: %v", e)
 
 	config = `{
@@ -171,7 +170,7 @@ func TestOptionsNoService(t *testing.T) {
   		]
 	}`
 
-	_, e = NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider", os.Stdout)
+	_, e = NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider")
 	require.NotNilf(t, e, "error should be thrown, error: %v", e)
 }
 
@@ -203,7 +202,7 @@ func TestOptionsNoServices(t *testing.T) {
 	}
 
 	ztsAzureDomains := []string{"zts-azure-domain"}
-	opts, e := NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider", os.Stdout)
+	opts, e := NewOptions([]byte(config), &identityDocument, "/tmp", "1.0.0", "", "", ztsAzureDomains, "US", "azure.provider")
 	require.Nilf(t, e, "error should not be thrown, error: %v", e)
 
 	// Make sure one service is set
@@ -214,8 +213,8 @@ func TestOptionsNoServices(t *testing.T) {
 }
 
 func assertService(expected Service, actual Service) bool {
-	log.Printf("expected: %+v", expected)
-	log.Printf("actual: %+v", actual)
+	log.Printf("expected: %+v\n", expected)
+	log.Printf("actual: %+v\n", actual)
 	return expected.Name == actual.Name &&
 		expected.User == actual.User &&
 		expected.Uid == actual.Uid &&
@@ -225,8 +224,8 @@ func assertService(expected Service, actual Service) bool {
 }
 
 func assertInServices(svcs []Service, actual Service) bool {
-	log.Printf("svcs passed: %+v", svcs)
-	log.Printf("actual: %+v", actual)
+	log.Printf("svcs passed: %+v\n", svcs)
+	log.Printf("actual: %+v\n", actual)
 	for _, s := range svcs {
 		if s.Name == actual.Name && s.User == actual.User && s.Uid == actual.Uid && s.Group == actual.Group && s.Gid == actual.Gid && s.Filename == actual.Filename {
 			return true

--- a/utils/msd-agent/svc/service_aws_ec2.go
+++ b/utils/msd-agent/svc/service_aws_ec2.go
@@ -9,7 +9,6 @@ import (
 	"github.com/AthenZ/athenz/libs/go/sia/aws/meta"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
 	"github.com/AthenZ/athenz/provider/aws/sia-ec2"
-	"os"
 )
 
 var Ec2MetaEndPoint = "http://169.254.169.254:80"
@@ -24,13 +23,12 @@ type EC2Fetcher struct {
 
 func (fetcher *EC2Fetcher) Fetch(host MsdHost, accountId string) (ServicesData, error) {
 
-	sysLogger := os.Stderr
-	config, configAccount, err := sia.GetEC2Config(SIA_CONFIG, Ec2MetaEndPoint, false, "", accountId, sysLogger)
+	config, configAccount, err := sia.GetEC2Config(SIA_CONFIG, Ec2MetaEndPoint, false, "", accountId)
 	if err != nil {
 		log.Fatalf("Unable to formulate config, error: %v\n", err)
 	}
 
-	opts, err := options.NewOptions(config, configAccount, SIA_DIR, "", false, "", sysLogger)
+	opts, err := options.NewOptions(config, configAccount, SIA_DIR, "", false, "")
 	if err != nil {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}

--- a/utils/msd-agent/svc/service_aws_eks.go
+++ b/utils/msd-agent/svc/service_aws_eks.go
@@ -8,7 +8,6 @@ import (
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/stssession"
 	"github.com/AthenZ/athenz/provider/aws/sia-eks"
-	"os"
 )
 
 var EksMetaEndPoint = "http://169.254.169.254:80"
@@ -18,13 +17,12 @@ type EKSFetcher struct {
 
 func (fetcher *EKSFetcher) Fetch(host MsdHost, accountId string) (ServicesData, error) {
 
-	sysLogger := os.Stderr
-	config, configAccount, err := sia.GetEKSConfig(SIA_CONFIG, EksMetaEndPoint, false, "", sysLogger)
+	config, configAccount, err := sia.GetEKSConfig(SIA_CONFIG, EksMetaEndPoint, false, "")
 	if err != nil {
 		log.Fatalf("Unable to formulate config, error: %v\n", err)
 	}
 
-	opts, err := options.NewOptions(config, configAccount, SIA_DIR, "", false, "", sysLogger)
+	opts, err := options.NewOptions(config, configAccount, SIA_DIR, "", false, "")
 	if err != nil {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
@@ -36,7 +34,7 @@ func (fetcher *EKSFetcher) Fetch(host MsdHost, accountId string) (ServicesData, 
 }
 
 func (fetcher *EKSFetcher) GetAccountId() (string, error) {
-	accountId, _, _, err := stssession.GetMetaDetailsFromCreds("-service", false, "", os.Stderr)
+	accountId, _, _, err := stssession.GetMetaDetailsFromCreds("-service", false, "")
 	if err != nil {
 		log.Fatalf("Unable to get account id from available credentials, error: %v", err)
 	}

--- a/utils/msd-agent/svc/service_aws_fargate.go
+++ b/utils/msd-agent/svc/service_aws_fargate.go
@@ -7,7 +7,6 @@ import (
 	"github.com/AthenZ/athenz/libs/go/athenz-common/log"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
 	"github.com/AthenZ/athenz/provider/aws/sia-fargate"
-	"os"
 )
 
 var FargateMetaEndPoint = "http://169.254.170.2"
@@ -17,13 +16,12 @@ type FargateFetcher struct {
 
 func (fetcher *FargateFetcher) Fetch(host MsdHost, accountId string) (ServicesData, error) {
 
-	sysLogger := os.Stderr
-	config, configAccount, err := sia.GetFargateConfig(SIA_CONFIG, FargateMetaEndPoint, false, accountId, "", sysLogger)
+	config, configAccount, err := sia.GetFargateConfig(SIA_CONFIG, FargateMetaEndPoint, false, accountId, "")
 	if err != nil {
 		log.Fatalf("Unable to formulate config, error: %v\n", err)
 	}
 
-	opts, err := options.NewOptions(config, configAccount, SIA_DIR, "", false, "", sysLogger)
+	opts, err := options.NewOptions(config, configAccount, SIA_DIR, "", false, "")
 	if err != nil {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}

--- a/utils/msd-agent/svc/service_azure_vm.go
+++ b/utils/msd-agent/svc/service_azure_vm.go
@@ -17,12 +17,12 @@ type AzureVmFetcher struct {
 
 func (fetcher *AzureVmFetcher) Fetch(host MsdHost, accountId string) (ServicesData, error) {
 
-	identityDocument, err := attestation.GetIdentityDocument(AzureVmMetaEndPoint, ApiVersion, log.GetWriter())
+	identityDocument, err := attestation.GetIdentityDocument(AzureVmMetaEndPoint, ApiVersion)
 	if err != nil {
 		log.Fatalf("Unable to get the instance identity document, error: %v", err)
 	}
 
-	opts, err := options.NewOptions(host.SiaConfig, identityDocument, "", SIA_DIR, "", "", nil, "", "", nil)
+	opts, err := options.NewOptions(host.SiaConfig, identityDocument, "", SIA_DIR, "", "", nil, "", "")
 	if err != nil {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}


### PR DESCRIPTION
replace logutil.LogInfo calls with log.Printf and log util.LogFatal calls with log.Fatalf

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>