### PR TITLE
support sandns_hostname for aws ec2 

### DIFF
--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -209,7 +209,7 @@ func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl 
 			return err
 		}
 	}
-	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard, opts.InstanceIdSanDNS)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard, opts.SanDnsHostname, opts.InstanceIdSanDNS)
 	if err != nil {
 		return err
 	}
@@ -234,6 +234,12 @@ func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl 
 	if svc.ExpiryTime > 0 {
 		expiryTime := int32(svc.ExpiryTime)
 		info.ExpiryTime = &expiryTime
+	}
+	if opts.SanDnsHostname {
+		hostname, err := os.Hostname()
+		if err != nil {
+			info.Hostname = zts.DomainName(hostname)
+		}
 	}
 
 	client, err := util.ZtsClient(ztsUrl, opts.ZTSServerName, "", "", opts.ZTSCACertFile)
@@ -303,7 +309,7 @@ func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl s
 		log.Printf("Unable to read private key from %s, err: %v\n", keyFile, err)
 		return err
 	}
-	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard, opts.InstanceIdSanDNS)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CertCountryName, opts.CertOrgName, opts.Domain, svc.Name, data.Role, opts.InstanceId, opts.Provider, opts.ZTSAWSDomains, opts.SanDnsWildcard, opts.SanDnsHostname, opts.InstanceIdSanDNS)
 	if err != nil {
 		log.Printf("Unable to generate CSR for %s, err: %v\n", opts.Name, err)
 		return err
@@ -331,6 +337,12 @@ func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl s
 	if svc.ExpiryTime > 0 {
 		expiryTime := int32(svc.ExpiryTime)
 		info.ExpiryTime = &expiryTime
+	}
+	if opts.SanDnsHostname {
+		hostname, err := os.Hostname()
+		if err != nil {
+			info.Hostname = zts.DomainName(hostname)
+		}
 	}
 
 	ident, err := client.PostInstanceRefreshInformation(zts.ServiceName(opts.Provider), zts.DomainName(opts.Domain), zts.SimpleName(svc.Name), zts.PathElement(opts.InstanceId), info)

--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -126,6 +126,7 @@ func TestRegisterInstance(test *testing.T) {
 		Region:           "us-west-2",
 		InstanceId:       "pod-1234",
 		Provider:         "athenz.aws.us-west-2",
+		SanDnsHostname:   true,
 	}
 
 	a := &attestation.AttestationData{

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -79,6 +79,7 @@ type Config struct {
 	Ssh             *bool                    `json:"ssh,omitempty"`               //ssh certificate support
 	SshHostKeyType  hostkey.KeyType          `json:"ssh_host_key_type,omitempty"` //ssh host key type - rsa, ecdsa, etc
 	SanDnsWildcard  bool                     `json:"sandns_wildcard,omitempty"`   //san dns wildcard support
+	SanDnsHostname  bool                     `json:"sandns_hostname,omitempty"`   //san dns hostname support
 	UseRegionalSTS  bool                     `json:"regionalsts,omitempty"`       //whether to use a regional STS endpoint (default is false)
 	Accounts        []ConfigAccount          `json:"accounts,omitempty"`          //array of configured accounts
 	GenerateRoleKey bool                     `json:"generate_role_key,omitempty"` //private key to be generated for role certificate
@@ -140,6 +141,7 @@ type Options struct {
 	Roles              []Role           //map of roles to retrieve certificates for
 	Region             string           //region name
 	SanDnsWildcard     bool             //san dns wildcard support
+	SanDnsHostname     bool             //san dns hostname support
 	Version            string           //sia version number
 	ZTSDomains         []string         //zts domain prefixes
 	Services           []Service        //array of configured services
@@ -298,6 +300,9 @@ func InitEnvConfig(config *Config) (*Config, *ConfigAccount, error) {
 	if !config.SanDnsWildcard {
 		config.SanDnsWildcard = util.ParseEnvBooleanFlag("ATHENZ_SIA_SANDNS_WILDCARD")
 	}
+	if !config.SanDnsHostname {
+		config.SanDnsHostname = util.ParseEnvBooleanFlag("ATHENZ_SIA_SANDNS_HOSTNAME")
+	}
 	if !config.UseRegionalSTS {
 		config.UseRegionalSTS = util.ParseEnvBooleanFlag("ATHENZ_SIA_REGIONAL_STS")
 	}
@@ -390,6 +395,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 	//update regional sts and wildcard settings based on config settings
 	useRegionalSTS := false
 	sanDnsWildcard := false
+	sanDnsHostname := false
 	sdsUdsPath := ""
 	sdsUdsUid := 0
 	generateRoleKey := false
@@ -403,6 +409,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 	if config != nil {
 		useRegionalSTS = config.UseRegionalSTS
 		sanDnsWildcard = config.SanDnsWildcard
+		sanDnsHostname = config.SanDnsHostname
 		sdsUdsPath = config.SDSUdsPath
 		sdsUdsUid = config.SDSUdsUid
 		expiryTime = config.ExpiryTime
@@ -557,6 +564,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		Version:          fmt.Sprintf("SIA-AWS %s", version),
 		UseRegionalSTS:   useRegionalSTS,
 		SanDnsWildcard:   sanDnsWildcard,
+		SanDnsHostname:   sanDnsHostname,
 		Services:         services,
 		Roles:            roles,
 		TokenDir:         fmt.Sprintf("%s/tokens", siaDir),

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -528,6 +528,7 @@ func idCommandId(arg string) int {
 
 func TestInitEnvConfig(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_SANDNS_WILDCARD", "true")
+	os.Setenv("ATHENZ_SIA_SANDNS_HOSTNAME", "true")
 	os.Setenv("ATHENZ_SIA_REGIONAL_STS", "true")
 	os.Setenv("ATHENZ_SIA_GENERATE_ROLE_KEY", "true")
 	os.Setenv("ATHENZ_SIA_ROTATE_KEY", "false")
@@ -545,6 +546,7 @@ func TestInitEnvConfig(t *testing.T) {
 	cfg, cfgAccount, err := InitEnvConfig(nil)
 	require.Nilf(t, err, "error should be empty, error: %v", err)
 	assert.True(t, cfg.SanDnsWildcard)
+	assert.True(t, cfg.SanDnsHostname)
 	assert.True(t, cfg.UseRegionalSTS)
 	assert.True(t, cfg.GenerateRoleKey)
 	assert.False(t, cfg.RotateKey)

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -261,7 +261,7 @@ func PrivateKeyFromFile(filename string) (*rsa.PrivateKey, error) {
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
 }
 
-func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, service, commonName, instanceId, provider string, ztsDomains []string, wildCardDnsName, instanceIdSanDNS bool) (string, error) {
+func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, service, commonName, instanceId, provider string, ztsDomains []string, wildCardDnsName, hostnameDnsName, instanceIdSanDNS bool) (string, error) {
 
 	log.Println("Generating X.509 Service Certificate CSR...")
 
@@ -283,6 +283,15 @@ func GenerateSvcCertCSR(key *rsa.PrivateKey, countryName, orgName, domain, servi
 		if wildCardDnsName {
 			host = fmt.Sprintf("*.%s.%s.%s", service, hyphenDomain, ztsDomain)
 			csrDetails.HostList = append(csrDetails.HostList, host)
+		}
+	}
+	// include os hostname if requested
+	if hostnameDnsName {
+		hostname, err := os.Hostname()
+		if err == nil {
+			csrDetails.HostList = append(csrDetails.HostList, hostname)
+		} else {
+			log.Printf("Unable to extract instance hostname: %v\n", err)
 		}
 	}
 	// for backward compatibility a sanDNS entry with instance id in the hostname

--- a/libs/java/instance_provider/pom.xml
+++ b/libs/java/instance_provider/pom.xml
@@ -133,6 +133,11 @@
       <artifactId>athenz-server-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProvider.java
@@ -261,7 +261,7 @@ public class InstanceAWSProvider implements InstanceProvider {
         
         StringBuilder instanceId = new StringBuilder(256);
         if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
-                instanceService, getDnsSuffixes(), instanceId)) {
+                instanceService, getDnsSuffixes(), true, instanceId)) {
             throw error("Unable to validate certificate request hostnames");
         }
         

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAzureProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAzureProvider.java
@@ -210,7 +210,7 @@ public class InstanceAzureProvider implements InstanceProvider {
         
         StringBuilder instanceId = new StringBuilder(256);
         if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
-                instanceService, dnsSuffixes, instanceId)) {
+                instanceService, dnsSuffixes, false, instanceId)) {
             throw error("Unable to validate certificate request hostnames");
         }
 

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceZTSProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceZTSProvider.java
@@ -240,7 +240,7 @@ public class InstanceZTSProvider implements InstanceProvider {
 
         StringBuilder instanceId = new StringBuilder(256);
         if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
-                instanceService, dnsSuffixes, instanceId)) {
+                instanceService, dnsSuffixes, false, instanceId)) {
             throw forbiddenError("Unable to validate certificate request DNS");
         }
 

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/SecureBootProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/SecureBootProvider.java
@@ -62,12 +62,12 @@ public class SecureBootProvider implements InstanceProvider {
         // obtain list of valid principals for this principal if one is configured
 
         final String principalList = System.getProperty(ZTS_PROP_SB_PRINCIPAL_LIST);
-        if (principalList != null && !principalList.isEmpty()) {
+        if (!StringUtil.isEmpty(principalList)) {
             principals = new HashSet<>(Arrays.asList(principalList.split(",")));
         }
 
         final String issuerList = System.getProperty(ZTS_PROP_SB_ISSUER_DN_LIST);
-        if (issuerList != null && !issuerList.isEmpty()) {
+        if (!StringUtil.isEmpty(issuerList)) {
             issuerDNs = parseDnList(Arrays.asList(issuerList.split(";")));
         }
 
@@ -170,7 +170,7 @@ public class SecureBootProvider implements InstanceProvider {
         // validate the certificate san DNS names
         StringBuilder instanceId = new StringBuilder(256);
         if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
-                instanceService, dnsSuffixes, instanceId)) {
+                instanceService, dnsSuffixes, false, instanceId)) {
             throw forbiddenError("Unable to validate certificate request DNS", logTxt(confirmation));
         }
 
@@ -241,7 +241,8 @@ public class SecureBootProvider implements InstanceProvider {
                 InstanceProvider.ZTS_INSTANCE_CERT_HOSTNAME);
 
         // It's possible the refresh request is coming in without the hostname in the URI
-        if (certHostname == null || certHostname.isEmpty()) {
+
+        if (StringUtil.isEmpty(certHostname)) {
             return true;
         }
         return hostname.equals(certHostname);
@@ -259,7 +260,7 @@ public class SecureBootProvider implements InstanceProvider {
                 InstanceProvider.ZTS_INSTANCE_SAN_IP);
 
         String[] sanIps = null;
-        if (sanIpStr != null && !sanIpStr.isEmpty()) {
+        if (!StringUtil.isEmpty(sanIpStr)) {
             sanIps = sanIpStr.split(",");
         }
 

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/SecureBootProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/SecureBootProviderTest.java
@@ -365,8 +365,15 @@ public class SecureBootProviderTest {
 
     @Test
     public void testValidateSanIp() {
+
         assertTrue(new SecureBootProvider().validateSanIp("athenz-examples1.abc.com", null));
         assertTrue(new SecureBootProvider().validateSanIp("athenz-examples1.abc.com", new HashMap<>()));
+        assertTrue(new SecureBootProvider().validateSanIp("athenz-examples1.abc.com",
+                Collections.singletonMap(InstanceProvider.ZTS_INSTANCE_SAN_IP, "")));
+        assertTrue(new SecureBootProvider().validateSanIp("athenz-examples1.abc.com",
+                Collections.singletonMap(InstanceProvider.ZTS_INSTANCE_SAN_IP, ",")));
+        assertTrue(new SecureBootProvider().validateSanIp("athenz-examples1.abc.com",
+                Collections.singletonMap(InstanceProvider.ZTS_INSTANCE_SAN_IP, ",,,,")));
 
         HostnameResolver hostnameResolver = Mockito.mock(HostnameResolver.class);
         Mockito.when(hostnameResolver.getAllByName("athenz-examples1.abc.com")).thenReturn(
@@ -392,6 +399,7 @@ public class SecureBootProviderTest {
                 Collections.singletonMap(InstanceProvider.ZTS_INSTANCE_SAN_IP, "10.1.1.3,2001:db8:a0b:12f0:0:0:0:1")));
         assertFalse(provider.validateSanIp("athenz-examples1.abc.com",
                 Collections.singletonMap(InstanceProvider.ZTS_INSTANCE_SAN_IP, "10.1.1.2,2001:db8:a0b:12f0:0:0:0:2")));
+
 
     }
 

--- a/provider/azure/sia-vm/authn.go
+++ b/provider/azure/sia-vm/authn.go
@@ -144,7 +144,7 @@ func registerSvc(svc options.Service, data *attestation.Data, ztsUrl string, ide
 
 	provider := getProviderName(opts.Provider, identityDocument.Location)
 	commonName := fmt.Sprintf("%s.%s", opts.Domain, svc.Name)
-	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard, false)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard, opts.SanDnsHostname, false)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func refreshSvc(svc options.Service, data *attestation.Data, ztsUrl string, iden
 	}
 	provider := getProviderName(opts.Provider, identityDocument.Location)
 	commonName := fmt.Sprintf("%s.%s", opts.Domain, svc.Name)
-	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard, false)
+	csr, err := util.GenerateSvcCertCSR(key, opts.CountryName, "", opts.Domain, svc.Name, commonName, identityDocument.VmId, provider, opts.ZTSAzureDomains, opts.SanDnsWildcard, opts.SanDnsHostname, false)
 	if err != nil {
 		log.Printf("Unable to generate CSR for %s, err: %v\n", opts.Name, err)
 		return err

--- a/provider/azure/sia-vm/options/options.go
+++ b/provider/azure/sia-vm/options/options.go
@@ -65,6 +65,7 @@ type Config struct {
 	Ssh            *bool                    `json:"ssh,omitempty"`             //ssh certificate support
 	Accounts       []ConfigAccount          `json:"accounts,omitempty"`        //array of configured accounts
 	SanDnsWildcard bool                     `json:"sandns_wildcard,omitempty"` //san dns wildcard support
+	SanDnsHostname bool                     `json:"sandns_hostname,omitempty"` //san dns hostname support
 }
 
 // Role contains role details. Attributes are set based on the config values
@@ -109,6 +110,7 @@ type Options struct {
 	ZTSAzureDomains  []string
 	CountryName      string
 	SanDnsWildcard   bool
+	SanDnsHostname   bool
 }
 
 func initProfileConfig(identityDocument *attestation.IdentityDocument) (*ConfigAccount, error) {
@@ -175,8 +177,10 @@ func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, si
 	}
 
 	sanDnsWildcard := false
+	sanDnsHostname := false
 	if config != nil {
 		sanDnsWildcard = config.SanDnsWildcard
+		sanDnsHostname = config.SanDnsHostname
 	}
 
 	var services []Service
@@ -251,6 +255,7 @@ func NewOptions(bytes []byte, identityDocument *attestation.IdentityDocument, si
 		ZTSAzureDomains:  ztsAzureDomains,
 		CountryName:      countryName,
 		SanDnsWildcard:   sanDnsWildcard,
+		SanDnsHostname:   sanDnsHostname,
 	}, nil
 }
 


### PR DESCRIPTION
the ec2 hostname must be configured with the following format:
<instance-id>.<service>.<domain-with-dashes>.<provider-suffix>