### PR TITLE
use add-regular-role in zms-cli instead of add-group-role

### DIFF
--- a/clients/go/zms/examples/get-access/example.md
+++ b/clients/go/zms/examples/get-access/example.md
@@ -41,7 +41,7 @@ and create a service and obtain the TLS certificate in Athenz UI
 
 
   - Setup role/policy in target domain
-    - zms-cli -d home.userid.movies add-group-role editors home.userid.helloworld
+    - zms-cli -d home.userid.movies add-regular-role editors home.userid.helloworld
     - zms-cli -d home.userid.movies add-policy editors_policy grant read to editors on rec.movie
 
   - go build

--- a/docker/setup-scripts/sample-identity.sh
+++ b/docker/setup-scripts/sample-identity.sh
@@ -65,13 +65,13 @@ echo 'ZMS and ZTS sync-ed.' | colored_cat p
 echo '5. Setting up ZTS as provider'
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role providers sys.auth.zts
+    -d sys.auth add-regular-role providers sys.auth.zts
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy providers grant launch to providers on 'instance'
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role provider.sys.auth.zts sys.auth.zts
+    -d sys.auth add-regular-role provider.sys.auth.zts sys.auth.zts
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy provider.sys.auth.zts grant launch to provider.sys.auth.zts on 'dns.zts.athenz.cloud'

