### PR TITLE
allow tokens to include openid issuer

### DIFF
--- a/servers/zts/conf/athenz.properties
+++ b/servers/zts/conf/athenz.properties
@@ -133,8 +133,3 @@ athenz.ssl_trust_store_password=athenz
 # How long to wait for the Jetty server to shut down, in milliseconds
 # If the athenz.graceful_shutdown is not true, this setting is invalid.
 #athenz.graceful_shutdown_timeout=30000
-
-# To specify the issuer field in the OpenID configuration metadata object.
-# This is also used to generate the JWKS URI in the configuration object,
-# so it must be the full https scheme endpoint for the server including the port.
-#athenz.zts.openid_issuer=

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -26,7 +26,7 @@ athenz.auth.private_key_store.private_key_id=0
 #athenz.zts.ssl_key_manager_password=
 
 # The path to the keystore file that contains the client's private key
-# and certificate. Currently this is only used by the HttpCertSigner
+# and certificate. Currently, this is only used by the HttpCertSigner
 # class implementation.
 #athenz.zts.ssl_key_store=/home/athenz/var/zts_server/certs/zts_keystore.pkcs12
 
@@ -59,19 +59,19 @@ javax.net.ssl.trustStorePassword=athenz
 #athenz.zts.zms_url=
 
 # SelfCertSignerFactory implementation - if this factory class is used
-# is used for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
 # property), this setting specifies the private key filename that is used to sign
 # certificate requests.
 #athenz.zts.self_signer_private_key_fname=/home/athenz/var/zts_server/keys/zts_private.pem
 
 # SelfCertSignerFactory implementation - if this factory class is used
-# is used for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
 # property), this setting specifies the private key password that is used to sign
 # certificate requests.
 #athenz.zts.self_signer_private_key_password=
 
 # SelfCertSignerFactory implementation - if this factory class is used
-# is used for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
 # property), this setting specifies the dn for the CA certificate that ZTS
 # will use
 #athenz.zts.self_signer_cert_dn=cn=Self Signed Athenz CA,o=Athenz,c=US
@@ -83,14 +83,14 @@ javax.net.ssl.trustStorePassword=athenz
 
 # HttpCertSignerFactory implementation - if this factory class is used
 # for the CertSigner implementation (athenz.zts.cert_signer_factory_class
-# property), this setting specifies in seconds the connect timeout
+# property), this setting specifies in seconds the connect-timeout
 #athenz.zts.certsign_connect_timeout=10
 
 # HttpCertSignerFactory implementation - if this factory class is used
 # for the CertSigner implementation (athenz.zts.cert_signer_factory_class
 # property), this setting specifies in seconds the request timeout.
-# We're setting the initial value to a small on so we know right away
-# if our idle connection has been been closed by cert signer and we'll
+# We're setting the initial value to a small one, so we know right away
+# if our idle connection has been closed by cert signer, and we'll
 # use our retry setting to retry with a max timeout of 30 seconds.
 #athenz.zts.certsign_request_timeout=5
 
@@ -146,7 +146,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # Specifies if the ZMS File based change log store implementation
 # will use the getJWSDomain api instead of getSignedDomain api to
 # fetch updated domains. getJWSDomain is extensible as it does not
-# use the internal method of singing the json document and instead
+# use the internal method of singing the json document, and instead
 # it uses standards based jws format
 #athenz.zts.zms_domain_jws_support=false
 
@@ -170,7 +170,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 #athenz.zts.role_token_default_timeout=7200
 
 # Specifies the maximum expiry timeout that a client can ask for when
-# requesting a oauth2 id token. If the client asks for a longer timeout, the
+# requesting an oauth2 id token. If the client asks for a longer timeout, the
 # server will automatically replace the value with this one
 #athenz.zts.id_token_max_timeout=43200
 
@@ -244,7 +244,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 
 # if using the jdbc connector (either mysql or aws) for zms
 # certificate data storage and the athenz.zts.cert_jdbc_use_ssl property
