### PR TITLE
gcp provider

### DIFF
--- a/libs/java/instance_provider/pom.xml
+++ b/libs/java/instance_provider/pom.xml
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9927</code.coverage.min>
+    <code.coverage.min>0.9949</code.coverage.min>
   </properties>
 
   <dependencyManagement>
@@ -39,6 +39,13 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
         <version>${aws.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>${gcp.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -137,6 +144,11 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
       <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>${gcp.api-client.version}</version>
     </dependency>
   </dependencies>
 

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/InstanceProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/InstanceProvider.java
@@ -53,7 +53,6 @@ public interface InstanceProvider {
     String ZTS_INSTANCE_SAN_IP             = "sanIP";
     String ZTS_INSTANCE_SAN_URI            = "sanURI";
     String ZTS_INSTANCE_CLIENT_IP          = "clientIP";
-    String ZTS_INSTANCE_CLOUD_ACCOUNT      = "cloudAccount";
     String ZTS_INSTANCE_ID                 = "instanceId";
     String ZTS_INSTANCE_CSR_PUBLIC_KEY     = "csrPublicKey";
     String ZTS_INSTANCE_HOSTNAME           = "hostname";
@@ -61,10 +60,12 @@ public interface InstanceProvider {
     String ZTS_INSTANCE_PRIVATE_IP         = "instancePrivateIp";
     String ZTS_INSTANCE_AWS_ACCOUNT        = "awsAccount";
     String ZTS_INSTANCE_AZURE_SUBSCRIPTION = "azureSubscription";
+    String ZTS_INSTANCE_GCP_PROJECT        = "gcpProject";
     String ZTS_INSTANCE_CERT_HOSTNAME      = "certHostname";
     String ZTS_INSTANCE_CERT_RSA_MOD_HASH  = "certRsaModHash";
     String ZTS_INSTANCE_CERT_SUBJECT_DN    = "certSubjectDn";
     String ZTS_INSTANCE_CERT_ISSUER_DN     = "certIssuerDn";
+
 
     enum Scheme {
         HTTP,

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/GCPAdditionalAttestationData.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/GCPAdditionalAttestationData.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+
+import java.math.BigDecimal;
+
+/**
+ * GCPAdditionalAttestationData - additional information a booting
+ * instance should provide to ZTS to authenticate.
+ */
+
+public class GCPAdditionalAttestationData {
+
+    @Expose
+    private BigDecimal instanceCreationTimestamp;
+
+    @Expose
+    private String instanceId;
+
+    @Expose
+    private String instanceName;
+
+    @Expose
+    private String projectId;
+
+    @Expose
+    private String projectNumber;
+
+    @Expose
+    private String zone;
+
+    public BigDecimal getInstanceCreationTimestamp() {
+        return instanceCreationTimestamp;
+    }
+
+    @JsonProperty("instance_creation_timestamp")
+    public void setInstanceCreationTimestamp(BigDecimal instanceCreationTimestamp) {
+        this.instanceCreationTimestamp = instanceCreationTimestamp;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    @JsonProperty("instance_id")
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    @JsonProperty("instance_name")
+    public void setInstanceName(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    @JsonProperty("project_id")
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getProjectNumber() {
+        return projectNumber;
+    }
+
+    @JsonProperty("project_number")
+    public void setProjectNumber(String projectNumber) {
+        this.projectNumber = projectNumber;
+    }
+
+    public String getZone() {
+        return zone;
+    }
+
+    public void setZone(String zone) {
+        this.zone = zone;
+    }
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/GCPAttestationData.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/GCPAttestationData.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * GCPAttestationData - the information a booting
+ * instance must provide to ZTS to authenticate.
+ */
+@JsonInclude()
+public class GCPAttestationData {
+    private String identityToken;
+
+    public String getIdentityToken() {
+        return identityToken;
+    }
+
+    public void setIdentityToken(String identityToken) {
+        this.identityToken = identityToken;
+    }
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/GCPDerivedAttestationData.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/GCPDerivedAttestationData.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import java.util.List;
+
+public class GCPDerivedAttestationData {
+
+    private List<String> audience;
+
+    private String authorizedParty;
+
+    private String email;
+
+    private boolean emailVerified;
+
+    private String issuer;
+    private GCPAdditionalAttestationData additionalAttestationData;
+
+    public List<String> getAudience() {
+        return audience;
+    }
+
+    public void setAudience(List<String> audience) {
+        this.audience = audience;
+    }
+
+    public String getAuthorizedParty() {
+        return authorizedParty;
+    }
+
+    public void setAuthorizedParty(String authorizedParty) {
+        this.authorizedParty = authorizedParty;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public boolean isEmailVerified() {
+        return emailVerified;
+    }
+
+    public void setEmailVerified(boolean emailVerified) {
+        this.emailVerified = emailVerified;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public GCPAdditionalAttestationData getAdditionalAttestationData() {
+        return additionalAttestationData;
+    }
+
+    public void setAdditionalAttestationData(GCPAdditionalAttestationData additionalAttestationData) {
+        this.additionalAttestationData = additionalAttestationData;
+    }
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProvider.java
@@ -1,0 +1,330 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.yahoo.athenz.auth.KeyStore;
+import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigLong;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ResourceException;
+import com.yahoo.rdl.JSON;
+import com.yahoo.rdl.Timestamp;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
+
+public class InstanceGCPProvider implements InstanceProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceGCPProvider.class);
+
+    static final String GCP_PROP_BOOT_TIME_OFFSET = "athenz.zts.gcp_boot_time_offset";
+    static final String GCP_PROP_DNS_SUFFIX       = "athenz.zts.gcp_dns_suffix";
+    static final String GCP_PROP_REGION_NAME      = "athenz.zts.gcp_region_name";
+
+    static final String GCP_PROP_CERT_VALIDITY_NO_ADDITIONAL_INFO = "athenz.zts.gcp_cert_validity_no_additional_info";
+
+    DynamicConfigLong bootTimeOffsetSeconds; // boot time offset in seconds
+    long certValidityTime;                   // cert validity for STS creds only case
+    boolean supportRefresh = false;
+    String gcpRegion;
+    Set<String> dnsSuffixes = null;
+    InstanceGCPUtils gcpUtils = null;
+
+    public long getTimeOffsetInMilli() {
+        return bootTimeOffsetSeconds.get() * 1000;
+    }
+
+    @Override
+    public Scheme getProviderScheme() {
+        return Scheme.HTTP;
+    }
+    @Override
+    public void initialize(String provider, String endpoint, SSLContext sslContext, KeyStore keyStore) {
+
+        // create our helper object to validate gcp identity token
+
+        gcpUtils = new InstanceGCPUtils();
+
+        // how long the instance must be booted in the past before we
+        // stop validating the instance requests
+
+        long timeout = TimeUnit.SECONDS.convert(5, TimeUnit.MINUTES);
+        bootTimeOffsetSeconds = new DynamicConfigLong(CONFIG_MANAGER, GCP_PROP_BOOT_TIME_OFFSET, timeout);
+
+        // determine the dns suffix. if this is not specified we'll
+        // be rejecting all entries
+
+        dnsSuffixes = new HashSet<>();
+        final String dnsSuffix = System.getProperty(GCP_PROP_DNS_SUFFIX);
+        if (StringUtil.isEmpty(dnsSuffix)) {
+            LOGGER.error("GCP DNS Suffix not specified - no instance requests will be authorized");
+        } else {
+            dnsSuffixes.addAll(Arrays.asList(dnsSuffix.split(",")));
+        }
+
+        // default certificate expiry for requests without instance
+        // identity document
+
+        int certValidityDays = Integer.parseInt(System.getProperty(GCP_PROP_CERT_VALIDITY_NO_ADDITIONAL_INFO, "7"));
+        certValidityTime = TimeUnit.MINUTES.convert(certValidityDays, TimeUnit.DAYS);
+
+        // get the gcp region
+
+        gcpRegion = System.getProperty(GCP_PROP_REGION_NAME);
+    }
+
+    public ResourceException error(String message) {
+        return error(ResourceException.FORBIDDEN, message);
+    }
+
+    public ResourceException error(int errorCode, String message) {
+        LOGGER.error(message);
+        return new ResourceException(errorCode, message);
+    }
+
+    protected Set<String> getDnsSuffixes() {
+        return dnsSuffixes;
+    }
+
+    boolean validateGCPProject(final String gcpProject, final String docProject, StringBuilder errMsg) {
+
+        if (!gcpProject.equalsIgnoreCase(docProject)) {
+            LOGGER.error("ZTS GCP Domain Lookup project id: {}", gcpProject);
+            errMsg.append("mismatch between project values - instance identity value= ").append(docProject);
+            return false;
+        }
+
+        return true;
+    }
+
+    boolean validateGCPProvider(final String provider, final String region, StringBuilder errMsg) {
+
+        final String suffix = "." + region;
+        if (!provider.endsWith(suffix)) {
+            errMsg.append("provider ").append(provider).append(" does not end with expected suffix ").append(region);
+            return false;
+        }
+
+        return true;
+    }
+
+    boolean validateGCPInstanceId(final String reqInstanceId, final String docInstanceId,
+                                  StringBuilder errMsg) {
+
+        if (!reqInstanceId.equalsIgnoreCase(docInstanceId)) {
+            errMsg.append("mismatch between instance-id values: request= ").append(reqInstanceId)
+                    .append(" vs. attested= ").append(docInstanceId);
+            return false;
+        }
+
+        return true;
+    }
+
+    protected boolean validateIdentityToken(final String provider, GCPAttestationData attestationData,
+                                            GCPDerivedAttestationData derivedAttestationData,
+                                            final String gcpProject, final String instanceId, boolean checkTime,
+                                            StringBuilder errMsg) {
+
+        GoogleIdToken.Payload validatedPayload = gcpUtils.validateGCPIdentityToken(attestationData.getIdentityToken(), errMsg);
+
+        if (validatedPayload == null) {
+            return false;
+        }
+
+        // create a derived attestation data object from validated token's payload for further use
+
+        gcpUtils.populateAttestationData(validatedPayload, derivedAttestationData);
+
+        // verify that the project lookup and the project in the document match
+
+        if (!validateGCPProject(gcpProject, gcpUtils.getProjectIdFromAttestedData(derivedAttestationData), errMsg)) {
+            return false;
+        }
+
+        if (derivedAttestationData.getAdditionalAttestationData() != null) {
+
+            if (!validateGCPProvider(provider,
+                    gcpUtils.getGCPRegionFromZone(derivedAttestationData.getAdditionalAttestationData().getZone()),
+                    errMsg)) {
+                return false;
+            }
+
+            final String attestedInstanceId = derivedAttestationData.getAdditionalAttestationData().getInstanceId();
+            if (!validateGCPInstanceId(instanceId, attestedInstanceId, errMsg)) {
+                return false;
+            }
+            // verify that the boot uptime for the instance is now
+            return !checkTime || validateInstanceBootTime(derivedAttestationData.getAdditionalAttestationData().getInstanceCreationTimestamp(), errMsg);
+        }
+
+        return true;
+    }
+
+    private boolean validateInstanceBootTime(BigDecimal bootTimestamp, StringBuilder errMsg) {
+
+        // first check to see if the boot time enforcement is enabled
+
+        if (getTimeOffsetInMilli() <= 0) {
+            return true;
+        }
+
+        Timestamp bootTime = Timestamp.fromMillis(bootTimestamp.longValue());
+        if (bootTime.millis() < System.currentTimeMillis() - getTimeOffsetInMilli()) {
+            errMsg.append("Instance boot time is not recent enough: ");
+            errMsg.append(bootTime);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public InstanceConfirmation confirmInstance(InstanceConfirmation confirmation) {
+
+        GCPAttestationData attestationData = JSON.fromString(confirmation.getAttestationData(),
+                GCPAttestationData.class);
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        StringBuilder errMsg = new StringBuilder(256);
+
+        final Map<String, String> instanceAttributes = confirmation.getAttributes();
+        final String instanceDomain = confirmation.getDomain();
+        final String instanceService = confirmation.getService();
+
+        // make sure request is for a valid gcp project
+
+        final String gcpProject = InstanceUtils.getInstanceProperty(instanceAttributes, ZTS_INSTANCE_GCP_PROJECT);
+        if (StringUtil.isEmpty(gcpProject)) {
+            throw error("Unable to find GCP Project id");
+        }
+
+        // validate the certificate host names
+
+        StringBuilder instanceId = new StringBuilder(256);
+        if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
+                instanceService, getDnsSuffixes(), true, instanceId)) {
+            throw error("Unable to validate certificate request hostnames");
+        }
+
+        validateAttestationData(confirmation, attestationData, derivedAttestationData, gcpProject,
+                instanceId.toString(), true, errMsg);
+
+        // validate that the domain/service given in the confirmation
+        // request match the attestation data
+        // we are using gcpProject name instead of domain name here since there is a 1:1
+        // mapping between gcp project and Athenz domain.
+
+        validateAthenzService(derivedAttestationData, instanceService, gcpProject);
+
+        // set the attributes to be returned to the ZTS server
+        // additional metadata is only available on GCE so using that
+        // as a basis to provide SSH host certificate
+
+        setConfirmationAttributes(confirmation, derivedAttestationData.getAdditionalAttestationData() != null);
+
+        return confirmation;
+    }
+
+    @Override
+    public InstanceConfirmation refreshInstance(InstanceConfirmation confirmation) {
+        // if we don't have an attestation data then we're going to
+        // return not found exception unless the provider is required
+        // to support refresh and in that case we'll return forbidden
+
+        final String attestationDataStr = confirmation.getAttestationData();
+        if (attestationDataStr == null || attestationDataStr.isEmpty()) {
+            int errorCode = supportRefresh ? ResourceException.FORBIDDEN : ResourceException.NOT_FOUND;
+            throw error(errorCode, "No attestation data provided during refresh");
+        }
+
+        GCPAttestationData attestationData = JSON.fromString(attestationDataStr, GCPAttestationData.class);
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        StringBuilder errMsg = new StringBuilder(256);
+
+        final Map<String, String> instanceAttributes = confirmation.getAttributes();
+        final String instanceService = confirmation.getService();
+
+        // make sure request is for a valid gcp project
+
+        final String gcpProject = InstanceUtils.getInstanceProperty(instanceAttributes, ZTS_INSTANCE_GCP_PROJECT);
+        if (StringUtil.isEmpty(gcpProject)) {
+            throw error("Unable to find GCP Project id");
+        }
+
+        // extract the instance id as well
+
+        final String instanceId = InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_ID);
+        if (instanceId == null) {
+            throw error("Unable to extract Instance Id");
+        }
+
+        validateAttestationData(confirmation, attestationData, derivedAttestationData,
+                gcpProject, instanceId, false, errMsg);
+
+        validateAthenzService(derivedAttestationData, instanceService, gcpProject);
+
+        // set the attributes to be returned to the ZTS server
+        setConfirmationAttributes(confirmation, derivedAttestationData.getAdditionalAttestationData().getInstanceId() != null);
+
+
+        return confirmation;
+    }
+
+    private void validateAttestationData(InstanceConfirmation confirmation, GCPAttestationData attestationData, GCPDerivedAttestationData derivedAttestationData, String gcpProject, String instanceId,
+                                         boolean checkTime, StringBuilder errMsg) {
+
+        // validate the instance identity token
+
+        if (!validateIdentityToken(confirmation.getProvider(), attestationData, derivedAttestationData, gcpProject,
+                instanceId, checkTime, errMsg)) {
+            throw error("Unable to validate instance identity token: " + errMsg);
+        }
+    }
+
+    private void validateAthenzService(GCPDerivedAttestationData derivedAttestationData, String instanceService, String gcpProject) {
+        // validate that the gcp project/service given in the confirmation
+        // request match the attestation data
+        // we are using gcp project name instead of domain name here since there is a 1:1
+        // mapping between gcp project and Athenz domain.
+
+        final String serviceName = gcpProject + "." + instanceService;
+        final String attestedServiceName = gcpUtils.getServiceNameFromAttestedData(derivedAttestationData);
+        if (!serviceName.equals(attestedServiceName)) {
+            throw error("Service name mismatch: attested=" + attestedServiceName + " vs. requested=" + serviceName);
+        }
+    }
+
+    protected void setConfirmationAttributes(InstanceConfirmation confirmation, boolean additionalMetadataAvailable) {
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(InstanceProvider.ZTS_CERT_SSH, Boolean.toString(additionalMetadataAvailable));
+        if (!additionalMetadataAvailable) {
+            attributes.put(InstanceProvider.ZTS_CERT_EXPIRY_TIME, Long.toString(certValidityTime));
+        }
+        confirmation.setAttributes(attributes);
+    }
+
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPUtils.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPUtils.java
@@ -1,0 +1,161 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.util.ArrayMap;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.Map;
+
+public class InstanceGCPUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceGCPUtils.class);
+    GoogleIdTokenVerifier googleIdTokenVerifier;
+    static final String GCP_PROP_EXPECTED_AUDIENCE = "athenz.zts.gcp_identity_expected_audience";
+    private static final String GCP_ATTESTATION_KEY_GOOGLE = "google";
+    private static final String GCP_ATTESTATION_KEY_COMPUTE_ENGINE = "compute_engine";
+    private static final String GCP_SERVICE_ACCOUNT_EMAIL_SEPARATOR = "@";
+    private static final String DOT = ".";
+    private static final String GCP_REGION_ZONE_SEPARATOR = "-";
+
+    private static final String GCP_OPTIONAL_ATTR_PROJECT_NUMBER = "project_number";
+    private static final String GCP_OPTIONAL_ATTR_PROJECT_ID = "project_id";
+    private static final String GCP_OPTIONAL_ATTR_ZONE = "zone";
+    private static final String GCP_OPTIONAL_ATTR_INSTANCE_NAME = "instance_name";
+    private static final String GCP_OPTIONAL_ATTR_INSTANCE_ID = "instance_id";
+    private static final String GCP_OPTIONAL_ATTR_INSTANCE_CREATION_TIMESTAMP = "instance_creation_timestamp";
+
+    public InstanceGCPUtils() {
+        this(new NetHttpTransport(), new GsonFactory());
+    }
+
+    public void setGoogleIdTokenVerifier(final GoogleIdTokenVerifier googleIdTokenVerifier) {
+        this.googleIdTokenVerifier = googleIdTokenVerifier;
+    }
+
+    public InstanceGCPUtils(HttpTransport httpTransport, JsonFactory jsonFactory) {
+        final String expectedAudience = System.getProperty(GCP_PROP_EXPECTED_AUDIENCE, "");
+        if (StringUtil.isEmpty(expectedAudience)) {
+            LOGGER.error("Expected audience in the GCP Identity token is not specified. No identity will be issued.");
+        }
+        googleIdTokenVerifier = new GoogleIdTokenVerifier
+                .Builder(httpTransport, jsonFactory)
+                .setAudience(List.of(expectedAudience))
+                .build();
+    }
+    public GoogleIdToken.Payload validateGCPIdentityToken(final String token, StringBuilder errMsg) {
+
+        try {
+            GoogleIdToken validatedToken = googleIdTokenVerifier.verify(token);
+            if (validatedToken != null) {
+                /* Sample decoded token by GCE metadata server ( with format=full optional parameter to the metadata server)
+                {"aud":"https://my-zts-server","azp":"102023896904281105569","email":"my-sa@my-gcp-project.iam.gserviceaccount.com",
+                "email_verified":true,"exp":1678259131,"iat":1678255531,"iss":"https://accounts.google.com","sub":"102023896904281105569",
+                "google":{"compute_engine":{"instance_creation_timestamp":1677459985,"instance_id":"3692465099344887023",
+                "instance_name":"my-vm","project_id":"my-gcp-project","project_number":1234567890123,"zone":"us-west1-a"}}}
+
+                Sample decoded token by GKE metadata server
+                {"aud":"https://my-zts-server","azp":"102023896904281105569","email":"my-sa@my-gcp-project.iam.gserviceaccount.com",
+                "email_verified":true,"exp":1678259131,"iat":1678255531,"iss":"https://accounts.google.com","sub":"102023896904281105569"}
+                 */
+                return validatedToken.getPayload();
+            }
+        } catch (IllegalArgumentException | GeneralSecurityException | IOException e) {
+            LOGGER.error("unable to validate GCP instance identity token error={} type={}", e.getMessage(), e.getClass());
+            errMsg.append("unable to validate GCP instance identity token. Reason=")
+                    .append(e.getMessage());
+        }
+        return null;
+    }
+
+    public void populateAttestationData(GoogleIdToken.Payload validatedPayload,
+                                        GCPDerivedAttestationData derivedAttestationData) {
+        derivedAttestationData.setAudience(validatedPayload.getAudienceAsList());
+        derivedAttestationData.setEmail(validatedPayload.getEmail());
+        derivedAttestationData.setEmailVerified(validatedPayload.getEmailVerified());
+        derivedAttestationData.setIssuer(validatedPayload.getIssuer());
+        derivedAttestationData.setAuthorizedParty(validatedPayload.getAuthorizedParty());
+
+        Object googleObjValue = validatedPayload.get(GCP_ATTESTATION_KEY_GOOGLE);
+        if (googleObjValue instanceof ArrayMap) {
+            Map<String, Map<String, Object>> googleValueMap = (ArrayMap) googleObjValue;
+            if (googleValueMap.containsKey(GCP_ATTESTATION_KEY_COMPUTE_ENGINE)) {
+
+                Map<String, Object> computeEngineExtras = googleValueMap.get(GCP_ATTESTATION_KEY_COMPUTE_ENGINE);
+                GCPAdditionalAttestationData additionalAttestationData = new GCPAdditionalAttestationData();
+
+                additionalAttestationData.setProjectNumber(computeEngineExtras.get(GCP_OPTIONAL_ATTR_PROJECT_NUMBER).toString());
+                additionalAttestationData.setProjectId((String) computeEngineExtras.get(GCP_OPTIONAL_ATTR_PROJECT_ID));
+                additionalAttestationData.setZone((String) computeEngineExtras.get(GCP_OPTIONAL_ATTR_ZONE));
+                additionalAttestationData.setInstanceName((String) computeEngineExtras.get(GCP_OPTIONAL_ATTR_INSTANCE_NAME));
+                additionalAttestationData.setInstanceId((String) computeEngineExtras.get(GCP_OPTIONAL_ATTR_INSTANCE_ID));
+                additionalAttestationData.setInstanceCreationTimestamp((BigDecimal) computeEngineExtras.get(GCP_OPTIONAL_ATTR_INSTANCE_CREATION_TIMESTAMP));
+
+                derivedAttestationData.setAdditionalAttestationData(additionalAttestationData);
+            }
+        }
+    }
+
+    public String getServiceNameFromAttestedData(GCPDerivedAttestationData derivedAttestationData) {
+        String service = "";
+        String gcpProject = "";
+        if (derivedAttestationData.isEmailVerified() &&
+                derivedAttestationData.getEmail().contains(GCP_SERVICE_ACCOUNT_EMAIL_SEPARATOR) &&
+                derivedAttestationData.getEmail().contains(DOT)) {
+            service = derivedAttestationData.getEmail()
+                    .substring(0, derivedAttestationData.getEmail().indexOf(GCP_SERVICE_ACCOUNT_EMAIL_SEPARATOR));
+            gcpProject = derivedAttestationData.getEmail()
+                    .substring(derivedAttestationData.getEmail().indexOf(GCP_SERVICE_ACCOUNT_EMAIL_SEPARATOR) + 1,
+                            derivedAttestationData.getEmail().indexOf(DOT));
+        }
+        return gcpProject + "." + service;
+    }
+
+    public String getProjectIdFromAttestedData(GCPDerivedAttestationData derivedAttestationData) {
+        String gcpProject = "";
+        if (derivedAttestationData.isEmailVerified() &&
+                derivedAttestationData.getEmail().contains(GCP_SERVICE_ACCOUNT_EMAIL_SEPARATOR)
+                && derivedAttestationData.getEmail().contains(DOT)) {
+            gcpProject = derivedAttestationData.getEmail()
+                    .substring(derivedAttestationData.getEmail().indexOf(GCP_SERVICE_ACCOUNT_EMAIL_SEPARATOR) + 1,
+                            derivedAttestationData.getEmail().indexOf(DOT));
+        }
+        return gcpProject;
+    }
+
+    public String getGCPRegionFromZone(final String zone) {
+        if (zone != null) {
+            int zoneIdIndex = zone.lastIndexOf(GCP_REGION_ZONE_SEPARATOR);
+            if (zoneIdIndex != -1) {
+                return zone.substring(0, zoneIdIndex);
+            }
+        }
+        return zone;
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/GCPAdditionalAttestationDataTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/GCPAdditionalAttestationDataTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+
+import static org.testng.Assert.*;
+
+public class GCPAdditionalAttestationDataTest {
+    @Test
+    public void testFields() {
+        GCPAdditionalAttestationData addAttestationData = new GCPAdditionalAttestationData();
+        addAttestationData.setInstanceId("instanceid");
+        addAttestationData.setInstanceName("myinstance");
+        addAttestationData.setZone("us-west1-a");
+        addAttestationData.setProjectId("project-123");
+        addAttestationData.setInstanceCreationTimestamp(BigDecimal.valueOf(123456789099L));
+        addAttestationData.setProjectNumber("12343");
+
+        assertEquals(addAttestationData.getInstanceId(), "instanceid");
+        assertEquals(addAttestationData.getInstanceName(), "myinstance");
+        assertEquals(addAttestationData.getZone(), "us-west1-a");
+        assertEquals(addAttestationData.getProjectId(), "project-123");
+        assertEquals(addAttestationData.getInstanceCreationTimestamp().longValue(), 123456789099L);
+        assertEquals(addAttestationData.getProjectNumber(), "12343");
+
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/GCPAttestationDataTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/GCPAttestationDataTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class GCPAttestationDataTest {
+
+    @Test
+    public void testFields() {
+        GCPAttestationData attestationData = new GCPAttestationData();
+        attestationData.setIdentityToken("abc");
+        assertEquals(attestationData.getIdentityToken(), "abc");
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/GCPDerivedAttestationDataTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/GCPDerivedAttestationDataTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.*;
+
+public class GCPDerivedAttestationDataTest {
+
+    @Test
+    public void testFields() {
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmail("sa@gcp-project.iam.gserviceaccount.com");
+        derivedAttestationData.setIssuer("https://google.com");
+        derivedAttestationData.setAuthorizedParty("azp");
+        derivedAttestationData.setAudience(List.of("https://my-aud"));
+        derivedAttestationData.setEmailVerified(true);
+        derivedAttestationData.setAdditionalAttestationData(new GCPAdditionalAttestationData());
+
+        assertEquals(derivedAttestationData.getEmail(), "sa@gcp-project.iam.gserviceaccount.com");
+        assertEquals(derivedAttestationData.getIssuer(), "https://google.com");
+        assertEquals(derivedAttestationData.getAuthorizedParty(), "azp");
+        assertThat(derivedAttestationData.getAudience(), hasItems("https://my-aud"));
+        assertTrue(derivedAttestationData.isEmailVerified());
+        assertNotNull(derivedAttestationData.getAdditionalAttestationData());
+
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProviderTest.java
@@ -1,0 +1,699 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.util.ArrayMap;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ResourceException;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.yahoo.athenz.instance.provider.InstanceProvider.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.testng.Assert.*;
+
+public class InstanceGCPProviderTest {
+
+    @BeforeMethod
+    public void setup() {
+        System.setProperty(InstanceGCPProvider.GCP_PROP_DNS_SUFFIX, "gcp.athenz.cloud");
+        System.setProperty(InstanceGCPProvider.GCP_PROP_REGION_NAME, "us-west1");
+    }
+
+    @AfterMethod
+    public void shutdown() {
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_DNS_SUFFIX);
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_REGION_NAME);
+    }
+
+    @Test
+    public void testInitializeDefaults() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+        assertEquals(provider.getTimeOffsetInMilli(), 300000);
+        provider.close();
+    }
+
+    @Test
+    public void testInitialize() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+        assertEquals(provider.getTimeOffsetInMilli(), 60000);
+        provider.close();
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+    }
+
+    @Test
+    public void testInitializeDNSSuffix() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_DNS_SUFFIX);
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+        assertTrue(provider.getDnsSuffixes().isEmpty());
+        provider.close();
+
+        provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_DNS_SUFFIX, "");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+        assertTrue(provider.getDnsSuffixes().isEmpty());
+        provider.close();
+
+        provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_DNS_SUFFIX, "athenz1.cloud,athenz2.cloud");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+        assertEquals(provider.getDnsSuffixes().size(), 2);
+        assertTrue(provider.getDnsSuffixes().contains("athenz1.cloud"));
+        assertTrue(provider.getDnsSuffixes().contains("athenz2.cloud"));
+        provider.close();
+    }
+
+    @Test
+    public void testError() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        ResourceException exc = provider.error("unable to access");
+        assertEquals(exc.getCode(), 403);
+        assertEquals(exc.getMessage(), "ResourceException (403): unable to access");
+        provider.close();
+    }
+
+    @Test
+    public void testValidateGCPProject() {
+
+        StringBuilder errMsg = new StringBuilder(256);
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        assertTrue(provider.validateGCPProject("1234", "1234", errMsg));
+        assertFalse(provider.validateGCPProject("1235", "1234", errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testGetProviderScheme() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.HTTP);
+        provider.close();
+    }
+
+    @Test
+    public void testValidateGCPProvider() {
+
+        StringBuilder errMsg = new StringBuilder(256);
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        assertTrue(provider.validateGCPProvider("gcp.gce.us-west1", "us-west1", errMsg));
+        assertFalse(provider.validateGCPProvider("gcp.gce", "us-west1", errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateInstanceId() {
+
+        StringBuilder errMsg = new StringBuilder(256);
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        assertTrue(provider.validateGCPInstanceId("1234", "1234", errMsg));
+        assertFalse(provider.validateGCPInstanceId("1235", "1234", errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityTokenInvalidToken() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "gcp-proj1";
+        String instanceId = "123";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any())).thenReturn(null);
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertFalse(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+        provider.close();
+    }
+
+    private GoogleIdToken.Payload createPayload(boolean makeAdditional) {
+        GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
+        payload.setAudience("https://my-zts-server");
+        payload.setIssuer("https://accounts.google.com");
+        payload.setEmail("my-sa@my-gcp-project.iam.gserviceaccount.com");
+        payload.setEmailVerified(true);
+        payload.setAuthorizedParty("102023896904281105569");
+
+        if (makeAdditional) {
+            Map<String, Map<String, Object>> extras = new ArrayMap<>();
+            Map<String, Object> extrasCE = new ArrayMap<>();
+
+            extrasCE.put("instance_creation_timestamp", new BigDecimal(1677459985));
+            extrasCE.put("instance_id", "3692465099344887023");
+            extrasCE.put("instance_name", "my-vm");
+            extrasCE.put("project_id", "my-gcp-project");
+            extrasCE.put("project_number", new BigDecimal(1234567890123L));
+            extrasCE.put("zone", "us-west1-a");
+
+            extras.put("compute_engine", extrasCE);
+            payload.set("google", extras);
+        }
+        return payload;
+    }
+
+    private GoogleIdToken.Payload createRecentPayload(boolean makeAdditional) {
+        GoogleIdToken.Payload payload = createPayload(makeAdditional);
+        if (makeAdditional) {
+            ((Map<String, Map<String, Object>>)payload.get("google")).get("compute_engine")
+                    .put("instance_creation_timestamp", new BigDecimal(System.currentTimeMillis() - 4000));
+        }
+        return payload;
+    }
+
+    @Test
+    public void testValidateIdentityTokenInvalidProject() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "invalid";
+        String instanceId = "123";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any())).thenReturn(createPayload(true));
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertFalse(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityTokenIncompleteAttestationData() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "my-gcp-project";
+        String instanceId = "123";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any())).thenReturn(createPayload(false));
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertTrue(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityTokenInvalidProvider() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "my-gcp-project";
+        String instanceId = "123";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        GoogleIdToken.Payload dummyPayload = createPayload(true);
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken("abc", errMsg)).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(dummyPayload, derivedAttestationData);
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertFalse(provider.validateIdentityToken("gcp.gce", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityTokenInvalidInstanceId() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "my-gcp-project";
+        String instanceId = "123";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        GoogleIdToken.Payload dummyPayload = createPayload(true);
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken("abc", errMsg)).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(dummyPayload, derivedAttestationData);
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertFalse(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityTokenBootTime() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "my-gcp-project";
+        String instanceId = "3692465099344887023";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        GoogleIdToken.Payload dummyPayload = createPayload(true);
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken("abc", errMsg)).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(dummyPayload, derivedAttestationData);
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertFalse(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityTokenBootTimeZeroOffset() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "0");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "my-gcp-project";
+        String instanceId = "3692465099344887023";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        GoogleIdToken.Payload dummyPayload = createPayload(true);
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken("abc", errMsg)).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(dummyPayload, derivedAttestationData);
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertTrue(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testValidateIdentityToken() {
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GCPAttestationData attestationData = new GCPAttestationData();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        String gcpProject = "my-gcp-project";
+        String instanceId = "3692465099344887023";
+        StringBuilder errMsg = new StringBuilder(256);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        attestationData.setIdentityToken("abc");
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken("abc", errMsg)).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(dummyPayload, derivedAttestationData);
+        provider.gcpUtils = gcpUtilsMock;
+
+        assertTrue(provider.validateIdentityToken("gcp.gce.us-west1", attestationData, derivedAttestationData,
+                gcpProject, instanceId, true, errMsg));
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceEmptyProject() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("athenz");
+        confirmation.setService("gcp");
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "");
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (Exception ignored) {
+        }
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidSANDNS() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("athenz");
+        confirmation.setService("gcp");
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (Exception ignored) {}
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidAttestationData() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(null);
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-service");
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch(Exception ignored) {}
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceServiceMismatch() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-evil-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-evil-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-evil-service");
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch(Exception ignored) {}
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+    @Test
+    public void testConfirmInstance() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-service");
+        confirmation.setAttributes(attrs);
+
+        provider.confirmInstance(confirmation);
+
+        assertEquals(confirmation.getAttributes().size(), 1);
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_SSH), "true");
+
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceNoAdditionalMetadata() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(false);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-service");
+        confirmation.setAttributes(attrs);
+
+        provider.confirmInstance(confirmation);
+
+        assertEquals(confirmation.getAttributes().size(), 2);
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_SSH), "false");
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_EXPIRY_TIME), "10080");
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testRefreshInstance() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_ID, "3692465099344887023");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-service");
+
+        confirmation.setAttributes(attrs);
+
+        provider.refreshInstance(confirmation);
+
+        assertEquals(confirmation.getAttributes().size(), 1);
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_SSH), "true");
+
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testRefreshInstanceNoAttestationData() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_ID, "3692465099344887023");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-service");
+
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.refreshInstance(confirmation);
+            fail();
+        } catch (Exception ignored) {}
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testRefreshInstanceEmptyProject() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("athenz");
+        confirmation.setService("gcp");
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "");
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.refreshInstance(confirmation);
+            fail();
+        } catch (Exception ignored) {
+        }
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testRefreshInstanceNoInstanceId() {
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.gcpUtils = gcpUtilsMock;
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-service");
+
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.refreshInstance(confirmation);
+            fail();
+        } catch (Exception ignored) {}
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPUtilsTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPUtilsTest.java
@@ -1,0 +1,222 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.util.ArrayMap;
+import com.yahoo.athenz.auth.token.IdToken;
+import com.yahoo.athenz.auth.util.Crypto;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.io.*;
+
+import java.math.BigDecimal;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.testng.Assert.*;
+
+public class InstanceGCPUtilsTest {
+
+    private final File ecPrivateKey = new File("./src/test/resources/unit_test_ec_private.key");
+
+    @Test
+    public void testInitialize() {
+        System.setProperty(InstanceGCPUtils.GCP_PROP_EXPECTED_AUDIENCE, "https://zts.athenz.io");
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        assertNotNull(utils.googleIdTokenVerifier);
+        System.clearProperty(InstanceGCPUtils.GCP_PROP_EXPECTED_AUDIENCE);
+    }
+
+    @Test
+    public void testInitializeNoAudience() {
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        assertNotNull(utils.googleIdTokenVerifier);
+    }
+
+    @Test
+    public void testValidateGCPSignatureInvalid() {
+        System.setProperty(InstanceGCPUtils.GCP_PROP_EXPECTED_AUDIENCE, "https://zts.athenz.io");
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+
+        // invalid jwt
+        assertNull(utils.validateGCPIdentityToken("invalidjwt", new StringBuilder()));
+
+        // valid jwt but invalid id token
+        IdToken sampleToken = new IdToken();
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        String nonGoogleToken = sampleToken.getSignedToken(privateKey, "eckey1", SignatureAlgorithm.ES256);
+        assertNull(utils.validateGCPIdentityToken(nonGoogleToken, new StringBuilder()));
+
+        System.clearProperty(InstanceGCPUtils.GCP_PROP_EXPECTED_AUDIENCE);
+    }
+
+    @Test
+    public void testValidateGCPSignature() throws GeneralSecurityException, IOException {
+        System.setProperty(InstanceGCPUtils.GCP_PROP_EXPECTED_AUDIENCE, "https://zts.athenz.io");
+
+        IdToken sampleToken = new IdToken();
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        String nonGoogleToken = sampleToken.getSignedToken(privateKey, "eckey1", SignatureAlgorithm.ES256);
+
+
+        GoogleIdTokenVerifier googleIdTokenVerifierMock = Mockito.mock(GoogleIdTokenVerifier.class);
+        GoogleIdToken idTokenMock = Mockito.mock(GoogleIdToken.class);
+        Mockito.when(googleIdTokenVerifierMock.verify(any(GoogleIdToken.class))).thenReturn(true);
+        Mockito.when(googleIdTokenVerifierMock.verify(anyString())).thenReturn(idTokenMock);
+
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        utils.setGoogleIdTokenVerifier(googleIdTokenVerifierMock);
+        try {
+            utils.validateGCPIdentityToken(nonGoogleToken, new StringBuilder());
+        } catch (Exception ex) {
+            fail();
+        }
+
+        System.clearProperty(InstanceGCPUtils.GCP_PROP_EXPECTED_AUDIENCE);
+    }
+
+    @Test
+    public void testPopulateAttestationData() {
+        GoogleIdToken.Payload payload = new GoogleIdToken.Payload();
+        payload.setAudience("https://my-zts-server");
+        payload.setIssuer("https://accounts.google.com");
+        payload.setEmail("my-sa@my-gcp-project.iam.gserviceaccount.com");
+        payload.setEmailVerified(true);
+        payload.setAuthorizedParty("102023896904281105569");
+
+        Map<String, Map<String, Object>> extras = new ArrayMap<>();
+        Map<String, Object> extrasCE = new ArrayMap<>();
+        extrasCE.put("instance_creation_timestamp", new BigDecimal(1677459985444L));
+        extrasCE.put("instance_id", "3692465099344887023");
+        extrasCE.put("instance_name", "my-vm");
+        extrasCE.put("project_id", "my-gcp-project");
+        extrasCE.put("project_number", new BigDecimal(1234567890123L));
+        extrasCE.put("zone", "us-west1-a");
+        extras.put("compute_engine", extrasCE);
+
+        payload.set("google", extras);
+
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        utils.populateAttestationData(payload, derivedAttestationData);
+
+        assertThat(derivedAttestationData.getAudience(), hasItems("https://my-zts-server"));
+        assertEquals(derivedAttestationData.getEmail(), "my-sa@my-gcp-project.iam.gserviceaccount.com");
+        assertTrue(derivedAttestationData.isEmailVerified());
+        assertEquals(derivedAttestationData.getIssuer(), "https://accounts.google.com");
+        assertEquals(derivedAttestationData.getAuthorizedParty(), "102023896904281105569");
+
+        assertNotNull(derivedAttestationData.getAdditionalAttestationData());
+
+        assertEquals(derivedAttestationData.getAdditionalAttestationData().getInstanceId(), "3692465099344887023");
+        assertEquals(derivedAttestationData.getAdditionalAttestationData().getInstanceCreationTimestamp().longValue(), 1677459985444L);
+        assertEquals(derivedAttestationData.getAdditionalAttestationData().getInstanceName(), "my-vm");
+        assertEquals(derivedAttestationData.getAdditionalAttestationData().getProjectId(), "my-gcp-project");
+        assertEquals(derivedAttestationData.getAdditionalAttestationData().getProjectNumber(), "1234567890123");
+        assertEquals(derivedAttestationData.getAdditionalAttestationData().getZone(), "us-west1-a");
+    }
+
+    @Test
+    public void testGetServiceNameFromAttestedData() {
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmailVerified(true);
+        derivedAttestationData.setEmail("my-sa@my-gcp-project.iam.gserviceaccount.com");
+        assertEquals(utils.getServiceNameFromAttestedData(derivedAttestationData), "my-gcp-project.my-sa");
+    }
+
+    @Test
+    public void testGetServiceNameFromAttestedDataInvalid() {
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmail("xyz");
+        assertEquals(utils.getServiceNameFromAttestedData(derivedAttestationData), ".");
+    }
+
+    @Test
+    public void testGetServiceNameFromAttestedDataUnverified() {
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmailVerified(false);
+        derivedAttestationData.setEmail("acc@a.com");
+        assertEquals(utils.getServiceNameFromAttestedData(derivedAttestationData), ".");
+    }
+
+    @Test
+    public void testGetProjectIdFromAttestedData() {
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmailVerified(true);
+        derivedAttestationData.setEmail("my-sa@my-gcp-project.iam.gserviceaccount.com");
+        assertEquals(utils.getProjectIdFromAttestedData(derivedAttestationData), "my-gcp-project");
+    }
+
+    @Test
+    public void testGetProjectIdFromAttestedDataInvalid() {
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmail("xyz");
+        assertEquals(utils.getProjectIdFromAttestedData(derivedAttestationData), "");
+    }
+
+    @Test
+    public void testGetProjectIdFromAttestedDataUnverified() {
+
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        GCPDerivedAttestationData derivedAttestationData = new GCPDerivedAttestationData();
+        derivedAttestationData.setEmailVerified(false);
+        derivedAttestationData.setEmail("acc@a.com");
+        assertEquals(utils.getProjectIdFromAttestedData(derivedAttestationData), "");
+    }
+
+    @Test
+    public void testGetGCPRegionFromZone() {
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        String actual = utils.getGCPRegionFromZone("us-west1-a");
+        assertEquals(actual, "us-west1");
+    }
+
+    @Test
+    public void testGetGCPRegionFromZoneNull() {
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        String actual = utils.getGCPRegionFromZone(null);
+        assertNull(actual);
+    }
+
+    @Test
+    public void testGetGCPRegionFromZoneInvalid() {
+        InstanceGCPUtils utils = new InstanceGCPUtils();
+        String actual = utils.getGCPRegionFromZone("uswest1");
+        assertEquals(actual, "uswest1");
+    }
+}

