### PR TITLE
sia agent - exit when refresh fails after configured number of attempts

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/AthenZ/athenz/clients/go/zts"
+	"github.com/AthenZ/athenz/libs/go/athenzutils"
 	"github.com/AthenZ/athenz/libs/go/sia/access/config"
 	"github.com/AthenZ/athenz/libs/go/sia/access/tokens"
 	"github.com/AthenZ/athenz/libs/go/sia/options"
@@ -633,6 +634,12 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 		errors := make(chan error, 1)
 		certUpdates := make(chan bool, 1)
 
+		// keep track of failed counts for refresh operations. Since we typically
+		// get certs valid for several days, there is no need to exit immediately
+		// and keep retrying. instead, we'll just skip this run and retry again
+		// in the configured number of minutes (based on the refresh interval)
+		failedRefreshCount := 0
+
 		go func() {
 			for {
 				// if we just did our initial setup there is no point
@@ -642,10 +649,17 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 				if !initialSetup {
 					err = RefreshInstance(ztsUrl, metaEndpoint, opts)
 					if err != nil {
-						errors <- fmt.Errorf("refresh identity failed: %v\n", err)
-						return
+						failedRefreshCount++
+						if shouldExitRightAway(failedRefreshCount, opts) {
+							errors <- fmt.Errorf("refresh identity failed: %v\n", err)
+							return
+						} else {
+							log.Printf("refresh identity failed for svcs %s, error: %v\n", svcs, err)
+							log.Printf("refresh will be retried in %d minutes, failure %d of %d\n", opts.RefreshInterval, failedRefreshCount, opts.FailCountForExit)
+						}
+					} else {
+						log.Printf("identity successfully refreshed for services: %s\n", svcs)
 					}
-					log.Printf("identity successfully refreshed for services: %s\n", svcs)
 				}
 				initialSetup = false
 				if tokenOpts != nil {
@@ -791,4 +805,27 @@ func serviceAlreadyRegistered(opts *options.Options, svc options.Service) bool {
 	keyFile := util.GetSvcKeyFileName(opts.KeyDir, svc.KeyFilename, opts.Domain, svc.Name)
 	certFile := util.GetSvcCertFileName(opts.CertDir, svc.CertFilename, opts.Domain, svc.Name)
 	return util.FileExists(keyFile) && util.FileExists(certFile)
+}
+
+func shouldExitRightAway(failedRefreshCount int, opts *options.Options) bool {
+	// if the failed count already matches or exceeds our configured
+	// value then we return right away
+	if failedRefreshCount >= opts.FailCountForExit {
+		return true
+	}
+	// if the count hasn't reached the limit, we will skip this
+	// failure only if all the certificates that we're refreshing
+	// are not going to expire before the next refresh happens
+	for _, svc := range opts.Services {
+		svcCertFile := util.GetSvcCertFileName(opts.CertDir, svc.CertFilename, opts.Domain, svc.Name)
+		// if we're not able to parse/load the certificate file, we'll exit right away
+		x509Cert, err := athenzutils.LoadX509Certificate(svcCertFile)
+		if err != nil {
+			return true
+		}
+		if x509Cert.NotAfter.Unix()-time.Now().Unix() < int64(opts.RefreshInterval*60) {
+			return true
+		}
+	}
+	return false
 }

--- a/libs/go/sia/aws/options/data/sia_config_threshold_role
+++ b/libs/go/sia/aws/options/data/sia_config_threshold_role
@@ -24,5 +24,6 @@
                 }
             }
         }
