### PR TITLE
increased/configure json string limit for jackson

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -486,3 +486,16 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # Boolean property indicating if the server should enforce a unique
 # product id association with each domain.
 #athenz.zms.enforce_unique_product_ids=true
+
+# Specifies the max nesting depth for jackson json parsing library. By default,
+# we're using the same value as the library.
+#athenz.zms.json_max_nesting_depth=1000
+
+# Specifies the max number length for jackson json parsing library. By default,
+# we're using the same value as the library.
+#athenz.zms.json_max_number_length=1000
+
+# Specifies the max string length for jackson json parsing library. By default,
+# we increase this value to 200GB to support large domains that may exist
+# in Athenz.
+#athenz.zms.json_max_string_length=200000000

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -404,4 +404,8 @@ public final class ZMSConsts {
     //pending member
     public static final String PENDING_REQUEST_ADD_STATE = "ADD";
     public static final String PENDING_REQUEST_DELETE_STATE = "DELETE";
+
+    public static final String ZMS_PROP_JSON_MAX_NESTING_DEPTH = "athenz.zms.json_max_nesting_depth";
+    public static final String ZMS_PROP_JSON_MAX_NUMBER_LENGTH = "athenz.zms.json_max_number_length";
+    public static final String ZMS_PROP_JSON_MAX_STRING_LENGTH = "athenz.zms.json_max_string_length";
 }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -15,6 +15,7 @@
  */
 package com.yahoo.athenz.zms;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.Bytes;
 import com.oath.auth.KeyRefresherException;
@@ -598,7 +599,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // create our json mapper
 
-        jsonMapper = new ObjectMapper();
+        loadJsonMapper();
 
         // before we do anything we need to load our configuration
         // settings
@@ -688,6 +689,21 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         
         loadDomainChangePublisher();
 