--- a/libs/java/instance_provider/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/libs/java/instance_provider/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <aws.version>1.12.416</aws.version>
     <aws2.version>2.20.13</aws2.version>
+    <gcp.bom.version>25.4.0</gcp.bom.version>
+    <gcp.api-client.version>2.2.0</gcp.api-client.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <commons.daemon.version>1.3.3</commons.daemon.version>
     <guava.version>31.1-jre</guava.version>

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3914,6 +3914,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             attributes.put(InstanceProvider.ZTS_INSTANCE_AZURE_SUBSCRIPTION, azureSubscription);
         }
 
+        final String gcpProject = cloudStore.getGCPProject(domain);
+        if (gcpProject != null) {
+            attributes.put(InstanceProvider.ZTS_INSTANCE_GCP_PROJECT, gcpProject);
+        }
+
         // if this is a class based provider then we're also going
         // to provide the public key in the CSR
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -65,6 +65,8 @@ public class CloudStore {
     BasicSessionCredentials credentials;
     final private Map<String, String> awsAccountCache;
     final private Map<String, String> azureSubscriptionCache;
+
+    final private Map<String, String> gcpProjectCache;
     ConcurrentHashMap<String, AWSTemporaryCredentials> awsCredsCache;
     ConcurrentHashMap<String, Long> awsInvalidCredsCache;
     private HttpClient httpClient;
@@ -82,6 +84,10 @@ public class CloudStore {
         // initialize azure cache
 
         azureSubscriptionCache = new ConcurrentHashMap<>();
+
+        // initialize gcp cache
+
+        gcpProjectCache = new ConcurrentHashMap<>();
 
         // Instantiate and start our HttpClient
 
@@ -600,11 +606,15 @@ public class CloudStore {
         return azureSubscriptionCache.get(domainName);
     }
 
+    public String getGCPProject(String domainName) {
+        return gcpProjectCache.get(domainName);
+    }
+
     void updateAwsAccount(final String domainName, final String awsAccount) {
 
         /* if we have a value specified for the domain, then we're just
          * going to insert it into our map and update the record. If
-         * the new value is not present and we had a value stored before
+         * the new value is not present, and we had a value stored before
          * then let's remove it */
 
         if (!StringUtil.isEmpty(awsAccount)) {
@@ -618,13 +628,27 @@ public class CloudStore {
 
         /* if we have a value specified for the domain, then we're just
          * going to insert it into our map and update the record. If
-         * the new value is not present and we had a value stored before
+         * the new value is not present, and we had a value stored before
          * then let's remove it */
 
         if (!StringUtil.isEmpty(azureSubscription)) {
             azureSubscriptionCache.put(domainName, azureSubscription);
-        } else if (awsAccountCache.get(domainName) != null) {
+        } else if (azureSubscriptionCache.get(domainName) != null) {
             azureSubscriptionCache.remove(domainName);
+        }
+    }
+
+    void updateGCPProject(final String domainName, final String gcpProject) {
+
+        /* if we have a value specified for the domain, then we're just
+         * going to insert it into our map and update the record. If
+         * the new value is not present, and we had a value stored before
+         * then let's remove it */
+
+        if (!StringUtil.isEmpty(gcpProject)) {
+            gcpProjectCache.put(domainName, gcpProject);
+        } else if (gcpProjectCache.get(domainName) != null) {
+            gcpProjectCache.remove(domainName);
         }
     }
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
@@ -1378,6 +1378,7 @@ public class DataStore implements DataCacheProvider, RolesProvider {
         if (getCloudStore() != null) {
             getCloudStore().updateAwsAccount(name, dataCache.getDomainData().getAccount());
             getCloudStore().updateAzureSubscription(name, dataCache.getDomainData().getAzureSubscription());
+            getCloudStore().updateGCPProject(name, dataCache.getDomainData().getGcpProject());
         }
 
         /* update the cache for the given domain */

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -4948,6 +4948,7 @@ public class ZTSImplTest {
 
         DataStore store = new DataStore(structStore, null, ztsMetric);
         Mockito.when(mockCloudStore.getAzureSubscription("athenz")).thenReturn("12345");
+        Mockito.when(mockCloudStore.getGCPProject("athenz")).thenReturn("my-gcp-project-xsdc");
         ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
 
         SignedDomain providerDomain = signedAuthorizedProviderDomain();
@@ -9452,7 +9453,6 @@ public class ZTSImplTest {
 
         System.setProperty(ZTSConsts.ZTS_PROP_HOSTNAME, "server1.athenz");
         assertEquals("server1.athenz", ZTSImpl.getServerHostName());
-
         System.clearProperty(ZTSConsts.ZTS_PROP_HOSTNAME);
     }
 
@@ -14054,6 +14054,7 @@ public class ZTSImplTest {
 
         DataStore store = new DataStore(structStore, null, ztsMetric);
         Mockito.when(mockCloudStore.getAzureSubscription("athenz")).thenReturn("12345");
+        Mockito.when(mockCloudStore.getGCPProject("athenz")).thenReturn(null);
         ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
 
         Path path = Paths.get("src/test/resources//athenz.instanceid.hostname.pem");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -1097,6 +1097,19 @@ public class CloudStoreTest {
         assertNull(cloudStore.getAzureSubscription("athenz"));
         cloudStore.updateAzureSubscription("athenz", "12345");
         assertEquals("12345", cloudStore.getAzureSubscription("athenz"));
+        cloudStore.updateAzureSubscription("athenz", "");
+        assertNull(cloudStore.getAzureSubscription("athenz"));
+        cloudStore.close();
+    }
+
+    @Test
+    public void testGetGcpProject() {
+        CloudStore cloudStore = new CloudStore();
+        assertNull(cloudStore.getGCPProject("athenz"));
+        cloudStore.updateGCPProject("athenz", "athenz-gcp-xsdc");
+        assertEquals(cloudStore.getGCPProject("athenz"), "athenz-gcp-xsdc");
+        cloudStore.updateGCPProject("athenz", "");
+        assertNull(cloudStore.getGCPProject("athenz"));
         cloudStore.close();
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/transportrules/TransportRulesProcessorTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/transportrules/TransportRulesProcessorTest.java
@@ -62,4 +62,10 @@ public class TransportRulesProcessorTest {
                 {"TCP-IN:AA:WE", null},
         };
     }
+
+    @Test
+    public void testTransportRulesProcessorConstructor() {
+        TransportRulesProcessor trp = new TransportRulesProcessor();
+        assertNotNull(trp);
+    }
 }


### PR DESCRIPTION
backend provider for Google Cloud to perform validation before issuing identity to GCP workloads. The current provider supports GCE and GKE workloads based on the the identity token generated from Google Metadata Server. 

Implementation details -

GCPAttestationData contains the identity token obtained from the Google Metadata Server.
Depending on which environment token is obtained from ( GCE vs GKE ) it can contain additional information. Hence GCPDerivedAttestationData covers the common attributes obtained from a valid identity token.
GCPAdditionalAttestationData contains the additional information only provided by GCE Metadata Server.

GCPUtils uses the google-java-api-client library to validate the identity token.

Since the region where workload is bootstrapped, workload identifier and bootstrap time is only available from GCE Metadata Server, those validations are done optionally when the information is present.