### PR TITLE
set the locale to be used for log testing

### DIFF
--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
@@ -15,10 +15,10 @@
  */
 package com.yahoo.athenz.common.server.log.jetty;
 
-import com.yahoo.athenz.common.server.log.jetty.AthenzRequestLog;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.server.*;
 import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -29,6 +29,7 @@ import javax.net.ssl.SSLSession;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Locale;
 
 import static org.testng.Assert.*;
 
@@ -42,11 +43,21 @@ public class AthenzRequestLogTest {
 
     private static final String TEST_FILE = "./unit-test-athenz.log";
 
+    private Locale defaultLocale;
+
     @BeforeMethod
     public void setup() throws IOException {
         // remove test file in case left over from previous runs
         File file = new File(TEST_FILE);
         Files.deleteIfExists(file.toPath());
+
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        Locale.setDefault(defaultLocale);
     }
 
     @Test


### PR DESCRIPTION
## Description

The AthenzRequestLogTest will fail if the Locale setting in the build environment is not en_US, so fix it to set the Locale that the test expects.

```
$ mvn test -rf :athenz-server-common
...
[ERROR] Failures:
[ERROR]   AthenzRequestLogTest.testAthenzRequestLogAllFields:230 10.10.11.13 - athenz.zts [01/1月/1970:00:00:00 +0000] "GET /request-uri?query=true HTTP/1.1" 200 10240 "-" "-" 102400 1677818473890 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 expected [true] but found [false]
[ERROR]   AthenzRequestLogTest.testAthenzRequestLogNullFields:90 10.10.11.12 - - [01/1月/1970:00:00:00 +0000] "GET /original-uri HTTP/1.1" -1 1234 "-" "-" - 1677818473919 Auth-None - -
 expected [true] but found [false]
[ERROR]   AthenzRequestLogTest.testAthenzRequestLogStatusValues1:134 10.11.12.13 - - [01/1月/1970:00:00:00 +0000] "GET /original-uri HTTP/1.1" 401 100 "-" "-" 10 1677818473928 Auth-None - -
 expected [true] but found [false]
[ERROR]   AthenzRequestLogTest.testAthenzRequestLogStatusValues2:178 2001:0db8:85a3:0000:0000:8a2e:0370:7334 - - [01/1月/1970:00:00:00 +0000] "GET /original-uri HTTP/1.1" 401 5 "-" "-" 3 1677818473933 Auth-None - -
 expected [true] but found [false]
[ERROR]   AthenzRequestLogTest.testAthenzRequestLogXForwardedForDisabled:284 10.10.11.12 - athenz.zts [01/1月/1970:00:00:00 +0000] "GET /request-uri?query=true HTTP/1.1" 200 10240 "-" "-" 102400 1677818473940 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 expected [true] but found [false]
...
```