### PR TITLE
Enable to get policy with tags.

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -3794,7 +3794,7 @@ public class DBService implements RolesProvider {
         Policy policy = con.getPolicy(domainName, policyName, version);
         if (policy != null) {
             policy.setAssertions(con.listAssertions(domainName, policyName, version));
-            policy.setTags(con.getPolicyTags(domainName, policyName, version));
+            policy.setTags(con.getPolicyTags(domainName, policyName, version != null ? version : policy.getVersion()));
         }
 
         return policy;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -33901,6 +33901,39 @@ public class ZMSImplTest {
         assertFalse(zmsImpl.validateGcpProjectDetails("1234", ""));
         assertFalse(zmsImpl.validateGcpProjectDetails("1234", null));
     }
+    @Test
+    public void testGetPolicyWithTags() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        final String domainName = "setup-policy-with-tags";
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+        Map<String, TagValueList> policy1Tags = Collections.singletonMap("tag-key", new TagValueList().setList(Arrays.asList("val2", "val3")));
+        Policy policy1 = zmsTestInitializer.createPolicyObject(domainName, "policy1");
+        policy1.setTags(policy1Tags);
+        zmsImpl.putPolicy(ctx, domainName, "policy1", auditRef, false, policy1);
+
+        Policy policy1version2 = zmsTestInitializer.createPolicyObject(domainName, "policy1");
+        Map<String, TagValueList> policy2Tags = Collections.singletonMap("tag-key2", new TagValueList().setList(Arrays.asList("val5", "val6")));
+        policy1version2.setVersion("2");
+        policy1version2.setActive(false);
+        policy1version2.setTags(policy2Tags);
+        zmsImpl.putPolicy(ctx, domainName, "policy1", auditRef, false, policy1version2);
+
+        Policy returnedPolicy = zmsImpl.getPolicy(ctx, domainName, "policy1");
+        verifyPolicyHasTag(returnedPolicy, "tag-key", "val2");
+
+        zmsImpl.setActivePolicyVersion(ctx,domainName, "policy1",new PolicyOptions().setFromVersion("0").setVersion("2"), "test");
+
+        Policy returnedPolicy2 = zmsImpl.getPolicy(ctx, domainName, "policy1");
+        verifyPolicyHasTag(returnedPolicy2, "tag-key2", "val6");
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+    }
 
     @Test
     public void testSetupPolicyListWithTags() {


### PR DESCRIPTION
The function getPolicy was passing a null value for the "version" variable, which resulted in the policy being returned without the tags. This is because each policy version is associated with its own set of tags.