### PR TITLE
Set a connect timeout when fetching JWT signing keys

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsHelper.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsHelper.java
@@ -67,6 +67,7 @@ public class JwtsHelper {
         try {
             URLConnection con = getUrlConnection(serverUri);
             con.setRequestProperty("Accept", "application/json");
+            con.setConnectTimeout(10000);
             con.setReadTimeout(15000);
             con.setDoOutput(true);
             if (con instanceof HttpURLConnection) {


### PR DESCRIPTION
The default appears to be "infinity":

Ref: https://github.com/openjdk/jdk/blob/c1a87498eac64a014786274e564e1b0b1e4afc51/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L428
Ref: https://github.com/openjdk/jdk/blob/c1a87498eac64a014786274e564e1b0b1e4afc51/src/java.base/share/classes/sun/net/NetworkClient.java#L47-L48
Ref: https://github.com/openjdk/jdk/blob/c1a87498eac64a014786274e564e1b0b1e4afc51/src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L3437-L3452
