### PR TITLE
specify TLS 1.2/1.3 version for RDS communication with IAM creds

### DIFF
--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactoryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactoryTest.java
@@ -60,7 +60,6 @@ public class AWSObjectStoreFactoryTest {
 
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_USER, "rds-user");
-        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_IAM_ROLE, "role");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "1");
 
         System.clearProperty(ZMSConsts.ZMS_PROP_AWS_RDS_REPLICA_INSTANCE);
@@ -81,7 +80,6 @@ public class AWSObjectStoreFactoryTest {
 
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_USER, "rds-user");
-        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_IAM_ROLE, "role");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "30000");
 
         System.clearProperty(ZMSConsts.ZMS_PROP_AWS_RDS_REPLICA_INSTANCE);
@@ -110,7 +108,6 @@ public class AWSObjectStoreFactoryTest {
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_REPLICA_INSTANCE, "replica");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_USER, "rds-user");
-        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_IAM_ROLE, "role");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "30000");
 
         AWSObjectStoreFactory factory = new TestAWSObjectStoreFactory();


### PR DESCRIPTION
* also fixed default db name to be zms_server to match our schema
* remove unused rds-iam-role variable

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>