### PR TITLE
for id token requests, carry out full role name match and not suffix

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -1584,7 +1584,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         Set<String> roles = new HashSet<>();
 
         dataStore.getAccessibleRoles(data, providerDomainName, userName,
-                requestedRoleList, roles, false);
+                requestedRoleList, false, roles, false);
 
         // we are going to process the list and only keep the tenant
         // domains - this is based on the role names since our tenant
@@ -1794,7 +1794,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         Set<String> roles = new HashSet<>();
         dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoleList,
-                roles, false);
+                false, roles, false);
 
         if (roles.isEmpty()) {
             throw forbiddenError(tokenErrorMessage(caller, principalName, domainName, requestedRoleList),
@@ -1809,7 +1809,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         if (proxyForPrincipal != null) {
             Set<String> rolesForProxy = new HashSet<>();
             dataStore.getAccessibleRoles(data, domainName, proxyForPrincipal,
-                    requestedRoleList, rolesForProxy, false);
+                    requestedRoleList, false, rolesForProxy, false);
             roles.retainAll(rolesForProxy);
 
             // check again in case we removed all the roles and ended up
@@ -2182,7 +2182,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // process our request and retrieve the roles for the principal
 
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principalName, roleNames, roles, false);
+        dataStore.getAccessibleRoles(data, domainName, principalName, roleNames, true, roles, false);
         return getIdTokenGroupsFromRoles(roles, domainName, fullArn);
     }
 
@@ -2431,7 +2431,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // process our request and retrieve the roles for the principal
 
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoles, roles, false);
+        dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoles, false, roles, false);
 
         // we return failure if we don't have access to any roles
 
@@ -2458,7 +2458,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             // process the role lookup for the proxy principal
 
             Set<String> rolesForProxy = new HashSet<>();
-            dataStore.getAccessibleRoles(data, domainName, proxyForPrincipal, requestedRoles, rolesForProxy, false);
+            dataStore.getAccessibleRoles(data, domainName, proxyForPrincipal, requestedRoles, false, rolesForProxy, false);
             roles.retainAll(rolesForProxy);
 
             // check again in case we removed all the roles and ended up
@@ -2702,8 +2702,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // process our request and retrieve the roles for the principal
 
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principal, null,
-                roles, false);
+        dataStore.getAccessibleRoles(data, domainName, principal, null, false, roles, false);
 
         return new RoleAccess().setRoles(new ArrayList<>(roles));
     }
