### PR TITLE
allow ssh-principals with service name based dns cnames

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3722,7 +3722,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
             SSHCertRecord certRecord = generateSSHCertRecord(ctx, cn, certReqInstanceId, instancePrivateIp);
             instanceCertManager.generateSSHIdentity(null, identity, info.getHostname(), info.getSsh(),
-                    info.getSshCertRequest(), certRecord, ZTSConsts.ZTS_SSH_HOST);
+                    info.getSshCertRequest(), certRecord, ZTSConsts.ZTS_SSH_HOST, false);
             metric.stopTiming(timerSSHCertMetric, null, principalDomain);
         }
 
@@ -4237,7 +4237,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             SSHCertRecord certRecord = generateSSHCertRecord(ctx, domain + "." + service, instanceId,
                     instancePrivateIp);
             instanceCertManager.generateSSHIdentity(null, identity, info.getHostname(), info.getSsh(),
-                    info.getSshCertRequest(), certRecord, ZTSConsts.ZTS_SSH_HOST);
+                    info.getSshCertRequest(), certRecord, ZTSConsts.ZTS_SSH_HOST, true);
             metric.stopTiming(timerSSHCertMetric, null, principalDomain);
         }
 
@@ -4323,7 +4323,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         InstanceIdentity identity = new InstanceIdentity().setName(principalName);
         Object timerSSHCertMetric = metric.startTiming("certsignssh_timing", null, principalDomain);
         if (!instanceCertManager.generateSSHIdentity(principal, identity, null, sshCsr, sshCertRequest,
-                null, ZTSConsts.ZTS_SSH_USER)) {
+                null, ZTSConsts.ZTS_SSH_USER, true)) {
             throw serverError("unable to generate ssh identity", caller, domain, principalDomain);
         }
         metric.stopTiming(timerSSHCertMetric, null, principalDomain);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -5331,7 +5331,7 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.doThrow(new ResourceException(500, "Invalid SSH")).when(instanceManager)
                 .generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-                        Mockito.any(), Mockito.any(), Mockito.any());
+                        Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -5394,7 +5394,7 @@ public class ZTSImplTest {
         Mockito.when(providerClient.confirmInstance(Mockito.any())).thenReturn(confirmation);
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean())).thenReturn(true);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -6092,7 +6092,7 @@ public class ZTSImplTest {
                 .setProvider("athenz.provider").setToken(false);
 
         Mockito.doReturn(false).when(instanceManager).generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean());
 
         ResourceContext context = createResourceContext(null);
 
@@ -6273,7 +6273,7 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.getX509CertRecord("athenz.provider", "1001", "athenz.production")).thenReturn(certRecord);
         Mockito.when(instanceManager.updateX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean())).thenReturn(true);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -6949,7 +6949,7 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.getX509CertRecord("athenz.provider", "1001", "athenz.production")).thenReturn(certRecord);
         Mockito.when(instanceManager.updateX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), eq("ssh-csr"),
-                Mockito.any(), Mockito.any(), eq("user"))).thenReturn(false);
+                Mockito.any(), Mockito.any(), eq("user"), Mockito.anyBoolean())).thenReturn(false);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -7903,7 +7903,7 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
         Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr",
-                null, null, "user")).thenReturn(true);
+                null, null, "user", true)).thenReturn(true);
 
         ztsImpl.instanceCertManager = instanceManager;
 
@@ -7954,7 +7954,7 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
         Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr",
-                null, null, "user")).thenReturn(true);
+                null, null, "user", true)).thenReturn(true);
 
         ztsImpl.instanceCertManager = instanceManager;
 
@@ -8005,7 +8005,7 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
         Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr",
-                null, null, "user")).thenReturn(false);
+                null, null, "user", true)).thenReturn(false);
 
         ztsImpl.instanceCertManager = instanceManager;
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -403,11 +403,11 @@ public class InstanceCertManagerTest {
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, true, null);
         instanceManager.setSSHSigner(null);
 
-        boolean result = instanceManager.generateSSHIdentity(null, identity, null, null, null, null, null);
+        boolean result = instanceManager.generateSSHIdentity(null, identity, null, null, null, null, null, true);
         assertTrue(result);
         assertNull(identity.getSshCertificate());
         
-        result = instanceManager.generateSSHIdentity(null, identity, null, "", null, null, null);
+        result = instanceManager.generateSSHIdentity(null, identity, null, "", null, null, null, true);
         assertTrue(result);
         assertNull(identity.getSshCertificate());
         instanceManager.shutdown();
@@ -421,7 +421,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity,"host.athenz.com", "{\"csr\":\"csr\"}",
-                null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST);
+                null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST, true);
         assertFalse(result);
     }
     
@@ -440,7 +440,7 @@ public class InstanceCertManagerTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         boolean result = instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, new SSHCertRecord(), "host");
+                null, new SSHCertRecord(), "host", true);
         assertFalse(result);
         instanceManager.shutdown();
     }
@@ -461,11 +461,11 @@ public class InstanceCertManagerTest {
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
 
         // first we should get the resource exception
-        boolean result = instanceManager.generateSSHIdentity(null, identity, "", sshCsr, null, new SSHCertRecord(), "host");
+        boolean result = instanceManager.generateSSHIdentity(null, identity, "", sshCsr, null, new SSHCertRecord(), "host", true);
         assertFalse(result);
 
         // next we should get the io exception
-        result = instanceManager.generateSSHIdentity(null, identity, "", sshCsr, null, new SSHCertRecord(), "host");
+        result = instanceManager.generateSSHIdentity(null, identity, "", sshCsr, null, new SSHCertRecord(), "host", true);
         assertFalse(result);
 
         instanceManager.shutdown();
@@ -488,7 +488,7 @@ public class InstanceCertManagerTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         boolean result = instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, new SSHCertRecord(), "host");
+                null, new SSHCertRecord(), "host", true);
         assertFalse(result);
         instanceManager.shutdown();
     }
