### PR TITLE
In athenz-auth-core skip tests for arm architecture

### DIFF
--- a/libs/java/auth_core/pom.xml
+++ b/libs/java/auth_core/pom.xml
@@ -105,4 +105,28 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>arm-os-build</id>
+      <activation>
+        <os>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <configuration>
+              <excludes>
+                <exclude>**/UserAuthorityTest.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
(libpam.os not available)

Signed-off-by: Ofer Levi <ofer.levi@verizonmedia.com>