### PR TITLE
extend role support in identity agent to specify service ownership

### DIFF
--- a/libs/go/sia/aws/options/data/sia_config_same_user_role_mismatch
+++ b/libs/go/sia/aws/options/data/sia_config_same_user_role_mismatch
@@ -1,0 +1,31 @@
+{
+    "version": "1.0.0",
+    "service": "api",
+    "services": {
+        "api": {
+            "user": "nobody"
+        },
+        "ui": {
+            "user": "nobody"
+        },
+        "yamas": {
+            "user": "nobody"
+        }
+    },
+    "accounts": [
+        {
+            "domain": "athenz",
+            "user": "nobody",
+            "account": "123456789012",
+            "roles": {
+                "sports:role.readers": {
+                    "service": "api"
+                },
+                "sports:role.writers": {
+                    "user": "root",
+                    "group": "nobody"
+                }
+            }
+        }
+    ]
+}

--- a/libs/go/sia/aws/options/data/sia_config_same_user_with_roles
+++ b/libs/go/sia/aws/options/data/sia_config_same_user_with_roles
@@ -1,0 +1,30 @@
+{
+    "version": "1.0.0",
+    "service": "api",
+    "services": {
+        "api": {
+            "user": "nobody"
+        },
+        "ui": {
+            "user": "nobody"
+        },
+        "yamas": {
+            "user": "nobody"
+        }
+    },
+    "accounts": [
+        {
+            "domain": "athenz",
+            "user": "nobody",
+            "account": "123456789012",
+            "roles": {
+                "sports:role.readers": {
+                    "service": "api"
+                },
+                "sports:role.writers": {
+                    "user": "nobody"
+                }
+            }
+        }
+    ]
+}

--- a/libs/go/sia/aws/options/data/sia_config_with_roles
+++ b/libs/go/sia/aws/options/data/sia_config_with_roles
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0",
+    "service": "api",
+    "services": {
+        "api": {},
+        "ui": {
+            "user": "root"
+        },
+        "yamas": {
+            "user": "nobody",
+            "group": "sys"
+        }
+    },
+    "accounts": [
+        {
+            "domain": "athenz",
+            "user": "nobody",
+            "account": "123456789012",
+            "roles": {
+                "sports:role.readers": {
+                    "service": "ui"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
role certificate object now takes three new attributes in the config:
Service: <service-name>
User: <user-name for uid>
Group: <group-name for gid>
If the User and/or Group is specified, we take the uid/gid from the given names. Otherwise, we inherit the uid/gid from the specified service. If no service is specified, then we fall back to the default behavior where we use the details of the primary service.

Also the role object can be specified as part of the ATHENZ_SIA_ACCOUNT_ROLES env values. Useful for fargate deployments where the admin doesn't want to mount a volume just for the config file.

Signed-off-by: Henry Avetisyan <hga@verizonmedia.com>