### PR TITLE
feat: code signing provider

### DIFF
--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/InstanceProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/InstanceProvider.java
@@ -42,6 +42,8 @@ public interface InstanceProvider {
      */
     String ZTS_CERT_USAGE_CLIENT = "client";
     String ZTS_CERT_USAGE_SERVER = "server";
+    String ZTS_CERT_USAGE_CODE_SIGNING = "codeSigning";
+    String ZTS_CERT_USAGE_TIMESTAMPING = "timestamping";
 
     /**
      * Instance specific attribute names. The san entries

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CodeSigningAttestationData.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CodeSigningAttestationData.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * CodeSigningAttestationData - the information a code signing certificate
+ * requester must provide to ZTS to authenticate.
+ */
+@JsonInclude()
+public class CodeSigningAttestationData {
+    private String identityToken;
+
+    public String getIdentityToken() {
+        return identityToken;
+    }
+
+    public void setIdentityToken(String identityToken) {
+        this.identityToken = identityToken;
+    }
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceCodeSigningProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceCodeSigningProvider.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.yahoo.athenz.auth.KeyStore;
+import com.yahoo.athenz.auth.token.IdToken;
+import com.yahoo.athenz.auth.token.jwts.JwtsHelper;
+import com.yahoo.athenz.auth.token.jwts.JwtsSigningKeyResolver;
+import com.yahoo.athenz.instance.provider.*;
+import com.yahoo.rdl.JSON;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InstanceCodeSigningProvider implements InstanceProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceCodeSigningProvider.class);
+    static final String CODE_SIGNING_PROP_CERT_VALIDITY = "athenz.zts.code_signing_cert_validity";
+    static final String ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS = "athenz.zts.code_signing_attr_validator_factory_class";
+    static final String ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI = "athenz.zts.code_signing_oidc_provider_openid_config_uri";
+    static final String ZTS_PROP_ZTS_OPENID_ISSUER = "athenz.zts.openid_issuer";
+
+    static final String ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE = "athenz.zts.code_signing_attestation_expected_audience";
+    int certValidityTime;
+    AttrValidator attrValidator;
+    JwtsSigningKeyResolver signingKeyResolver;
+    String codeSigningOidcProviderJwksUri;
+
+    String codeSigningAttestationExpectedAudience;
+
+    @Override
+    public Scheme getProviderScheme() {
+        return Scheme.CLASS;
+    }
+
+    @Override
+    public void initialize(String provider, String endpoint, SSLContext sslContext, KeyStore keyStore) {
+        certValidityTime = Integer.parseInt(System.getProperty(CODE_SIGNING_PROP_CERT_VALIDITY, "15"));
+        this.attrValidator = newAttrValidator(sslContext);
+
+        final String ztsOpenIdConfigUri = System.getProperty(ZTS_PROP_ZTS_OPENID_ISSUER) + "/.well-known/openid-configuration";
+        final String openIdConfigUri = System.getProperty(ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI, ztsOpenIdConfigUri);
+        JwtsHelper helper = new JwtsHelper();
+        codeSigningOidcProviderJwksUri = helper.extractJwksUri(openIdConfigUri, sslContext);
+
+        if (StringUtil.isEmpty(codeSigningOidcProviderJwksUri)) {
+            LOGGER.error("configured oidc provider for code signing does not have valid jwks uri - no code signing certificates will be issued");
+        }
+        signingKeyResolver = new JwtsSigningKeyResolver(codeSigningOidcProviderJwksUri, sslContext, true);
+         if (signingKeyResolver.publicKeyCount() == 0) {
+            LOGGER.error("No code signing oidc provider public keys available - no code signing certificates will be issued");
+        }
+        codeSigningAttestationExpectedAudience = System.getProperty(ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE, "");
+    }
+
+    static AttrValidator newAttrValidator(final SSLContext sslContext) {
+        final String factoryClass = System.getProperty(ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS);
+        if (factoryClass == null) {
+            return null;
+        }
+
+        AttrValidatorFactory attrValidatorFactory;
+        try {
+            attrValidatorFactory = (AttrValidatorFactory) Class.forName(factoryClass).getConstructor().newInstance();
+        } catch (Exception e) {
+            LOGGER.error("Invalid AttributeValidatorFactory class: {}", factoryClass, e);
+            throw new IllegalArgumentException("Invalid AttributeValidatorFactory class");
+        }
+
+        return attrValidatorFactory.create(sslContext);
+    }
+    public ResourceException error(String message) {
+        return error(ResourceException.FORBIDDEN, message);
+    }
+
+    public ResourceException error(int errorCode, String message) {
+        LOGGER.error(message);
+        return new ResourceException(errorCode, message);
+    }
+
+    @Override
+    public InstanceConfirmation confirmInstance(InstanceConfirmation confirmation) {
+        CodeSigningAttestationData attestationData = JSON.fromString(confirmation.getAttestationData(),
+                CodeSigningAttestationData.class);
+
+        IdToken idToken;
+        // first make sure we have a valid id_token provided by the configured OIDC provider
+        try {
+            idToken = new IdToken(attestationData.getIdentityToken(), signingKeyResolver);
+        } catch (Exception ex) {
+            throw error("invalid attestation data for code signing certificate request");
+        }
+
+        // next make sure the id_token audience matches with configuration
+        if (!codeSigningAttestationExpectedAudience.equals(idToken.getAudience())) {
+            throw error("attestation id_token does not contain expected audience. provided audience=" + idToken.getAudience());
+        }
+
+        // next make sure code signing certificate is requested for id_token subject
+        String csrPrincipal = confirmation.getDomain() + "." + confirmation.getService();
+        if (!idToken.getSubject().equals(csrPrincipal)) {
+            throw error("subject mismatch between attestation id_token=" + idToken.getSubject() +
+                    " and requested certificate=" + csrPrincipal);
+        }
+
+        // Confirm the instance attributes as per the attribute validator
+        if (attrValidator != null && !attrValidator.confirm(confirmation)) {
+            throw error("Unable to validate request instance attributes using attributeValidator=" + attrValidator);
+        }
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(InstanceProvider.ZTS_CERT_EXPIRY_TIME, Long.toString(certValidityTime));
+        attributes.put(ZTS_CERT_USAGE, ZTS_CERT_USAGE_CODE_SIGNING);
+        attributes.put(ZTS_CERT_REFRESH, "false");
+        confirmation.setAttributes(attributes);
+
+        return confirmation;
+    }
+
+    @Override
+    public InstanceConfirmation refreshInstance(InstanceConfirmation confirmation) {
+        // we do not allow refresh of code signing certificates
+        throw error("Code signing X.509 Certificates cannot be refreshed");
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/CodeSigningAttestationDataTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/CodeSigningAttestationDataTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class CodeSigningAttestationDataTest {
+
+    @Test
+    public void testFields() {
+        CodeSigningAttestationData attestationData = new CodeSigningAttestationData();
+        attestationData.setIdentityToken("abc");
+        assertEquals(attestationData.getIdentityToken(), "abc");
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceCodeSigningProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceCodeSigningProviderTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.yahoo.athenz.auth.token.IdToken;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.instance.provider.AttrValidator;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ResourceException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+import static org.testng.Assert.*;
+
+public class InstanceCodeSigningProviderTest {
+
+    private final File ecPrivateKey = new File("./src/test/resources/unit_test_ec_private.key");
+    private final File ecPublicKey = new File("./src/test/resources/unit_test_ec_public.key");
+
+    @Test
+    public void testInitializeDefaults() throws IOException {
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_ZTS_OPENID_ISSUER, "https://zts.athenz.io");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        assertEquals(provider.certValidityTime, 15);
+        provider.close();
+    }
+
+    @Test
+    public void testInitialize() throws IOException {
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        File configUri = new File("./src/test/resources/codesigning-openid-uri.json");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI, "file://" + configUri.getCanonicalPath());
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        assertEquals(provider.certValidityTime, 15);
+        assertEquals(provider.codeSigningOidcProviderJwksUri, "file://src/test/resources/keys.json");
+        provider.close();
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI);
+
+    }
+
+    @Test
+    public void testNewAttrValidator() {
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS, "com.yahoo.athenz.instance.provider.impl.MockAttrValidatorFactory");
+        AttrValidator attrValidator = InstanceCodeSigningProvider.newAttrValidator(null);
+        assertNotNull(attrValidator);
+        assertTrue(attrValidator.confirm(null));
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNewAttrValidatorFail() {
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS, "NoClass");
+        InstanceCodeSigningProvider.newAttrValidator(null);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS);
+    }
+
+    @Test
+    public void testGetProviderScheme() {
+        assertTrue(new InstanceCodeSigningProvider().getProviderScheme().equals(InstanceProvider.Scheme.CLASS));
+    }
+
+    @Test
+    public void testError() {
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        ResourceException exc = provider.error("unable to access");
+        assertEquals(exc.getCode(), 403);
+        assertEquals(exc.getMessage(), "ResourceException (403): unable to access");
+        provider.close();
+    }
+
+    @Test
+    public void testRefreshInstance() {
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        try {
+            provider.refreshInstance(confirmation);
+            fail();
+        } catch (ResourceException re){
+            assertEquals(re.getCode(), ResourceException.FORBIDDEN);
+        }
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidIdToken() {
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ResourceException re) {
+            assertEquals(re.getCode(), ResourceException.FORBIDDEN);
+        }
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidAudience() throws IOException {
+
+        File configFile = new File("./src/test/resources/codesigning-openid.json");
+        File jwksUri = new File("./src/test/resources/codesigning-jwks.json");
+        createOpenIdConfigFile(configFile, jwksUri, true);
+
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        File configUri = new File("./src/test/resources/codesigning-openid-uri.json");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI, "file://" + configUri.getCanonicalPath());
+
+        IdToken sampleToken = new IdToken();
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        long now = System.currentTimeMillis() / 1000;
+        sampleToken.setExpiryTime(now + 3600);
+        sampleToken.setIssueTime(now);
+        String testToken = sampleToken.getSignedToken(privateKey, "eckey1", SignatureAlgorithm.ES256);
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"" + testToken + "\"}");
+        PublicKey publicKey = Crypto.loadPublicKey(ecPublicKey);
+
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        provider.signingKeyResolver.addPublicKey("eckey1", publicKey);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ResourceException re) {
+            assertEquals(re.getCode(), ResourceException.FORBIDDEN);
+        }
+        provider.close();
+        removeOpenIdConfigFile(configFile, jwksUri);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI);
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidSubject() throws IOException {
+
+        File configFile = new File("./src/test/resources/codesigning-openid.json");
+        File jwksUri = new File("./src/test/resources/codesigning-jwks.json");
+        createOpenIdConfigFile(configFile, jwksUri, true);
+
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        File configUri = new File("./src/test/resources/codesigning-openid-uri.json");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI, "file://" + configUri.getCanonicalPath());
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE, "https://zts.athenz.io");
+        IdToken sampleToken = new IdToken();
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        long now = System.currentTimeMillis() / 1000;
+        sampleToken.setExpiryTime(now + 3600);
+        sampleToken.setIssueTime(now);
+        sampleToken.setAudience("https://zts.athenz.io");
+        sampleToken.setSubject("athenz.zxz");
+        String testToken = sampleToken.getSignedToken(privateKey, "eckey1", SignatureAlgorithm.ES256);
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"" + testToken + "\"}");
+        PublicKey publicKey = Crypto.loadPublicKey(ecPublicKey);
+
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        provider.signingKeyResolver.addPublicKey("eckey1", publicKey);
+        confirmation.setDomain("athenz");
+        confirmation.setService("api");
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ResourceException re) {
+            assertEquals(re.getCode(), ResourceException.FORBIDDEN);
+        }
+        provider.close();
+        removeOpenIdConfigFile(configFile, jwksUri);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE);
+    }
+
+    @Test
+    public void testConfirmInstanceFailedAttrValidation() throws IOException {
+
+        File configFile = new File("./src/test/resources/codesigning-openid.json");
+        File jwksUri = new File("./src/test/resources/codesigning-jwks.json");
+        createOpenIdConfigFile(configFile, jwksUri, true);
+
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        File configUri = new File("./src/test/resources/codesigning-openid-uri.json");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI, "file://" + configUri.getCanonicalPath());
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE, "https://zts.athenz.io");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS, "com.yahoo.athenz.instance.provider.impl.MockFailingAttrValidatorFactory");
+        IdToken sampleToken = new IdToken();
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        long now = System.currentTimeMillis() / 1000;
+        sampleToken.setExpiryTime(now + 3600);
+        sampleToken.setIssueTime(now);
+        sampleToken.setAudience("https://zts.athenz.io");
+        sampleToken.setSubject("athenz.api");
+        String testToken = sampleToken.getSignedToken(privateKey, "eckey1", SignatureAlgorithm.ES256);
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"" + testToken + "\"}");
+        PublicKey publicKey = Crypto.loadPublicKey(ecPublicKey);
+
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        provider.signingKeyResolver.addPublicKey("eckey1", publicKey);
+        confirmation.setDomain("athenz");
+        confirmation.setService("api");
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ResourceException re) {
+            assertEquals(re.getCode(), ResourceException.FORBIDDEN);
+        }
+        provider.close();
+        removeOpenIdConfigFile(configFile, jwksUri);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS);
+    }
+
+    @Test
+    public void testConfirmInstance() throws IOException {
+
+        File configFile = new File("./src/test/resources/codesigning-openid.json");
+        File jwksUri = new File("./src/test/resources/codesigning-jwks.json");
+        createOpenIdConfigFile(configFile, jwksUri, true);
+
+        InstanceCodeSigningProvider provider = new InstanceCodeSigningProvider();
+        File configUri = new File("./src/test/resources/codesigning-openid-uri.json");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI, "file://" + configUri.getCanonicalPath());
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE, "https://zts.athenz.io");
+        System.setProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS, "com.yahoo.athenz.instance.provider.impl.MockAttrValidatorFactory");
+        IdToken sampleToken = new IdToken();
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        long now = System.currentTimeMillis() / 1000;
+        sampleToken.setExpiryTime(now + 3600);
+        sampleToken.setIssueTime(now);
+        sampleToken.setAudience("https://zts.athenz.io");
+        sampleToken.setSubject("athenz.api");
+        String testToken = sampleToken.getSignedToken(privateKey, "eckey1", SignatureAlgorithm.ES256);
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"" + testToken + "\"}");
+        PublicKey publicKey = Crypto.loadPublicKey(ecPublicKey);
+
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceCodeSigningProvider", null, null);
+        provider.signingKeyResolver.addPublicKey("eckey1", publicKey);
+        confirmation.setDomain("athenz");
+        confirmation.setService("api");
+        provider.confirmInstance(confirmation);
+        assertEquals(confirmation.getAttributes().size(), 3);
+
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_USAGE), "codeSigning");
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_REFRESH), "false");
+        assertEquals(confirmation.getAttributes().get(InstanceProvider.ZTS_CERT_EXPIRY_TIME), "15");
+
+        provider.close();
+        removeOpenIdConfigFile(configFile, jwksUri);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_OIDC_PROVIDER_OPENID_CONFIG_URI);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTESTATION_EXPECTED_AUDIENCE);
+        System.clearProperty(InstanceCodeSigningProvider.ZTS_PROP_CODE_SIGNING_ATTR_VALIDATOR_FACTORY_CLASS);
+    }
+
+    private void removeOpenIdConfigFile(File configFile, File jwksUri) {
+        try {
+            Files.delete(configFile.toPath());
+        } catch (Exception ignored) {
+        }
+        try {
+            Files.delete(jwksUri.toPath());
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void createOpenIdConfigFile(File configFile, File jwksUri, boolean createJkws) throws IOException {
+
+        final String fileContents = "{\n" +
+                "    \"jwks_uri\": \"file://" + jwksUri.getCanonicalPath() + "\"\n" +
+                "}";
+        Files.write(configFile.toPath(), fileContents.getBytes());
+
+        if (createJkws) {
+            final String keyContents = "{\n" +
+                    "    \"keys\": [\n" +
+                    "        {\n" +
+                    "        \"kty\": \"EC\",\n" +
+                    "        \"kid\": \"c9986ee3-7b2a-4f20-d86a-0839356f2541\",\n" +
+                    "        \"alg\": \"ES256\",\n" +
+                    "        \"use\": \"sig\",\n" +
+                    "        \"crv\": \"P-256\",\n" +
+                    "        \"x\": \"Rbb6kjqP5au-I7BKfclt2nmizr5CbeYBFjCs7hMBUDU\"\n" +
+                    "        \"y\": \"VMHAvuMYRntAmIYMN80exPpplufSMeehuNHWXTRICs8\"\n" +
+                    "        }\n" +
+                    "    ]\n" +
+                    "}";
+            Files.write(jwksUri.toPath(), keyContents.getBytes());
+        }
+    }
+}

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/MockFailingAttrValidatorFactory.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/MockFailingAttrValidatorFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.yahoo.athenz.instance.provider.AttrValidator;
+import com.yahoo.athenz.instance.provider.AttrValidatorFactory;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+
+import javax.net.ssl.SSLContext;
+
+public class MockFailingAttrValidatorFactory implements AttrValidatorFactory {
+    @Override
+    public AttrValidator create(final SSLContext sslContext) {
+        return instanceConfirmation -> false;
+    }
+}

--- a/libs/java/instance_provider/src/test/resources/codesigning-openid-uri.json
+++ b/libs/java/instance_provider/src/test/resources/codesigning-openid-uri.json
@@ -1,0 +1,4 @@
+{
+  "token_endpoint":"https://localhost/oauth2/token",
+  "jwks_uri":"file://src/test/resources/keys.json"
+}

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -639,3 +639,18 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # this property specifies the audience field to be used while requesting id token from
 # Google Metadata server. Without this value being present, Metadata server doesn't issue the id token.
 #athenz.zts.gcp_identity_expected_audience=
+
+# ZTS can be used as a certificate authority providing code signing certificate
+# this property specifies the OIDC provider's config
+#athenz.zts.code_signing_oidc_provider_openid_config_uri=
+
+# When id_token is used to prove identity of the entity requesting code signing certificates from ZTS
+# this property specifies the audience field to be used while requesting id token from the OIDC provider
+#athenz.zts.code_signing_attestation_expected_audience=
+
+# If additional validations to be performed before issuing a code signing certificate
+# then this property allows setting a factory class providing the additional validator implementation
+#athenz.zts.code_signing_attr_validator_factory_class=
+
+# This property allows customizing the expiry time of the code signing certificate
+#athenz.zts.code_signing_cert_validity=

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/crypki/HttpCertSigner.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/crypki/HttpCertSigner.java
@@ -375,12 +375,21 @@ public class HttpCertSigner implements CertSigner {
     public Object getX509CertSigningRequest(String provider, String csr, String keyUsage, int expireMins, Priority priority) {
 
         // Key Usage value used in Go - https://golang.org/src/crypto/x509/x509.go?s=18153:18173#L558
-        // we're only interested in ExtKeyUsageClientAuth - with value of 2
 
         List<Integer> extKeyUsage = null;
         if (InstanceProvider.ZTS_CERT_USAGE_CLIENT.equals(keyUsage)) {
             extKeyUsage = new ArrayList<>();
             extKeyUsage.add(2);
+        }
+
+        if (InstanceProvider.ZTS_CERT_USAGE_CODE_SIGNING.equals(keyUsage)) {
+            extKeyUsage = new ArrayList<>();
+            extKeyUsage.add(3);
+        }
+
+        if (InstanceProvider.ZTS_CERT_USAGE_TIMESTAMPING.equals(keyUsage)) {
+            extKeyUsage = new ArrayList<>();
+            extKeyUsage.add(8);
         }
 
         X509CertificateSigningRequest csrCert = new X509CertificateSigningRequest();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/HttpCertSignerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/HttpCertSignerTest.java
@@ -176,6 +176,18 @@ public class HttpCertSignerTest {
         assertEquals(pem, "pem-value");
         Mockito.verify(httpClient, times(3)).execute(Mockito.any(HttpPost.class));
 
+        response = mockRequest(201, pemResponse);
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(response);
+        pem = certSigner.generateX509Certificate("aws", null, "csr", InstanceProvider.ZTS_CERT_USAGE_CODE_SIGNING, 15);
+        assertEquals(pem, "pem-value");
+        Mockito.verify(httpClient, times(4)).execute(Mockito.any(HttpPost.class));
+
+        response = mockRequest(201, pemResponse);
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(response);
+        pem = certSigner.generateX509Certificate("aws", null, "csr", InstanceProvider.ZTS_CERT_USAGE_TIMESTAMPING, 30);
+        assertEquals(pem, "pem-value");
+        Mockito.verify(httpClient, times(5)).execute(Mockito.any(HttpPost.class));
+
         certSigner.close();
     }
 


### PR DESCRIPTION
This PR implements a provider which issues an X.509 certificate with its "extended key usage" attribute set to "codeSigning" in lieu of an OIDC id token. Any standard OIDC provider can be configured to provide the id token to establish the identity of the code signing certificate requester or ZTS itself can act as an OIDC provider.
This issued code signing certificate can be used to sign any software artifacts ( packages, SBOMs etc ) to secure the software supply chain.