--- a/docker/setup-scripts/zts-auto-config.sh
+++ b/docker/setup-scripts/zts-auto-config.sh
@@ -213,7 +213,7 @@ zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${D
 echo '12. setup general providers role for all providers' | colored_cat g
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role providers sys.auth.zts athenz.aws.us-west-2 athenz.aws-ecs.us-west-2 athenz.aws-lambda.us-west-2
+    -d sys.auth add-regular-role providers sys.auth.zts athenz.aws.us-west-2 athenz.aws-ecs.us-west-2 athenz.aws-lambda.us-west-2
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy providers grant launch to providers on 'instance'
@@ -222,7 +222,7 @@ zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${D
 echo '13. setup ZTS as identity provider' | colored_cat g
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role provider.sys.auth.zts sys.auth.zts
+    -d sys.auth add-regular-role provider.sys.auth.zts sys.auth.zts
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy provider.sys.auth.zts grant launch to provider.sys.auth.zts on 'dns.zts.athenz.cloud'
@@ -233,19 +233,19 @@ zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${D
 echo '14. setup AWS identity provider' | colored_cat g
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role provider.athenz.aws.us-west-2 athenz.aws.us-west-2
+    -d sys.auth add-regular-role provider.athenz.aws.us-west-2 athenz.aws.us-west-2
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy provider.athenz.aws.us-west-2 grant launch to provider.athenz.aws.us-west-2 on 'dns.aws.athenz.cloud'
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role provider.athenz.aws-ecs.us-west-2 athenz.aws-ecs.us-west-2
+    -d sys.auth add-regular-role provider.athenz.aws-ecs.us-west-2 athenz.aws-ecs.us-west-2
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy provider.athenz.aws-ecs.us-west-2 grant launch to provider.athenz.aws-ecs.us-west-2 on 'dns.aws.athenz.cloud'
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
-    -d sys.auth add-group-role provider.athenz.aws-lambda.us-west-2 athenz.aws-lambda.us-west-2
+    -d sys.auth add-regular-role provider.athenz.aws-lambda.us-west-2 athenz.aws-lambda.us-west-2
 
 zms-cli -z "${ZMS_URL}/zms/v1" --key "${DOMAIN_ADMIN_CERT_KEY_PATH}" --cert "${DOMAIN_ADMIN_CERT_PATH}" -c "${ATHENZ_CA_PATH}" \
     -d sys.auth add-policy provider.athenz.aws-lambda.us-west-2 grant launch to provider.athenz.aws-lambda.us-west-2 on 'dns.aws.athenz.cloud'

--- a/docs/copper_argos_dev.md
+++ b/docs/copper_argos_dev.md
@@ -344,7 +344,7 @@ Policy: api_providers
 * Create the provider’s role:
 
 ```
-$ zms-cli -d sys.auth add-group-role providers
+$ zms-cli -d sys.auth add-regular-role providers
 ```
 
 * Create the provider’s policy:
@@ -399,7 +399,7 @@ $ zms-cli -d sys.auth add-member providers openstack.cluster1
   * Register the dns suffix for the provider service. For example, cluster1.ostk.athenz.cloud
 
 ```
-$ zms-cli -d sys.auth add-group-role provider.openstack.providers openstack.cluster1
+$ zms-cli -d sys.auth add-regular-role provider.openstack.providers openstack.cluster1
 $ zms-cli -d sys.auth add-policy provider.openstack.providers grant launch to provider.openstack.providers on dns.cluster1.ostk.athenz.cloud
 ```
 
@@ -409,7 +409,7 @@ $ zms-cli -d sys.auth add-policy provider.openstack.providers grant launch to pr
 * Authorize provider service to launch its instances. For example, weater domain wants to authorize its service api to be launched by openstack.cluster1 provider.
 
 ```
-$ zms-cli -d weather add-group-role openstack_providers openstack.cluster1
+$ zms-cli -d weather add-regular-role openstack_providers openstack.cluster1
 $ zms-cli -d weather add-policy openstack_providers grant launch to openstack_providers on weather:service.api
 ```
 

--- a/docs/zms_client.md
+++ b/docs/zms_client.md
@@ -206,13 +206,13 @@ ZMS allows you to remove yourself from the `admin` role.
     Once you've been removed, you'll need to ask another domain
     administrator to re-add you to the `admin` role.
 
-## Adding a Group Role
-----------------------
+## Adding a Regular Role
+------------------------
 
-To add new group role to a domain, the administrator will execute the
+To add new regular role to a domain, the administrator will execute the
 following zms-cli command:
 
-    $ zms-cli -d <domain> add-group-role <role> <member> [<member> ...]
+    $ zms-cli -d <domain> add-regular-role <role> <member> [<member> ...]
 
 <h3 id="parameters-1">Parameters</h3>
 
@@ -236,10 +236,10 @@ administrator can add and/or delete members using the `add-member` and
 
 When the domain administrator executes the command below, a new role
 called `readers` will be added to the the domain `athenz.ci` will
-have the following members: user - `yby.john` and service -
+have the following members: user - `user.john` and service -
 `media.sports.storage`:
 
-    $ zms-cli -d athenz.ci add-group-role readers yby.john media.sports.storage
+    $ zms-cli -d athenz.ci add-regular-role readers user.john media.sports.storage
 
 ## Managing a Group Role Membership
 -----------------------------------

--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -50,7 +50,7 @@ type Zms struct {
 }
 
 type SuccessMessage struct {
-	Status int
+	Status  int
 	Message string
 }
 
@@ -70,12 +70,12 @@ func (cli Zms) buildJSONOutput(res interface{}) (*string, error) {
 
 func (cli Zms) buildYAMLOutput(res interface{}) (*string, error) {
 	if cli.OutputFormat == JSONOutputFormat || cli.OutputFormat == YAMLOutputFormat {
-	yamlOutput, err := yaml.Marshal(res)
-	if err != nil {
-		return nil, fmt.Errorf("failed to produce YAML output: %v", err)
-	}
-	output := string(yamlOutput)
-	return &output, nil
+		yamlOutput, err := yaml.Marshal(res)
+		if err != nil {
+			return nil, fmt.Errorf("failed to produce YAML output: %v", err)
+		}
+		output := string(yamlOutput)
+		return &output, nil
 	} else {
 		// For manual yaml, we just return the message as text. We should remove
 		// it once we removed the "manual yaml" option
@@ -487,9 +487,10 @@ func (cli *Zms) EvalCommand(params []string) (*string, error) {
 				return cli.AddDelegatedRole(dn, args[0], args[1])
 			}
 		case "add-group-role":
+		case "add-regular-role":
 			if argc >= 1 {
 				roleMembers := cli.convertRoleMembers(args[1:])
-				return cli.AddGroupRole(dn, args[0], roleMembers)
+				return cli.AddRegularRole(dn, args[0], roleMembers)
 			}
 		case "add-provider-role-member", "add-provider-role-members":
 			if argc >= 4 {
@@ -989,7 +990,7 @@ func (cli *Zms) EvalCommand(params []string) (*string, error) {
 				}
 				return cli.SetGroupSelfServe(dn, args[0], selfServe)
 			}
-        case "set-group-member-expiry-days":
+		case "set-group-member-expiry-days":
 			if argc == 2 {
 				days, err := cli.getInt32(args[1])
 				if err != nil {
@@ -1733,19 +1734,20 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString(" examples:\n")
 		buf.WriteString("   " + domainExample + " add-delegated-role tenant.sports.readers sports\n")
 	case "add-group-role":
+	case "add-regular-role":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " add-group-role role member [member ... ]\n")
+		buf.WriteString("   " + domainParam + " add-regular-role role member [member ... ]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain  : name of the domain that role belongs to\n")
 		}
-		buf.WriteString("   role    : name of the standard group role\n")
-		buf.WriteString("   member  : list of group members that could be either users or services\n")
+		buf.WriteString("   role    : name of the standard role\n")
+		buf.WriteString("   member  : list of members that could be either users or services\n")
 		buf.WriteString(" examples:\n")
-		buf.WriteString("   " + domainExample + " add-group-role readers " + cli.UserDomain + ".john " + cli.UserDomain + ".joe media.sports.storage\n")
+		buf.WriteString("   " + domainExample + " add-regular-role readers " + cli.UserDomain + ".john " + cli.UserDomain + ".joe media.sports.storage\n")
 	case "add-member":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " add-member group_role user_or_service [user_or_service ...]\n")
+		buf.WriteString("   " + domainParam + " add-member regular_role user_or_service [user_or_service ...]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1756,7 +1758,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " add-member readers " + cli.UserDomain + ".john " + cli.UserDomain + ".joe media.sports.storage\n")
 	case "add-temporary-member":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " add-temporary-member group_role user_or_service expiration [review]\n")
+		buf.WriteString("   " + domainParam + " add-temporary-member regular_role user_or_service expiration [review]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1770,7 +1772,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " add-temporary-member readers " + cli.UserDomain + ",john 2017-03-02T15:04:05.999Z 2017-01-02T15:09:05.999Z\n")
 	case "add-reviewed-member":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " add-reviewed-member group_role user_or_service review\n")
+		buf.WriteString("   " + domainParam + " add-reviewed-member regular_role user_or_service review\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1782,7 +1784,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " add-reviewed-member readers " + cli.UserDomain + ",john 2017-03-02T15:04:05.999Z\n")
 	case "check-member":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " check-member group_role user_or_service [user_or_service ...]\n")
+		buf.WriteString("   " + domainParam + " check-member regular_role user_or_service [user_or_service ...]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1793,7 +1795,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " check-member readers " + cli.UserDomain + ".john " + cli.UserDomain + ".joe media.sports.storage\n")
 	case "check-active-member":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " check-active-member group_role user_or_service\n")
+		buf.WriteString("   " + domainParam + " check-active-member regular_role user_or_service\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1804,7 +1806,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " check-active-member readers " + cli.UserDomain + ".john\n")
 	case "delete-member":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " delete-member group_role user_or_service [user_or_service ...]\n")
+		buf.WriteString("   " + domainParam + " delete-member regular_role user_or_service [user_or_service ...]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1985,7 +1987,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " delete-group readers\n")
 	case "add-role-tag":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " add-role-tag group_role tag_key tag_value [tag_value ...]\n")
+		buf.WriteString("   " + domainParam + " add-role-tag regular_role tag_key tag_value [tag_value ...]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -1997,7 +1999,7 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " add-role-tag readers readers-tag-key reader-tag-value-1 reader-tag-value-2\n")
 	case "delete-role-tag":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   " + domainParam + " delete-role-tag group_role tag_key [tag_value]\n")
+		buf.WriteString("   " + domainParam + " delete-role-tag regular_role tag_key [tag_value]\n")
 		buf.WriteString(" parameters:\n")
 		if !interactive {
 			buf.WriteString("   domain          : name of the domain that role belongs to\n")
@@ -2886,37 +2888,37 @@ func (cli Zms) HelpListCommand() string {
 	buf.WriteString("   show-roles [tag_key] [tag_value]\n")
 	buf.WriteString("   show-roles-principal\n")
 	buf.WriteString("   add-delegated-role role trusted_domain\n")
-	buf.WriteString("   add-group-role role member [member ... ]\n")
-	buf.WriteString("   add-member group_role user_or_service [user_or_service ...]\n")
-	buf.WriteString("   add-temporary-member group_role user_or_service expiration\n")
-	buf.WriteString("   add-reviewed-member group_role user_or_service review\n")
-	buf.WriteString("   check-member group_role user_or_service [user_or_service ...]\n")
-	buf.WriteString("   check-active-member group_role user_or_service\n")
-	buf.WriteString("   delete-member group_role user_or_service [user_or_service ...]\n")
+	buf.WriteString("   add-regular-role role member [member ... ]\n")
+	buf.WriteString("   add-member regular_role user_or_service [user_or_service ...]\n")
+	buf.WriteString("   add-temporary-member regular_role user_or_service expiration\n")
+	buf.WriteString("   add-reviewed-member regular_role user_or_service review\n")
+	buf.WriteString("   check-member regular_role user_or_service [user_or_service ...]\n")
+	buf.WriteString("   check-active-member regular_role user_or_service\n")
+	buf.WriteString("   delete-member regular_role user_or_service [user_or_service ...]\n")
 	buf.WriteString("   add-provider-role-member provider_service resource_group provider_role user_or_service [user_or_service ...]\n")
 	buf.WriteString("   show-provider-role-member provider_service resource_group provider_role\n")
 	buf.WriteString("   delete-provider-role-member provider_service resource_group provider_role user_or_service [user_or_service ...]\n")
 	buf.WriteString("   list-domain-role-members\n")
 	buf.WriteString("   delete-domain-role-member member\n")
 	buf.WriteString("   delete-role role\n")
-	buf.WriteString("   set-role-audit-enabled group_role audit-enabled\n")
-	buf.WriteString("   set-role-review-enabled group_role review-enabled\n")
-	buf.WriteString("   set-role-self-serve group_role self-serve\n")
-	buf.WriteString("   set-role-member-expiry-days group_role user-member-expiry-days\n")
-	buf.WriteString("   set-role-service-expiry-days group_role service-member-expiry-days\n")
-	buf.WriteString("   set-role-group-expiry-days group_role group-member-expiry-days\n")
-	buf.WriteString("   set-role-member-review-days group_role user-member-review-days\n")
-	buf.WriteString("   set-role-service-review-days group_role service-member-review-days\n")
-	buf.WriteString("   set-role-group-review-days group_role group-member-review-days\n")
-	buf.WriteString("   set-role-token-expiry-mins group_role token-expiry-mins\n")
-	buf.WriteString("   set-role-cert-expiry-mins group_role cert-expiry-mins\n")
-	buf.WriteString("   set-role-token-sign-algorithm group_role algorithm\n")
-	buf.WriteString("   set-role-notify-roles group_role rolename[,rolename...]\n")
-	buf.WriteString("   set-role-user-authority-filter group_role attribute[,attribute...]\n")
-	buf.WriteString("   set-role-user-authority-expiration group_role attribute\n")
-	buf.WriteString("   add-role-tag group_role tag_key tag_value [tag_value ...]\n")
-	buf.WriteString("   delete-role-tag group_role tag_key [tag_value]\n")
-	buf.WriteString("   put-membership-decision group_role user_or_service [expiration] decision\n")
+	buf.WriteString("   set-role-audit-enabled regular_role audit-enabled\n")
+	buf.WriteString("   set-role-review-enabled regular_role review-enabled\n")
+	buf.WriteString("   set-role-self-serve regular_role self-serve\n")
+	buf.WriteString("   set-role-member-expiry-days regular_role user-member-expiry-days\n")
+	buf.WriteString("   set-role-service-expiry-days regular_role service-member-expiry-days\n")
+	buf.WriteString("   set-role-group-expiry-days regular_role group-member-expiry-days\n")
+	buf.WriteString("   set-role-member-review-days regular_role user-member-review-days\n")
+	buf.WriteString("   set-role-service-review-days regular_role service-member-review-days\n")
+	buf.WriteString("   set-role-group-review-days regular_role group-member-review-days\n")
+	buf.WriteString("   set-role-token-expiry-mins regular_role token-expiry-mins\n")
+	buf.WriteString("   set-role-cert-expiry-mins regular_role cert-expiry-mins\n")
+	buf.WriteString("   set-role-token-sign-algorithm regular_role algorithm\n")
+	buf.WriteString("   set-role-notify-roles regular_role rolename[,rolename...]\n")
+	buf.WriteString("   set-role-user-authority-filter regular_role attribute[,attribute...]\n")
+	buf.WriteString("   set-role-user-authority-expiration regular_role attribute\n")
+	buf.WriteString("   add-role-tag regular_role tag_key tag_value [tag_value ...]\n")
+	buf.WriteString("   delete-role-tag regular_role tag_key [tag_value]\n")
+	buf.WriteString("   put-membership-decision regular_role user_or_service [expiration] decision\n")
 	buf.WriteString("\n")
 	buf.WriteString(" Group commands:\n")
 	buf.WriteString("   list-group\n")
@@ -2934,7 +2936,7 @@ func (cli Zms) HelpListCommand() string {
 	buf.WriteString("   set-group-review-enabled group review-enabled\n")
 	buf.WriteString("   set-group-self-serve group self-serve\n")
 	buf.WriteString("   set-group-member-expiry-days group user-member-expiry-days\n")
-    buf.WriteString("   set-group-service-expiry-days group service-member-expiry-days\n")
+	buf.WriteString("   set-group-service-expiry-days group service-member-expiry-days\n")
 	buf.WriteString("   set-group-notify-roles group rolename[,rolename...]\n")
 	buf.WriteString("   set-group-user-authority-filter group attribute[,attribute...]\n")
 	buf.WriteString("   set-group-user-authority-expiration group attribute\n")

--- a/libs/go/zmscli/import.go
+++ b/libs/go/zmscli/import.go
@@ -70,7 +70,7 @@ func (cli Zms) importRoles(dn string, lstRoles []*zms.Role, validatedAdmins []st
 				}
 				b := cli.Verbose
 				cli.Verbose = true
-				_, err = cli.AddGroupRole(dn, rn, roleMembers)
+				_, err = cli.AddRegularRole(dn, rn, roleMembers)
 				cli.Verbose = b
 			}
 			if err != nil {
@@ -94,7 +94,7 @@ func (cli Zms) importRoles(dn string, lstRoles []*zms.Role, validatedAdmins []st
 			roleMembers := make([]*zms.RoleMember, 0)
 			b := cli.Verbose
 			cli.Verbose = true
-			_, err := cli.AddGroupRole(dn, rn, roleMembers)
+			_, err := cli.AddRegularRole(dn, rn, roleMembers)
 			cli.Verbose = b
 			if err != nil {
 				if skipErrors {
@@ -145,7 +145,7 @@ func (cli Zms) importRolesOld(dn string, lstRoles []interface{}, validatedAdmins
 				}
 				b := cli.Verbose
 				cli.Verbose = true
-				_, err = cli.AddGroupRole(dn, rn, roleMembers)
+				_, err = cli.AddRegularRole(dn, rn, roleMembers)
 				cli.Verbose = b
 			}
 			if err != nil {
@@ -169,7 +169,7 @@ func (cli Zms) importRolesOld(dn string, lstRoles []interface{}, validatedAdmins
 			roleMembers := make([]*zms.RoleMember, 0)
 			b := cli.Verbose
 			cli.Verbose = true
-			_, err := cli.AddGroupRole(dn, rn, roleMembers)
+			_, err := cli.AddRegularRole(dn, rn, roleMembers)
 			cli.Verbose = b
 			if err != nil {
 				if skipErrors {

--- a/libs/go/zmscli/role.go
+++ b/libs/go/zmscli/role.go
@@ -122,7 +122,7 @@ func (cli Zms) AddDelegatedRole(dn string, rn string, trusted string) (*string, 
 	return output, err
 }
 
-func (cli Zms) AddGroupRole(dn string, rn string, roleMembers []*zms.RoleMember) (*string, error) {
+func (cli Zms) AddRegularRole(dn string, rn string, roleMembers []*zms.RoleMember) (*string, error) {
 	fullResourceName := dn + ":role." + rn
 	var role zms.Role
 	_, err := cli.Zms.GetRole(zms.DomainName(dn), zms.EntityName(rn), nil, nil, nil)


### PR DESCRIPTION
add-group-role is kept as supported command for backward compatibility

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>