+    }
+
+    void loadJsonMapper() {
+
+        int maxNestingDepth = Integer.parseInt(System.getProperty(ZMSConsts.ZMS_PROP_JSON_MAX_NESTING_DEPTH, "1000"));
+        int maxNumberLength = Integer.parseInt(System.getProperty(ZMSConsts.ZMS_PROP_JSON_MAX_NUMBER_LENGTH, "1000"));
+        int maxStringLength = Integer.parseInt(System.getProperty(ZMSConsts.ZMS_PROP_JSON_MAX_STRING_LENGTH, "200000000"));
+
+        final StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder()
+                .maxNestingDepth(maxNestingDepth)
+                .maxNumberLength(maxNumberLength)
+                .maxStringLength(maxStringLength).build();
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(streamReadConstraints);
+
+        jsonMapper = new ObjectMapper();
     }
 
     void loadDomainChangePublisher() {

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -676,3 +676,16 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # on ZMS servers. This setting specifies the number of domains to refresh during each
 # run with a default value of 10
 #athenz.zts.zms_domain_fetch_count=10
+
+# Specifies the max nesting depth for jackson json parsing library. By default,
+# we're using the same value as the library.
+#athenz.zts.json_max_nesting_depth=1000
+
+# Specifies the max number length for jackson json parsing library. By default,
+# we're using the same value as the library.
+#athenz.zts.json_max_number_length=1000
+
+# Specifies the max string length for jackson json parsing library. By default,
+# we increase this value to 200GB to support large domains that may exist
+# in Athenz.
+#athenz.zts.json_max_string_length=200000000

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -250,4 +250,8 @@ public final class ZTSConsts {
     public static final String ZTS_OPENID_RESPONSE_IT_ONLY    = "id_token";
     public static final String ZTS_OPENID_RESPONSE_BOTH_IT_AT = "id_token token";
     public static final String ZTS_OPENID_SUBJECT_TYPE_PUBLIC = "public";
+
+    public static final String ZTS_PROP_JSON_MAX_NESTING_DEPTH = "athenz.zts.json_max_nesting_depth";
+    public static final String ZTS_PROP_JSON_MAX_NUMBER_LENGTH = "athenz.zts.json_max_number_length";
+    public static final String ZTS_PROP_JSON_MAX_STRING_LENGTH = "athenz.zts.json_max_string_length";
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -99,6 +99,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 
 import static com.yahoo.athenz.common.ServerCommonConsts.*;
 import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
@@ -276,7 +277,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         // create our json mapper
 
-        jsonMapper = new ObjectMapper();
+        loadJsonMapper();
 
         // before we do anything we need to load our configuration
         // settings
@@ -367,6 +368,21 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // load Athenz JWK configuration
 
         loadAthenzJWK();
+    }
+
+    void loadJsonMapper() {
+
+        int maxNestingDepth = Integer.parseInt(System.getProperty(ZTSConsts.ZTS_PROP_JSON_MAX_NESTING_DEPTH, "1000"));
+        int maxNumberLength = Integer.parseInt(System.getProperty(ZTSConsts.ZTS_PROP_JSON_MAX_NUMBER_LENGTH, "1000"));
+        int maxStringLength = Integer.parseInt(System.getProperty(ZTSConsts.ZTS_PROP_JSON_MAX_STRING_LENGTH, "200000000"));
+
+        final StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder()
+                .maxNestingDepth(maxNestingDepth)
+                .maxNumberLength(maxNumberLength)
+                .maxStringLength(maxStringLength).build();
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(streamReadConstraints);
+
+        jsonMapper = new ObjectMapper();
     }
 
     protected void loadAthenzJWK() {

--- a/syncers/zms_aws_domain_syncer/src/main/java/com/yahoo/athenz/zms_aws_domain_syncer/Config.java
+++ b/syncers/zms_aws_domain_syncer/src/main/java/com/yahoo/athenz/zms_aws_domain_syncer/Config.java
@@ -48,6 +48,9 @@ public class Config {
     static final String DEFAULT_STATE_BUILDER_TIMEOUT = "1800";
     static final String DEFAULT_DOMAIN_REFRESH_COUNT = "10";
     static final String DEFAULT_DOMAIN_REFRESH_TIMEOUT = "2592000";
+    static final String DEFAULT_JSON_MAX_NESTING_DEPTH = "1000";
+    static final String DEFAULT_JSON_MAX_NUMBER_LENGTH = "1000";
+    static final String DEFAULT_JSON_MAX_STRING_LENGTH = "200000000";
 
     // system properties - take precedence over config file settings
 
@@ -72,6 +75,9 @@ public class Config {
     static final String SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT = "state_builder_timeout";
     static final String SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT = "domain_refresh_count";
     static final String SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT = "domain_refresh_timeout";
+    static final String SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH = "json_max_nesting_depth";
+    static final String SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH = "json_max_number_length";
+    static final String SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH = "json_max_string_length";
 
     static final String[] SYNC_CFG_PARAMS = {
             SYNC_CFG_PARAM_DEBUG,
@@ -92,7 +98,10 @@ public class Config {
             SYNC_CFG_PARAM_STATE_BUILDER_THREADS,
             SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT,
             SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT,
-            SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT
+            SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT,
+            SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH,
+            SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH,
+            SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH
     };
 
     static final String ZMS_CFG_PARAM_ZMS_URL = "zmsUrl";
@@ -248,6 +257,9 @@ public class Config {
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT, DEFAULT_STATE_BUILDER_TIMEOUT);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT, DEFAULT_DOMAIN_REFRESH_COUNT);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT, DEFAULT_DOMAIN_REFRESH_TIMEOUT);
+            propertyMap.putIfAbsent(SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH, DEFAULT_JSON_MAX_NESTING_DEPTH);
+            propertyMap.putIfAbsent(SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH, DEFAULT_JSON_MAX_NUMBER_LENGTH);
+            propertyMap.putIfAbsent(SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH, DEFAULT_JSON_MAX_STRING_LENGTH);
 
             syncMergeStatus = true;
         } catch (Exception ex) {

--- a/syncers/zms_aws_domain_syncer/src/main/java/com/yahoo/athenz/zms_aws_domain_syncer/ZmsSyncer.java
+++ b/syncers/zms_aws_domain_syncer/src/main/java/com/yahoo/athenz/zms_aws_domain_syncer/ZmsSyncer.java
@@ -18,6 +18,7 @@
 
 package com.yahoo.athenz.zms_aws_domain_syncer;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.yahoo.athenz.zms.DomainData;
 import com.yahoo.athenz.zms.JWSDomain;
 import com.yahoo.athenz.zms.SignedDomain;
@@ -76,6 +77,7 @@ public class ZmsSyncer {
     private List<DomainState> processedDomains = null;
 
     public ZmsSyncer() throws Exception {
+        setupJsonParserLimits();
         awsSyncer = new AwsSyncer();
         zmsReader = new ZmsReader();
         stateFileBuilder = new StateFileBuilder();
@@ -85,6 +87,19 @@ public class ZmsSyncer {
         this.awsSyncer = awsSyncer;
         this.zmsReader = zmsReader;
         this.stateFileBuilder = stateFileBuilder;
+    }
+
+    void setupJsonParserLimits() {
+
+        int maxNestingDepth = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH));
+        int maxNumberLength = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH));
+        int maxStringLength = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH));
+
+        final StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder()
+                .maxNestingDepth(maxNestingDepth)
+                .maxNumberLength(maxNumberLength)
+                .maxStringLength(maxStringLength).build();
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(streamReadConstraints);
     }
 
     public boolean processDomains() throws Exception {


### PR DESCRIPTION
staring with 2.15.x, Jackson json parser started having a max limit on string length (initially 5MB, in 2.15.2 increased to 20MB). However, with large domain in Athenz, when we're passing jws domains, the payload is the base64 encoded jws document so it's treated as one string and rejected since it could be bigger than 20MB.

The zms/zms/syncer - all now default to 200MB for the string length plus provide configurable system properties to change those values if necessary.