### PR TITLE
sia: use hostname -f if os.Hostname does not return fqdn

### DIFF
--- a/libs/go/sia/agent/agent_test.go
+++ b/libs/go/sia/agent/agent_test.go
@@ -63,15 +63,15 @@ func (tp TestProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (tp TestProvider) GetHostname() string {
+func (tp TestProvider) GetHostname(bool) string {
 	return tp.Hostname
 }
 
-func (tp TestProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (tp TestProvider) AttestationData(string, crypto.PrivateKey, *signature.SignatureInfo) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (tp TestProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (tp TestProvider) PrepareKey(string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -79,23 +79,23 @@ func (tp TestProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (tp TestProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (tp TestProvider) GetSanDns(string, bool, bool, []string) []string {
 	return nil
 }
 
-func (tp TestProvider) GetSanUri(svc string, opts ip.Opts) []*url.URL {
+func (tp TestProvider) GetSanUri(string, ip.Opts) []*url.URL {
 	return nil
 }
 
-func (tp TestProvider) GetEmail(service string) []string {
+func (tp TestProvider) GetEmail(string) []string {
 	return nil
 }
 
-func (tp TestProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (tp TestProvider) GetRoleDnsNames(*x509.Certificate, string) []string {
 	return nil
 }
 
-func (tp TestProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (tp TestProvider) GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP {
 	return nil
 }
 
@@ -103,15 +103,15 @@ func (tp TestProvider) GetSuffix() string {
 	return ""
 }
 
-func (tp TestProvider) CloudAttestationData(base, svc, ztsServerName string) (string, error) {
+func (tp TestProvider) CloudAttestationData(string, string, string) (string, error) {
 	return "abc", nil
 }
 
-func (tp TestProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (tp TestProvider) GetAccountDomainServiceFromMeta(string) (string, string, string, error) {
 	return "testAcct", "testDom", "testSvc", nil
 }
 
-func (tp TestProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (tp TestProvider) GetAccessManagementProfileFromMeta(string) (string, error) {
 	return "testProf", nil
 }
 
@@ -490,7 +490,7 @@ func TestGetServiceHostname(test *testing.T) {
 			svc := options.Service{
 				Name: tt.service,
 			}
-			hostname := getServiceHostname(&opts, svc)
+			hostname := getServiceHostname(&opts, svc, false)
 			if tt.result != hostname {
 				test.Errorf("%s: invalid value returned - expected: %v, received %v", tt.name, tt.result, hostname)
 			}

--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -65,15 +65,15 @@ func (tp TestProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (tp TestProvider) GetHostname() string {
+func (tp TestProvider) GetHostname(bool) string {
 	return tp.Hostname
 }
 
-func (tp TestProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (tp TestProvider) AttestationData(string, crypto.PrivateKey, *signature.SignatureInfo) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (tp TestProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (tp TestProvider) PrepareKey(string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -81,23 +81,23 @@ func (tp TestProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (tp TestProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (tp TestProvider) GetSanDns(string, bool, bool, []string) []string {
 	return nil
 }
 
-func (tp TestProvider) GetSanUri(svc string, opts ip.Opts) []*url.URL {
+func (tp TestProvider) GetSanUri(string, ip.Opts) []*url.URL {
 	return nil
 }
 
-func (tp TestProvider) GetEmail(service string) []string {
+func (tp TestProvider) GetEmail(string) []string {
 	return nil
 }
 
-func (tp TestProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (tp TestProvider) GetRoleDnsNames(*x509.Certificate, string) []string {
 	return nil
 }
 
-func (tp TestProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (tp TestProvider) GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP {
 	return nil
 }
 
@@ -105,7 +105,7 @@ func (tp TestProvider) GetSuffix() string {
 	return ""
 }
 
-func (tp TestProvider) CloudAttestationData(base, svc, ztsServerName string) (string, error) {
+func (tp TestProvider) CloudAttestationData(string, string, string) (string, error) {
 	a, _ := json.Marshal(&attestation.AttestationData{
 		Role: "athenz.hockey",
 	})
@@ -113,11 +113,11 @@ func (tp TestProvider) CloudAttestationData(base, svc, ztsServerName string) (st
 	return string(a), nil
 }
 
-func (tp TestProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (tp TestProvider) GetAccountDomainServiceFromMeta(string) (string, string, string, error) {
 	return "testAcct", "testDom", "testSvc", nil
 }
 
-func (tp TestProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (tp TestProvider) GetAccessManagementProfileFromMeta(string) (string, error) {
 	return "testProf", nil
 }
 
@@ -504,7 +504,7 @@ func TestGetServiceHostname(test *testing.T) {
 			svc := options.Service{
 				Name: tt.service,
 			}
-			hostname := getServiceHostname(&opts, svc)
+			hostname := getServiceHostname(&opts, svc, false)
 			if tt.result != hostname {
 				test.Errorf("%s: invalid value returned - expected: %v, received %v", tt.name, tt.result, hostname)
 			}

--- a/libs/go/sia/host/provider/provider.go
+++ b/libs/go/sia/host/provider/provider.go
@@ -41,7 +41,7 @@ type Provider interface {
 	GetName() string
 
 	// GetHostname returns the name of the hostname as recognized by the provider
-	GetHostname() string
+	GetHostname(bool) string
 
 	// GetCsrDn returns the x.509 Distinguished Name for use in the CSR
 	GetCsrDn() pkix.Name

--- a/libs/go/sia/host/utils/utils.go
+++ b/libs/go/sia/host/utils/utils.go
@@ -1,0 +1,46 @@
+//
+// Copyright The Athenz Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// GetHostname returns the hostname
+func GetHostname(fqdn bool) string {
+	// if the fqdn flag is passed we can't use the go api
+	// since it doesn't provide an option for it. so we'll
+	// just resolve calling the hostname directly.
+	if fqdn {
+		hostname, err := exec.Command("/bin/hostname", "-f").Output()
+		if err != nil {
+			log.Printf("Cannot exec '/bin/hostname -f': %v", err)
+			return os.Getenv("HOSTNAME")
+		}
+		return strings.Trim(string(hostname), "\n\r ")
+	} else {
+		hostname, err := os.Hostname()
+		if err != nil {
+			log.Printf("Unable to obtain os hostname: %v\n", err)
+			return os.Getenv("HOSTNAME")
+		}
+		return hostname
+	}
+}

--- a/libs/go/sia/host/utils/utils_test.go
+++ b/libs/go/sia/host/utils/utils_test.go
@@ -1,0 +1,34 @@
+//
+// Copyright The Athenz Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package utils
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetHostname(t *testing.T) {
+	hostname, _ := os.Hostname()
+	// with false flag we should get the exact same value
+	assert.Equal(t, hostname, GetHostname(false))
+	// with true flag our hostname is the extract string
+	// or a subset of the response
+	testHostname := GetHostname(true)
+	assert.True(t, strings.HasPrefix(testHostname, hostname))
+}

--- a/libs/go/sia/options/mockawsprovider.go
+++ b/libs/go/sia/options/mockawsprovider.go
@@ -24,15 +24,15 @@ func (tp MockAWSProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (tp MockAWSProvider) GetHostname() string {
+func (tp MockAWSProvider) GetHostname(bool) string {
 	return tp.Hostname
 }
 
-func (tp MockAWSProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (tp MockAWSProvider) AttestationData(string, crypto.PrivateKey, *signature.SignatureInfo) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (tp MockAWSProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (tp MockAWSProvider) PrepareKey(string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -40,23 +40,23 @@ func (tp MockAWSProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (tp MockAWSProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (tp MockAWSProvider) GetSanDns(string, bool, bool, []string) []string {
 	return nil
 }
 
-func (tp MockAWSProvider) GetSanUri(svc string, opts ip.Opts) []*url.URL {
+func (tp MockAWSProvider) GetSanUri(string, ip.Opts) []*url.URL {
 	return nil
 }
 
-func (tp MockAWSProvider) GetEmail(service string) []string {
+func (tp MockAWSProvider) GetEmail(string) []string {
 	return nil
 }
 
-func (tp MockAWSProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (tp MockAWSProvider) GetRoleDnsNames(*x509.Certificate, string) []string {
 	return nil
 }
 
-func (tp MockAWSProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (tp MockAWSProvider) GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP {
 	return nil
 }
 
@@ -64,7 +64,7 @@ func (tp MockAWSProvider) GetSuffix() string {
 	return ""
 }
 
-func (tp MockAWSProvider) CloudAttestationData(base, svc, ztsServerName string) (string, error) {
+func (tp MockAWSProvider) CloudAttestationData(string, string, string) (string, error) {
 	a, _ := json.Marshal(&attestation.AttestationData{
 		Role: "athenz.hockey",
 	})
@@ -72,10 +72,10 @@ func (tp MockAWSProvider) CloudAttestationData(base, svc, ztsServerName string) 
 	return string(a), nil
 }
 
-func (tp MockAWSProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (tp MockAWSProvider) GetAccountDomainServiceFromMeta(string) (string, string, string, error) {
 	return "mockAWSAccount", "mockAthenzDomain", "mockAthenzService", nil
 }
 
-func (tp MockAWSProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (tp MockAWSProvider) GetAccessManagementProfileFromMeta(string) (string, error) {
 	return "testProf", nil
 }

--- a/provider/aws/sia-ec2/provider.go
+++ b/provider/aws/sia-ec2/provider.go
@@ -23,10 +23,9 @@ import (
 	"fmt"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
-	"log"
+	"github.com/AthenZ/athenz/libs/go/sia/host/utils"
 	"net"
 	"net/url"
-	"os"
 )
 
 type EC2Provider struct {
@@ -39,13 +38,8 @@ func (ec2 EC2Provider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (ec2 EC2Provider) GetHostname() string {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Printf("Unable to obtain os hostname: %v\n", err)
-		return ""
-	}
-	return hostname
+func (ec2 EC2Provider) GetHostname(fqdn bool) string {
+	return utils.GetHostname(fqdn)
 }
 
 func (ec2 EC2Provider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {

--- a/provider/aws/sia-eks/provider.go
+++ b/provider/aws/sia-eks/provider.go
@@ -23,10 +23,9 @@ import (
 	"fmt"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
-	"log"
+	"github.com/AthenZ/athenz/libs/go/sia/host/utils"
 	"net"
 	"net/url"
-	"os"
 )
 
 type EKSProvider struct {
@@ -39,13 +38,8 @@ func (eks EKSProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (eks EKSProvider) GetHostname() string {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Printf("Unable to obtain os hostname: %v\n", err)
-		return os.Getenv("HOSTNAME")
-	}
-	return hostname
+func (eks EKSProvider) GetHostname(fqdn bool) string {
+	return utils.GetHostname(fqdn)
 }
 
 func (eks EKSProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {

--- a/provider/aws/sia-fargate/provider.go
+++ b/provider/aws/sia-fargate/provider.go
@@ -37,7 +37,7 @@ func (fargate FargateProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (fargate FargateProvider) GetHostname() string {
+func (fargate FargateProvider) GetHostname(fqdn bool) string {
 	return ""
 }
 

--- a/provider/gcp/sia-gce/provider.go
+++ b/provider/gcp/sia-gce/provider.go
@@ -25,10 +25,9 @@ import (
 	"github.com/AthenZ/athenz/libs/go/sia/gcp/meta"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
-	"log"
+	"github.com/AthenZ/athenz/libs/go/sia/host/utils"
 	"net"
 	"net/url"
-	"os"
 )
 
 type GCEProvider struct {
@@ -41,13 +40,8 @@ func (gke GCEProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (gke GCEProvider) GetHostname() string {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Printf("Unable to obtain os hostname: %v\n", err)
-		return os.Getenv("HOSTNAME")
-	}
-	return hostname
+func (gke GCEProvider) GetHostname(fqdn bool) string {
+	return utils.GetHostname(fqdn)
 }
 
 func (gke GCEProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {

--- a/provider/gcp/sia-gke/provider.go
+++ b/provider/gcp/sia-gke/provider.go
@@ -25,10 +25,9 @@ import (
 	"github.com/AthenZ/athenz/libs/go/sia/gcp/meta"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
-	"log"
+	"github.com/AthenZ/athenz/libs/go/sia/host/utils"
 	"net"
 	"net/url"
-	"os"
 )
 
 type GKEProvider struct {
@@ -41,13 +40,8 @@ func (gke GKEProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (gke GKEProvider) GetHostname() string {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Printf("Unable to obtain os hostname: %v\n", err)
-		return os.Getenv("HOSTNAME")
-	}
-	return hostname
+func (gke GKEProvider) GetHostname(fqdn bool) string {
+	return utils.GetHostname(fqdn)
 }
 
 func (gke GKEProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {


### PR DESCRIPTION
the instance owner has the option to enable sandns_hostname flag in SIA (e.g. AWS, GCP) to include the instance's hostname in the identity certificate. SIA uses os.Hostname() api but that sometimes does not return fqdn and golang does not provide an option to force the -f flag. So if the sandns_hostname option is enabled, sia will call os.Hostname() first and it does not get a fqdn, it tries "/bin/hostname -f" to see if it gets one.