### PR TITLE
support athenz.client@ as user-info in provider endpoint to use zts client certs

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -332,10 +332,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         // create our instance manager and provider
         
-        instanceCertManager = new InstanceCertManager(privateKeyStore, authorizer, hostnameResolver, readOnlyMode.get(), userAuthority);
+        instanceCertManager = new InstanceCertManager(privateKeyStore, authorizer, hostnameResolver,
+                readOnlyMode.get(), userAuthority);
 
-        instanceProviderManager = new InstanceProviderManager(dataStore,
-                ZTSUtils.createServerClientSSLContext(privateKeyStore), privateKey, this);
+        instanceProviderManager = new InstanceProviderManager(dataStore, ZTSUtils.getAthenzServerSSLContext(privateKeyStore),
+                ZTSUtils.getAthenzClientSSLContext(privateKeyStore), privateKey, this);
         
         // make sure to set the keystore for any instance that requires it
         

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -72,8 +72,6 @@ public class ZTSUtils {
     private static final String ATHENZ_PROP_TRUSTSTORE_TYPE                     = "athenz.ssl_trust_store_type";
     private static final String ATHENZ_PROP_PUBLIC_CERT_PATH_FOR_SSL            = "athenz.ssl_client_public_cert_path";
     private static final String ATHENZ_PROP_PRIVATE_KEY_PATH_FOR_SSL            = "athenz.ssl_client_private_key_path";
-    private static final String ATHENZ_PROP_USE_FILE_CERT_AND_KEY_FOR_SSL       = "athenz.ssl_client_use_file_cert_and_key";
-    private static final String ATHENZ_DEFAULT_USE_FILE_CERT_AND_KEY_FOR_SSL    = "false";
 
     private static final String ATHENZ_PROP_KEYSTORE_PASSWORD_APPNAME   = "athenz.ssl_key_store_password_appname";
     private static final String ATHENZ_PROP_TRUSTSTORE_PASSWORD_APPNAME = "athenz.ssl_trust_store_password_appname";
@@ -291,15 +289,7 @@ public class ZTSUtils {
         return new Identity().setName(cn).setCertificate(pemCert);
     }
 
-    public static SSLContext createServerClientSSLContext(PrivateKeyStore privateKeyStore) {
-        if (Boolean.parseBoolean(System.getProperty(ATHENZ_PROP_USE_FILE_CERT_AND_KEY_FOR_SSL, ATHENZ_DEFAULT_USE_FILE_CERT_AND_KEY_FOR_SSL))) {
-            return getSslContextUsingKeyCertFiles(privateKeyStore);
-        } else {
-            return getSslContextUsingKeyStores(privateKeyStore);
-        }
-    }
-
-    private static SSLContext getSslContextUsingKeyCertFiles(PrivateKeyStore privateKeyStore) {
+    public static SSLContext getAthenzClientSSLContext(PrivateKeyStore privateKeyStore) {
         final String trustStorePath = System.getProperty(ATHENZ_PROP_TRUSTSTORE_PATH);
         if (trustStorePath == null) {
             LOGGER.error("Unable to create client ssl context: no truststore path specified");
@@ -338,7 +328,7 @@ public class ZTSUtils {
         }
     }
 
-    private static SSLContext getSslContextUsingKeyStores(PrivateKeyStore privateKeyStore) {
+    public static SSLContext getAthenzServerSSLContext(PrivateKeyStore privateKeyStore) {
         final String keyStorePath = System.getProperty(ATHENZ_PROP_KEYSTORE_PATH);
         if (keyStorePath == null) {
             LOGGER.error("Unable to create client ssl context: no keystore path specified");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
@@ -38,6 +38,7 @@ import com.yahoo.athenz.common.metrics.Metric;
 import com.yahoo.athenz.common.server.dns.HostnameResolver;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
 import com.yahoo.athenz.zts.store.MockZMSFileChangeLogStore;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -185,7 +186,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", true, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech", null);
         assertNull(client);
     }
@@ -196,7 +197,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", true, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, SSLContext.getDefault(), null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, SSLContext.getDefault(), null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", null);
         assertNotNull(client);
         client.close();
@@ -208,7 +209,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", true, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, SSLContext.getDefault(), null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, SSLContext.getDefault(), null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather2", null);
         assertNull(client);
     }
@@ -219,7 +220,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainClassEndpoint("coretech", "weather", true, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", new HostnameResolver(){});
         assertNotNull(client);
         client.close();
@@ -233,7 +234,7 @@ public class InstanceProviderManagerTest {
 
         PrivateKey privateKey = Mockito.mock(PrivateKey.class);
         ServerPrivateKey serverPrivateKey = new ServerPrivateKey(privateKey, "0");
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, serverPrivateKey, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, serverPrivateKey, null);
         InstanceProvider client = provider.getProvider("sys.auth.zts", new HostnameResolver(){});
         assertNotNull(client);
         client.close();
@@ -246,7 +247,7 @@ public class InstanceProviderManagerTest {
         store.processSignedDomain(signedDomain, false);
 
         System.setProperty("athenz.instance.test.class.exception", "true");
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", new HostnameResolver(){});
         assertNull(client);
         System.clearProperty("athenz.instance.test.class.exception");
@@ -258,7 +259,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", true, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech2.weather", null);
         assertNull(client);
     }
@@ -269,7 +270,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", true, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather2", null);
         assertNull(client);
     }