-# is set to true, this property specifies whether or not the jdbc client
+# is set to true, this property specifies if the jdbc client
 # must verify the server certificate or not
 #athenz.zts.cert_jdbc_verify_server_certificate=false
 
@@ -349,31 +349,31 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # provided by AWS.
 #athenz.zts.aws_public_cert
 
-# If ZTS is running within AWS and we need to validate the host identity document
+# If ZTS is running within AWS, and we need to validate the host identity document
 # before we issue a TLS certificate for a service identified by its IAM role,
 # the server verifies that the instance was booted within the configured number
 # of seconds
 #athenz.zts.aws_boot_time_offset=300
 
-# Comma separated list of URIs that require authentication according to the RDL
+# Comma separated list of URIs that require authentication according to the RDL,
 # but we want the server to make the authentication as optional. The URI can
 # include regex values based on + character to match resource URIs
 # for example, /zts/v1/domain/.+/service
 #athenz.zts.no_auth_uri_list
 
-# Boolean flag to control whether or not to include c=1 component in the issued
-# role token when the rolename argument passed to the api is null. The presence
+# Boolean flag to control if to include c=1 component in the issued
+# role token when the role name argument passed to the api is null. The presence
 # of the c=1 in the role token then would indicate that the token contains all
 # the roles that the principal has access in the domain
 #athenz.zts.role_complete_flag=true
 
-# If configured, specifies whether or not the server should send
+# If configured, specifies if the server should send
 # back the x.509 signer certificate in the response. It's possible
 # that the environment already has an external way of distributing
 # signer certificates
 #athenz.zts.resp_x509_signer_certs=true
 
-# If configured, specifies whether or not the server should send
+# If configured, specifies if the server should send
 # back the ssh signer certificate in the response. It's possible
 # that the environment already has an external way of distributing
 # signer certificates
@@ -441,7 +441,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 
 # List of valid values separated by | that a certificate
 # request can include in the Subject O field. For example, if
-# you allow to create certs with c=US,o=Company,cn=athenz.api
+# you allow creating certs with c=US,o=Company,cn=athenz.api
 # and c=US,o=Company Inc.,cn=athenz.api, then the value for
 # this property would be set to "Company|Company Inc.". If
 # the property is not set, then no validation is carried out.
@@ -457,7 +457,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 
 # List of valid values separated by | that a certificate
 # request can include in the Subject OU field. For example, if
-# you allow to create certs with c=US,o=Company,OU=Athenz,cn=athenz.api
+# you allow creating certs with c=US,o=Company,OU=Athenz,cn=athenz.api
 # and c=US,o=Company Inc.,ou=Yahoo,cn=athenz.api, then the value for
 # this property would be set to "Athenz|Yahoo". In case the
 # certificate is requested from a Copper Argos provider, the provider
@@ -467,7 +467,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 #athenz.zts.cert_allowed_ou_values=
 
 # During certificate refresh operations zts server looks up
-# the original certificate details (serial number, timestamp, etc)
+# the original certificate details (serial number, timestamp, etc.)
 # to detect compromise. If this database is lost, then server
 # will not be able to refresh any certs, so we provide an option
 # to regenerate the db based on requests rather than rejecting
@@ -482,7 +482,7 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # When requesting role and service certificates not through
 # Copper Argos providers, the server can verify that the IP
 # address in the request indeed matches to the connection
-# IP address. Typically this should be enabled by default
+# IP address. Typically, this should be enabled by default
 # but keeping it false for now for backward compatibility
 # reasons.
 #athenz.zts.cert_request_verify_ip=false
@@ -573,12 +573,12 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 #athenz.common.server.clog.zts_server_trust_store_password_app=
 
 # Comma separated list of domain that have dynamic services. For example,
