### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func setup() {
@@ -106,15 +105,11 @@ func TestUpdateFileExisting(test *testing.T) {
 
 func TestRegisterInstance(test *testing.T) {
 
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	keyFile := fmt.Sprintf("%s/athenz.hockey.key.pem", siaDir)
 	certFile := fmt.Sprintf("%s/athenz.hockey.cert.pem", siaDir)
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
-
-	require.Nil(test, err)
 
 	opts := &options.Options{
 		Domain: "athenz",
@@ -138,7 +133,7 @@ func TestRegisterInstance(test *testing.T) {
 		Role: "athenz.hockey",
 	}
 
-	err = RegisterInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5081/zts/v1", opts, false)
+	err := RegisterInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5081/zts/v1", opts, false)
 	assert.Nil(test, err, "unable to register instance")
 
 	if err != nil {
@@ -169,15 +164,13 @@ func copyFile(src, dst string) error {
 
 func TestRefreshInstance(test *testing.T) {
 
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	keyFile := fmt.Sprintf("%s/athenz.hockey.key.pem", siaDir)
 	certFile := fmt.Sprintf("%s/athenz.hockey.cert.pem", siaDir)
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
 
-	err = copyFile("devel/data/key.pem", keyFile)
+	err := copyFile("devel/data/key.pem", keyFile)
 	if err != nil {
 		test.Errorf("Unable to copy file %s to %s - %v\n", "devel/data/key.pem", keyFile, err)
 		return
@@ -228,16 +221,14 @@ func TestRefreshInstance(test *testing.T) {
 
 func TestRoleCertificateRequest(test *testing.T) {
 
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	keyFile := fmt.Sprintf("%s/athenz.hockey.key.pem", siaDir)
 	certFile := fmt.Sprintf("%s/athenz.hockey.cert.pem", siaDir)
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
 	roleCertFile := fmt.Sprintf("%s/testrole.cert.pem", siaDir)
 
-	err = copyFile("devel/data/key.pem", keyFile)
+	err := copyFile("devel/data/key.pem", keyFile)
 	if err != nil {
 		test.Errorf("Unable to copy file %s to %s - %v\n", "devel/data/key.pem", keyFile, err)
 		return

--- a/libs/go/sia/futil/futil_test.go
+++ b/libs/go/sia/futil/futil_test.go
@@ -13,10 +13,7 @@ import (
 )
 
 func TestWriteFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", "writeFile")
-	require.Nilf(t, err, "unexpected err: %v", err)
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	type args struct {
 		name string
@@ -56,9 +53,7 @@ func TestWriteFile(t *testing.T) {
 }
 
 func TestMakeSiaDirs(t *testing.T) {
-	dir, err := os.MkdirTemp("", "siaDir")
-	require.Nilf(t, err, "unexpected err: %v", err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	type args struct {
 		dirs []string
@@ -103,10 +98,8 @@ func TestMakeSiaDirs(t *testing.T) {
 }
 
 func TestSymlink(t *testing.T) {
-	sshDir, err := ioutil.TempDir("", "ssh.")
-	require.Nilf(t, err, "unexpected err: %v", err)
+	sshDir := t.TempDir()
 	log.Printf("sshDir: %q", sshDir)
-	defer os.RemoveAll(sshDir)
 
 	source := filepath.Join(sshDir, "source")
 	ioutil.WriteFile(source, []byte("source file"), 0400)
@@ -114,7 +107,7 @@ func TestSymlink(t *testing.T) {
 	existingLink := filepath.Join(sshDir, "existingLink")
 	existingSource := filepath.Join(sshDir, "existingSource")
 	ioutil.WriteFile(existingSource, []byte("earlier source file"), 0000)
-	err = os.Symlink(existingSource, existingLink)
+	err := os.Symlink(existingSource, existingLink)
 	require.Nilf(t, err, "unexpected err: %v", err)
 
 	regularFile := filepath.Join(sshDir, "regular")

--- a/libs/go/sia/host/hostdoc/hostdoc_test.go
+++ b/libs/go/sia/host/hostdoc/hostdoc_test.go
@@ -19,11 +19,11 @@ package hostdoc
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/host/hostdoc/raw"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/AthenZ/athenz/libs/go/sia/host/hostdoc/raw"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,9 +181,7 @@ func parseHostDocument(hostDocPath string) (*raw.Doc, error) {
 }
 
 func TestWriteHostDoc(t *testing.T) {
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(t, err, "should be able to create temp folder for sia")
-	defer os.RemoveAll(siaDir)
+	siaDir := t.TempDir()
 
 	type args struct {
 		doc         raw.Doc

--- a/libs/go/sia/ssh/hostcert/hostcert_test.go
+++ b/libs/go/sia/ssh/hostcert/hostcert_test.go
@@ -38,11 +38,8 @@ const EC_HOST_CERT = "ssh_host_ecdsa_key-cert.pub"
 
 const sshcaKeyId = "AthenzSSHCA"
 
-func makeSshDir() (string, string, error) {
-	sshDir, err := ioutil.TempDir("", "ssh.")
-	if err != nil {
-		return "", "", err
-	}
+func makeSshDir(t *testing.T) (string, string, error) {
+	sshDir := t.TempDir()
 
 	defaultCert, err := makeHostCert(sshDir, sshcaKeyId, EC_HOST_CERT)
 	if err != nil {
@@ -95,8 +92,7 @@ func makeHostCertFromKey(keyId string, prikey crypto.PrivateKey, pubkey crypto.P
 }
 
 func TestLoad(t *testing.T) {
-	sshDir, validCert, err := makeSshDir()
-	defer os.RemoveAll(sshDir)
+	sshDir, validCert, err := makeSshDir(t)
 	require.Nilf(t, err, "unexpected err: %v", err)
 
 	invalidCert := filepath.Join(sshDir, "invalid_cert")
@@ -143,8 +139,7 @@ func TestLoad(t *testing.T) {
 }
 
 func TestVerifyFn(t *testing.T) {
-	sshDir, validCert, err := makeSshDir()
-	defer os.RemoveAll(sshDir)
+	sshDir, validCert, err := makeSshDir(t)
 	require.Nilf(t, err, "unexpected err: %v", err)
 
 	notHostCert := filepath.Join(sshDir, "ssh_host_rsa_key.pub")
@@ -206,8 +201,7 @@ func TestVerifyFn(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	sshDir, hostCertFile, err := makeSshDir()
-	defer os.RemoveAll(sshDir)
+	sshDir, hostCertFile, err := makeSshDir(t)
 	require.Nilf(t, err, "unexpected err: %v", err)
 
 	hostCertBytes, err := ioutil.ReadFile(hostCertFile)

--- a/libs/go/sia/ssh/hostkey/hostkey_test.go
+++ b/libs/go/sia/ssh/hostkey/hostkey_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -31,9 +30,7 @@ import (
 )
 
 func TestPubKey(t *testing.T) {
-	tmpSshDir, e := ioutil.TempDir("", "ssh")
-	require.Nilf(t, e, "unexpected error: %v", e)
-	defer os.RemoveAll(tmpSshDir)
+	tmpSshDir := t.TempDir()
 
 	sshPubFile := fmt.Sprintf(filepath.Join(tmpSshDir, "ssh_host_ed25519_key.pub"))
 

--- a/provider/azure/sia-vm/authn_test.go
+++ b/provider/azure/sia-vm/authn_test.go
@@ -18,15 +18,16 @@ package sia
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm/data/attestation"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm/devel/ztsmock"
 	"github.com/AthenZ/athenz/provider/azure/sia-vm/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"os"
-	"testing"
 )
 
 func setup() {
@@ -56,15 +57,11 @@ func TestGetProviderName(test *testing.T) {
 }
 
 func TestRegisterInstance(test *testing.T) {
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	keyFile := fmt.Sprintf("%s/athenz.hockey.key.pem", siaDir)
 	certFile := fmt.Sprintf("%s/athenz.hockey.cert.pem", siaDir)
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
-
-	require.Nil(test, err)
 
 	opts := &options.Options{
 		Domain: "athenz",
@@ -103,7 +100,7 @@ func TestRegisterInstance(test *testing.T) {
 		Document:          nil,
 	}
 
-	err = RegisterInstance([]*attestation.Data{a}, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts)
+	err := RegisterInstance([]*attestation.Data{a}, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts)
 	assert.Nil(test, err, "unable to regster instance")
 
 	_, err = os.Stat(keyFile)
@@ -117,13 +114,9 @@ func TestRegisterInstance(test *testing.T) {
 }
 
 func TestRegisterInstanceMultiple(test *testing.T) {
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
-
-	require.Nil(test, err)
 
 	opts := &options.Options{
 		Domain: "athenz",
@@ -162,7 +155,7 @@ func TestRegisterInstanceMultiple(test *testing.T) {
 		Document:          nil,
 	}
 
-	err = RegisterInstance(data, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts)
+	err := RegisterInstance(data, "http://127.0.0.1:5081/zts/v1", &identityDocument, opts)
 	assert.Nil(test, err, "unable to regster instance")
 
 	// Verify the first service
@@ -198,15 +191,13 @@ func copyFile(src, dst string) error {
 }
 
 func TestRefreshInstance(test *testing.T) {
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	keyFile := fmt.Sprintf("%s/athenz.hockey.key.pem", siaDir)
 	certFile := fmt.Sprintf("%s/athenz.hockey.cert.pem", siaDir)
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
 
-	err = copyFile("devel/data/unit_test_key.pem", keyFile)
+	err := copyFile("devel/data/unit_test_key.pem", keyFile)
 	require.Nil(test, err, fmt.Sprintf("unable to copy file: %q to %q, error: %v", "devel/data/unit_test_key.pem", keyFile, err))
 
 	err = copyFile("devel/data/cert.pem", certFile)
@@ -259,16 +250,14 @@ func TestRefreshInstance(test *testing.T) {
 }
 
 func TestRoleCertificateRequest(test *testing.T) {
-	siaDir, err := ioutil.TempDir("", "sia.")
-	require.Nil(test, err)
-	defer os.RemoveAll(siaDir)
+	siaDir := test.TempDir()
 
 	keyFile := fmt.Sprintf("%s/athenz.hockey.key.pem", siaDir)
 	certFile := fmt.Sprintf("%s/athenz.hockey.cert.pem", siaDir)
 	caCertFile := fmt.Sprintf("%s/ca.cert.pem", siaDir)
 	roleCertFile := fmt.Sprintf("%s/testrole.cert.pem", siaDir)
 
-	err = copyFile("devel/data/unit_test_key.pem", keyFile)
+	err := copyFile("devel/data/unit_test_key.pem", keyFile)
 	require.Nil(test, err, fmt.Sprintf("unable to copy file: %q to %q, error: %v", "devel/data/unit_test_key.pem", keyFile, err))
 
 	err = copyFile("devel/data/cert.pem", certFile)


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	assert.Nil(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```