-    ]
+    ],
+    "fail_count_for_exit": 5
 }

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -72,40 +72,41 @@ type ConfigAccount struct {
 	Zts          string                `json:"zts,omitempty"`                        //the ZTS to contact
 	Roles        map[string]ConfigRole `json:"roles,omitempty"`                      //map of roles to retrieve certificates for
 	Version      string                `json:"version,omitempty"`                    //sia version number
-	Threshold    float64               `json:"cert_threshold_to_check,omitempty"`    //Threshold to verify for all certs
-	SshThreshold float64               `json:"sshcert_threshold_to_check,omitempty"` //Threshold to verify for ssh certs
+	Threshold    float64               `json:"cert_threshold_to_check,omitempty"`    //threshold to verify for all certs
+	SshThreshold float64               `json:"sshcert_threshold_to_check,omitempty"` //threshold to verify for ssh certs
 }
 
 // Config represents entire sia_config file
 type Config struct {
-	Version          string                   `json:"version,omitempty"`            //name of the provider
-	Service          string                   `json:"service,omitempty"`            //name of the service for the identity
-	Services         map[string]ConfigService `json:"services,omitempty"`           //names of the multiple services for the identity
-	Ssh              *bool                    `json:"ssh,omitempty"`                //ssh certificate support
-	SshHostKeyType   hostkey.KeyType          `json:"ssh_host_key_type,omitempty"`  //ssh host key type - rsa, ecdsa, etc
-	SshPrincipals    string                   `json:"ssh_principals,omitempty"`     //ssh additional principals
-	SanDnsWildcard   bool                     `json:"sandns_wildcard,omitempty"`    //san dns wildcard support
-	SanDnsHostname   bool                     `json:"sandns_hostname,omitempty"`    //san dns hostname support
-	UseRegionalSTS   bool                     `json:"regionalsts,omitempty"`        //whether to use a regional STS endpoint (default is false)
-	Accounts         []ConfigAccount          `json:"accounts,omitempty"`           //array of configured accounts
-	GenerateRoleKey  bool                     `json:"generate_role_key,omitempty"`  //private key to be generated for role certificate
-	RotateKey        bool                     `json:"rotate_key,omitempty"`         //rotate private key support
-	User             string                   `json:"user,omitempty"`               //the username to chown the cert/key dirs to. If absent, then root
-	Group            string                   `json:"group,omitempty"`              //the group name to chown the cert/key dirs to. If absent, then athenz
-	SDSUdsPath       string                   `json:"sds_uds_path,omitempty"`       //uds path if the agent should support uds connections
-	SDSUdsUid        int                      `json:"sds_uds_uid,omitempty"`        //uds connections must be from the given user uid
-	ExpiryTime       int                      `json:"expiry_time,omitempty"`        //service and role certificate expiry in minutes
-	RefreshInterval  int                      `json:"refresh_interval,omitempty"`   //specifies refresh interval in minutes
-	ZTSRegion        string                   `json:"zts_region,omitempty"`         //specifies zts region for the requests
-	DropPrivileges   bool                     `json:"drop_privileges,omitempty"`    //drop privileges to configured user instead of running as root
-	AccessTokens     map[string]ac.Role       `json:"access_tokens,omitempty"`      //map of role name to token attributes
-	FileDirectUpdate bool                     `json:"file_direct_update,omitempty"` //update key/cert files directly instead of using rename
-	SiaKeyDir        string                   `json:"sia_key_dir,omitempty"`        //sia keys directory to override /var/lib/sia/keys
-	SiaCertDir       string                   `json:"sia_cert_dir,omitempty"`       //sia certs directory to override /var/lib/sia/certs
-	SiaTokenDir      string                   `json:"sia_token_dir,omitempty"`      //sia tokens directory to override /var/lib/sia/tokens
-	SiaBackupDir     string                   `json:"sia_backup_dir,omitempty"`     //sia backup directory to override /var/lib/sia/backup
-	HostnameSuffix   string                   `json:"hostname_suffix,omitempty"`    //hostname suffix in case we need to auto-generate hostname
-	AccessManagement bool                     `json:"access_management"`            //access management support
+	Version          string                   `json:"version,omitempty"`             //name of the provider
+	Service          string                   `json:"service,omitempty"`             //name of the service for the identity
+	Services         map[string]ConfigService `json:"services,omitempty"`            //names of the multiple services for the identity
+	Ssh              *bool                    `json:"ssh,omitempty"`                 //ssh certificate support
+	SshHostKeyType   hostkey.KeyType          `json:"ssh_host_key_type,omitempty"`   //ssh host key type - rsa, ecdsa, etc
+	SshPrincipals    string                   `json:"ssh_principals,omitempty"`      //ssh additional principals
+	SanDnsWildcard   bool                     `json:"sandns_wildcard,omitempty"`     //san dns wildcard support
+	SanDnsHostname   bool                     `json:"sandns_hostname,omitempty"`     //san dns hostname support
+	UseRegionalSTS   bool                     `json:"regionalsts,omitempty"`         //whether to use a regional STS endpoint (default is false)
+	Accounts         []ConfigAccount          `json:"accounts,omitempty"`            //array of configured accounts
+	GenerateRoleKey  bool                     `json:"generate_role_key,omitempty"`   //private key to be generated for role certificate
+	RotateKey        bool                     `json:"rotate_key,omitempty"`          //rotate private key support
+	User             string                   `json:"user,omitempty"`                //the username to chown the cert/key dirs to. If absent, then root
+	Group            string                   `json:"group,omitempty"`               //the group name to chown the cert/key dirs to. If absent, then athenz
+	SDSUdsPath       string                   `json:"sds_uds_path,omitempty"`        //uds path if the agent should support uds connections
+	SDSUdsUid        int                      `json:"sds_uds_uid,omitempty"`         //uds connections must be from the given user uid
+	ExpiryTime       int                      `json:"expiry_time,omitempty"`         //service and role certificate expiry in minutes
+	RefreshInterval  int                      `json:"refresh_interval,omitempty"`    //specifies refresh interval in minutes
+	ZTSRegion        string                   `json:"zts_region,omitempty"`          //specifies zts region for the requests
+	DropPrivileges   bool                     `json:"drop_privileges,omitempty"`     //drop privileges to configured user instead of running as root
+	AccessTokens     map[string]ac.Role       `json:"access_tokens,omitempty"`       //map of role name to token attributes
+	FileDirectUpdate bool                     `json:"file_direct_update,omitempty"`  //update key/cert files directly instead of using rename
+	SiaKeyDir        string                   `json:"sia_key_dir,omitempty"`         //sia keys directory to override /var/lib/sia/keys
+	SiaCertDir       string                   `json:"sia_cert_dir,omitempty"`        //sia certs directory to override /var/lib/sia/certs
+	SiaTokenDir      string                   `json:"sia_token_dir,omitempty"`       //sia tokens directory to override /var/lib/sia/tokens
+	SiaBackupDir     string                   `json:"sia_backup_dir,omitempty"`      //sia backup directory to override /var/lib/sia/backup
+	HostnameSuffix   string                   `json:"hostname_suffix,omitempty"`     //hostname suffix in case we need to auto-generate hostname
+	AccessManagement bool                     `json:"access_management,omitempty"`   //access management support
+	FailCountForExit int                      `json:"fail_count_for_exit,omitempty"` //number of failed counts before exiting program
 }
 
 type AccessProfileConfig struct {
@@ -202,6 +203,7 @@ type Options struct {
 	SshPrincipals      string            //ssh additional principals
 	AccessManagement   bool              //access management support
 	AddlSanDNSEntries  []string          //additional san dns entries to be added to the CSR
+	FailCountForExit   int               //number of failed counts before exiting program
 }
 
 const (
@@ -384,6 +386,12 @@ func InitEnvConfig(config *Config) (*Config, *ConfigAccount, error) {
 			config.RefreshInterval = refreshInterval
 		}
 	}
+	if config.FailCountForExit == 0 {
+		failCount := util.ParseEnvIntFlag("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", 0)
+		if failCount > 0 {
+			config.FailCountForExit = failCount
+		}
+	}
 	if config.ZTSRegion == "" {
 		config.ZTSRegion = os.Getenv("ATHENZ_SIA_ZTS_REGION")
 	}
@@ -487,6 +495,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 	sshHostKeyType := hostkey.Rsa
 	sshPrincipals := ""
 	accessManagement := false
+	failCountForExit := 2
 
 	if config != nil {
 		useRegionalSTS = config.UseRegionalSTS
@@ -529,6 +538,9 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		}
 		if config.SshPrincipals != "" {
 			sshPrincipals = config.SshPrincipals
+		}
+		if config.FailCountForExit > 0 {
+			failCountForExit = config.FailCountForExit
 		}
 
 		//update generate role and rotate key options if config is provided
@@ -694,6 +706,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		SshHostKeyType:    sshHostKeyType,
 		SshPrincipals:     sshPrincipals,
 		AccessManagement:  accessManagement,
+		FailCountForExit:  failCountForExit,
 	}, nil
 }
 

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -198,6 +198,7 @@ func TestOptionsNoConfig(t *testing.T) {
 	assert.Equal(t, "/var/lib/sia/certs", opts.CertDir)
 	assert.Equal(t, "/var/lib/sia/tokens", opts.TokenDir)
 	assert.Equal(t, "/var/lib/sia/backup", opts.BackupDir)
+	assert.Equal(t, 2, opts.FailCountForExit)
 }
 
 // TestOptionsNoProfileConfig tests the scenario when there is no /etc/sia/profile_config, the system uses instance profile arn
