### PR TITLE
add wildcard support for ServiceSkipDomains

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -576,6 +576,9 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # screwdriver domain has dynamic projects for CI/CD, and we need to give
 # identity without creating a service. These services will be automatically
 # skipped from validation before certs are issued.
+# This property supports the use of wildcard characters for
+# prefix matching, allowing for skipping validation checks
+# across multiple domains (e.g. coretech.api*).
 #athenz.zts.validate_service_skip_domains=
 
 # Boolean flag to enforce that all services are registered before

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3534,7 +3534,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                     if (domainName.startsWith(serviceSkipDomainPrefix)) {
                         return;
                     }
-                } else if (validateServiceSkipDomains.contains(domainName)) {
+                } else if (serviceSkipDomain.equals(domainName)) {
                     // if skipDomain doesn't have wildcard, we conduct a perfect match search
                     return;
                 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3526,18 +3526,16 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // need to check anything
 
         final String domainName = domainData.getName();
-        if (domainName != null) {
-            for (String serviceSkipDomain : validateServiceSkipDomains) {
-                // first, we perform validation using wildcards
-                if (serviceSkipDomain.endsWith("*")) {
-                    String serviceSkipDomainPrefix = serviceSkipDomain.substring(0, serviceSkipDomain.length() - 1);
-                    if (domainName.startsWith(serviceSkipDomainPrefix)) {
-                        return;
-                    }
-                } else if (serviceSkipDomain.equals(domainName)) {
-                    // if skipDomain doesn't have wildcard, we conduct a perfect match search
+        for (String serviceSkipDomain : validateServiceSkipDomains) {
+            // first, we perform validation using wildcards
+            if (serviceSkipDomain.endsWith("*")) {
+                String serviceSkipDomainPrefix = serviceSkipDomain.substring(0, serviceSkipDomain.length() - 1);
+                if (domainName.startsWith(serviceSkipDomainPrefix)) {
                     return;
                 }
+            } else if (serviceSkipDomain.equals(domainName)) {
+                // if skipDomain doesn't have wildcard, we conduct a perfect match search
+                return;
             }
         }
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -143,7 +143,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     protected Set<String> authorizedProxyUsers = null;
     protected Set<String> validCertSubjectOrgValues = null;
     protected Set<String> validCertSubjectOrgUnitValues = null;
-    protected Set<String> validateServiceSkipDomains;
+    protected List<String> validateServiceSkipDomains;
     protected boolean secureRequestsOnly = true;
     protected int svcTokenTimeout = 86400;
     protected Set<String> authFreeUriSet = null;
@@ -683,7 +683,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // dynamic - e.g. screwdriver projects
 
         final String skipDomains = System.getProperty(ZTSConsts.ZTS_PROP_VALIDATE_SERVICE_SKIP_DOMAINS, "");
-        validateServiceSkipDomains = new HashSet<>(Arrays.asList(skipDomains.split(",")));
+        validateServiceSkipDomains = Arrays.asList(skipDomains.split(","));
 
         validateInstanceServiceIdentity = new DynamicConfigBoolean(CONFIG_MANAGER, ZTSConsts.ZTS_PROP_VALIDATE_SERVICE_IDENTITY, true);
 
@@ -3526,8 +3526,19 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // need to check anything
 
         final String domainName = domainData.getName();
-        if (validateServiceSkipDomains.contains(domainName)) {
-            return;
+        if (domainName != null) {
+            for (String serviceSkipDomain : validateServiceSkipDomains) {
+                // first, we perform validation using wildcards
+                if (serviceSkipDomain.endsWith("*")) {
+                    String serviceSkipDomainPrefix = serviceSkipDomain.substring(0, serviceSkipDomain.length() - 1);
+                    if (domainName.startsWith(serviceSkipDomainPrefix)) {
+                        return;
+                    }
+                } else if (validateServiceSkipDomains.contains(domainName)) {
+                    // if skipDomain doesn't have wildcard, we conduct a perfect match search
+                    return;
+                }
+            }
         }
 
         List<com.yahoo.athenz.zms.ServiceIdentity> services = domainData.getServices();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -11600,7 +11600,7 @@ public class ZTSImplTest {
     @Test
     public void testValidateInstanceServiceIdentity() {
 
-        DomainData domainData = new DomainData();
+        DomainData domainData = new DomainData().setName("athenz");
 
         zts.validateInstanceServiceIdentity = new DynamicConfigBoolean(true);
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -184,7 +184,7 @@ public class ZTSImplTest {
                 "src/test/resources/cert_refresh_ipblocks.txt");
         System.setProperty(ZTSConsts.ZTS_PROP_CERT_ALLOWED_O_VALUES, "Athenz, Inc.|My Test Company|Athenz|Yahoo");
         System.setProperty(ZTSConsts.ZTS_PROP_NOAUTH_URI_LIST, "/zts/v1/schema,/zts/v1/status");
-        System.setProperty(ZTSConsts.ZTS_PROP_VALIDATE_SERVICE_SKIP_DOMAINS, "screwdriver");
+        System.setProperty(ZTSConsts.ZTS_PROP_VALIDATE_SERVICE_SKIP_DOMAINS, "screwdriver,rbac.*");
         System.setProperty(ZTSConsts.ZTS_PROP_OPENID_ISSUER, "https://athenz.cloud:4443/zts/v1");
 
         // setup our metric class
@@ -11647,6 +11647,12 @@ public class ZTSImplTest {
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
         }
+
+        // rbac.sre does not exists, but is accepted because rbac.* is included in skipDomains
+
+        domainData = new DomainData().setName("rbac.sre");
+        zts.validateInstanceServiceIdentity(domainData, "rbac.sre.backend", "unit-test");
+        zts.validateInstanceServiceIdentity(domainData, "rbac.sre.frontend", "unit-test");
 
         // screwdriver services are excluded from the check since they're dynamic
         // screwdriver is configured as service skip domain


### PR DESCRIPTION
## description
We have enabled the use of wildcards in the ServiceSkipDomains.

## reference
I implemented it based on the reference from https://github.com/AthenZ/athenz/pull/2202.