### PR TITLE
Prevent buffer overflow

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
@@ -110,7 +110,7 @@ public class FileCertRecordStoreConnection implements CertRecordStoreConnection 
         return new ArrayList<>();
     }
 
-    boolean notExpired(long currentTime, long lastModified, int expiryTimeMins) {
+    boolean notExpired(long currentTime, long lastModified, long expiryTimeMins) {
         return (currentTime - lastModified < expiryTimeMins * 60 * 1000);
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
@@ -37,7 +37,7 @@ public class FileCertRecordStoreConnectionTest {
         }
 
         @Override
-        boolean notExpired(long currentTime, long lastModified, int expiryTimeMins) {
+        boolean notExpired(long currentTime, long lastModified, long expiryTimeMins) {
             return true;
         }
     }
@@ -172,7 +172,12 @@ public class FileCertRecordStoreConnectionTest {
         
         X509CertRecord certRecordCheck = con.getX509CertRecord("ostk", "instance-id", "cn");
         assertNotNull(certRecordCheck);
-        
+
+        // Verify that certificates are not expired immediately
+        con.deleteExpiredX509CertRecords(43200); //30 days
+        certRecordCheck = con.getX509CertRecord("ostk", "instance-id", "cn");
+        assertNotNull(certRecordCheck);
+
         Thread.sleep(1000);
         con.deleteExpiredX509CertRecords(0);
 


### PR DESCRIPTION
The `notExpired` method currently always returns `false` under "normal" circumstances e.g when using zts defaults.