### PR TITLE
support ssh_principals field in sia_config with cert_request object for ecdsa

### DIFF
--- a/libs/go/sia/aws/options/data/sia_config
+++ b/libs/go/sia/aws/options/data/sia_config
@@ -17,5 +17,6 @@
             "user": "nobody",
             "account": "123456789012"
         }
-    ]
+    ],
+    "ssh_principals": "host1.athenz.io,host2.athenz.io"
 }

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -237,17 +237,17 @@ func TestOptionsWithProfileConfig(t *testing.T) {
 	opts, e := setOptions(cfg, cfgAccount, profileConfig, "/tmp", "1.0.0")
 	require.Nilf(t, e, "error should be empty, error: %v", e)
 	require.NotNil(t, opts, "should be able to get Options")
-	assert.True(t, opts.RefreshInterval == 1440)
-	assert.True(t, opts.ZTSRegion == "")
+	assert.Equal(t, 1440, opts.RefreshInterval)
+	assert.Empty(t, opts.ZTSRegion)
 
 	// Make sure profile is correct
-	assert.True(t, opts.Profile == "zts-profile")
-	assert.True(t, opts.ProfileRestrictTo == "")
+	assert.Equal(t, "zts-profile", opts.Profile)
+	assert.Empty(t, opts.ProfileRestrictTo)
 
 	// Make sure services are set
-	assert.True(t, len(opts.Services) == 3)
-	assert.True(t, opts.Domain == "athenz")
-	assert.True(t, opts.Name == "athenz.api")
+	assert.Equal(t, 3, len(opts.Services))
+	assert.Equal(t, "athenz", opts.Domain)
+	assert.Equal(t, "athenz.api", opts.Name)
 
 	// Zeroth service should be the one from "service" key, the remaining are from "services" in no particular order
 	assert.True(t, assertService(opts.Services[0], Service{Name: "api", User: "nobody", Uid: getUid("nobody"), Gid: getUserGid("nobody"), FileMode: 288, Threshold: DefaultThreshold}))
@@ -256,6 +256,7 @@ func TestOptionsWithProfileConfig(t *testing.T) {
 
 	assert.Equal(t, DefaultThreshold, opts.SshThreshold)
 	assert.Equal(t, DefaultThreshold, opts.Threshold)
+	assert.Equal(t, "host1.athenz.io,host2.athenz.io", opts.SshPrincipals)
 }
 
 // TestOptionsWithProfileConfigAndProfileTag test the scenario when profile config file is present anbd has profile tag key
@@ -356,6 +357,7 @@ func TestOptionsWithConfig(t *testing.T) {
 	assert.Equal(t, "/var/lib/sia/certs", opts.CertDir)
 	assert.Equal(t, "/var/lib/sia/tokens", opts.TokenDir)
 	assert.Equal(t, "/var/lib/sia/backup", opts.BackupDir)
+	assert.Equal(t, "host1.athenz.io,host2.athenz.io", opts.SshPrincipals)
 
 	// Make sure services are set
 	assert.Equal(t, 3, len(opts.Services))
@@ -658,6 +660,7 @@ func TestInitEnvConfig(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_KEY_DIR", "/var/athenz/keys")
 	os.Setenv("ATHENZ_SIA_CERT_DIR", "/var/athenz/certs")
 	os.Setenv("ATHENZ_SIA_TOKEN_DIR", "/var/athenz/tokens")
+	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
 
 	cfg, cfgAccount, err := InitEnvConfig(nil)
 	require.Nilf(t, err, "error should be empty, error: %v", err)
@@ -685,6 +688,7 @@ func TestInitEnvConfig(t *testing.T) {
 	assert.Equal(t, "api", cfgAccount.Service)
 	assert.Equal(t, "athenz.api", cfgAccount.Name)
 	assert.Equal(t, 2, len(cfgAccount.Roles))
+	assert.Equal(t, "host1.athenz.io", cfg.SshPrincipals)
 
 	os.Clearenv()
 }

--- a/libs/go/sia/util/data/ssh-pub-key
+++ b/libs/go/sia/util/data/ssh-pub-key
@@ -1,0 +1,1 @@
+ssh-pub-key

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -376,6 +376,52 @@ func GenerateSSHHostCSR(sshPubKeyFile string, domain, service, ip string, ztsAws
 	return string(csr), err
 }
 
+func GenerateSSHHostRequest(sshPubKeyFile string, domain, service, hostname, ip, instanceId, sshPrincipals string, ztsAwsDomains []string) (*zts.SSHCertRequest, error) {
+
+	log.Println("Generating SSH Host Certificate Request...")
+
+	pubkey, err := os.ReadFile(sshPubKeyFile)
+	if err != nil {
+		log.Printf("Unable to read SSH Public Key File: %v\n", err)
+		return nil, err
+	}
+	identity := domain + "." + service
+	hyphenDomain := strings.Replace(domain, ".", "-", -1)
+	var principals []string
+	if hostname != "" {
+		principals = append(principals, hostname)
+	}
+	if sshPrincipals != "" {
+		principals = append(principals, strings.Split(sshPrincipals, ",")...)
+	}
+	if ip != "" {
+		principals = append(principals, ip)
+	}
+	for _, ztsDomain := range ztsAwsDomains {
+		host := fmt.Sprintf("%s.%s.%s", service, hyphenDomain, ztsDomain)
+		principals = append(principals, host)
+	}
+	pubKeyAlgo := int32(x509.ECDSA)
+	dataRequest := &zts.SSHCertRequestData{
+		Principals:   principals,
+		PublicKey:    string(pubkey),
+		CaPubKeyAlgo: &pubKeyAlgo,
+	}
+	metaRequest := &zts.SSHCertRequestMeta{
+		TransId:       fmt.Sprintf("%x", time.Now().Unix()),
+		Requestor:     identity,
+		AthenzService: zts.EntityName(identity),
+		Origin:        ip,
+		InstanceId:    zts.PathElement(instanceId),
+		CertType:      "host",
+	}
+	req := &zts.SSHCertRequest{
+		CertRequestData: dataRequest,
+		CertRequestMeta: metaRequest,
+	}
+	return req, nil
+}
+
 func AppendUri(uriList []*url.URL, uriValue string) []*url.URL {
 	uri, err := url.Parse(uriValue)
 	if err == nil {

--- a/provider/aws/sia-ec2/authn.go
+++ b/provider/aws/sia-ec2/authn.go
@@ -36,26 +36,27 @@ func getDocValue(docMap map[string]interface{}, key string) string {
 	}
 }
 
-func GetEC2DocumentDetails(metaEndPoint string) ([]byte, []byte, string, string, string, *time.Time, error) {
+func GetEC2DocumentDetails(metaEndPoint string) ([]byte, []byte, string, string, string, string, *time.Time, error) {
 	document, err := meta.GetData(metaEndPoint, "/latest/dynamic/instance-identity/document")
 	if err != nil {
-		return nil, nil, "", "", "", nil, err
+		return nil, nil, "", "", "", "", nil, err
 	}
 	signature, err := meta.GetData(metaEndPoint, "/latest/dynamic/instance-identity/pkcs7")
 	if err != nil {
-		return nil, nil, "", "", "", nil, err
+		return nil, nil, "", "", "", "", nil, err
 	}
 	var docMap map[string]interface{}
 	err = json.Unmarshal(document, &docMap)
 	if err != nil {
-		return nil, nil, "", "", "", nil, err
+		return nil, nil, "", "", "", "", nil, err
 	}
 	account := getDocValue(docMap, "accountId")
 	region := getDocValue(docMap, "region")
 	instanceId := getDocValue(docMap, "instanceId")
+	privateIp := getDocValue(docMap, "privateIp")
 
 	timeCheck, _ := time.Parse(time.RFC3339, getDocValue(docMap, "pendingTime"))
-	return document, signature, account, instanceId, region, &timeCheck, err
+	return document, signature, account, instanceId, region, privateIp, &timeCheck, err
 }
 
 func GetECSOnEC2TaskId() string {

--- a/provider/aws/sia-ec2/authn_test.go
+++ b/provider/aws/sia-ec2/authn_test.go
@@ -51,7 +51,7 @@ func TestGetECSonEC2TaskId(t *testing.T) {
 }
 
 func TestGetEC2DocumentDetails(t *testing.T) {
-	document, signature, account, instanceId, region, time, err := GetEC2DocumentDetails("http://127.0.0.1:5080")
+	document, signature, account, instanceId, region, privateIp, time, err := GetEC2DocumentDetails("http://127.0.0.1:5080")
 	assert.Nil(t, err)
 	assert.NotNil(t, document)
 	assert.NotNil(t, signature)
@@ -60,4 +60,5 @@ func TestGetEC2DocumentDetails(t *testing.T) {
 	assert.True(t, instanceId == "i-03d1ae7035f931a90")
 	assert.True(t, region == "us-west-2")
 	assert.True(t, time.String() == "2016-05-02 22:23:14 +0000 UTC")
+	assert.Equal(t, "172.31.30.74", privateIp)
 }

--- a/provider/aws/sia-ec2/cmd/siad/main.go
+++ b/provider/aws/sia-ec2/cmd/siad/main.go
@@ -87,7 +87,7 @@ func main() {
 	log.Printf("SIA-EC2 version: %s \n", Version)
 
 	//obtain the ec2 document details
-	document, signature, account, instanceId, region, startTime, err := sia.GetEC2DocumentDetails(*ec2MetaEndPoint)
+	document, signature, account, instanceId, region, privateIp, startTime, err := sia.GetEC2DocumentDetails(*ec2MetaEndPoint)
 	if err != nil {
 		log.Fatalf("Unable to extract document details: %v\n", err)
 	}
@@ -105,6 +105,7 @@ func main() {
 	opts.Ssh = false
 	opts.EC2Document = string(document)
 	opts.EC2Signature = string(signature)
+	opts.PrivateIp = privateIp
 	opts.ZTSCACertFile = *ztsCACert
 	opts.ZTSServerName = *ztsServerName
 	opts.ZTSAWSDomains = strings.Split(*dnsDomains, ",")

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -4226,8 +4226,8 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             throw serverError("unable to generate identity", caller, domain, principalDomain);
         }
 
-        // if we're asked then we should also generate a ssh
-        // certificate for the instance as well
+        // if we're asked then we should also generate an ssh certificate for the instance as well.
+        // for instance based ssh certificates, we do not pass any principal details.
 
         if (sshCertAllowed) {
             Object timerSSHCertMetric = metric.startTiming("certsignssh_timing", null, principalDomain);
@@ -4236,7 +4236,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
             SSHCertRecord certRecord = generateSSHCertRecord(ctx, domain + "." + service, instanceId,
                     instancePrivateIp);
-            instanceCertManager.generateSSHIdentity(principal, identity, info.getHostname(), info.getSsh(),
+            instanceCertManager.generateSSHIdentity(null, identity, info.getHostname(), info.getSsh(),
                     info.getSshCertRequest(), certRecord, ZTSConsts.ZTS_SSH_HOST);
             metric.stopTiming(timerSSHCertMetric, null, principalDomain);
         }


### PR DESCRIPTION
we're slowly deprecating the use of rsa keys and the ssh csr that SIA generates. instead we should standardize the use of ssh cert request object which the PR does when asking for ecdsa keys