### PR TITLE
Remove log for sia lib to fix athenz cert check

### DIFF
--- a/libs/go/sia/util/os_util_linux.go
+++ b/libs/go/sia/util/os_util_linux.go
@@ -108,7 +108,6 @@ func gidForGroup(groupname string) int {
 		log.Printf("Invalid response from getent group command: %s\n", s)
 		return -1
 	}
-	log.Printf("Group %s id: %d\n", groupname, id)
 	return id
 }
 


### PR DESCRIPTION
Example output for Athenz cert check:

2023/02/01 18:08:29 Group athenz id: 10952
2023/02/01 18:08:29 Group athenz id: 10952
{"application":"athenz-cert-check","status_code":0,"status_msg":"All Certificates are valid"}

which will be invalid for yamas. Removing this log to fix the issue above


Signed-off-by: Ding Ma [dma@yahooinc.com](mailto:dma@yahooinc.com)