@@ -2829,7 +2828,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         String[] requestedRoleList = { roleName };
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoleList, roles, false);
+        dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoleList, false, roles, false);
 
         if (roles.isEmpty()) {
             throw forbiddenError(tokenErrorMessage(caller, principalName, domainName, requestedRoleList),
@@ -2844,7 +2843,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         if (proxyForPrincipal != null) {
 
             Set<String> rolesForProxy = new HashSet<>();
-            dataStore.getAccessibleRoles(data, domainName, proxyForPrincipal, requestedRoleList, rolesForProxy, false);
+            dataStore.getAccessibleRoles(data, domainName, proxyForPrincipal, requestedRoleList, false, rolesForProxy, false);
             roles.retainAll(rolesForProxy);
 
             // check again in case we removed all the roles and ended up
@@ -3374,7 +3373,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // retrieve the roles for the principal
 
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principal, null, roles, true);
+        dataStore.getAccessibleRoles(data, domainName, principal, null, false, roles, true);
 
         if (roles.isEmpty()) {
             LOGGER.error("verifyAWSAssumeRole: Principal: {} has no access to any roles in domain: {}",
@@ -4849,8 +4848,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // process our request and retrieve the roles for the principal
 
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principal, null,
-                roles, false);
+        dataStore.getAccessibleRoles(data, domainName, principal, null, false, roles, false);
 
         // create our response object and set the flag whether
         // or not the principal has access to the role

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
@@ -1415,7 +1415,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
 
     // Internal
     void processStandardMembership(Set<MemberRole> memberRoles, String rolePrefix, String[] requestedRoleList,
-            Set<String> accessibleRoles, boolean keepFullName) {
+            boolean fullNameMatch, Set<String> accessibleRoles, boolean keepFullName) {
 
         /* if we have no member roles, then we haven't added anything
          * to our return result list */
@@ -1435,7 +1435,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
                 continue;
             }
 
-            addRoleToList(memberRole.getRole(), rolePrefix, requestedRoleList,
+            addRoleToList(memberRole.getRole(), rolePrefix, requestedRoleList, fullNameMatch,
                     accessibleRoles, keepFullName);
         }
     }
@@ -1474,7 +1474,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
 
             if (trustedResources == null) {
                 processStandardMembership(groupMemberRoleSet, rolePrefix, requestedRoleList,
-                        accessibleRoles, keepFullName);
+                        false, accessibleRoles, keepFullName);
             } else {
                 for (String resource : trustedResources) {
 
@@ -1561,7 +1561,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
 
     // API
     public void getAccessibleRoles(DataCache data, String domainName, String identity,
-            String[] requestedRoleList, Set<String> accessibleRoles, boolean keepFullName) {
+            String[] requestedRoleList, boolean fullNameMatch, Set<String> accessibleRoles, boolean keepFullName) {
 
         /* if the domain hasn't been processed then we don't have anything to do */
 
@@ -1575,13 +1575,13 @@ public class DataStore implements DataCacheProvider, RolesProvider {
          * included in the list explicitly */
 
         processStandardMembership(data.getMemberRoleSet(identity),
-                rolePrefix, requestedRoleList, accessibleRoles, keepFullName);
+                rolePrefix, requestedRoleList, fullNameMatch, accessibleRoles, keepFullName);
 
         /* next look at all * wildcard roles that are configured
          * for all members to access */
 
         processStandardMembership(data.getAllMemberRoleSet(),
-                rolePrefix, requestedRoleList, accessibleRoles, keepFullName);
+                rolePrefix, requestedRoleList, fullNameMatch, accessibleRoles, keepFullName);
 
         /* then look at the prefix wildcard roles. in this map
          * we only process those where the key in the map is
@@ -1591,7 +1591,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
         for (String identityPrefix : roleSetMap.keySet()) {
             if (identity.startsWith(identityPrefix)) {
                 processStandardMembership(roleSetMap.get(identityPrefix),
-                        rolePrefix, requestedRoleList, accessibleRoles, keepFullName);
+                        rolePrefix, requestedRoleList, fullNameMatch, accessibleRoles, keepFullName);
             }
         }
 
@@ -1617,21 +1617,31 @@ public class DataStore implements DataCacheProvider, RolesProvider {
 
     // Internal
     void addRoleToList(String role, String rolePrefix, String[] requestedRoleList,
-            Set<String> accessibleRoles, boolean keepFullName) {
+            boolean fullNameMatch, Set<String> accessibleRoles, boolean keepFullName) {
 
-        /* any roles we return must start with the domain role prefix */
+        // any roles we return must start with the domain role prefix
 
         if (!role.startsWith(rolePrefix)) {
             return;
         }
 
-        /* and it must end with the suffix if requested */
+        // and it must end with the suffix if requested unless we've been
+        // asked to carry out a full name match
 
         if (requestedRoleList != null) {
             boolean matchFound = false;
             for (String requestedRole : requestedRoleList) {
-                if (role.endsWith(requestedRole)) {
-                    matchFound = true;
+
+                // if we're asked for a full role name match then our requested role
+                // only includes the role name, so we need to match against the role
+                // name component only
+
+                matchFound = fullNameMatch ? requestedRole.equals(role.substring(rolePrefix.length())) :
+                        role.endsWith(requestedRole);
+
+                // as soon as we find a match we should stop looking
+
+                if (matchFound) {
                     break;
                 }
             }
@@ -1640,7 +1650,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
             }
         }
 
-        /* when returning the value we're going to skip the prefix */
+        // when returning the value we're going to skip the prefix
 
         if (keepFullName) {
             accessibleRoles.add(role);
@@ -1697,7 +1707,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
 
         /* now check if the role is in the resource list as well */
 
-        addRoleToList(roleName, rolePrefix, requestedRoleList, accessibleRoles, keepFullName);
+        addRoleToList(roleName, rolePrefix, requestedRoleList, false, accessibleRoles, keepFullName);
     }
 
     // Internal

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
@@ -933,7 +933,7 @@ public class DataStoreTest {
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null, ztsMetric);
         Set<String> accessibleRoles = new HashSet<>();
-        store.addRoleToList("sports:role.admin", "coretech:role.", null, accessibleRoles, false);
+        store.addRoleToList("sports:role.admin", "coretech:role.", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
     }
     
@@ -945,7 +945,7 @@ public class DataStoreTest {
         DataStore store = new DataStore(clogStore, null, ztsMetric);
         
         Set<String> accessibleRoles = new HashSet<>();
-        store.addRoleToList("coretech:role.admin", "coretech:role.", null, accessibleRoles, false);
+        store.addRoleToList("coretech:role.admin", "coretech:role.", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
     }
@@ -959,9 +959,33 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         String[] requestedRoleList = { "admin" };
-        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, accessibleRoles, false);
+        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
+
+        accessibleRoles.clear();
+        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, true, accessibleRoles, false);
+        assertEquals(accessibleRoles.size(), 1);
+        assertTrue(accessibleRoles.contains("admin"));
+
+        accessibleRoles.clear();
+        store.addRoleToList("coretech:role.cluster-admin", "coretech:role.", requestedRoleList, true, accessibleRoles, false);
+        assertTrue(accessibleRoles.isEmpty());
+
+        accessibleRoles.clear();
+        String[] updatedRequestedRoleList = { "admin", "cluster-admin" };
+        store.addRoleToList("coretech:role.cluster-admin", "coretech:role.", updatedRequestedRoleList, true, accessibleRoles, false);
+        assertEquals(accessibleRoles.size(), 1);
+        assertTrue(accessibleRoles.contains("cluster-admin"));
+
+        accessibleRoles.clear();
+        store.addRoleToList("coretech:role.admin", "coretech:role.", updatedRequestedRoleList, true, accessibleRoles, false);
+        assertEquals(accessibleRoles.size(), 1);
+        assertTrue(accessibleRoles.contains("admin"));
+
+        accessibleRoles.clear();
+        store.addRoleToList("coretech:role.cluster-reader", "coretech:role.", requestedRoleList, true, accessibleRoles, false);
+        assertTrue(accessibleRoles.isEmpty());
     }
     
     @Test
@@ -973,7 +997,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         String[] requestedRoleList = { "admin2" };
-        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, accessibleRoles, false);
+        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
     }
     
