### PR TITLE
Add URI parsing in createHttpClient

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -688,7 +688,7 @@ public class ZTSClient implements Closeable {
         HttpHost proxy = null;
         if (proxyUrl != null && !proxyUrl.isEmpty()) {
             final URI u = URI.create(proxyUrl);
-            proxy = new HttpHost(u.getHost());
+            proxy = new HttpHost(u.getHost(), u.getPort(), u.getScheme());
         }
         RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(connTimeoutMs)

--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -686,7 +687,8 @@ public class ZTSClient implements Closeable {
         //apache http client expects in milliseconds
         HttpHost proxy = null;
         if (proxyUrl != null && !proxyUrl.isEmpty()) {
-            proxy = new HttpHost(proxyUrl);
+            final URI u = URI.create(proxyUrl);
+            proxy = new HttpHost(u.getHost());
         }
         RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(connTimeoutMs)


### PR DESCRIPTION
Added URI parsing in `createHttpClient` to initialize `HttpHost` with hostname, port, and scheme. 

Signed-off-by: Wenshan Xiong <wenshan.xiong@yahooinc.com>