-# screwdriver domain has dynamic projects for CI/CD and we need to give
+# screwdriver domain has dynamic projects for CI/CD, and we need to give
 # identity without creating a service. These services will be automatically
 # skipped from validation before certs are issued.
 #athenz.zts.validate_service_skip_domains=
 
-# Whether or not enforce that all services are registered before
+# Boolean flag to enforce that all services are registered before
 # an identity certificate is issued
 #athenz.zts.validate_service_identity=true
 
@@ -590,3 +590,8 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # sample/default entry for proxy principal access support is provided
 # in the conf/system_authz_details.json file.
 #athenz.zts.system_authz_details_path=
+
+# To specify the issuer field in the OpenID configuration metadata object.
+# This is also used to generate the JWKS URI in the configuration object,
+# so it must be the full https scheme endpoint for the server including the port.
+#athenz.zts.openid_issuer=

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -1955,7 +1955,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         accessToken.setExpiryTime(iat + tokenTimeout);
         accessToken.setUserId(principalName);
         accessToken.setSubject(principalName);
-        accessToken.setIssuer(useOpenIDIssuer ? ztsOpenIDIssuer: ztsOAuthIssuer);
+        accessToken.setIssuer(useOpenIDIssuer ? ztsOpenIDIssuer : ztsOAuthIssuer);
         accessToken.setProxyPrincipal(proxyUser);
         accessToken.setScope(new ArrayList<>(roles));
         accessToken.setAuthorizationDetails(authzDetails);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -190,6 +190,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     private static final String KEY_PROXY_FOR_PRINCIPAL = "proxy_for_principal";
     private static final String KEY_AUTHORIZATION_DETAILS = "authorization_details";
     private static final String KEY_PROXY_PRINCIPAL_SPIFFE_URIS = "proxy_principal_spiffe_uris";
+    private static final String KEY_OPENID_ISSUER = "openid_issuer";
     private static final String KEY_TYPE = "type";
 
     private static final String OAUTH_GRANT_CREDENTIALS = "client_credentials";
@@ -1778,6 +1779,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         String authzDetails = null;
         List<String> proxyPrincipalsSpiffeUris = null;
         int expiryTime = 0;
+        boolean useOpenIDIssuer = false;
 
         String[] comps = request.split("&");
         for (String comp : comps) {
@@ -1819,6 +1821,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                 case KEY_PROXY_PRINCIPAL_SPIFFE_URIS:
                     proxyPrincipalsSpiffeUris = getProxyPrincipalSpiffeUris(value.toLowerCase(),
                             principalDomain, caller);
+                    break;
+                case KEY_OPENID_ISSUER:
+                    useOpenIDIssuer = Boolean.parseBoolean(value);
                     break;
             }
         }
@@ -1950,7 +1955,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         accessToken.setExpiryTime(iat + tokenTimeout);
         accessToken.setUserId(principalName);
         accessToken.setSubject(principalName);
-        accessToken.setIssuer(ztsOAuthIssuer);
+        accessToken.setIssuer(useOpenIDIssuer ? ztsOpenIDIssuer: ztsOAuthIssuer);
         accessToken.setProxyPrincipal(proxyUser);
         accessToken.setScope(new ArrayList<>(roles));
         accessToken.setAuthorizationDetails(authzDetails);
@@ -1981,7 +1986,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             idToken.setVersion(1);
             idToken.setAudience(tokenRequest.getDomainName() + "." + serviceName);
             idToken.setSubject(principalName);
-            idToken.setIssuer(ztsOAuthIssuer);
+            idToken.setIssuer(useOpenIDIssuer ? ztsOpenIDIssuer : ztsOAuthIssuer);
 
             // id tokens are only valid for up to 12 hours max
             // (value configured as a system property).


### PR DESCRIPTION
For backward compatibility we'll default to using oauth2 issuer but provide an option in the token request to include the correct openid issuer which is also included in the well-known openid configuration document.

Also included some minor grammatical errors in the properties file.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>