@@ -280,7 +281,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", true, false);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", null);
         assertNull(client);
     }
@@ -292,7 +293,7 @@ public class InstanceProviderManagerTest {
                 true, true, "http://invalid");
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", null);
         assertNull(client);
     }
@@ -304,7 +305,7 @@ public class InstanceProviderManagerTest {
                 true, true, "://test.athenz.com/");
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", null);
         assertNull(client);
     }
@@ -315,7 +316,7 @@ public class InstanceProviderManagerTest {
         SignedDomain signedDomain = createSignedDomainHttpsEndpoint("coretech", "weather", false, true);
         store.processSignedDomain(signedDomain, false);
         
-        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(store, null, null, null, null);
         InstanceProvider client = provider.getProvider("coretech.weather", null);
         assertNull(client);
     }
@@ -323,7 +324,7 @@ public class InstanceProviderManagerTest {
     @Test
     public void testGetProviderScheme() throws URISyntaxException {
 
-        InstanceProviderManager provider = new InstanceProviderManager(null, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(null, null, null, null, null);
 
         URI uri = new URI("https://test.athenz2.com/");
         assertEquals(provider.getProviderScheme(uri), ProviderScheme.HTTPS);
@@ -344,7 +345,7 @@ public class InstanceProviderManagerTest {
     @Test
     public void testGetProviderEndpointScheme() throws URISyntaxException {
         
-        InstanceProviderManager provider = new InstanceProviderManager(null, null, null, null);
+        InstanceProviderManager provider = new InstanceProviderManager(null, null, null, null, null);
         URI uri = new URI("https://test.athenz2.com/");
         assertEquals(provider.getProviderEndpointScheme(uri), ProviderScheme.HTTPS);
         
@@ -401,7 +402,7 @@ public class InstanceProviderManagerTest {
     public void testGetClassInstance() {
         HostnameResolver hostnameResolver = new HostnameResolver(){};
 
-        InstanceProviderManager providerManager = new InstanceProviderManager(null, null, null, null);
+        InstanceProviderManager providerManager = new InstanceProviderManager(null, null, null, null, null);
         InstanceProvider provider = providerManager.getClassProvider("unknown.class", "provider", hostnameResolver);
         assertNull(provider);
         
@@ -435,7 +436,7 @@ public class InstanceProviderManagerTest {
     
     @Test
     public void testVerifyProviderEndpoint() {
-        InstanceProviderManager providerManager = new InstanceProviderManager(null, null, null, null);
+        InstanceProviderManager providerManager = new InstanceProviderManager(null, null, null, null, null);
         assertTrue(providerManager.verifyProviderEndpoint("test1.athenz.com"));
         assertTrue(providerManager.verifyProviderEndpoint("test1.athenz2.com"));
         assertFalse(providerManager.verifyProviderEndpoint("test1.athenz3.com"));
@@ -446,5 +447,47 @@ public class InstanceProviderManagerTest {
         assertTrue(providerManager.verifyProviderEndpoint("test1.athenz.com"));
         assertTrue(providerManager.verifyProviderEndpoint("test1.athenz2.com"));
         assertTrue(providerManager.verifyProviderEndpoint("test1.athenz3.com"));
+    }
+
+    @Test
+    public void testGetProviderEndpoint() throws URISyntaxException {
+        InstanceProviderManager providerManager = new InstanceProviderManager(null, null, null, null, null);
+
+        String providerEndpoint = "https://test.athenz2.com/";
+        URI uri = new URI(providerEndpoint);
+        assertEquals(providerManager.getProviderEndpoint(uri, false, providerEndpoint), providerEndpoint);
+
+        providerEndpoint = "https://athenz.client@test.athenz2.com/";
+        uri = new URI(providerEndpoint);
+        assertEquals(providerManager.getProviderEndpoint(uri, true, providerEndpoint), "https://test.athenz2.com/");
+
+        providerEndpoint = "https://athenz.client%82@test.athenz2.com/";
+        uri = new URI(providerEndpoint);
+        assertEquals(providerManager.getProviderEndpoint(uri, true, providerEndpoint), "https://test.athenz2.com/");
+    }
+
+    @Test
+    public void testGetSSLContext() {
+
+        SSLContext serverContext = Mockito.mock(SSLContext.class);
+        SSLContext clientContext = Mockito.mock(SSLContext.class);
+
+        // when both are specified, the appropriate context is returned
+
+        InstanceProviderManager providerManager = new InstanceProviderManager(null, serverContext, clientContext, null, null);
+        assertEquals(providerManager.getSSLContext(true), clientContext);
+        assertEquals(providerManager.getSSLContext(false), serverContext);
+
+        // if client is only specified then we get that for both values
+
+        providerManager = new InstanceProviderManager(null, null, clientContext, null, null);
+        assertEquals(providerManager.getSSLContext(true), clientContext);
+        assertEquals(providerManager.getSSLContext(false), clientContext);
+
+        // if server is only specified then we get that for both values
+
+        providerManager = new InstanceProviderManager(null, serverContext, null, null, null);
+        assertEquals(providerManager.getSSLContext(true), serverContext);
+        assertEquals(providerManager.getSSLContext(false), serverContext);
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -346,7 +346,7 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNotNull(sslContext);
 
         System.clearProperty("athenz.ssl_key_store");
@@ -361,7 +361,6 @@ public class ZTSUtilsTest {
         String certPath = Resources.getResource("gdpr.aws.core.cert.pem").getPath();//public
         String keyPath = Resources.getResource("unit_test_gdpr.aws.core.key.pem").getPath();//private
 
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         System.setProperty("athenz.ssl_client_public_cert_path", certPath);
         System.setProperty("athenz.ssl_client_private_key_path", keyPath);
         String filePath = Resources.getResource("truststore.jks").getFile();
@@ -369,10 +368,9 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNotNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_client_public_cert_path");
         System.clearProperty("athenz.ssl_client_private_key_path");
         System.clearProperty("athenz.ssl_trust_store");
@@ -385,7 +383,6 @@ public class ZTSUtilsTest {
         String certPath = Resources.getResource("athenz.instanceid.csr").getPath();//public
         String keyPath = Resources.getResource("unit_test_gdpr.aws.core.key.pem").getPath();//private
 
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         System.setProperty("athenz.ssl_client_public_cert_path", certPath);
         System.setProperty("athenz.ssl_client_private_key_path", keyPath);
         String filePath = Resources.getResource("truststore.jks").getFile();
@@ -393,10 +390,9 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_client_public_cert_path");
         System.clearProperty("athenz.ssl_client_private_key_path");
         System.clearProperty("athenz.ssl_trust_store");
@@ -407,7 +403,6 @@ public class ZTSUtilsTest {
     @Test
     public void testCreateSSLClientContextObjectLocalCertBadPath() {
 
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         System.setProperty("athenz.ssl_client_public_cert_path", "/cert/not/found.pem");
         System.setProperty("athenz.ssl_client_private_key_path", "/key/not/found.pem");
         String filePath = Resources.getResource("truststore.jks").getFile();
@@ -415,10 +410,9 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_client_public_cert_path");
         System.clearProperty("athenz.ssl_client_private_key_path");
         System.clearProperty("athenz.ssl_trust_store");
@@ -429,7 +423,6 @@ public class ZTSUtilsTest {
     @Test
     public void testCreateSSLClientContextObjectLocalCertBadKeyPath() {
         String certPath = Resources.getResource("gdpr.aws.core.cert.pem").getPath();//public
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         System.setProperty("athenz.ssl_client_public_cert_path", certPath);
         System.setProperty("athenz.ssl_client_private_key_path", "/key/not/found.pem");
         String filePath = Resources.getResource("truststore.jks").getFile();
@@ -437,10 +430,9 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_client_public_cert_path");
         System.clearProperty("athenz.ssl_client_private_key_path");
         System.clearProperty("athenz.ssl_trust_store");
@@ -450,30 +442,26 @@ public class ZTSUtilsTest {
 
     @Test
     public void testCreateSSLClientContextObjectLocalCertTrustStoreNotSpecified() {
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_trust_store_type");
         System.clearProperty("athenz.ssl_trust_store_password");
     }
 
     @Test
     public void testCreateSSLClientContextObjectLocalCertNotSpecified() {
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         String filePath = Resources.getResource("truststore.jks").getFile();
         System.setProperty("athenz.ssl_trust_store", filePath);
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_trust_store");
         System.clearProperty("athenz.ssl_trust_store_type");
         System.clearProperty("athenz.ssl_trust_store_password");
@@ -483,16 +471,14 @@ public class ZTSUtilsTest {
     public void testCreateSSLClientContextObjectLocalCertKeyNotSpecified() {
         String certPath = Resources.getResource("gdpr.aws.core.cert.pem").getPath();//public
         System.setProperty("athenz.ssl_client_public_cert_path", certPath);
-        System.setProperty("athenz.ssl_client_use_file_cert_and_key", "true");
         String filePath = Resources.getResource("truststore.jks").getFile();
         System.setProperty("athenz.ssl_trust_store", filePath);
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzClientSSLContext(null);
         assertNull(sslContext);
 
-        System.clearProperty("athenz.ssl_client_use_file_cert_and_key");
         System.clearProperty("athenz.ssl_client_public_cert_path");
         System.clearProperty("athenz.ssl_trust_store");
         System.clearProperty("athenz.ssl_trust_store_type");
@@ -504,7 +490,7 @@ public class ZTSUtilsTest {
 
         // make sure we have no keystore path
         System.clearProperty("athenz.ssl_key_store");
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 
@@ -517,7 +503,7 @@ public class ZTSUtilsTest {
 
         // make sure we have no truststore path
         System.clearProperty("athenz.ssl_trust_store");
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 
@@ -533,7 +519,7 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "invalid");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 
@@ -549,7 +535,7 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.clearProperty("athenz.ssl_trust_store_password");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 
@@ -565,7 +551,7 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 
@@ -581,7 +567,7 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "JKS");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 
@@ -597,7 +583,7 @@ public class ZTSUtilsTest {
         System.setProperty("athenz.ssl_trust_store_type", "PKS12");
         System.setProperty("athenz.ssl_trust_store_password", "123456");
 
-        SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
+        SSLContext sslContext = ZTSUtils.getAthenzServerSSLContext(null);
         assertNull(sslContext);
     }
 


### PR DESCRIPTION
e.g. https://athenz.client@provider.athenz.io/

when connecting, zts will remove the athenz.client@ and use uri https://provider.athenz.io/

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>