### PR TITLE
replace go get with go install as recommended by go 1.17

### DIFF
--- a/clients/go/msd/Makefile
+++ b/clients/go/msd/Makefile
@@ -49,8 +49,8 @@ endif
 build: src/$(RDL_LIB)
 
 src/$(RDL_LIB):
-	go get $(RDL_LIB)
-	go get github.com/ardielle/ardielle-tools/...
+	go install $(RDL_LIB)
+	go install github.com/ardielle/ardielle-tools/...
 
 model.go: $(RDL_FILE)
 	$(GOPATH)/bin/rdl -ps generate -t -o $@ athenz-go-model $(RDL_FILE)

--- a/clients/go/zms/Makefile
+++ b/clients/go/zms/Makefile
@@ -49,8 +49,8 @@ endif
 build: src/$(RDL_LIB)
 
 src/$(RDL_LIB):
-	go get $(RDL_LIB)
-	go get github.com/ardielle/ardielle-tools/...
+	go install $(RDL_LIB)
+	go install github.com/ardielle/ardielle-tools/...
 
 model.go: $(RDL_FILE)
 	$(GOPATH)/bin/rdl -ps generate -t -o $@ athenz-go-model $(RDL_FILE)

--- a/clients/go/zts/Makefile
+++ b/clients/go/zts/Makefile
@@ -49,8 +49,8 @@ endif
 build: src/$(RDL_LIB)
 
 src/$(RDL_LIB):
-	go get $(RDL_LIB)
-	go get github.com/ardielle/ardielle-tools/...
+	go install $(RDL_LIB)
+	go install github.com/ardielle/ardielle-tools/...
 
 model.go: $(RDL_FILE)
 	$(GOPATH)/bin/rdl -ps generate -t -o $@ go-model $(RDL_FILE)

