### PR TITLE
set GOPATH from 'go env GOPATH' if not set

### DIFF
--- a/rdl/rdl-gen-athenz-go-client/make_generator.sh
+++ b/rdl/rdl-gen-athenz-go-client/make_generator.sh
@@ -24,8 +24,8 @@ command -v go >/dev/null 2>&1 || {
 }
 
 if [ -z "${GOPATH}" ]; then
-    echo >&2 "GOPATH is not set. please configure this environment variable"
-    exit 1;
+    export GOPATH=$(go env GOPATH)
+    echo >&2 "GOPATH is not set, setting to ${GOPATH} (from 'go env GOPATH')."
 fi
 
 go install github.com/ardielle/ardielle-go/...

--- a/rdl/rdl-gen-athenz-go-model/make_generator.sh
+++ b/rdl/rdl-gen-athenz-go-model/make_generator.sh
@@ -24,8 +24,8 @@ command -v go >/dev/null 2>&1 || {
 }
 
 if [ -z "${GOPATH}" ]; then
-    echo >&2 "GOPATH is not set. please configure this environment variable"
-    exit 1;
+    export GOPATH=$(go env GOPATH)
+    echo >&2 "GOPATH is not set, setting to ${GOPATH} (from 'go env GOPATH')."
 fi
 
 go install github.com/ardielle/ardielle-go/...

--- a/rdl/rdl-gen-athenz-java-client/make_generator.sh
+++ b/rdl/rdl-gen-athenz-java-client/make_generator.sh
@@ -24,8 +24,8 @@ command -v go >/dev/null 2>&1 || {
 }
 
 if [ -z "${GOPATH}" ]; then
-    echo >&2 "GOPATH is not set. please configure this environment variable"
-    exit 1;
+    export GOPATH=$(go env GOPATH)
+    echo >&2 "[INFO] GOPATH is not set, setting to ${GOPATH} (from 'go env GOPATH)."
 fi
 
 go install github.com/ardielle/ardielle-go/...

--- a/rdl/rdl-gen-athenz-java-model/make_generator.sh
+++ b/rdl/rdl-gen-athenz-java-model/make_generator.sh
@@ -24,8 +24,8 @@ command -v go >/dev/null 2>&1 || {
 }
 
 if [ -z "${GOPATH}" ]; then
-    echo >&2 "GOPATH is not set. please configure this environment variable"
-    exit 1;
+    export GOPATH=$(go env GOPATH)
+    echo >&2 "[INFO] GOPATH is not set, setting to ${GOPATH} (from 'go env GOPATH)."
 fi
 
 go install github.com/ardielle/ardielle-go/...

--- a/rdl/rdl-gen-athenz-server/make_generator.sh
+++ b/rdl/rdl-gen-athenz-server/make_generator.sh
@@ -24,8 +24,8 @@ command -v go >/dev/null 2>&1 || {
 }
 
 if [ -z "${GOPATH}" ]; then
-    echo >&2 "GOPATH is not set. please configure this environment variable"
-    exit 1;
+    export GOPATH=$(go env GOPATH)
+    echo >&2 "[INFO] GOPATH is not set, setting to ${GOPATH} (from 'go env GOPATH)."
 fi
 
 if [ ! -d "${GOPATH}/bin" ]; then


### PR DESCRIPTION
The build failure when `GOPATH` is not explicitly set seems unnecessary since the value can be taken from `go env GOPATH`. 

https://pkg.go.dev/cmd/go#hdr-GOPATH_environment_variable
> If the environment variable is unset, GOPATH defaults to a subdirectory named "go" in the user's home directory ($HOME/go on Unix, %USERPROFILE%\go on Windows), unless that directory holds a Go distribution. Run "go env GOPATH" to see the current GOPATH. 