### PR TITLE
for id tokens with group scope always use full arns

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2012,7 +2012,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         List<String> idTokenGroups = null;
         if (tokenRequest.isGroupsScope()) {
 
-            idTokenGroups = processIdTokenGroups(principalName, tokenRequest, domainName, fullArn,
+            idTokenGroups = processIdTokenGroups(principalName, tokenRequest, domainName, true,
                     principalDomain, caller);
 
         } else if (tokenRequest.isRolesScope()) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -13488,8 +13488,8 @@ public class ZTSImplTest {
         List<String> userGroups = (List<String>) claims.getBody().get("groups");
         assertNotNull(userGroups);
         assertEquals(userGroups.size(), 2);
-        assertTrue(userGroups.contains("dev-team"));
-        assertTrue(userGroups.contains("pe-team"));
+        assertTrue(userGroups.contains("coretech:group.dev-team"));
+        assertTrue(userGroups.contains("coretech:group.pe-team"));
 
         // get only one of the groups and include state
 
@@ -13516,7 +13516,7 @@ public class ZTSImplTest {
         userGroups = (List<String>) claims.getBody().get("groups");
         assertNotNull(userGroups);
         assertEquals(userGroups.size(), 1);
-        assertTrue(userGroups.contains("dev-team"));
+        assertTrue(userGroups.contains("coretech:group.dev-team"));
 
         // requesting a group that the user is not part of
 


### PR DESCRIPTION
when the calling is asking for an id token with groups claim that include the groups scope, then we must always use the full arn. Otherwise, if we have a role called writers and a group called writers, then with full arn set to false, we'll get groups claim with the same "writers" value which would be ambiguous and result in wrong authorization calls. Now, with roles scope , we'll get either "writers" or "athenz:role.writers" as the groups claims value and with groups scope we'll get "athenz:group:writers" groups claim - no longer ambiguous.