### PR TITLE
Update dynamodbMaxRetries to avoid Integer Overflow

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/RetryDynamoDBCommand.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/RetryDynamoDBCommand.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 public class RetryDynamoDBCommand<T> {
-    private final Long dynamodbMaxRetries = Long.parseLong(
+    private final int dynamodbMaxRetries = Integer.parseInt(
             System.getProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_RETRIES, "10"));
 
     private final Long dynamodbRetriesSleepMillis = Long.parseLong(


### PR DESCRIPTION
I changed the type of `dynamodbMaxRetries` to `int`.

Becasue there are a for iteration with comparsion between `int` and `Long` and the `Long` dynamodbMaxRetries is controlled by config `athenz.zts.cert_dynamodb_retries`.
```java
for (int retryNumber = 1; retryNumber <= dynamodbMaxRetries; ++retryNumber) {
```

Therefore, if dynamodbMaxRetries is set to larger than `Integer.MAX_VALUE`, the variable `retryNumber` will overflow and this for iteration will stuck in an endless loop, which may cause "Denial of Service".