### PR TITLE
Fix for role member expiry notifications

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationCommon.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationCommon.java
@@ -20,6 +20,7 @@ import com.yahoo.athenz.auth.AuthorityConsts;
 import com.yahoo.athenz.auth.util.AthenzUtils;
 import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.server.util.ResourceUtils;
+import com.yahoo.athenz.zms.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,19 +98,27 @@ public class NotificationCommon {
     }
 
     void addDomainRoleRecipients(Notification notification, final String domainName, final String roleName) {
-        Set<String> domainRoleMembers = domainRoleMembersFetcher.getDomainRoleMembers(domainName, roleName);
-        if (domainRoleMembers == null || domainRoleMembers.isEmpty()) {
+        try {
+            Set<String> domainRoleMembers = domainRoleMembersFetcher.getDomainRoleMembers(domainName, roleName);
+            if (domainRoleMembers == null || domainRoleMembers.isEmpty()) {
+                return;
+            }
+
+            notification.getRecipients().addAll(domainRoleMembers);
+        } catch (ResourceException ex) {
+            LOGGER.error("Error getting domain role members ", ex);
             return;
         }
-
-        notification.getRecipients().addAll(domainRoleMembers);
     }
 
     void addNotificationRecipient(Notification notification, final String recipient, boolean ignoreService) {
 
-        int idx = recipient.indexOf(AuthorityConsts.ROLE_SEP);
-        if (idx != -1) {
-            addDomainRoleRecipients(notification, recipient.substring(0, idx), recipient);
+        int roleDomainIndex = recipient.indexOf(AuthorityConsts.ROLE_SEP);
+        int groupDomainIndex = recipient.indexOf(AuthorityConsts.GROUP_SEP);
+        if (roleDomainIndex != -1) {
+            addDomainRoleRecipients(notification, recipient.substring(0, roleDomainIndex), recipient);
+        } else if (groupDomainIndex != -1) {
+            // Do nothing. Group members will not get individual notifications.
         } else if (recipient.startsWith(userDomainPrefix)) {
             notification.addRecipient(recipient);
         } else if (!ignoreService) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/NotificationTestsCommon.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/NotificationTestsCommon.java
@@ -16,7 +16,6 @@
 
 package com.yahoo.athenz.zts.notification;
 
-import com.yahoo.athenz.zms.DomainData;
 import com.yahoo.athenz.zms.Role;
 import com.yahoo.athenz.zms.RoleMember;
 import com.yahoo.athenz.zts.store.DataStore;


### PR DESCRIPTION
When soon to be expired role member is a group, only send notification
to the domain admin

Signed-off-by: Ofer Levi <ofer.levi@verizonmedia.com>