@@ -986,7 +1010,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         String[] requestedRoleList = { "admin2", "admin3", "admin" };
-        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, accessibleRoles, false);
+        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
     }
@@ -1000,7 +1024,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         String[] requestedRoleList = { "admin2", "admin3", "admin4" };
-        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, accessibleRoles, false);
+        store.addRoleToList("coretech:role.admin", "coretech:role.", requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
     }
     
@@ -1866,7 +1890,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("writers"));
@@ -1884,14 +1908,14 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("writers"));
         assertTrue(accessibleRoles.contains("all"));
         
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user3", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user3", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 3);
         assertTrue(accessibleRoles.contains("readers"));
@@ -1899,14 +1923,14 @@ public class DataStoreTest {
         assertTrue(accessibleRoles.contains("all"));
         
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user5", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user5", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("writers"));
         assertTrue(accessibleRoles.contains("all"));
         
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "coretech", "athenz.service", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "athenz.service", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("all"));
@@ -1914,7 +1938,7 @@ public class DataStoreTest {
         // make sure the prefix is fully matched
         
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "coretech", "athenz.use", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "athenz.use", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("all"));
@@ -1931,7 +1955,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 0);
     }
@@ -1949,7 +1973,7 @@ public class DataStoreTest {
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
         String[] requestedRoleList = { "coretech:role.admin" };
-        store.getAccessibleRoles(data, "coretech", "user_domain.user", requestedRoleList, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user", requestedRoleList, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
@@ -1967,7 +1991,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.nonexistentuser", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.nonexistentuser", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 0);
     }