@@ -514,7 +514,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, sshCertRecord, "host"));
+                null, sshCertRecord, "host", true));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
         instanceManager.shutdown();
@@ -540,7 +540,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertFalse(instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, sshCertRecord, "host"));
+                null, sshCertRecord, "host", true));
         instanceManager.shutdown();
     }
 
@@ -565,7 +565,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, sshCertRecord, "user"));
+                null, sshCertRecord, "user", true));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-user");
         instanceManager.shutdown();
@@ -604,7 +604,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity, hostname, sshCsr,
-                null, sshCertRecord, "host");
+                null, sshCertRecord, "host", true);
         assertTrue(result);
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
@@ -644,7 +644,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity, hostname, sshCsr,
-                null, new SSHCertRecord(), "host");
+                null, new SSHCertRecord(), "host", true);
         assertFalse(result);
         instanceManager.shutdown();
     }
@@ -688,7 +688,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, hostname, null,
-                sshRequest, sshCertRecord, "host"));
+                sshRequest, sshCertRecord, "host", true));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
         instanceManager.shutdown();
@@ -720,12 +720,15 @@ public class InstanceCertManagerTest {
         when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
 
         HostnameResolver hostnameResolver = Mockito.mock(HostnameResolver.class);
+        List<String> apiList = Arrays.asList("host1.athenz.cloud", "cname.athenz.info", "vip.athenz.info");
+        when(hostnameResolver.isValidHostCnameList("athenz.service", null, apiList, CertType.SSH_HOST))
+                .thenReturn(true);
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, hostnameResolver, true, null);
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, null, null,
-                sshRequest, sshCertRecord, "host"));
+                sshRequest, sshCertRecord, "host", true));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
         instanceManager.shutdown();
@@ -770,7 +773,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertFalse(instanceManager.generateSSHIdentity(null, identity, hostname, null,
-                sshRequest, sshCertRecord, "host"));
+                sshRequest, sshCertRecord, "host", true));
         instanceManager.shutdown();
     }
 
@@ -789,7 +792,7 @@ public class InstanceCertManagerTest {
         String sshCsr = "{\"pubkey\":\"key\",\"certtype\":\"host\"";
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.test");
         boolean result = instanceManager.generateSSHIdentity(null, identity, hostname,
-                sshCsr, null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST);
+                sshCsr, null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST, true);
         assertFalse(result);
     }
 
@@ -907,15 +910,15 @@ public class InstanceCertManagerTest {
         sshCertRecord.setService("athenz.examples.httpd");
 
         SSHCertRequest sshCertRequest = new SSHCertRequest();
-        assertFalse(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
+        assertTrue(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
 
         sshCertRequest.setCertRequestData(new SSHCertRequestData());
         sshCertRequest.setCertRequestMeta(null);
-        assertFalse(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
+        assertTrue(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
 
         sshCertRequest.setCertRequestData(null);
         sshCertRequest.setCertRequestMeta(new SSHCertRequestMeta());
-        assertFalse(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
+        assertTrue(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
 
         // null principals returns true
 
@@ -923,6 +926,39 @@ public class InstanceCertManagerTest {
         sshCertRequest.setCertRequestMeta(new SSHCertRequestMeta());
         assertTrue(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
 
+        // empty principals list return true
+
+        sshCertRequest.setCertRequestData(new SSHCertRequestData().setPrincipals(Collections.emptyList()));
+        assertTrue(instanceManager.validPrincipals(hostname, sshCertRecord, sshCertRequest));
+
+        instanceManager.shutdown();
+    }
+
+    @Test
+    public void testValidateSSHHostnamesResolverTests() {
+
+        // without resolver we get a failure
+
+        List<String> principals = new ArrayList<>();
+        principals.add("127.0.0.1");
+        principals.add("cname.athenz.io");
+
+        SSHCertRecord record = new SSHCertRecord();
+        record.setService("athenz.api");
+
+        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, true, null);
+        assertFalse(instanceManager.validateSSHHostnames("host1.athenz.io", principals, record));
+        instanceManager.shutdown();
+
+        // now test with resolver
+
+        HostnameResolver hostnameResolver = Mockito.mock(HostnameResolver.class);
+        when(hostnameResolver.isValidHostname(anyString())).thenReturn(true);
+        when(hostnameResolver.isValidHostCnameList("athenz.api", "host1.athenz.io",
+                Collections.singletonList("cname.athenz.io"), CertType.SSH_HOST)).thenReturn(true);
+
+        instanceManager = new InstanceCertManager(null, null, hostnameResolver, true, null);
+        assertTrue(instanceManager.validateSSHHostnames("host1.athenz.io", principals, record));
         instanceManager.shutdown();
     }
 


### PR DESCRIPTION
when sia provides an ssh host certificate request where the principal is based on dns suffix or a cname one without relying on hostname, current changes now allow that support by relying on the configured hostname resolver.

So you can have an instance with service api and domain sports with dns suffix athenz.io to include the following ssh principals:

10.11.11.11 - internal private ip of the hostname
api.sports.athenz.io - service based name
bastion.sports.athenz.cloud - this is configured as cname for api.sports.athenz.io thus allowed.

the logic for the last 2 checks is part of the HostnameResolver interface implementation.