### PR TITLE
process service/role/policy in correct order in zms-cli update-domain

### DIFF
--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -1404,6 +1404,15 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   admin     : additional list of administrators to be added to the domain\n")
 		buf.WriteString(" examples:\n")
 		buf.WriteString("   import-domain coretech coretech.yaml " + cli.UserDomain + ".john\n")
+	case "update-domain":
+		buf.WriteString(" syntax:\n")
+		buf.WriteString("   [-o json] update-domain domain [file.yaml [admin ...]] - no file means stdin\n")
+		buf.WriteString(" parameters:\n")
+		buf.WriteString("   domain    : name of the domain being updated\n")
+		buf.WriteString("   file.yaml : file that contains domain contents in yaml format\n")
+		buf.WriteString("   admin     : additional list of administrators to be added to the domain\n")
+		buf.WriteString(" examples:\n")
+		buf.WriteString("   update-domain coretech coretech.yaml " + cli.UserDomain + ".john\n")
 	case "export-domain":
 		buf.WriteString(" syntax:\n")
 		buf.WriteString("   [-o json] export-domain domain [file.yaml or file.json] - no file means stdout\n")

--- a/libs/go/zmscli/import.go
+++ b/libs/go/zmscli/import.go
@@ -283,39 +283,55 @@ func (cli Zms) generatePublicKeys(lstPublicKeys []interface{}) []*zms.PublicKeyE
 	return publicKeys
 }
 
-func (cli Zms) importServices(dn string, lstServices []*zms.ServiceIdentity) error {
+func (cli Zms) importServices(dn string, lstServices []*zms.ServiceIdentity, skipErrors bool) error {
 	for _, service := range lstServices {
 		name := string(service.Name)
 		_, _ = fmt.Fprintf(os.Stdout, "Processing service "+name+"...\n")
 		publicKeys := service.PublicKeys
 		_, err := cli.AddServiceWithKeys(dn, name, publicKeys)
 		if err != nil {
-			return err
+			if skipErrors {
+				fmt.Println("***", err)
+			} else {
+				return err
+			}
 		}
 		if service.ProviderEndpoint != "" {
 			_, err = cli.SetServiceEndpoint(dn, name, service.ProviderEndpoint)
 			if err != nil {
-				return err
+				if skipErrors {
+					fmt.Println("***", err)
+				} else {
+					return err
+				}
 			}
 		}
 
 		if service.User != "" || service.Group != "" || service.Executable != "" {
 			_, err = cli.SetServiceExe(dn, name, service.Executable, service.User, service.Group)
 			if err != nil {
-				return err
+				if skipErrors {
+					fmt.Println("***", err)
+				} else {
+					return err
+				}
 			}
 		}
 		if len(service.Hosts) > 0 {
 			_, err = cli.AddServiceHost(dn, name, service.Hosts)
 			if err != nil {
-				return err
+				if skipErrors {
+					fmt.Println("***", err)
+				} else {
+					return err
+				}
 			}
 		}
 	}
 	return nil
 }
 
-func (cli Zms) importServicesOld(dn string, lstServices []interface{}) error {
+func (cli Zms) importServicesOld(dn string, lstServices []interface{}, skipErrors bool) error {
 	for _, service := range lstServices {
 		serviceMap := service.(map[interface{}]interface{})
 		name := serviceMap["name"].(string)
@@ -334,7 +350,11 @@ func (cli Zms) importServicesOld(dn string, lstServices []interface{}) error {
 			if endpoint != "" {
 				_, err = cli.SetServiceEndpoint(dn, name, endpoint)
 				if err != nil {
-					return err
+					if skipErrors {
+						fmt.Println("***", err)
+					} else {
+						return err
+					}
 				}
 			}
 		}
@@ -353,7 +373,11 @@ func (cli Zms) importServicesOld(dn string, lstServices []interface{}) error {
 		if user != "" || group != "" || exe != "" {
 			_, err = cli.SetServiceExe(dn, name, exe, user, group)
 			if err != nil {
-				return err
+				if skipErrors {
+					fmt.Println("***", err)
+				} else {
+					return err
+				}
 			}
 		}
 		if val, ok := serviceMap["hosts"]; ok {
@@ -364,7 +388,11 @@ func (cli Zms) importServicesOld(dn string, lstServices []interface{}) error {
 			}
 			_, err = cli.AddServiceHost(dn, name, hosts)
 			if err != nil {
-				return err
+				if skipErrors {
+					fmt.Println("***", err)
+				} else {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
also pass the import/update flag when processing services so we skip any existing services instead of rejecting the request.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>