### PR TITLE
Update DB Dockerfile to fix deploy-dev

### DIFF
--- a/docker/db/zms/Dockerfile
+++ b/docker/db/zms/Dockerfile
@@ -17,7 +17,8 @@ COPY zms_server.sql /docker-entrypoint-initdb.d/
 # In docker env., skip-name-resolve is enable by default. Disable it to allow login with reverse DNS lookup.
 # https://github.com/docker-library/mariadb/blob/3b2e52a6a0a525d879053a33886f35d3a5c38603/10.4/Dockerfile#L121
 RUN rm /etc/mysql/conf.d/docker.cnf; \
-	echo '[mysqld]\nskip-host-cache' > /etc/mysql/conf.d/docker.cnf
+	echo '[mysqld]\nskip-host-cache' > /etc/mysql/conf.d/docker.cnf; \
+	sed 's/skip-name-resolve/# skip-name-resolve/g' -i /etc/mysql/my.cnf
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/docker/db/zts/Dockerfile
+++ b/docker/db/zts/Dockerfile
@@ -17,7 +17,8 @@ COPY zts_server.sql /docker-entrypoint-initdb.d/
 # In docker env., skip-name-resolve is enable by default. Disable it to allow login with reverse DNS lookup.
 # https://github.com/docker-library/mariadb/blob/3b2e52a6a0a525d879053a33886f35d3a5c38603/10.4/Dockerfile#L121
 RUN rm /etc/mysql/conf.d/docker.cnf; \
-	echo '[mysqld]\nskip-host-cache' > /etc/mysql/conf.d/docker.cnf
+	echo '[mysqld]\nskip-host-cache' > /etc/mysql/conf.d/docker.cnf; \
+	sed 's/skip-name-resolve/# skip-name-resolve/g' -i /etc/mysql/my.cnf
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 


### PR DESCRIPTION
When I tried to use `make deploy-dev` to deploy the servers in my development environment, I got this error in the `server.log`

![image](https://user-images.githubusercontent.com/20693041/228745067-09411aa7-cca1-4f1c-ba83-54ce457c83ed.png)

The command I used to deploy is

```bash
make remove-all && make build && make deploy-dev
```

I believe it's caused by the misconfiguration of mysql db, so I made some modification to make it work normally.

I have tested these new `Dockerfile` and now it works well.