@@ -293,16 +294,17 @@ func TestOptionsWithRoleThreshold(t *testing.T) {
 	opts, e := setOptions(cfg, cfgAccount, profileConfig, "/tmp", "1.0.0")
 	require.Nilf(t, e, "error should be empty, error: %v", e)
 	require.NotNil(t, opts, "should be able to get Options")
-	assert.True(t, opts.RefreshInterval == 1440)
-	assert.True(t, opts.ZTSRegion == "")
+	assert.Equal(t, 1440, opts.RefreshInterval)
+	assert.Empty(t, opts.ZTSRegion)
+	assert.Equal(t, 5, opts.FailCountForExit)
 
 	// Make sure profile is correct
-	assert.True(t, opts.Profile == "zts-profile")
+	assert.Equal(t, "zts-profile", opts.Profile)
 
 	// Make sure services are set
-	assert.True(t, len(opts.Services) == 3)
-	assert.True(t, opts.Domain == "athenz")
-	assert.True(t, opts.Name == "athenz.api")
+	assert.Equal(t, 3, len(opts.Services))
+	assert.Equal(t, "athenz", opts.Domain)
+	assert.Equal(t, "athenz.api", opts.Name)
 
 	// Zeroth service should be the one from "service" key, the remaining are from "services" in no particular order
 	assert.True(t, assertService(opts.Services[0], Service{Name: "api", User: "nobody", Uid: getUid("nobody"), Gid: getUserGid("nobody"), FileMode: 288, Threshold: 20}))
@@ -311,7 +313,7 @@ func TestOptionsWithRoleThreshold(t *testing.T) {
 	assert.Equal(t, float64(25), opts.Roles[0].Threshold)
 
 	assert.Equal(t, DefaultThreshold, opts.SshThreshold)
-	assert.True(t, opts.Threshold == 20)
+	assert.Equal(t, float64(20), opts.Threshold)
 }
 
 func TestOptionsWithServiceAccountThreshold(t *testing.T) {
@@ -661,6 +663,7 @@ func TestInitEnvConfig(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_CERT_DIR", "/var/athenz/certs")
 	os.Setenv("ATHENZ_SIA_TOKEN_DIR", "/var/athenz/tokens")
 	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
+	os.Setenv("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", "10")
 
 	cfg, cfgAccount, err := InitEnvConfig(nil)
 	require.Nilf(t, err, "error should be empty, error: %v", err)
@@ -689,6 +692,7 @@ func TestInitEnvConfig(t *testing.T) {
 	assert.Equal(t, "athenz.api", cfgAccount.Name)
 	assert.Equal(t, 2, len(cfgAccount.Roles))
 	assert.Equal(t, "host1.athenz.io", cfg.SshPrincipals)
+	assert.Equal(t, 10, cfg.FailCountForExit)
 
 	os.Clearenv()
 }

--- a/libs/go/sia/options/data/sia_config_threshold_role
+++ b/libs/go/sia/options/data/sia_config_threshold_role
@@ -26,5 +26,6 @@
                 }
             }
         }
-    ]
+    ],
+    "fail_count_for_exit": 5
 }


### PR DESCRIPTION
let's assume we have a setup where the certs are issued for 7 days and refresh daily (default behavior).
when SIA refreshes the certs and the certificate signer is down, the refresh will fail. This will cause the sia container to exit and a new one is created. however, the cert signer might be down for a so our sia container keeps restarting. however, the existing key/cert pair is valid for at least 6 days, so there is no reason to exit.

now, we have a configurable value with default setting of 2. this means we won't be exiting if we fail to refresh our certs, instead, we'll just ignore the failure and try again tomorrow. If after 2 refresh operations, we still fail, we'll exit.

In addition, when we fail, we also check if the cert will expire before the next rotation. So even if the fail count is below the limit, if the next refresh will be too late, we'll exit as well so that the container can keep trying to fetch new certs periodically.