### PR TITLE
Make aws email provider public

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
@@ -55,7 +55,7 @@ public class AWSEmailProvider implements EmailProvider {
         }
     }
 
-    AWSEmailProvider() {
+    public AWSEmailProvider() {
         this(initSES());
     }
 


### PR DESCRIPTION
so it can be used by other services depending on athenz-server-common

Signed-off-by: Ofer Levi <ofer.levi@verizonmedia.com>