--- a/clients/java/msd/scripts/make_stubs.sh
+++ b/clients/java/msd/scripts/make_stubs.sh
@@ -17,17 +17,17 @@ if [ ! -z "${SCREWDRIVER}" ]; then
 fi
 
 # Note this script is dependent on the rdl utility.
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/clients/java/zms/scripts/make_stubs.sh
+++ b/clients/java/zms/scripts/make_stubs.sh
@@ -14,17 +14,17 @@ if [ ! -z "${SCREWDRIVER}" ] || [ ! -z "${TRAVIS_PULL_REQUEST}" ] || [ ! -z "${T
 fi
 
 # Note this script is dependent on the rdl utility.
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/clients/java/zts/core/scripts/make_stubs.sh
+++ b/clients/java/zts/core/scripts/make_stubs.sh
@@ -14,17 +14,17 @@ if [ ! -z "${SCREWDRIVER}" ] || [ ! -z "${TRAVIS_PULL_REQUEST}" ] || [ ! -z "${T
 fi
 
 # Note this script is dependent on the rdl utility.
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/core/msd/scripts/make_stubs.sh
+++ b/core/msd/scripts/make_stubs.sh
@@ -16,18 +16,18 @@ if [ ! -z "${SCREWDRIVER}" ]; then
 fi
 
 # Note this script is dependent on the rdl utility.
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 #
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/core/zms/scripts/make_stubs.sh
+++ b/core/zms/scripts/make_stubs.sh
@@ -14,18 +14,18 @@ if [ ! -z "${SCREWDRIVER}" ] || [ ! -z "${TRAVIS_PULL_REQUEST}" ] || [ ! -z "${T
 fi
 
 # Note this script is dependent on the rdl utility.
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 #
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/core/zts/scripts/make_stubs.sh
+++ b/core/zts/scripts/make_stubs.sh
@@ -14,18 +14,18 @@ if [ ! -z "${SCREWDRIVER}" ] || [ ! -z "${TRAVIS_PULL_REQUEST}" ] || [ ! -z "${T
 fi
 
 # Note this script is dependent on the rdl utility.
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 #
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/rdl/rdl-gen-athenz-go-client/make_generator.sh
+++ b/rdl/rdl-gen-athenz-go-client/make_generator.sh
@@ -28,7 +28,7 @@ if [ -z "${GOPATH}" ]; then
     exit 1;
 fi
 
-go get -u github.com/ardielle/ardielle-go/...
+go install github.com/ardielle/ardielle-go/...
 go build
 cp rdl-gen-athenz-go-client ${GOPATH}/bin/rdl-gen-athenz-go-client
 

--- a/rdl/rdl-gen-athenz-go-model/make_generator.sh
+++ b/rdl/rdl-gen-athenz-go-model/make_generator.sh
@@ -28,7 +28,7 @@ if [ -z "${GOPATH}" ]; then
     exit 1;
 fi
 
-go get -u github.com/ardielle/ardielle-go/...
+go install github.com/ardielle/ardielle-go/...
 go build
 cp rdl-gen-athenz-go-model ${GOPATH}/bin/rdl-gen-athenz-go-model
 

--- a/rdl/rdl-gen-athenz-java-client/make_generator.sh
+++ b/rdl/rdl-gen-athenz-java-client/make_generator.sh
@@ -28,7 +28,7 @@ if [ -z "${GOPATH}" ]; then
     exit 1;
 fi
 
-go get -u github.com/ardielle/ardielle-go/...
+go install github.com/ardielle/ardielle-go/...
 go build
 cp rdl-gen-athenz-java-client ${GOPATH}/bin/rdl-gen-athenz-java-client
 

--- a/rdl/rdl-gen-athenz-java-model/make_generator.sh
+++ b/rdl/rdl-gen-athenz-java-model/make_generator.sh
@@ -28,7 +28,7 @@ if [ -z "${GOPATH}" ]; then
     exit 1;
 fi
 
-go get -u github.com/ardielle/ardielle-go/...
+go install github.com/ardielle/ardielle-go/...
 go build
 cp rdl-gen-athenz-java-model ${GOPATH}/bin/rdl-gen-athenz-java-model
 

--- a/rdl/rdl-gen-athenz-server/make_generator.sh
+++ b/rdl/rdl-gen-athenz-server/make_generator.sh
@@ -33,7 +33,7 @@ if [ ! -d "${GOPATH}/bin" ]; then
     exit 1;
 fi
 
-go get -u github.com/ardielle/ardielle-go/...
+go install github.com/ardielle/ardielle-go/...
 go build
 cp rdl-gen-athenz-server ${GOPATH}/bin/rdl-gen-athenz-server
 

--- a/servers/zms/scripts/make_stubs.sh
+++ b/servers/zms/scripts/make_stubs.sh
@@ -17,14 +17,14 @@ if [ ! -z "${SCREWDRIVER}" ] || [ ! -z "${TRAVIS_PULL_REQUEST}" ] || [ ! -z "${T
 fi
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }

--- a/servers/zts/scripts/make_stubs.sh
+++ b/servers/zts/scripts/make_stubs.sh
@@ -16,17 +16,17 @@ fi
 # Note this script is dependent on the rdl utility.
 #
 # Use open source version of rdl https://github.com/ardielle/ardielle-tools
-# go get github.com/ardielle/ardielle-tools/...
+# go install github.com/ardielle/ardielle-tools/...
 
 if [ -x "$(command -v go)" ]; then
-    go get -u github.com/ardielle/ardielle-tools/...
+    go install github.com/ardielle/ardielle-tools/...
 fi
 
 command -v rdl >/dev/null 2>&1 || {
     echo >&2 "------------------------------------------------------------------------";
     echo >&2 "SOURCE WARNING";
     echo >&2 "------------------------------------------------------------------------";
-    echo >&2 "Please install rdl utility: go get -u github.com/ardielle/ardielle-tools/...";
+    echo >&2 "Please install rdl utility: go install github.com/ardielle/ardielle-tools/...";
     echo >&2 "Skipping source generation...";
     exit 0;
 }


### PR DESCRIPTION
[INFO] go get: installing executables with 'go get' in module mode is deprecated.
[INFO] 	To adjust and download dependencies of the current module, use 'go get -d'.
[INFO] 	To install using requirements of the current module, use 'go install'.
[INFO] 	To install ignoring the current module, use 'go install' with a version,
[INFO] 	like 'go install example.com/cmd@latest'.
[INFO] 	For more information, see https://golang.org/doc/go-get-install-deprecation
[INFO] 	or run 'go help get' or 'go help install'.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>