### PR TITLE
UI: apply timezone settings

### DIFF
--- a/ui/src/__tests__/components/group/GroupRow.test.js
+++ b/ui/src/__tests__/components/group/GroupRow.test.js
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render } from '@testing-library/react';
 import GroupRow from '../../../components/group/GroupRow';
 import { colors } from '../../../components/denali/styles';
 import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('GroupRow', () => {
     it('should render', () => {
-        let details = {
+        const details = {
             name: 'athens:group.testui',
             modified: '2017-08-03T18:44:41.867Z',
         };
-        let domain = 'domain';
-        let color = colors.row;
-        let idx = '50';
+        const domain = 'domain';
+        const color = colors.row;
+        const idx = '50';
+        const timeZone = 'UTC';
+
         const { getByTestId } = renderWithRedux(
             <table>
                 <tbody>
@@ -36,6 +37,7 @@ describe('GroupRow', () => {
                         domain={domain}
                         color={color}
                         idx={idx}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>

--- a/ui/src/__tests__/components/group/GroupTable.test.js
+++ b/ui/src/__tests__/components/group/GroupTable.test.js
@@ -14,30 +14,31 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render } from '@testing-library/react';
 import GroupTable from '../../../components/group/GroupTable';
-import API from '../../../api';
 import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('GroupTable', () => {
     it('should render', () => {
-        let domains = [];
-        let groups = [];
+        const domains = [];
         domains.push('dom1');
         domains.push('dom2');
         domains.push('dom3');
         domains.push('dom4');
-        let group1 = {
+
+        const groups = [];
+        const group1 = {
             name: 'a',
         };
-
-        let group2 = {
+        const group2 = {
             name: 'b',
         };
         groups.push(group1);
         groups.push(group2);
+
+        const timeZone = 'UTC';
+
         const { getByTestId } = renderWithRedux(
-            <GroupTable groups={groups} domain={domains} />
+            <GroupTable groups={groups} domain={domains} timeZone={timeZone} />
         );
         const grouptable = getByTestId('grouptable');
 

--- a/ui/src/__tests__/components/header/RoleDetails.test.js
+++ b/ui/src/__tests__/components/header/RoleDetails.test.js
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render } from '@testing-library/react';
+import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';;
 import CollectionDetails from '../../../components/header/CollectionDetails';
 
 describe('RoleDetails', () => {
-    it('should render', () => {
+    it('should renderWithRedux', () => {
         const roleMetadata = {
             modified: '2020-02-12T21:44:37.792Z',
         };
 
-        const { getByTestId } = render(
+        const { getByTestId } = renderWithRedux(
             <CollectionDetails collectionDetails={roleMetadata} />
         );
         const domainDetails = getByTestId('collection-details');
         expect(domainDetails).toMatchSnapshot();
     });
-    it('should render with mock data', () => {
+    it('should renderWithRedux with mock data', () => {
         const roleMetadata = {
             modified: '2020-12-01T21:44:37.792Z',
             lastReviewedDate: '2020-12-01T21:44:37.792Z',
         };
 
-        const { getByTestId } = render(
+        const { getByTestId } = renderWithRedux(
             <CollectionDetails collectionDetails={roleMetadata} />
         );
         const roleDetails = getByTestId('collection-details');

--- a/ui/src/__tests__/components/header/__snapshots__/RoleDetails.test.js.snap
+++ b/ui/src/__tests__/components/header/__snapshots__/RoleDetails.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RoleDetails should render 1`] = `
+exports[`RoleDetails should renderWithRedux 1`] = `
 .emotion-0 {
   margin: 20px 0;
 }
@@ -69,7 +69,7 @@ exports[`RoleDetails should render 1`] = `
 </div>
 `;
 
-exports[`RoleDetails should render with mock data 1`] = `
+exports[`RoleDetails should renderWithRedux with mock data 1`] = `
 .emotion-0 {
   margin: 20px 0;
 }

--- a/ui/src/__tests__/components/pending-approval/PendingApprovalTableRow.test.js
+++ b/ui/src/__tests__/components/pending-approval/PendingApprovalTableRow.test.js
@@ -26,6 +26,7 @@ describe('PendingApprovalTable', () => {
         const roleName = 'c';
         const checked = false;
         const userComment = 'd';
+        const timeZone = 'UTC';
 
         const { getByTestId } = render(
             <table>
@@ -40,6 +41,7 @@ describe('PendingApprovalTable', () => {
                         pendingDecision={() => {}}
                         auditRefMissing={false}
                         pendingState={PENDING_STATE_ENUM.ADD}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>

--- a/ui/src/__tests__/components/policy/PolicyRow.test.js
+++ b/ui/src/__tests__/components/policy/PolicyRow.test.js
@@ -23,10 +23,11 @@ describe('PolicyRow', () => {
     it('should render', () => {
         const color = colors.row;
         const name = 'sections';
+        const timeZone = 'UTC';
         const { getByTestId } = renderWithRedux(
             <table>
                 <tbody>
-                    <PolicyRow name={name} color={color} isActive={true} />
+                    <PolicyRow name={name} color={color} isActive={true} timeZone={timeZone} />
                 </tbody>
             </table>
         );

--- a/ui/src/__tests__/components/role/RoleMember.test.js
+++ b/ui/src/__tests__/components/role/RoleMember.test.js
@@ -16,12 +16,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import Member from '../../../components/member/Member';
+import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('Member', () => {
     it('should render', () => {
         let member = { memberName: 'user.test2' };
 
-        const { getByTestId } = render(<Member item={member} idx={0} />);
+        const { getByTestId } = renderWithRedux(<Member item={member} idx={0} />);
         const roleMember = getByTestId('tag');
         expect(roleMember).toMatchSnapshot();
     });

--- a/ui/src/__tests__/components/role/RoleRow.test.js
+++ b/ui/src/__tests__/components/role/RoleRow.test.js
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render } from '@testing-library/react';
 import RoleRow from '../../../components/role/RoleRow';
 import { colors } from '../../../components/denali/styles';
 import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('RoleRow', () => {
     it('should render', () => {
-        let details = {
+        const details = {
             name: 'athens:role.ztssia_cert_rotate',
             modified: '2017-08-03T18:44:41.867Z',
         };
-        let domain = 'domain';
-        let color = colors.row;
-        let idx = '50';
+        const domain = 'domain';
+        const color = colors.row;
+        const idx = '50';
+        const timeZone = 'UTC';
         const { getByTestId } = renderWithRedux(
             <table>
                 <tbody>
@@ -36,6 +36,7 @@ describe('RoleRow', () => {
                         domain={domain}
                         color={color}
                         idx={idx}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>

--- a/ui/src/__tests__/components/role/RoleSectionRow.test.js
+++ b/ui/src/__tests__/components/role/RoleSectionRow.test.js
@@ -20,12 +20,13 @@ import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('RoleRow', () => {
     it('should render', () => {
-        let details = {
+        const details = {
             name: 'athens:role.ztssia_cert_rotate',
             modified: '2017-08-03T18:44:41.867Z',
         };
-        let domain = 'domain';
-        let color = colors.row;
+        const domain = 'domain';
+        const color = colors.row;
+        const timeZone = 'UTC';
         const { getByTestId } = renderWithRedux(
             <table>
                 <tbody>
@@ -33,6 +34,7 @@ describe('RoleRow', () => {
                         details={details}
                         domain={domain}
                         color={color}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>

--- a/ui/src/__tests__/components/role/RoleTable.test.js
+++ b/ui/src/__tests__/components/role/RoleTable.test.js
@@ -21,23 +21,26 @@ import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('RoleTable', () => {
     it('should render', () => {
-        let domains = [];
-        let roles = [];
+        const domains = [];
         domains.push('dom1');
         domains.push('dom2');
         domains.push('dom3');
         domains.push('dom4');
-        let role1 = {
+
+        const roles = [];
+        const role1 = {
             name: 'a',
         };
-
-        let role2 = {
+        const role2 = {
             name: 'b',
         };
         roles.push(role1);
         roles.push(role2);
+
+        const timeZone = 'UTC';
+
         const { getByTestId } = renderWithRedux(
-            <RoleTable roles={roles} domain={domains} />
+            <RoleTable roles={roles} domain={domains} timeZone={timeZone} />
         );
         const roletable = getByTestId('roletable');
 

--- a/ui/src/__tests__/components/service/InstanceTable.test.js
+++ b/ui/src/__tests__/components/service/InstanceTable.test.js
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 import React from 'react';
-import { render } from '@testing-library/react';
 import InstanceTable from '../../../components/service/InstanceTable';
 import API from '../../../api';
 import { renderWithRedux } from '../../../tests_utils/ComponentsTestUtils';
 
 describe('InstanceTable', () => {
     it('should render', () => {
-        let domain = 'test.domain';
-        let _csrf = '_csrfToken';
-        let api = API();
-        let instances = [
+        const domain = 'test.domain';
+        const _csrf = '_csrfToken';
+        const api = API();
+        const timeZone = 'UTC';
+        const instances = [
             {
                 domainName: null,
                 serviceName: null,
@@ -41,10 +41,11 @@ describe('InstanceTable', () => {
                 domain={domain}
                 _csrf={_csrf}
                 category={'dynamic'}
+                timeZone={timeZone}
             />
         );
         const instanceTable = getByTestId('instancetable');
 
         expect(instanceTable).toMatchSnapshot();
-    });
+   });
 });

--- a/ui/src/__tests__/components/service/ServiceRow.test.js
+++ b/ui/src/__tests__/components/service/ServiceRow.test.js
@@ -39,6 +39,7 @@ describe('ServiceRow', () => {
         const modified = '2017-12-19T20:24:41.195Z';
         const color = '';
         const newService = false;
+        const timeZone = 'UTC';
         const { getByTestId } = renderWithRedux(
             <table>
                 <tbody>
@@ -48,6 +49,7 @@ describe('ServiceRow', () => {
                         color={color}
                         modified={modified}
                         newService={newService}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>
@@ -81,6 +83,7 @@ describe('ServiceRow', () => {
 
         const color = '';
         const newService = false;
+        const timeZone = 'UTC';
         const { getByText, getByTitle } = renderWithRedux(
             <table>
                 <tbody>
@@ -90,6 +93,7 @@ describe('ServiceRow', () => {
                         color={color}
                         modified={modified}
                         newService={newService}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>,
@@ -147,6 +151,7 @@ describe('ServiceRow', () => {
         MockApi.setMockApi(api);
         const color = '';
         const newService = false;
+        const timeZone = 'UTC';
         const { getByText, getByTitle } = renderWithRedux(
             <table>
                 <tbody>
@@ -157,6 +162,7 @@ describe('ServiceRow', () => {
                         color={color}
                         modified={modified}
                         newService={newService}
+                        timeZone={timeZone}
                     />
                 </tbody>
             </table>,

--- a/ui/src/__tests__/pages/workflow/domain.test.js
+++ b/ui/src/__tests__/pages/workflow/domain.test.js
@@ -106,6 +106,9 @@ describe('PendingApprovalPage', () => {
                 value: 'home.domain1',
             },
         ];
+
+        const timeZone = 'UTC';
+
         const mockApi = {
             ...mockAllDomainDataApiCalls(domainDetails, headerDetails),
             listUserDomains: jest.fn().mockReturnValue(
@@ -122,6 +125,9 @@ describe('PendingApprovalPage', () => {
             getPendingDomainMembersList: jest
                 .fn()
                 .mockReturnValue(Promise.resolve(pendingData)),
+            getTimeZone: jest
+                .fn()
+                .mockReturnValue(Promise.resolve(timeZone)),
         };
         // const pendingUserData = buildUserForState(pendingData);
         // const domainData = buildDomainDataForState(pendingData, domain);

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -1853,6 +1853,21 @@ const Api = (req) => {
             });
         },
 
+        getTimeZone() {
+            return new Promise((resolve, reject) => {
+                fetchr
+                    .read('time-zone')
+                    .params()
+                    .end((err, data) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(data);
+                        }
+                    });
+            });
+        },
+
         getFeatureFlag() {
             return new Promise((resolve, reject) => {
                 fetchr

--- a/ui/src/components/domain/ManageDomains.js
+++ b/ui/src/components/domain/ManageDomains.js
@@ -28,7 +28,7 @@ import { deleteSubDomain } from '../../redux/thunks/domains';
 import { connect } from 'react-redux';
 import { withRouter } from 'next/router';
 import { selectBusinessServices } from '../../redux/selectors/domainData';
-import { selectBusinessServicesAll } from '../../redux/selectors/domains';
+import { selectBusinessServicesAll, selectTimeZone } from '../../redux/selectors/domains';
 
 const ManageDomainSectionDiv = styled.div`
     margin: 20px;
@@ -356,8 +356,8 @@ class ManageDomains extends React.Component {
                           <TDStyled color={color} align={left}>
                               {this.dateUtils.getLocalDate(
                                   item.domain.modified,
-                                  'UTC',
-                                  'UTC'
+                                  this.props.timeZone,
+                                  this.props.timeZone
                               )}
                           </TDStyled>
                           <TDStyled color={color} align={center}>
@@ -491,6 +491,7 @@ const mapStateToProps = (state, props) => {
         ...props,
         validBusinessServices: selectBusinessServices(state),
         validBusinessServicesAll: selectBusinessServicesAll(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/group/GroupList.js
+++ b/ui/src/components/group/GroupList.js
@@ -26,6 +26,7 @@ import { connect } from 'react-redux';
 import { selectGroups } from '../../redux/selectors/group';
 import { selectDomainAuditEnabled } from '../../redux/selectors/domainData';
 import { selectIsLoading } from '../../redux/selectors/loading';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 
 const GroupsSectionDiv = styled.div`
@@ -168,6 +169,7 @@ class GroupList extends React.Component {
                     <GroupTable
                         groups={groups}
                         domain={this.props.domain}
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         onSubmit={this.reloadGroups}
                         justificationRequired={this.props.isDomainAuditEnabled}
@@ -192,6 +194,7 @@ const mapStateToProps = (state, props) => {
         isLoading: selectIsLoading(state),
         groups: selectGroups(state),
         isDomainAuditEnabled: selectDomainAuditEnabled(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/group/GroupRow.js
+++ b/ui/src/components/group/GroupRow.js
@@ -220,14 +220,18 @@ class GroupRow extends React.Component {
                     {NameSpan}
                 </TDStyled>
                 <TDStyled color={color} align={center}>
-                    {this.localDate.getLocalDate(group.modified, 'UTC', 'UTC')}
+                    {this.localDate.getLocalDate(
+                        group.modified,
+                        this.props.timeZone,
+                        this.props.timeZone
+                    )}
                 </TDStyled>
                 <TDStyled color={color} align={center}>
                     {group.lastReviewedDate
                         ? this.localDate.getLocalDate(
                               group.lastReviewedDate,
-                              'UTC',
-                              'UTC'
+                              this.props.timeZone,
+                              this.props.timeZone
                           )
                         : 'N/A'}
                 </TDStyled>

--- a/ui/src/components/group/GroupTable.js
+++ b/ui/src/components/group/GroupTable.js
@@ -73,6 +73,7 @@ export default class GroupTable extends React.Component {
                             color={color}
                             key={item.name}
                             onUpdateSuccess={this.props.onSubmit}
+                            timeZone={this.props.timeZone}
                             _csrf={this.props._csrf}
                             justificationRequired={
                                 this.props.justificationRequired

--- a/ui/src/components/header/CollectionDetails.js
+++ b/ui/src/components/header/CollectionDetails.js
@@ -16,6 +16,8 @@
 import styled from '@emotion/styled';
 import DateUtils from '../utils/DateUtils';
 import React from 'react';
+import { selectTimeZone } from '../../redux/selectors/domains';
+import { connect } from 'react-redux';
 
 const DomainSectionDiv = styled.div`
     margin: 20px 0;
@@ -40,7 +42,7 @@ const LabelDiv = styled.div`
     text-transform: uppercase;
 `;
 
-export default class CollectionDetails extends React.Component {
+class CollectionDetails extends React.Component {
     constructor(props) {
         super(props);
     }
@@ -49,14 +51,14 @@ export default class CollectionDetails extends React.Component {
         let localDate = new DateUtils();
         let modifiedDate = localDate.getLocalDate(
             this.props.collectionDetails.modified,
-            'UTC',
-            'UTC'
+            this.props.timeZone,
+            this.props.timeZone
         );
         let lastReviewedDate = this.props.collectionDetails.lastReviewedDate
             ? localDate.getLocalDate(
                   this.props.collectionDetails.lastReviewedDate,
-                  'UTC',
-                  'UTC'
+                  this.props.timeZone,
+                  this.props.timeZone
               )
             : 'N/A';
         return (
@@ -75,3 +77,12 @@ export default class CollectionDetails extends React.Component {
         );
     }
 }
+
+const mapStateToProps = (state, props) => {
+    return {
+        ...props,
+        timeZone: selectTimeZone(state),
+    };
+};
+
+export default connect(mapStateToProps, null)(CollectionDetails);

--- a/ui/src/components/header/DomainDetails.js
+++ b/ui/src/components/header/DomainDetails.js
@@ -34,6 +34,7 @@ import {
 import {
     selectBusinessServicesAll,
     selectProductMasterLink,
+    selectTimeZone,
 } from '../../redux/selectors/domains';
 import { getBusinessServicesAll } from '../../redux/thunks/domains';
 import { makeRolesExpires } from '../../redux/actions/roles';
@@ -289,8 +290,8 @@ class DomainDetails extends React.Component {
         let localDate = new DateUtils();
         let modifiedDate = localDate.getLocalDate(
             this.props.domainDetails.modified,
-            'UTC',
-            'UTC'
+            this.props.timeZone,
+            this.props.timeZone
         );
         let showOnBoardToAWS = false;
         if (
@@ -463,6 +464,7 @@ const mapStateToProps = (state, props) => {
         auditEnabled: selectDomainAuditEnabled(state),
         businessServices: selectBusinessServices(state),
         businessServicesAll: selectBusinessServicesAll(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/history/CollectionHistoryList.js
+++ b/ui/src/components/history/CollectionHistoryList.js
@@ -23,6 +23,7 @@ import Alert from '../denali/Alert';
 import { MODAL_TIME_OUT } from '../constants/constants';
 import DateUtils from '../utils/DateUtils';
 import { selectIsLoading } from '../../redux/selectors/loading';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { connect } from 'react-redux';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 
@@ -283,8 +284,8 @@ class CollectionHistoryList extends React.Component {
                     <TDStyled color={color} align={left}>
                         {this.dateUtils.getLocalDate(
                             item.created,
-                            'UTC',
-                            'UTC'
+                            this.props.timeZone,
+                            this.props.timeZone
                         )}
                     </TDStyled>
                     <TDStyled color={color} align={left}>
@@ -399,6 +400,7 @@ const mapStateToProps = (state, props) => {
     return {
         ...props,
         isLoading: selectIsLoading(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/history/HistoryList.js
+++ b/ui/src/components/history/HistoryList.js
@@ -28,6 +28,7 @@ import { connect } from 'react-redux';
 import { selectRoles } from '../../redux/selectors/roles';
 import { getDomainHistory } from '../../redux/thunks/domain';
 import { selectHistoryRows } from '../../redux/selectors/domainData';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { selectIsLoading } from '../../redux/selectors/loading';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 
@@ -283,7 +284,11 @@ class HistoryList extends React.Component {
                         </Menu>
                     </TDStyled>
                     <TDStyled color={color} align={left}>
-                        {this.dateUtils.getLocalDate(item.when, 'UTC', 'UTC')}
+                        {this.dateUtils.getLocalDate(
+                            item.when,
+                            this.props.timeZone,
+                            this.props.timeZone
+                        )}
                     </TDStyled>
                     <TDStyled color={color} align={left}>
                         {item.details}
@@ -407,6 +412,7 @@ const mapStateToProps = (state, props) => {
         isLoading: selectIsLoading(state),
         roles: selectRoles(state),
         historyrows: selectHistoryRows(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/member/GroupMemberList.js
+++ b/ui/src/components/member/GroupMemberList.js
@@ -88,8 +88,8 @@ class GroupMemberList extends React.Component {
                             {item.expiration
                                 ? this.localDate.getLocalDate(
                                       item.expiration,
-                                      'UTC',
-                                      'UTC'
+                                      this.props.timeZone,
+                                      this.props.timeZone
                                   )
                                 : 'N/A'}
                         </StyledTd>

--- a/ui/src/components/member/Member.js
+++ b/ui/src/components/member/Member.js
@@ -20,6 +20,8 @@ import DateUtils from '../utils/DateUtils';
 import Menu from '../denali/Menu/Menu';
 import Icon from '../denali/icons/Icon';
 import { colors } from '../denali/styles';
+import { selectTimeZone } from '../../redux/selectors/domains';
+import { connect } from 'react-redux';
 
 const StyledTag = styled(Tag)`
     background: rgba(53, 112, 244, 0.08);
@@ -51,7 +53,7 @@ const StyledAnchor = styled.a`
 const StyledAnchorActiveInline = { color: colors.linkActive };
 const StyledTagFullNameExpiryActiveInline = { color: colors.black };
 
-export default class Member extends React.Component {
+class Member extends React.Component {
     constructor(props) {
         super(props);
         this.onClickRemove = this.onClickRemove.bind(this);
@@ -71,11 +73,11 @@ export default class Member extends React.Component {
     render() {
         let exp = this.props.item.expiration;
         if (exp) {
-            exp = this.localDate.getLocalDate(exp, 'UTC', 'UTC');
+            exp = this.localDate.getLocalDate(exp, this.props.timeZone, this.props.timeZone);
         }
         let review = this.props.item.reviewReminder;
         if (review) {
-            review = this.localDate.getLocalDate(review, 'UTC', 'UTC');
+            review = this.localDate.getLocalDate(exp, this.props.timeZone, this.props.timeZone);
         }
 
         let fullName = '';
@@ -219,3 +221,12 @@ export default class Member extends React.Component {
         }
     }
 }
+
+const mapStateToProps = (state, props) => {
+    return {
+        ...props,
+        timeZone: selectTimeZone(state),
+    };
+};
+
+export default connect(mapStateToProps, null)(Member);

--- a/ui/src/components/member/Member.js
+++ b/ui/src/components/member/Member.js
@@ -77,7 +77,7 @@ class Member extends React.Component {
         }
         let review = this.props.item.reviewReminder;
         if (review) {
-            review = this.localDate.getLocalDate(exp, this.props.timeZone, this.props.timeZone);
+            review = this.localDate.getLocalDate(review, this.props.timeZone, this.props.timeZone);
         }
 
         let fullName = '';

--- a/ui/src/components/member/MemberList.js
+++ b/ui/src/components/member/MemberList.js
@@ -21,6 +21,7 @@ import { MODAL_TIME_OUT } from '../constants/constants';
 import AddMember from './AddMember';
 import MemberTable from './MemberTable';
 import { selectIsLoading } from '../../redux/selectors/loading';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { connect } from 'react-redux';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 import { arrayEquals } from '../utils/ArrayUtils';
@@ -149,6 +150,7 @@ class MemberList extends React.Component {
                     collection={collection}
                     members={approvedMembers}
                     caption='Approved'
+                    timeZone={this.props.timeZone}
                     _csrf={this.props._csrf}
                     onSubmit={this.reloadMembers}
                     justificationRequired={justificationReq}
@@ -163,6 +165,7 @@ class MemberList extends React.Component {
                         members={pendingMembers}
                         pending={true}
                         caption='Pending'
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         onSubmit={this.reloadMembers}
                         justificationRequired={justificationReq}
@@ -186,6 +189,7 @@ const mapStateToProps = (state, props) => {
     return {
         ...props,
         isLoading: selectIsLoading(state),
+        timeZone: selectTimeZone(state)
     };
 };
 

--- a/ui/src/components/member/MemberRow.js
+++ b/ui/src/components/member/MemberRow.js
@@ -306,6 +306,7 @@ class MemberRow extends React.Component {
                             <GroupMemberList
                                 member={member}
                                 groupName={member.memberName}
+                                timeZone={this.props.timeZone}
                             />
                         </StyledMenu>
                     </GroupTDStyled>
@@ -323,8 +324,8 @@ class MemberRow extends React.Component {
                         {member.expiration
                             ? this.localDate.getLocalDate(
                                   member.expiration,
-                                  'UTC',
-                                  'UTC'
+                                  this.props.timeZone,
+                                  this.props.timeZone
                               )
                             : 'N/A'}
                         <Menu
@@ -352,8 +353,8 @@ class MemberRow extends React.Component {
                             {member.reviewReminder
                                 ? this.localDate.getLocalDate(
                                       member.reviewReminder,
-                                      'UTC',
-                                      'UTC'
+                                      this.props.timeZone,
+                                      this.props.timeZone
                                   )
                                 : 'N/A'}
                             <Menu

--- a/ui/src/components/member/MemberTable.js
+++ b/ui/src/components/member/MemberTable.js
@@ -144,6 +144,7 @@ export default class MemberTable extends React.Component {
                             color={color}
                             key={item.memberName}
                             onUpdateSuccess={this.props.onSubmit}
+                            timeZone={this.props.timeZone}
                             _csrf={this.props._csrf}
                             justificationRequired={
                                 this.props.justificationRequired

--- a/ui/src/components/pending-approval/PendingApprovalTable.js
+++ b/ui/src/components/pending-approval/PendingApprovalTable.js
@@ -29,7 +29,7 @@ import {
 import produce from 'immer';
 import { processPendingMembers } from '../../redux/thunks/domains';
 import { connect } from 'react-redux';
-import { selectPendingMembersList } from '../../redux/selectors/domains';
+import { selectPendingMembersList, selectTimeZone } from '../../redux/selectors/domains';
 import NameUtils from '../utils/NameUtils';
 
 const TableHeader = styled.th`
@@ -411,6 +411,7 @@ class PendingApprovalTable extends React.Component {
                         }
                         pendingState={this.state.pendingMap[key].pendingState}
                         view={view}
+                        timeZone={this.props.timeZone}
                     />
                 );
             });
@@ -478,6 +479,7 @@ const mapStateToProps = (state, props) => {
             props.domainName,
             props.view
         ),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/pending-approval/PendingApprovalTableRow.js
+++ b/ui/src/components/pending-approval/PendingApprovalTableRow.js
@@ -201,8 +201,8 @@ export default class PendingApprovalTableRow extends React.Component {
                 <TableTd>
                     {this.dateUtils.getLocalDate(
                         this.props.requestTime,
-                        'UTC',
-                        'UTC'
+                        this.props.timeZone,
+                        this.props.timeZone
                     )}
                 </TableTd>
                 <TableTd>

--- a/ui/src/components/policy/PolicyList.js
+++ b/ui/src/components/policy/PolicyList.js
@@ -36,6 +36,7 @@ import { connect } from 'react-redux';
 import AddPolicy from './AddPolicy';
 import { selectPolicies } from '../../redux/selectors/policies';
 import { selectIsLoading } from '../../redux/selectors/loading';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 import { arrayEquals } from '../utils/ArrayUtils';
 
@@ -337,6 +338,7 @@ export class PolicyList extends React.Component {
                         this.state.policiesMap[policyName].length < 3
                     }
                     isChild={false}
+                    timeZone={this.props.timeZone}
                 />
             );
         });
@@ -451,6 +453,7 @@ const mapStateToProps = (state, props) => {
         ...props,
         isLoading: selectIsLoading(state),
         policies: selectPolicies(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/policy/PolicyRow.js
+++ b/ui/src/components/policy/PolicyRow.js
@@ -495,8 +495,8 @@ export class PolicyRow extends React.Component {
                 <TdStyled align={left} width={'20%'}>
                     {this.localDate.getLocalDate(
                         this.state.modified,
-                        'UTC',
-                        'UTC'
+                        this.props.timeZone,
+                        this.props.timeZone
                     )}
                 </TdStyled>
                 {/*Rules*/}

--- a/ui/src/components/review/ReviewList.js
+++ b/ui/src/components/review/ReviewList.js
@@ -20,6 +20,7 @@ import ReviewTable from './ReviewTable';
 import Alert from '../denali/Alert';
 import { MODAL_TIME_OUT } from '../constants/constants';
 import { selectIsLoading } from '../../redux/selectors/loading';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { connect } from 'react-redux';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 import { withRouter } from 'next/router';
@@ -95,6 +96,7 @@ class ReviewList extends React.Component {
                         role={collection}
                         roleDetails={collectionDetails}
                         members={this.props.members}
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         onUpdateSuccess={this.submitSuccess}
                     />
@@ -116,6 +118,7 @@ const mapStateToProps = (state, props) => {
     return {
         ...props,
         isLoading: selectIsLoading(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/review/ReviewRow.js
+++ b/ui/src/components/review/ReviewRow.js
@@ -85,10 +85,18 @@ export default class ReviewRow extends React.Component {
         let member = this.props.details;
         let color = this.props.color;
         let exp = member.expiration
-            ? this.localDate.getLocalDate(member.expiration, 'UTC', 'UTC')
+            ? this.localDate.getLocalDate(
+                member.expiration,
+                this.props.timeZone,
+                this.props.timeZone
+            )
             : 'N/A';
         let reminder = member.reviewReminder
-            ? this.localDate.getLocalDate(member.reviewReminder, 'UTC', 'UTC')
+            ? this.localDate.getLocalDate(
+                member.reviewReminder,
+                this.props.timeZone,
+                this.props.timeZone
+            )
             : 'N/A';
 
         rows.push(

--- a/ui/src/components/review/ReviewTable.js
+++ b/ui/src/components/review/ReviewTable.js
@@ -316,6 +316,7 @@ export class ReviewTable extends React.Component {
                                   color={color}
                                   onUpdate={this.onUpdate}
                                   submittedReview={this.state.submittedReview}
+                                  timeZone={this.props.timeZone}
                               />
                           );
                       })

--- a/ui/src/components/role/RoleGroup.js
+++ b/ui/src/components/role/RoleGroup.js
@@ -130,6 +130,7 @@ export default class RoleGroup extends React.Component {
                                 domain={domain}
                                 key={key}
                                 onUpdateSuccess={this.props.onUpdateSuccess}
+                                timeZone={this.props.timeZone}
                                 _csrf={this.props._csrf}
                                 newRole={this.props.newRole}
                             />

--- a/ui/src/components/role/RoleList.js
+++ b/ui/src/components/role/RoleList.js
@@ -30,7 +30,7 @@ import { selectRoles } from '../../redux/selectors/roles';
 import { selectDomainAuditEnabled } from '../../redux/selectors/domainData';
 import AddMemberToRoles from './AddMemberToRoles';
 import { selectIsLoading } from '../../redux/selectors/loading';
-import { selectHeaderDetails } from '../../redux/selectors/domains';
+import { selectHeaderDetails, selectTimeZone } from '../../redux/selectors/domains';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 
 const RolesSectionDiv = styled.div`
@@ -213,6 +213,7 @@ class RoleList extends React.Component {
                     <UserRoleTable
                         searchText={this.state.searchText}
                         domain={this.props.domainName}
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         newMember={this.state.successMessage}
                     />
@@ -220,6 +221,7 @@ class RoleList extends React.Component {
                     <RoleTable
                         domain={this.props.domainName}
                         prefixes={this.props.prefixes}
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         onSubmit={this.reloadRoles}
                         newRole={this.state.successMessage}
@@ -246,6 +248,7 @@ const mapStateToProps = (state, props) => {
         roles: selectRoles(state),
         users: selectHeaderDetails(state),
         isDomainAuditEnabled: selectDomainAuditEnabled(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/role/RoleRow.js
+++ b/ui/src/components/role/RoleRow.js
@@ -267,14 +267,18 @@ class RoleRow extends React.Component {
                     {roleNameSpan}
                 </TDStyledName>
                 <TDStyledTime color={color} align={left}>
-                    {this.localDate.getLocalDate(role.modified, 'UTC', 'UTC')}
+                    {this.localDate.getLocalDate(
+                        role.modified,
+                        this.props.timeZone,
+                        this.props.timeZone
+                    )}
                 </TDStyledTime>
                 <TDStyledTime color={color} align={left}>
                     {role.lastReviewedDate
                         ? this.localDate.getLocalDate(
                               role.lastReviewedDate,
-                              'UTC',
-                              'UTC'
+                              this.props.timeZone,
+                              this.props.timeZone
                           )
                         : 'N/A'}
                 </TDStyledTime>

--- a/ui/src/components/role/RoleSectionRow.js
+++ b/ui/src/components/role/RoleSectionRow.js
@@ -274,8 +274,8 @@ class RoleSectionRow extends React.Component {
                         {role.expiration
                             ? this.localDate.getLocalDate(
                                   role.expiration,
-                                  'UTC',
-                                  'UTC'
+                                  this.props.timeZone,
+                                  this.props.timeZone
                               )
                             : 'N/A'}
                     </TDTime>
@@ -318,16 +318,16 @@ class RoleSectionRow extends React.Component {
                     <TDTime color={color} align={left}>
                         {this.localDate.getLocalDate(
                             role.modified,
-                            'UTC',
-                            'UTC'
+                            this.props.timeZone,
+                            this.props.timeZone
                         )}
                     </TDTime>
                     <TDTime color={color} align={left}>
                         {role.lastReviewedDate
                             ? this.localDate.getLocalDate(
                                   role.lastReviewedDate,
-                                  'UTC',
-                                  'UTC'
+                                  this.props.timeZone,
+                                  this.props.timeZone
                               )
                             : 'N/A'}
                     </TDTime>

--- a/ui/src/components/role/RoleTable.js
+++ b/ui/src/components/role/RoleTable.js
@@ -138,6 +138,7 @@ export default class RoleTable extends React.Component {
                             domain={domain}
                             key={item.name}
                             onUpdateSuccess={this.props.onSubmit}
+                            timeZone={this.props.timeZone}
                             _csrf={this.props._csrf}
                         />
                     );
@@ -154,6 +155,7 @@ export default class RoleTable extends React.Component {
                             name={name}
                             roles={this.state.rows[name]}
                             onUpdateSuccess={this.props.onSubmit}
+                            timeZone={this.props.timeZone}
                             _csrf={this.props._csrf}
                             newRole={this.props.newRole}
                         />
@@ -175,6 +177,7 @@ export default class RoleTable extends React.Component {
                             domain={domain}
                             key={item.name}
                             onUpdateSuccess={this.props.onSubmit}
+                            timeZone={this.props.timeZone}
                             _csrf={this.props._csrf}
                             newRole={this.props.newRole}
                         />

--- a/ui/src/components/role/UserRoleRow.js
+++ b/ui/src/components/role/UserRoleRow.js
@@ -136,8 +136,8 @@ export default class UserRoleRow extends React.Component {
                         {role.expiration
                             ? this.dateUtils.getLocalDate(
                                   role.expiration,
-                                  'UTC',
-                                  'UTC'
+                                  this.props.timeZone,
+                                  this.props.timeZone
                               )
                             : null}
                     </TDStyledIcon>

--- a/ui/src/components/role/UserRoleTable.js
+++ b/ui/src/components/role/UserRoleTable.js
@@ -293,6 +293,7 @@ class UserRoleTable extends React.Component {
                               memberData={item}
                               onDelete={this.deleteItemMember}
                               deleteRoleMember={this.deleteItem}
+                              timeZone={this.props.timeZone}
                           />
                       );
                   })

--- a/ui/src/components/service/InstanceList.js
+++ b/ui/src/components/service/InstanceList.js
@@ -20,6 +20,7 @@ import SearchInput from '../denali/SearchInput';
 import InstanceTable from './InstanceTable';
 import AddStaticInstances from '../microsegmentation/AddStaticInstances';
 import InputDropdown from '../denali/InputDropdown';
+import { selectTimeZone } from '../../redux/selectors/domains';
 import { selectInstancesWorkLoadData } from '../../redux/selectors/services';
 import { connect } from 'react-redux';
 
@@ -214,6 +215,7 @@ class InstanceList extends React.Component {
                         instances={this.state.instances}
                         domain={this.props.domain}
                         service={this.props.service}
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         onSubmit={this.props.onInstancesUpdated}
                         category={this.props.category}
@@ -233,6 +235,7 @@ const mapStateToProps = (state, props) => {
             props.service,
             props.category
         ),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/service/InstanceRow.js
+++ b/ui/src/components/service/InstanceRow.js
@@ -193,8 +193,8 @@ class InstanceRow extends React.Component {
                     <TDStyled color={color} align={left}>
                         {this.localDate.getLocalDate(
                             details.certExpiryTime,
-                            'UTC',
-                            'UTC'
+                            this.props.timeZone,
+                            this.props.timeZone
                         )}
                     </TDStyled>
                 )}
@@ -202,8 +202,8 @@ class InstanceRow extends React.Component {
                     <TDStyled color={color} align={left}>
                         {this.localDate.getLocalDate(
                             details.updateTime,
-                            'UTC',
-                            'UTC'
+                            this.props.timeZone,
+                            this.props.timeZone
                         )}
                     </TDStyled>
                 )}
@@ -237,8 +237,8 @@ class InstanceRow extends React.Component {
                     <TDStyled color={color} align={center}>
                         {this.localDate.getLocalDate(
                             details.updateTime,
-                            'UTC',
-                            'UTC'
+                            this.props.timeZone,
+                            this.props.timeZone
                         )}
                     </TDStyled>
                 )}

--- a/ui/src/components/service/InstanceTable.js
+++ b/ui/src/components/service/InstanceTable.js
@@ -84,6 +84,7 @@ export default class InstanceTable extends React.Component {
                         onUpdateSuccess={this.props.onSubmit}
                         color={color}
                         key={item.uuid}
+                        timeZone={this.props.timeZone}
                         _csrf={this.props._csrf}
                         category={this.props.category}
                     />

--- a/ui/src/components/service/ServiceList.js
+++ b/ui/src/components/service/ServiceList.js
@@ -28,7 +28,7 @@ import { deleteService } from '../../redux/thunks/services';
 import { connect } from 'react-redux';
 import { selectServices } from '../../redux/selectors/services';
 import { selectIsLoading } from '../../redux/selectors/loading';
-import { selectFeatureFlag } from '../../redux/selectors/domains';
+import { selectTimeZone, selectFeatureFlag } from '../../redux/selectors/domains';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 
 const ServicesSectionDiv = styled.div`
@@ -138,6 +138,7 @@ class ServiceList extends React.Component {
                           newService={newService}
                           color={color}
                           key={item.name}
+                          timeZone={this.props.timeZone}
                           featureFlag={this.props.featureFlag}
                           _csrf={this.props._csrf}
                           onClickDeleteService={onClickDeleteService}
@@ -277,6 +278,7 @@ const mapStateToProps = (state, props) => {
         isLoading: selectIsLoading(state),
         services: selectServices(state),
         featureFlag: selectFeatureFlag(state),
+        timeZone: selectTimeZone(state),
     };
 };
 

--- a/ui/src/components/service/ServiceRow.js
+++ b/ui/src/components/service/ServiceRow.js
@@ -109,8 +109,8 @@ class ServiceRow extends React.Component {
                 <TdStyled color={color} align={left}>
                     {this.localDate.getLocalDate(
                         this.props.modified,
-                        'UTC',
-                        'UTC'
+                        this.props.timeZone,
+                        this.props.timeZone
                     )}
                 </TdStyled>
                 {this.props.featureFlag ? (

--- a/ui/src/pages/_app.js
+++ b/ui/src/pages/_app.js
@@ -18,8 +18,16 @@ import 'flatpickr/dist/themes/light.css';
 import 'denali-css/css/denali.css';
 import { wrapper } from '../redux/store';
 import { Provider } from 'react-redux';
+import { useEffect } from 'react';
+import { getTimeZone } from '../redux/thunks/domains';
+
 function MyApp({ Component, pageProps }) {
     const { store } = wrapper.useWrappedStore(pageProps);
+
+    useEffect(() => {
+        store.dispatch(getTimeZone());
+    }, []);
+
     return (
         <Provider store={store}>
             <Component {...pageProps} />;

--- a/ui/src/redux/actions/domains.js
+++ b/ui/src/redux/actions/domains.js
@@ -47,6 +47,17 @@ export const loadHeaderDetails = (headerDetails) => ({
     payload: { headerDetails: headerDetails },
 });
 
+export const RETURN_TIME_ZONE = 'RETURN_TIME_ZONE';
+export const returnTimeZone = () => ({
+    type: RETURN_TIME_ZONE,
+});
+
+export const LOAD_TIME_ZONE = 'LOAD_TIME_ZONE';
+export const loadTimeZone = (timeZone) => ({
+    type: LOAD_TIME_ZONE,
+    payload: { timeZone },
+});
+
 export const RETURN_AUTHORITY_ATTRIBUTES = 'RETURN_AUTHORITY_ATTRIBUTES';
 export const returnAuthorityAttributes = () => ({
     type: RETURN_AUTHORITY_ATTRIBUTES,

--- a/ui/src/redux/reducers/domains.js
+++ b/ui/src/redux/reducers/domains.js
@@ -22,6 +22,7 @@ import {
     LOAD_BUSINESS_SERVICES_ALL,
     LOAD_FEATURE_FLAG,
     LOAD_HEADER_DETAILS,
+    LOAD_TIME_ZONE,
     LOAD_PENDING_DOMAIN_MEMBERS_LIST,
     LOAD_USER_DOMAINS_LIST,
     PROCESS_GROUP_PENDING_MEMBERS_TO_STORE,
@@ -31,6 +32,7 @@ import {
     RETURN_DOMAIN_LIST,
     RETURN_FEATURE_FLAG,
     RETURN_HEADER_DETAILS,
+    RETURN_TIME_ZONE,
     STORE_DOMAIN_DATA,
     STORE_GROUPS,
     STORE_POLICIES,
@@ -239,6 +241,13 @@ export const domains = (state = {}, action) => {
             });
             return newState;
         }
+        case LOAD_TIME_ZONE: {
+            const { timeZone } = payload;
+            let newState = produce(state, (draft) => {
+                draft.timeZone = timeZone;
+            });
+            return newState;
+        }
         case LOAD_AUTHORITY_ATTRIBUTES: {
             const { authorityAttributes } = payload;
             let newState = produce(state, (draft) => {
@@ -256,6 +265,7 @@ export const domains = (state = {}, action) => {
         case RETURN_AUTHORITY_ATTRIBUTES:
         case RETURN_FEATURE_FLAG:
         case RETURN_HEADER_DETAILS:
+        case RETURN_TIME_ZONE:
         case RETURN_BUSINESS_SERVICES_ALL:
         case RETURN_DOMAIN_LIST:
         default:

--- a/ui/src/redux/selectors/domains.js
+++ b/ui/src/redux/selectors/domains.js
@@ -64,6 +64,10 @@ export const selectHeaderDetails = (state) => {
     return state.domains.headerDetails ? state.domains.headerDetails : {};
 };
 
+export const selectTimeZone = (state) => {
+    return state.domains.timeZone ? state.domains.timeZone : 'UTC';
+};
+
 export const selectProductMasterLink = (state) => {
     return selectHeaderDetails(state) &&
         selectHeaderDetails(state).productMasterLink

--- a/ui/src/redux/thunks/domains.js
+++ b/ui/src/redux/thunks/domains.js
@@ -28,6 +28,7 @@ import {
     loadBusinessServicesAll,
     loadFeatureFlag,
     loadHeaderDetails,
+    loadTimeZone,
     loadPendingDomainMembersList,
     loadUserDomainList,
     processGroupPendingMembersToStore,
@@ -37,6 +38,7 @@ import {
     returnDomainList,
     returnFeatureFlag,
     returnHeaderDetails,
+    returnTimeZone,
 } from '../actions/domains';
 import { buildErrorForDuplicateCase, getFullName } from '../utils';
 import { subDomainDelimiter } from '../config';
@@ -66,6 +68,15 @@ export const getHeaderDetails = () => async (dispatch, getState) => {
     } else {
         const headerDetails = await API().getHeaderDetails();
         dispatch(loadHeaderDetails(headerDetails));
+    }
+};
+
+export const getTimeZone = () => async (dispatch, getState) => {
+    if (getState().domains.timeZone) {
+        dispatch(returnTimeZone());
+    } else {
+        const timeZone = await API().getTimeZone();
+        dispatch(loadTimeZone(timeZone));
     }
 };
 

--- a/ui/src/server/handlers/api.js
+++ b/ui/src/server/handlers/api.js
@@ -2296,6 +2296,13 @@ Fetchr.registerService({
 });
 
 Fetchr.registerService({
+    name: 'time-zone',
+    read(req, resource, params, config, callback) {
+        callback(null, appConfig.timeZone);
+    },
+});
+
+Fetchr.registerService({
     name: 'feature-flag',
     read(req, resource, params, config, callback) {
         callback(null, appConfig.featureFlag);
@@ -3055,6 +3062,7 @@ module.exports.load = function (config, secrets) {
         productMasterLink: config.productMasterLink,
         allPrefixes: config.allPrefixes,
         zmsLoginUrl: config.zmsLoginUrl,
+        timeZone: config.timeZone,
         featureFlag: config.featureFlag,
         pageFeatureFlag: config.pageFeatureFlag,
         serviceHeaderLinks: config.serviceHeaderLinks,


### PR DESCRIPTION
## Background
At present, the time displayed in the UI is set to UTC by default. Consequently, users of the UI are required to individually convert the displayed time to their respective local time zones, which can be rather inconvenient.

## Overview
In this pull request, I intend to modify the UI so that the displayed time aligns with the server's TimeZone setting, thereby enhancing user experience.

To achieve this, the React components have been updated to obtain TimeZone settings from Redux. I was uncertain about the most appropriate Redux Store for storing the TimeZone settings and ultimately decided on the `domains` store. If you believe there is a more suitable location for these settings, kindly share your insights.

Additionally, as the TimeZone will be utilized across the majority of pages within the UI, I have incorporated the necessary changes into `_app.js`. If there is a more efficient or effective approach to implementing this feature, please do not hesitate to share your suggestions.