### PR TITLE
making access_management optional based on a config for EKS

### DIFF
--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -105,6 +105,7 @@ type Config struct {
 	SiaTokenDir      string                   `json:"sia_token_dir,omitempty"`      //sia tokens directory to override /var/lib/sia/tokens
 	SiaBackupDir     string                   `json:"sia_backup_dir,omitempty"`     //sia backup directory to override /var/lib/sia/backup
 	HostnameSuffix   string                   `json:"hostname_suffix,omitempty"`    //hostname suffix in case we need to auto-generate hostname
+	AccessManagement bool                     `json:"access_management"`            // access management support
 }
 
 type AccessProfileConfig struct {
@@ -199,6 +200,7 @@ type Options struct {
 	FileDirectUpdate   bool              //update key/cert files directly instead of using rename
 	HostnameSuffix     string            //hostname suffix in case we need to auto-generate hostname
 	SshPrincipals      string            //ssh additional principals
+	AccessManagement   bool              //access management support
 }
 
 const (
@@ -405,6 +407,9 @@ func InitEnvConfig(config *Config) (*Config, *ConfigAccount, error) {
 	if config.SshPrincipals == "" {
 		config.SshPrincipals = os.Getenv("ATHENZ_SIA_SSH_PRINCIPALS")
 	}
+	if !config.AccessManagement {
+		config.AccessManagement = util.ParseEnvBooleanFlag("ATHENZ_SIA_ACCESS_MANAGEMENT")
+	}
 
 	roleArn := os.Getenv("ATHENZ_SIA_IAM_ROLE_ARN")
 	if roleArn == "" {
@@ -480,6 +485,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 	backupDir := fmt.Sprintf("%s/backup", siaDir)
 	sshHostKeyType := hostkey.Rsa
 	sshPrincipals := ""
+	accessManagement := false
 
 	if config != nil {
 		useRegionalSTS = config.UseRegionalSTS
@@ -492,6 +498,8 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		ztsRegion = config.ZTSRegion
 		dropPrivileges = config.DropPrivileges
 		fileDirectUpdate = config.FileDirectUpdate
+		accessManagement = config.AccessManagement
+
 		if config.RefreshInterval > 0 {
 			refreshInterval = config.RefreshInterval
 		}
@@ -684,6 +692,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		FileDirectUpdate:  fileDirectUpdate,
 		SshHostKeyType:    sshHostKeyType,
 		SshPrincipals:     sshPrincipals,
+		AccessManagement:  accessManagement,
 	}, nil
 }
 

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -290,11 +290,12 @@ func InitGenericProfileConfig(metaEndPoint, roleSuffix, accessProfileSeparator s
 	}
 	profile, err := provider.GetAccessManagementProfileFromMeta(metaEndPoint)
 	if err != nil {
+		// access profile error can be ignored for now.
 		return &Config{
 			Account: account,
 			Domain:  domain,
 			Service: service,
-		}, nil, err
+		}, nil, nil
 	}
 	return &Config{
 			Account: account,

--- a/provider/aws/sia-eks/authn.go
+++ b/provider/aws/sia-eks/authn.go
@@ -55,12 +55,15 @@ func GetEKSConfig(configFile, profileConfigFile, metaEndpoint string, useRegiona
 			}
 		}
 	}
-	profileConfig, err := GetEKSAccessProfile(profileConfigFile, metaEndpoint, useRegionalSTS, region)
-	if err != nil {
-		log.Printf("Unable to determine user access management profile information: %v\n", err)
-	}
+	if config.AccessManagement {
+		profileConfig, err := GetEKSAccessProfile(profileConfigFile, metaEndpoint, useRegionalSTS, region)
+		if err != nil {
+			log.Printf("Unable to determine user access management profile information: %v\n", err)
+		}
 
-	return config, configAccount, profileConfig, nil
+		return config, configAccount, profileConfig, nil
+	}
+	return config, configAccount, nil, nil
 }
 
 func GetEKSAccessProfile(configFile, metaEndpoint string, useRegionalSTS bool, region string) (*options.AccessProfileConfig, error) {

--- a/provider/aws/sia-eks/authn_test.go
+++ b/provider/aws/sia-eks/authn_test.go
@@ -46,10 +46,9 @@ func TestGetConfigNoConfig(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, config)
 	require.NotNil(t, configAccount)
-	require.NotNil(t, accessProfileConfig)
+	require.Nil(t, accessProfileConfig)
 	assert.True(t, configAccount.Domain == "athenz")
 	assert.True(t, configAccount.Service == "hockey")
-	assert.True(t, accessProfileConfig.Profile == "stage")
 }
 
 // TestGetConfigWithConfig test the scenario when /etc/sia/sia_config is present

--- a/provider/aws/sia-eks/devel/data/sia_config
+++ b/provider/aws/sia-eks/devel/data/sia_config
@@ -15,5 +15,6 @@
             "user": "nobody",
             "account": "123456789012"
         }
-    ]
+    ],
+    "access_management": true
 }


### PR DESCRIPTION
Access management in EKS is not a common scenario, hence its better to explicitly configure in sia_config when access management in EKS is required.

second commit is not related to the first one. Just a small change to make using sia_config optional on GCE