@@ -1984,7 +2008,7 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user", null, false, accessibleRoles, false);
         
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
@@ -2043,14 +2067,14 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
         
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -2128,17 +2152,17 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
         
         accessibleRoles = new HashSet<>();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
         
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -2180,7 +2204,7 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
         
         File file = new File("/tmp/zts_server_unit_tests/zts_root/coretech");
@@ -2188,7 +2212,7 @@ public class DataStoreTest {
         
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -3590,7 +3614,7 @@ public class DataStoreTest {
         Set<String> accessibleRoles = new HashSet<>();
         String prefix = "coretech" + ROLE_POSTFIX;
         
-        store.processStandardMembership(null, prefix, null, accessibleRoles, false);
+        store.processStandardMembership(null, prefix, null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
     }
     
@@ -3607,7 +3631,7 @@ public class DataStoreTest {
         memberRoles.add(new MemberRole("coretech:role.admin", 0));
         memberRoles.add(new MemberRole("coretech:role.readers", 0));
         
-        store.processStandardMembership(memberRoles, prefix, null, accessibleRoles, false);
+        store.processStandardMembership(memberRoles, prefix, null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("readers"));
@@ -3628,7 +3652,7 @@ public class DataStoreTest {
         memberRoles.add(new MemberRole("coretech:role.admin", 0));
         memberRoles.add(new MemberRole("coretech:role.readers", 0));
         
-        store.processStandardMembership(memberRoles, prefix, requestedRoleList, accessibleRoles, false);
+        store.processStandardMembership(memberRoles, prefix, requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
     }
     
@@ -3647,7 +3671,7 @@ public class DataStoreTest {
         memberRoles.add(new MemberRole("coretech:role.admin", System.currentTimeMillis() - 1000));
         memberRoles.add(new MemberRole("coretech:role.readers", 0));
         
-        store.processStandardMembership(memberRoles, prefix, requestedRoleList, accessibleRoles, false);
+        store.processStandardMembership(memberRoles, prefix, requestedRoleList, false, accessibleRoles, false);
         assertTrue(accessibleRoles.isEmpty());
     }
     
@@ -3666,7 +3690,7 @@ public class DataStoreTest {
         memberRoles.add(new MemberRole("coretech:role.admin", 0));
         memberRoles.add(new MemberRole("coretech:role.readers", 0));
         
-        store.processStandardMembership(memberRoles, prefix, requestedRoleList, accessibleRoles, false);
+        store.processStandardMembership(memberRoles, prefix, requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
     }
     
@@ -3684,7 +3708,7 @@ public class DataStoreTest {
         memberRoles.add(new MemberRole("coretech:role.admin", 0));
         memberRoles.add(new MemberRole("coretech:role.readers", 0));
         
-        store.processStandardMembership(memberRoles, prefix, requestedRoleList, accessibleRoles, false);
+        store.processStandardMembership(memberRoles, prefix, requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
     }
     
@@ -3703,7 +3727,7 @@ public class DataStoreTest {
         memberRoles.add(new MemberRole("coretech:role.admin", 0));
         memberRoles.add(new MemberRole("coretech:role.readers", 0));
         
-        store.processStandardMembership(memberRoles, prefix, requestedRoleList, accessibleRoles, false);
+        store.processStandardMembership(memberRoles, prefix, requestedRoleList, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
     }
     
@@ -3863,17 +3887,17 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
         
         accessibleRoles = new HashSet<>();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
         
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -3925,17 +3949,17 @@ public class DataStoreTest {
         
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
         
         accessibleRoles = new HashSet<>();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
         
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -3949,17 +3973,17 @@ public class DataStoreTest {
 
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
 
         accessibleRoles = new HashSet<>();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
 
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -4619,14 +4643,14 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("access-domain1");
-        store.getAccessibleRoles(data, "access-domain1", "user.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain1", "user.user1", null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("role1"));
         assertTrue(accessibleRoles.contains("role2"));
 
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain1", "user.user2", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain1", "user.user2", null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 4);
         assertTrue(accessibleRoles.contains("role1"));
@@ -4635,7 +4659,7 @@ public class DataStoreTest {
         assertTrue(accessibleRoles.contains("role4"));
 
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain1", "user.user3", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain1", "user.user3", null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 4);
         assertTrue(accessibleRoles.contains("role1"));
@@ -4645,13 +4669,13 @@ public class DataStoreTest {
 
         data = store.getDataCache("access-domain3");
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain3", "user.user4", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain3", "user.user4", null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("role5"));
 
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain3", "user.user5", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain3", "user.user5", null, false, accessibleRoles, false);
         assertTrue(accessibleRoles.isEmpty());
 
         // sleep for a couple of seconds so user6 becomes expired
@@ -4659,7 +4683,7 @@ public class DataStoreTest {
         ZTSTestUtils.sleep(2000);
 
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain3", "user.user6", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain3", "user.user6", null, false, accessibleRoles, false);
         assertTrue(accessibleRoles.isEmpty());
 
         // now we're going to delete group1, group4 and group6 so user1 will no longer have access to role1
@@ -4671,11 +4695,11 @@ public class DataStoreTest {
         data = store.getDataCache("access-domain1");
 
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain1", "user.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain1", "user.user1", null, false, accessibleRoles, false);
         assertTrue(accessibleRoles.isEmpty());
 
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, "access-domain1", "user.user3", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "access-domain1", "user.user3", null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 3);
         assertTrue(accessibleRoles.contains("role1"));
@@ -4736,7 +4760,7 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("writers"));
@@ -4749,7 +4773,7 @@ public class DataStoreTest {
 
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertTrue(accessibleRoles.isEmpty());
     }
 
@@ -4909,17 +4933,17 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
 
         accessibleRoles = new HashSet<>();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
 
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -4933,17 +4957,17 @@ public class DataStoreTest {
 
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("coretech");
-        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user1", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 0);
 
         accessibleRoles = new HashSet<>();
-        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "coretech", "user_domain.user8", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 1);
         assertTrue(accessibleRoles.contains("admin"));
 
         accessibleRoles = new HashSet<>();
         data = store.getDataCache("sports");
-        store.getAccessibleRoles(data, "sports", "user_domain.user", null, accessibleRoles, false);
+        store.getAccessibleRoles(data, "sports", "user_domain.user", null, false, accessibleRoles, false);
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
         assertTrue(accessibleRoles.contains("writers"));
@@ -5246,7 +5270,7 @@ public class DataStoreTest {
 
         Set<String> accessibleRoles = new HashSet<>();
         DataCache data = store.getDataCache(roleDomainName);
-        store.getAccessibleRoles(data, roleDomainName, memberName, null, accessibleRoles, false);
+        store.getAccessibleRoles(data, roleDomainName, memberName, null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));
@@ -5268,7 +5292,7 @@ public class DataStoreTest {
 
         data = store.getDataCache(roleDomainName);
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, roleDomainName, memberName, null, accessibleRoles, false);
+        store.getAccessibleRoles(data, roleDomainName, memberName, null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 0);
 
@@ -5286,7 +5310,7 @@ public class DataStoreTest {
 
         data = store.getDataCache(roleDomainName);
         accessibleRoles.clear();
-        store.getAccessibleRoles(data, roleDomainName, memberName, null, accessibleRoles, false);
+        store.getAccessibleRoles(data, roleDomainName, memberName, null, false, accessibleRoles, false);
 
         assertEquals(accessibleRoles.size(), 2);
         assertTrue(accessibleRoles.contains("admin"));


### PR DESCRIPTION
for oidc id token requests, the client asks for specific roles. the internal api treats the role name as a suffix which is not quite correct for the oidc use case. so now we'll only return the full match roles names.