### PR TITLE
zts server code cleanup - replace deprecated calls, etc

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
@@ -37,8 +37,8 @@ public class RsrcCtxWrapper implements ResourceContext {
     com.yahoo.athenz.common.server.rest.ResourceContext ctx;
     boolean optionalAuth;
     Metric metric;
-    private Object timerMetric;
-    private String apiName;
+    private final Object timerMetric;
+    private final String apiName;
 
     public RsrcCtxWrapper(ServletContext servletContext, HttpServletRequest request, HttpServletResponse response,
                           Http.AuthorityList authList, boolean optionalAuth, Authorizer authorizer,

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -758,9 +758,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                 ZTSConsts.ZTS_CHANGE_LOG_STORE_FACTORY_CLASS);
         ChangeLogStoreFactory clogFactory;
         try {
-            clogFactory = (ChangeLogStoreFactory) Class.forName(clogFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid ChangeLogStoreFactory class: {} error: {}", clogFactoryClass, e.getMessage());
+            clogFactory = (ChangeLogStoreFactory) Class.forName(clogFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid ChangeLogStoreFactory class: {}", clogFactoryClass, ex);
             return null;
         }
 
@@ -778,9 +778,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         MetricFactory metricFactory;
         try {
-            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid MetricFactory class: {} error: {}", metricFactoryClass, e.getMessage());
+            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid MetricFactory class: {}", metricFactoryClass, ex);
             throw new IllegalArgumentException("Invalid metric class");
         }
 
@@ -799,9 +799,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         HostnameResolverFactory resolverFactory;
         try {
-            resolverFactory = (HostnameResolverFactory) Class.forName(resolverFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid HostnameResolverFactory class: {} error: {}", resolverFactoryClass, e.getMessage());
+            resolverFactory = (HostnameResolverFactory) Class.forName(resolverFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid HostnameResolverFactory class: {}", resolverFactoryClass, ex);
             throw new IllegalArgumentException("Invalid HostnameResolverFactory class");
         }
 
@@ -816,9 +816,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                 ZTSConsts.ZTS_PKEY_STORE_FACTORY_CLASS);
         PrivateKeyStoreFactory pkeyFactory;
         try {
-            pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid PrivateKeyStoreFactory class: {} error: {}", pkeyFactoryClass, e.getMessage());
+            pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid PrivateKeyStoreFactory class: {}", pkeyFactoryClass, ex);
             throw new IllegalArgumentException("Invalid private key store");
         }
 
@@ -876,9 +876,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         AuditLoggerFactory auditLogFactory;
 
         try {
-            auditLogFactory = (AuditLoggerFactory) Class.forName(auditFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid AuditLoggerFactory class: {} error: {}", auditFactoryClass, e.getMessage());
+            auditLogFactory = (AuditLoggerFactory) Class.forName(auditFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid AuditLoggerFactory class: {}", auditFactoryClass, ex);
             throw new IllegalArgumentException("Invalid audit logger class");
         }
 
@@ -894,9 +894,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         if (statusCheckerFactoryClass != null && !statusCheckerFactoryClass.isEmpty()) {
 
             try {
-                statusCheckerFactory = (StatusCheckerFactory) Class.forName(statusCheckerFactoryClass).newInstance();
-            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-                LOGGER.error("Invalid StatusCheckerFactory class: {} error: {}", statusCheckerFactoryClass, e.getMessage());
+                statusCheckerFactory = (StatusCheckerFactory) Class.forName(statusCheckerFactoryClass).getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                LOGGER.error("Invalid StatusCheckerFactory class: {}", statusCheckerFactoryClass, ex);
                 throw new IllegalArgumentException("Invalid status checker factory class");
             }
 
@@ -5447,9 +5447,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         Authority authority;
         try {
-            authority = (Authority) Class.forName(className).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid Authority class: {} error: {}", className, e.getMessage());
+            authority = (Authority) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid Authority class: {}", className, ex);
             return null;
         }
         return authority;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -76,6 +76,7 @@ import com.yahoo.rdl.*;
 import com.yahoo.rdl.Validator.Result;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.servlet.ServletContext;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.apache.http.conn.util.InetAddressUtils;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.eclipse.jetty.util.StringUtil;
@@ -231,6 +232,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     protected static Validator validator;
     protected NotificationManager notificationManager = null;
     protected StatusChecker statusChecker = null;
+
+    private static final RuntimeDelegate.HeaderDelegate<EntityTag> ENTITY_TAG_HEADER_DELEGATE =
+            RuntimeDelegate.getInstance().createHeaderDelegate(EntityTag.class);
 
     enum AthenzObject {
         INSTANCE_REGISTER_INFO {
@@ -1321,7 +1325,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         Timestamp modified = domainData.getModified();
         EntityTag eTag = new EntityTag(modified.toString());
-        final String tag = eTag.toString();
+        final String tag = ENTITY_TAG_HEADER_DELEGATE.toString(eTag);
 
         // Set timestamp for domain rather than youngest policy.
         // Since a policy could have been deleted, and can only be detected
@@ -1461,7 +1465,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         Timestamp modified = domainData.getModified();
         EntityTag eTag = new EntityTag(modified.toString());
-        String tag = eTag.toString();
+        final String tag = ENTITY_TAG_HEADER_DELEGATE.toString(eTag);
 
         // Set timestamp for domain rather than youngest policy.
         // Since a policy could have been deleted, and can only be detected

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
@@ -59,16 +59,16 @@ public class InstanceCertManager {
 
     private static final String CA_TYPE_X509 = "x509";
 
-    private Authorizer authorizer;
+    private final Authorizer authorizer;
     private CertSigner certSigner;
     private SSHSigner sshSigner;
-    private HostnameResolver hostnameResolver;
+    private final HostnameResolver hostnameResolver;
     private CertRecordStore certStore = null;
     private SSHRecordStore sshStore = null;
     private WorkloadRecordStore workloadStore = null;
     private ScheduledExecutorService certScheduledExecutor;
     private ScheduledExecutorService sshScheduledExecutor;
-    private List<IPBlock> certRefreshIPBlocks;
+    private final List<IPBlock> certRefreshIPBlocks;
     private Map<String, List<IPBlock>> instanceCertIPBlocks;
     private String caX509CertificateSigner = null;
     private Map<String, String> caX509ProviderCertificateSigners = null;
@@ -76,7 +76,7 @@ public class InstanceCertManager {
     private String sshHostCertificateSigner = null;
     private boolean responseSendSSHSignerCerts;
     private boolean responseSendX509SignerCerts;
-    private ObjectMapper jsonMapper;
+    private final ObjectMapper jsonMapper;
     private Map<String, CertificateAuthorityBundle> certAuthorityBundles = null;
     private final Authority notificationUserAuthority;
 
@@ -123,7 +123,6 @@ public class InstanceCertManager {
         // it can track of some details if enabled
 
         loadWorkloadObjectStore(keyStore);
-
 
         // load any configuration wrt certificate signers and any
         // configured certificate bundles
@@ -345,9 +344,9 @@ public class InstanceCertManager {
                 ZTSConsts.ZTS_CERT_SIGNER_FACTORY_CLASS);
         CertSignerFactory certSignerFactory;
         try {
-            certSignerFactory = (CertSignerFactory) Class.forName(certSignerFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid CertSignerFactory class: {} error: {}", certSignerFactoryClass, e.getMessage());
+            certSignerFactory = (CertSignerFactory) Class.forName(certSignerFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid CertSignerFactory class: {}", certSignerFactoryClass, ex);
             throw new IllegalArgumentException("Invalid certsigner class");
         }
 
@@ -366,9 +365,9 @@ public class InstanceCertManager {
         }
         SSHSignerFactory sshSignerFactory;
         try {
-            sshSignerFactory = (SSHSignerFactory) Class.forName(sshSignerFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid SSHSignerFactory class: {} error: {}", sshSignerFactoryClass, e.getMessage());
+            sshSignerFactory = (SSHSignerFactory) Class.forName(sshSignerFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid SSHSignerFactory class: {}", sshSignerFactoryClass, ex);
             throw new IllegalArgumentException("Invalid sshsigner class");
         }
 
@@ -457,10 +456,9 @@ public class InstanceCertManager {
                 ZTSConsts.ZTS_CERT_RECORD_STORE_FACTORY_CLASS);
         CertRecordStoreFactory certRecordStoreFactory;
         try {
-            certRecordStoreFactory = (CertRecordStoreFactory) Class.forName(certRecordStoreFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid CertRecordStoreFactory class: {} error: {}",
-                    certRecordStoreFactoryClass, e.getMessage());
+            certRecordStoreFactory = (CertRecordStoreFactory) Class.forName(certRecordStoreFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid CertRecordStoreFactory class: {}", certRecordStoreFactoryClass, ex);
             throw new IllegalArgumentException("Invalid cert record store factory class");
         }
 
@@ -478,10 +476,9 @@ public class InstanceCertManager {
 
         SSHRecordStoreFactory sshRecordStoreFactory;
         try {
-            sshRecordStoreFactory = (SSHRecordStoreFactory) Class.forName(sshRecordStoreFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid SSHRecordStoreFactory class: {} error: {}",
-                    sshRecordStoreFactoryClass, e.getMessage());
+            sshRecordStoreFactory = (SSHRecordStoreFactory) Class.forName(sshRecordStoreFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid SSHRecordStoreFactory class: {}", sshRecordStoreFactoryClass, ex);
             throw new IllegalArgumentException("Invalid ssh record store factory class");
         }
 
@@ -499,10 +496,9 @@ public class InstanceCertManager {
 
         WorkloadRecordStoreFactory workloadRecordStoreFactory;
         try {
-            workloadRecordStoreFactory = (WorkloadRecordStoreFactory) Class.forName(workloadRecordStoreFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid WorkloadRecordStoreFactory class: {} error: {}",
-                    workloadRecordStoreFactoryClass, e.getMessage());
+            workloadRecordStoreFactory = (WorkloadRecordStoreFactory) Class.forName(workloadRecordStoreFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid WorkloadRecordStoreFactory class: {}", workloadRecordStoreFactoryClass, ex);
             throw new IllegalArgumentException("Invalid workload record store factory class");
         }
 
@@ -1233,10 +1229,10 @@ public class InstanceCertManager {
         return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
     }
 
-    class ExpiredX509CertRecordCleaner implements Runnable {
+    static class ExpiredX509CertRecordCleaner implements Runnable {
         
-        private CertRecordStore store;
-        private int expiryTimeMins;
+        private final CertRecordStore store;
+        private final int expiryTimeMins;
         
         public ExpiredX509CertRecordCleaner(CertRecordStore store, int expiryTimeMins) {
             this.store = store;
@@ -1270,10 +1266,10 @@ public class InstanceCertManager {
         }
     }
 
-    class ExpiredSSHCertRecordCleaner implements Runnable {
+    static class ExpiredSSHCertRecordCleaner implements Runnable {
 
-        private SSHRecordStore store;
-        private int expiryTimeMins;
+        private final SSHRecordStore store;
+        private final int expiryTimeMins;
 
         public ExpiredSSHCertRecordCleaner(SSHRecordStore store, int expiryTimeMins) {
             this.store = store;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/SshHostCsr.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/SshHostCsr.java
@@ -17,15 +17,12 @@
 package com.yahoo.athenz.zts.cert;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A temporary class to help with transitioning to SSHCertRequest
  */
 @JsonInclude(JsonInclude.Include.ALWAYS)
 public class SshHostCsr {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SshHostCsr.class);
 
     private String[] principals;
     private String[] xPrincipals;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/AWSZTSHealthNotificationTask.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/AWSZTSHealthNotificationTask.java
@@ -96,7 +96,7 @@ public class AWSZTSHealthNotificationTask implements NotificationTask {
         private static final String AWS_ZTS_HEALTH_SUBJECT = "athenz.notification.email.aws.zts.health.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailAwsZtsHealthBody;
+        private final String emailAwsZtsHealthBody;
 
         public AWSZTSHealthNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTask.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTask.java
@@ -147,7 +147,7 @@ public class CertFailedRefreshNotificationTask implements NotificationTask {
         }
 
         List<String> snoozeTagValues = domainData.getTags().get(SNOOZED_DOMAIN_TAG_KEY).getList();
-        return snoozeTagValues.stream().anyMatch(value -> value.toLowerCase().equals(SNOOZED_DOMAIN_TAG_VALUE));
+        return snoozeTagValues.stream().anyMatch(value -> value.equalsIgnoreCase(SNOOZED_DOMAIN_TAG_VALUE));
     }
 
     private List<Notification> generateNotificationsForAdmins(Map<String, List<X509CertRecord>> domainToCertRecordsMap) {
@@ -170,7 +170,7 @@ public class CertFailedRefreshNotificationTask implements NotificationTask {
     private List<X509CertRecord> getRecordsWithValidHosts(List<X509CertRecord> unrefreshedCerts) {
         unrefreshedCerts.stream()
                 .filter(record -> StringUtil.isEmpty(record.getHostName()))
-                .peek(record -> LOGGER.warn("Record with empty hostName: {}", record.toString()))
+                .peek(record -> LOGGER.warn("Record with empty hostName: {}", record))
                 .collect(Collectors.toList());
 
         // Filter all records with non existing hosts or hosts not recognized by DNS
@@ -234,7 +234,7 @@ public class CertFailedRefreshNotificationTask implements NotificationTask {
         private static final String DEFAULT_ATHENZ_GUIDE = "https://athenz.github.io/athenz/";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailUnrefreshedCertsBody;
+        private final String emailUnrefreshedCertsBody;
         private final String serverName;
         private final int httpsPort;
         private final String athenzGuide;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/ZTSClientNotificationSenderImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/ZTSClientNotificationSenderImpl.java
@@ -44,10 +44,10 @@ public class ZTSClientNotificationSenderImpl implements ZTSClientNotificationSen
         this.notificationManager = notificationManager;
         this.rolesProvider = rolesProvider;
         this.serverName = serverName;
-        if (notificationManager != null) {
+        if (this.notificationManager != null) {
             this.notificationToEmailConverterCommon = new NotificationToEmailConverterCommon(notificationManager.getNotificationUserAuthority());
         }
-        if (this.notificationManager != null && this.rolesProvider != null && !StringUtil.isEmpty(this.serverName) && this.notificationToEmailConverterCommon != null) {
+        if (this.notificationManager != null && this.rolesProvider != null && !StringUtil.isEmpty(this.serverName)) {
             this.isInit = true;
         } else {
             LOGGER.warn("ZTSClientNotificationSenderImpl must be initiated with all arguments before it can be used");

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/RequireRoleCertCache.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/RequireRoleCertCache.java
@@ -162,7 +162,7 @@ public class RequireRoleCertCache {
         if (roleMembers == null) {
             roleMembers = new ArrayList<>();
         }
-        List<String> roles = roleMembers.stream().map(roleMemberCache -> roleMemberCache.getRole()).collect(Collectors.toList());
+        List<String> roles = roleMembers.stream().map(RoleMemberCache::getRole).collect(Collectors.toList());
         roles.addAll(requireRoleCertWildcard);
         roles.addAll(requireRoleCertPrefixTrie.findMatchingValues(principal));
         return roles;
@@ -215,7 +215,7 @@ public class RequireRoleCertCache {
                 AuthzHelper.isMemberExpired(member.getRoleMember().getExpiration(), currentTime);
     }
 
-    class RoleMemberCache {
+    static class RoleMemberCache {
         public RoleMemberCache(RoleMember roleMember, String role) {
             this.roleMember = roleMember;
             this.role = role;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/RolePrefixTrie.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/RolePrefixTrie.java
@@ -29,9 +29,9 @@ public class RolePrefixTrie implements PrefixTrie<String> {
 
     private final TrieNode root = new TrieNode();
 
-    private class TrieNode {
-        private HashMap<String, TrieNode> children = new HashMap<>();
-        private Set<String> roles = new HashSet<>();
+    private static class TrieNode {
+        private final HashMap<String, TrieNode> children = new HashMap<>();
+        private final Set<String> roles = new HashSet<>();
     }
 
     @Override

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStore.java
@@ -27,10 +27,10 @@ public class DynamoDBWorkloadRecordStore implements WorkloadRecordStore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DynamoDBWorkloadRecordStore.class);
 
-    private String tableName;
-    private String serviceIndexName;
-    private String ipIndexName;
-    private DynamoDB dynamoDB;
+    private final String tableName;
+    private final String serviceIndexName;
+    private final String ipIndexName;
+    private final DynamoDB dynamoDB;
 
     public DynamoDBWorkloadRecordStore(AmazonDynamoDB client, String tableName, String serviceIndexName, String ipIndexName) {
         this.dynamoDB = new DynamoDB(client);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreConnection.java
@@ -57,12 +57,12 @@ public class DynamoDBWorkloadRecordStoreConnection implements WorkloadRecordStor
 
     private static long expiryTime = 3660 * Long.parseLong(
             System.getProperty(ZTSConsts.ZTS_PROP_WORKLOAD_DYNAMODB_ITEM_TTL_HOURS, "720"));
-    private Table table;
+    private final Table table;
     private final Index serviceIndex;
     private final Index ipIndex;
 
     public DynamoDBWorkloadRecordStoreConnection(DynamoDB dynamoDB, final String tableName, final String serviceIndex, final String ipIndex) {
-        table = dynamoDB.getTable(tableName);
+        this.table = dynamoDB.getTable(tableName);
         this.serviceIndex = table.getIndex(serviceIndex);
         this.ipIndex = table.getIndex(ipIndex);
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import static com.yahoo.athenz.common.ServerCommonConsts.PROP_ATHENZ_CONF;
 import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_FILE_NAME;
-import static org.testng.Assert.fail;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertEquals;
@@ -38,7 +37,6 @@ import com.yahoo.athenz.common.metrics.Metric;
 import com.yahoo.athenz.common.server.dns.HostnameResolver;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
 import com.yahoo.athenz.zts.store.MockZMSFileChangeLogStore;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ResourceExceptionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ResourceExceptionTest.java
@@ -70,6 +70,6 @@ public class ResourceExceptionTest {
     public void testGetDataCast() {
         
         ResourceException exc = new ResourceException(400, 5000);
-        assertEquals(exc.getData(Integer.class), new Integer(5000));
+        assertEquals(exc.getData(Integer.class), Integer.valueOf(5000));
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cache/DataCacheTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cache/DataCacheTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.*;
 import java.util.*;
 
 import com.yahoo.athenz.zts.ZTSTestUtils;
-import org.hamcrest.MatcherAssert;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.zms.Assertion;

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -1359,10 +1359,8 @@ public class InstanceCertManagerTest {
         CertRecordStore store = Mockito.mock(CertRecordStore.class);
         when(store.getConnection()).thenThrow(new RuntimeException("invalid connection"));
 
-        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, true, null);
-
         InstanceCertManager.ExpiredX509CertRecordCleaner cleaner =
-                instanceManager.new ExpiredX509CertRecordCleaner(store, 100);
+                new InstanceCertManager.ExpiredX509CertRecordCleaner(store, 100);
 
         // make sure no exceptions are thrown
 
@@ -1372,14 +1370,12 @@ public class InstanceCertManagerTest {
     @Test
     public void testExpiredSSHCertRecordCleaner() {
 
-        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, true, null);
-
         FileSSHRecordStoreFactory factory = new FileSSHRecordStoreFactory();
         SSHRecordStore store = factory.create(null);
         assertNotNull(store);
 
         InstanceCertManager.ExpiredSSHCertRecordCleaner cleaner =
-                instanceManager.new ExpiredSSHCertRecordCleaner(store, 100);
+                new InstanceCertManager.ExpiredSSHCertRecordCleaner(store, 100);
 
         // make sure no exceptions are thrown
 
@@ -1392,10 +1388,8 @@ public class InstanceCertManagerTest {
         SSHRecordStore store = Mockito.mock(SSHRecordStore.class);
         when(store.getConnection()).thenThrow(new RuntimeException("invalid connection"));
 
-        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, true, null);
-
         InstanceCertManager.ExpiredSSHCertRecordCleaner cleaner =
-                instanceManager.new ExpiredSSHCertRecordCleaner(store, 100);
+                new InstanceCertManager.ExpiredSSHCertRecordCleaner(store, 100);
 
         // make sure no exceptions are thrown
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
@@ -709,8 +709,8 @@ public class CertFailedRefreshNotificationTaskTest {
         Map<String, String> details = new HashMap<>();
         details.put("domain", "dom1");
         details.put(NOTIFICATION_DETAILS_UNREFRESHED_CERTS,
-                        "service0;provider0;instanceID0;" + fiveDaysAgo.toString() + ";" + twentyFiveDaysFromNow + ";hostName1|" +
-                        "service1;provider1;instanceID1;" + fiveDaysAgo.toString() + ";" + twentyFiveDaysFromNow + ";hostName2");
+                        "service0;provider0;instanceID0;" + fiveDaysAgo + ";" + twentyFiveDaysFromNow + ";hostName1|" +
+                        "service1;provider1;instanceID1;" + fiveDaysAgo + ";" + twentyFiveDaysFromNow + ";hostName2");
 
         Notification notification = new Notification();
         notification.setDetails(details);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/RolePrefixTrieTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/RolePrefixTrieTest.java
@@ -74,7 +74,7 @@ public class RolePrefixTrieTest {
         return rolePrefixTrie;
     }
 
-    private class insertJob implements Runnable {
+    private static class insertJob implements Runnable {
         private final String prefix;
         private final String role;
         private final RolePrefixTrie rolePrefixTrie;
@@ -90,7 +90,7 @@ public class RolePrefixTrieTest {
         }
     }
 
-    private class findAndAssertJob implements Runnable {
+    private static class findAndAssertJob implements Runnable {
         private final String principal;
         private final RolePrefixTrie rolePrefixTrie;
         private final String[] roles;
@@ -131,8 +131,7 @@ public class RolePrefixTrieTest {
         try {
             es.shutdown();
             es.awaitTermination(1, TimeUnit.MINUTES);
-        } catch (InterruptedException e) {
-
+        } catch (InterruptedException ignored) {
         }
         return rolePrefixTrie;
     }
@@ -197,8 +196,7 @@ public class RolePrefixTrieTest {
         try {
             es.shutdown();
             es.awaitTermination(1, TimeUnit.MINUTES);
-        } catch (InterruptedException e) {
-
+        } catch (InterruptedException ignored) {
         }
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreConnectionTest.java
@@ -52,7 +52,7 @@ public class DynamoDBWorkloadRecordStoreConnectionTest {
 
     @BeforeMethod
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.doReturn(table).when(dynamoDB).getTable(tableName);
         Mockito.doReturn(serviceIndex).when(table).getIndex(serviceIndexName);
         Mockito.doReturn(ipIndex).when(table).getIndex(ipIndexName);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreFactoryTest.java
@@ -49,7 +49,7 @@ public class DynamoDBWorkloadRecordStoreFactoryTest {
 
     @BeforeMethod
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.doReturn(table).when(dynamoDB).getTable("Workloads-Table");
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/DynamoDBWorkloadRecordStoreTest.java
@@ -31,7 +31,7 @@ public class DynamoDBWorkloadRecordStoreTest {
 
     @BeforeMethod
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/JDBCWorkloadRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/workload/impl/JDBCWorkloadRecordStoreConnectionTest.java
@@ -40,7 +40,7 @@ public class JDBCWorkloadRecordStoreConnectionTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.doReturn(mockConn).when(mockDataSrc).getConnection();
         Mockito.doReturn(mockStmt).when(mockConn).createStatement();
         Mockito.doReturn(mockResultSet).when(mockPrepStmt).executeQuery();


### PR DESCRIPTION
Changes include:
- replace deprecated calls
- mark fields as final when possible
- remove unused imports, fields, arguments
- replace function references with lambdas when possible