### PR TITLE
zms server code cleanup - replace deprecated calls, etc

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -87,7 +87,7 @@ public class DBService implements RolesProvider {
     private static final String GCP_ARN_PREFIX  = "projects/";
 
     AuditReferenceValidator auditReferenceValidator;
-    private ScheduledExecutorService userAuthorityFilterExecutor;
+    private final ScheduledExecutorService userAuthorityFilterExecutor;
     protected DynamicConfigInteger purgeMembersMaxDbCallsPerRun;
     protected DynamicConfigInteger purgeMembersLimitPerCall;
     protected DynamicConfigInteger purgeMemberExpiryDays;
@@ -6446,17 +6446,17 @@ public class DBService implements RolesProvider {
     boolean updateUserAuthorityExpiry(RoleMember roleMember, final String userAuthorityExpiry) {
         return updateUserAuthorityExpiry(roleMember,
                 userAuthorityExpiry,
-                member -> member.getExpiration(),
-                (member, timestamp) -> member.setExpiration(timestamp),
-                member -> member.getMemberName());
+                RoleMember::getExpiration,
+                RoleMember::setExpiration,
+                RoleMember::getMemberName);
     }
 
     boolean updateUserAuthorityExpiry(GroupMember groupMember, final String userAuthorityExpiry) {
         return updateUserAuthorityExpiry(groupMember,
                 userAuthorityExpiry,
-                member -> member.getExpiration(),
-                (member, timestamp) -> member.setExpiration(timestamp),
-                member -> member.getMemberName());
+                GroupMember::getExpiration,
+                GroupMember::setExpiration,
+                GroupMember::getMemberName);
     }
 
     List<RoleMember> getRoleMembersWithUpdatedDisabledState(List<RoleMember> roleMembers, final String roleUserAuthorityFilter,
@@ -6553,11 +6553,11 @@ public class DBService implements RolesProvider {
                 userAuthorityExpiry,
                 null,
                 0,
-                member -> member.getExpiration(),
+                GroupMember::getExpiration,
                 member -> null,
-                (member, timestamp) -> member.setExpiration(timestamp),
+                GroupMember::setExpiration,
                 (member, timestamp) -> { },
-                member -> member.getMemberName());
+                GroupMember::getMemberName);
     }
 
     <T> List<T> getMembersWithUpdatedDueDates(List<T> members, Timestamp userExpiration,
@@ -6660,11 +6660,11 @@ public class DBService implements RolesProvider {
                 userAuthorityExpiry,
                 groupReview,
                 groupReviewMillis,
-                member -> member.getExpiration(),
-                member -> member.getReviewReminder(),
-                (member, timestamp) -> member.setExpiration(timestamp),
-                (member, timestamp) -> member.setReviewReminder(timestamp),
-                member -> member.getMemberName());
+                RoleMember::getExpiration,
+                RoleMember::getReviewReminder,
+                RoleMember::setExpiration,
+                RoleMember::setReviewReminder,
+                RoleMember::getMemberName);
     }
 
     private boolean insertRoleMembers(ResourceContext ctx, ObjectStoreConnection con, List<RoleMember> roleMembers,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -71,8 +71,8 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_AWS_RDS_IAM_ROLE           = "athenz.zms.aws_rds_iam_role";
     public static final String ZMS_PROP_AWS_RDS_ENGINE             = "athenz.zms.aws_rds_engine";
     public static final String ZMS_PROP_AWS_RDS_DATABASE           = "athenz.zms.aws_rds_database";
-    public static final String ZMS_PROP_AWS_RDS_MASTER_INSTANCE    = "athenz.zms.aws_rds_master_instance";
-    public static final String ZMS_PROP_AWS_RDS_MASTER_PORT        = "athenz.zms.aws_rds_master_port";
+    public static final String ZMS_PROP_AWS_RDS_PRIMARY_INSTANCE   = "athenz.zms.aws_rds_master_instance";
+    public static final String ZMS_PROP_AWS_RDS_PRIMARY_PORT       = "athenz.zms.aws_rds_master_port";
     public static final String ZMS_PROP_AWS_RDS_REPLICA_INSTANCE   = "athenz.zms.aws_rds_replica_instance";
     public static final String ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME = "athenz.zms.aws_rds_creds_refresh_time";
     public static final String ZMS_AUTO_UPDATE_TEMPLATE_FEATURE_FLAG = "athenz.zms.auto_update_template_feature_flag";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -746,7 +746,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     private void initializeServiceProviderManager() {
         try {
             serviceProviderManager = ServiceProviderManager.getInstance(dbService, this);
-            serviceProviderClient = new ServiceProviderClient(keyStore, serviceProviderManager, homeDomainPrefix);
+            serviceProviderClient = new ServiceProviderClient(keyStore, homeDomainPrefix);
         } catch (KeyRefresherException | IOException | InterruptedException e) {
             throw new RuntimeException("Failed to initialize service provider manager: " + e.getMessage());
         }
@@ -973,9 +973,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 ZMSConsts.ZMS_OBJECT_STORE_FACTORY_CLASS);
         ObjectStoreFactory objFactory;
         try {
-            objFactory = (ObjectStoreFactory) Class.forName(objFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid ObjectStoreFactory class: {} error: {}", objFactoryClass, e.getMessage());
+            objFactory = (ObjectStoreFactory) Class.forName(objFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid ObjectStoreFactory class: {}", objFactoryClass, ex);
             throw new IllegalArgumentException("Invalid object store");
         }
 
@@ -1005,9 +1005,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         AuthHistoryStoreFactory authHistoryStoreFactory;
         try {
-            authHistoryStoreFactory = (AuthHistoryStoreFactory) Class.forName(authHistoryFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid AuthHistoryStoreFactory class: {}", authHistoryFactoryClass, e);
+            authHistoryStoreFactory = (AuthHistoryStoreFactory) Class.forName(authHistoryFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid AuthHistoryStoreFactory class: {}", authHistoryFactoryClass, ex);
             throw new IllegalArgumentException("Invalid auth history store");
         }
 
@@ -1020,9 +1020,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 METRIC_DEFAULT_FACTORY_CLASS);
         MetricFactory metricFactory;
         try {
-            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid MetricFactory class: {} error: {}", metricFactoryClass, e.getMessage());
+            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid MetricFactory class: {}", metricFactoryClass, ex);
             throw new IllegalArgumentException("Invalid metric class");
         }
 
@@ -1038,9 +1038,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 ZMSConsts.ZMS_PRIVATE_KEY_STORE_FACTORY_CLASS);
         PrivateKeyStoreFactory pkeyFactory;
         try {
-            pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid PrivateKeyStoreFactory class: {} error: {}", pkeyFactoryClass, e.getMessage());
+            pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid PrivateKeyStoreFactory class: {}", pkeyFactoryClass, ex);
             throw new IllegalArgumentException("Invalid private key store");
         }
 
@@ -1063,10 +1063,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             StringBuilder privKeyId = new StringBuilder(256);
             PrivateKey pkey = keyStore.getPrivateKey(ZMSConsts.ZMS_SERVICE, serverHostName, privKeyId);
             privateKey = new ServerPrivateKey(pkey, privKeyId.toString());
-        } else if (privateECKey != null) {
-            privateKey = privateECKey;
         } else {
-            privateKey = privateRSAKey;
+            privateKey = Objects.requireNonNullElseGet(privateECKey, () -> privateRSAKey);
         }
     }
 
@@ -1076,9 +1074,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 ZMSConsts.ZMS_DOMAIN_META_STORE_FACTORY_CLASS);
         DomainMetaStoreFactory metaStoreFactory;
         try {
-            metaStoreFactory = (DomainMetaStoreFactory) Class.forName(metaStoreFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid DomainMetaStoreFactory class: {} error: {}", metaStoreFactoryClass, e.getMessage());
+            metaStoreFactory = (DomainMetaStoreFactory) Class.forName(metaStoreFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid DomainMetaStoreFactory class: {}", metaStoreFactoryClass, ex);
             throw new IllegalArgumentException("Invalid metastore factory");
         }
 
@@ -1122,9 +1120,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         AuditLoggerFactory auditLogFactory;
 
         try {
-            auditLogFactory = (AuditLoggerFactory) Class.forName(auditFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid AuditLoggerFactory class: {} error: {}", auditFactoryClass, e.getMessage());
+            auditLogFactory = (AuditLoggerFactory) Class.forName(auditFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid AuditLoggerFactory class: {}", auditFactoryClass, ex);
             throw new IllegalArgumentException("Invalid audit logger class");
         }
 
@@ -1140,9 +1138,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         if (!StringUtil.isEmpty(auditRefValidatorClass)) {
 
             try {
-                auditReferenceValidatorFactory = (AuditReferenceValidatorFactory) Class.forName(auditRefValidatorClass).newInstance();
-            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-                LOG.error("Invalid AuditReferenceValidatorFactory class: {} error: {}", auditRefValidatorClass, e.getMessage());
+                auditReferenceValidatorFactory = (AuditReferenceValidatorFactory) Class.forName(auditRefValidatorClass).getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                LOG.error("Invalid AuditReferenceValidatorFactory class: {}", auditRefValidatorClass, ex);
                 throw new IllegalArgumentException("Invalid audit reference factory class");
             }
 
@@ -1255,9 +1253,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         if (!StringUtil.isEmpty(statusCheckerFactoryClass)) {
 
             try {
-                statusCheckerFactory = (StatusCheckerFactory) Class.forName(statusCheckerFactoryClass).newInstance();
-            } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-                LOG.error("Invalid StatusCheckerFactory class: {} error: {}", statusCheckerFactoryClass, e.getMessage());
+                statusCheckerFactory = (StatusCheckerFactory) Class.forName(statusCheckerFactoryClass).getDeclaredConstructor().newInstance();
+            } catch (Exception ex) {
+                LOG.error("Invalid StatusCheckerFactory class: {}", statusCheckerFactoryClass, ex);
                 throw new IllegalArgumentException("Invalid status checker factory class");
             }
 
@@ -1272,7 +1270,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         final String caller = "initstore";
 
         List<String> domains = dbService.listDomains(null, 0, true);
-        if (domains.size() > 0 && domains.contains(SYS_AUTH)) {
+        if (!domains.isEmpty() && domains.contains(SYS_AUTH)) {
             return;
         }
 
@@ -1628,7 +1626,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         }
 
         DomainList subDomainList = listDomains(null, null, domainName + ".", null, 0, true);
-        if (subDomainList.getNames().size() > 0) {
+        if (!subDomainList.getNames().isEmpty()) {
             throw ZMSUtils.requestError(caller + ": Cannot delete domain " +
                     domainName + ": " + subDomainList.getNames().size() + " subdomains of it exist", caller);
         }
@@ -1673,9 +1671,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         Map<String, ServiceProviderManager.DomainDependencyProvider> serviceProvidersWithEndpoints = serviceProviderManager.getServiceProvidersWithEndpoints();
         List<String> serviceDependenciesDenied = serviceProvidersWithEndpoints.values()
                 .parallelStream()
-                .map(domainDependencyProvider -> {
-                    return getErrorOnServiceProviderDeny(domainName, principal, domainDependencyProvider);
-                })
+                .map(domainDependencyProvider -> getErrorOnServiceProviderDeny(domainName, principal, domainDependencyProvider))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
@@ -2636,7 +2632,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // verify that all template names are valid
 
         List<String> templateNames = domainTemplate.getTemplateNames();
-        if (templateNames == null || templateNames.size() == 0) {
+        if (ZMSUtils.isCollectionEmpty(templateNames)) {
             throw ZMSUtils.requestError("putDomainTemplate: No templates specified", caller);
         }
         validateSolutionTemplates(templateNames, caller);
@@ -2681,7 +2677,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // verify that all template names are valid
 
         List<String> templateNames = domainTemplate.getTemplateNames();
-        if (templateNames == null || templateNames.size() == 0) {
+        if (ZMSUtils.isCollectionEmpty(templateNames)) {
             throw ZMSUtils.requestError("putDomainTemplateExt: No templates specified", caller);
         }
 
@@ -3564,7 +3560,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // filter roles by their tags
         if (tagKey != null) {
             roles = roles.stream()
-                    .filter(role -> filterByTag(tagKey, tagValue, role, collection -> collection.getTags()))
+                    .filter(role -> filterByTag(tagKey, tagValue, role, Role::getTags))
                     .collect(Collectors.toList());
         }
 
@@ -4336,18 +4332,18 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         updateMemberDueDate(
                 memberExpiryDueDays,
                 roleMembers,
-                roleMember -> roleMember.getExpiration(),
-                (roleMember, expiration) -> roleMember.setExpiration(expiration),
-                roleMember -> roleMember.getPrincipalType());
+                RoleMember::getExpiration,
+                RoleMember::setExpiration,
+                RoleMember::getPrincipalType);
     }
 
     void updateRoleMemberReviewReminder(MemberDueDays memberReminderDueDays, List<RoleMember> roleMembers) {
         updateMemberDueDate(
                 memberReminderDueDays,
                 roleMembers,
-                roleMember -> roleMember.getReviewReminder(),
-                (roleMember, reviewReminder) -> roleMember.setReviewReminder(reviewReminder),
-                roleMember -> roleMember.getPrincipalType());
+                RoleMember::getReviewReminder,
+                RoleMember::setReviewReminder,
+                RoleMember::getPrincipalType);
     }
 
     private <T> void updateMemberDueDate(MemberDueDays memberDueDays,
@@ -5827,7 +5823,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // It's okay to not specify any public keys
 
         List<PublicKeyEntry> publicKeyList = service.getPublicKeys();
-        if (publicKeyList == null || publicKeyList.size() == 0) {
+        if (ZMSUtils.isCollectionEmpty(publicKeyList)) {
             return true;
         }
 
@@ -6587,7 +6583,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
             DomainMetaList dmlist = dbService.listModifiedDomains(timestamp, !readOnlyMode.get());
             List<Domain> modlist = dmlist.getDomains();
-            if (modlist == null || modlist.size() == 0) {
+            if (ZMSUtils.isCollectionEmpty(modlist)) {
                 return Response.status(ResourceException.NOT_MODIFIED)
                         .header("ETag", matchingTag).build();
             }
@@ -7358,8 +7354,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // we must have at least one role in the object
 
-        List<TenantRoleAction> list = roles.getRoles();
-        return (list != null && list.size() > 0);
+        return (!ZMSUtils.isCollectionEmpty(roles.getRoles()));
     }
 
     boolean validateProviderResourceGroupRolesObject(ProviderResourceGroupRoles roles, final String providerDomain,
@@ -7380,8 +7375,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // we must have at least one role in the object
 
-        List<TenantRoleAction> list = roles.getRoles();
-        return (list != null && list.size() > 0);
+        return (!ZMSUtils.isCollectionEmpty(roles.getRoles()));
     }
 
     // put the trust roles into provider domain
@@ -7781,7 +7775,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         List<String> dependentResourceGroups = getDependentServiceResourceGroupList(tenantDomain).getServiceAndResourceGroups().stream()
                 .filter(dependency -> dependency.getDomain().equals(tenantDomain) && dependency.getService().equals(provider))
                 .findAny()
-                .map(dependency -> dependency.getResourceGroups())
+                .map(DependentServiceResourceGroup::getResourceGroups)
                 .orElse(new ArrayList<>());
 
         return !dependentResourceGroups.isEmpty();
@@ -8174,7 +8168,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         final String caller = "validatedadminusers";
 
-        if (lst == null || lst.size() == 0) {
+        if (ZMSUtils.isCollectionEmpty(lst)) {
             throw ZMSUtils.requestError("validatedAdminUsers: Missing adminUsers", caller);
         }
         Set<String> users = new HashSet<>();
@@ -8972,9 +8966,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         Authority authority;
         try {
-            authority = (Authority) Class.forName(className).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid Authority class: {} error: {}", className, e.getMessage());
+            authority = (Authority) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid Authority class: {}", className, ex);
             return null;
         }
         return authority;
@@ -9641,7 +9635,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // filter groups by their tags
         if (tagKey != null) {
             groups = groups.stream()
-                    .filter(group -> filterByTag(tagKey, tagValue, group, collection -> collection.getTags()))
+                    .filter(group -> filterByTag(tagKey, tagValue, group, Group::getTags))
                     .collect(Collectors.toList());
         }
 
@@ -9912,8 +9906,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         updateGroupMemberDueDate(
                 memberExpiryDueDays,
                 groupMembers,
-                groupMember -> groupMember.getExpiration(),
-                (groupMember, expiration) -> groupMember.setExpiration(expiration));
+                GroupMember::getExpiration,
+                GroupMember::setExpiration);
     }
 
     private void updateGroupMemberDueDate(MemberDueDays memberExpiryDueDays,
@@ -9926,7 +9920,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 groupMembers,
                 dueDateGetter,
                 dueDateSetter,
-                groupMember -> groupMember.getPrincipalType());
+                GroupMember::getPrincipalType);
     }
 
     @Override

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingRoleMembershipApprovalNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingRoleMembershipApprovalNotificationTask.java
@@ -34,7 +34,7 @@ public class PendingRoleMembershipApprovalNotificationTask implements Notificati
     private final DBService dbService;
     private final int pendingRoleMemberLifespan;
     private final String monitorIdentity;
-    private NotificationCommon notificationCommon;
+    private final NotificationCommon notificationCommon;
     private final static String DESCRIPTION = "pending role membership approvals reminders";
     private final PendingRoleMembershipApprovalNotificationToEmailConverter pendingMembershipApprovalNotificationToEmailConverter;
     private final PendingRoleMembershipApprovalNotificationToMetricConverter pendingRoleMembershipApprovalNotificationToMetricConverter;
@@ -70,7 +70,7 @@ public class PendingRoleMembershipApprovalNotificationTask implements Notificati
         private static final String MEMBERSHIP_APPROVAL_REMINDER_SUBJECT = "athenz.notification.email.membership.reminder.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailMembershipApprovalReminderBody;
+        private final String emailMembershipApprovalReminderBody;
 
         public PendingRoleMembershipApprovalNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTask.java
@@ -35,8 +35,8 @@ public class PutRoleMembershipNotificationTask implements NotificationTask {
     final String domain;
     final String org;
     final Role role;
-    private Map<String, String> details;
-    private NotificationCommon notificationCommon;
+    private final Map<String, String> details;
+    private final NotificationCommon notificationCommon;
     private final static String DESCRIPTION = "Membership Approval Notification";
     private final PutMembershipNotificationToEmailConverter putMembershipNotificationToEmailConverter;
     private final PutMembershipNotificationToMetricConverter putMembershipNotificationToMetricConverter;
@@ -112,7 +112,7 @@ public class PutRoleMembershipNotificationTask implements NotificationTask {
         private static final String MEMBERSHIP_APPROVAL_SUBJECT = "athenz.notification.email.membership.approval.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailMembershipApprovalBody;
+        private final String emailMembershipApprovalBody;
 
         public PutMembershipNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
@@ -139,7 +139,7 @@ public class RoleMemberExpiryNotificationTask implements NotificationTask {
         private static final String PRINCIPAL_EXPIRY_SUBJECT = "athenz.notification.email.role_member.expiry.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailPrincipalExpiryBody;
+        private final String emailPrincipalExpiryBody;
 
         public RoleExpiryPrincipalNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;
@@ -175,7 +175,7 @@ public class RoleMemberExpiryNotificationTask implements NotificationTask {
         private static final String DOMAIN_MEMBER_EXPIRY_SUBJECT = "athenz.notification.email.domain.role_member.expiry.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailDomainMemberExpiryBody;
+        private final String emailDomainMemberExpiryBody;
 
         public RoleExpiryDomainNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTask.java
@@ -116,7 +116,7 @@ public class RoleMemberReviewNotificationTask implements NotificationTask {
         private static final String PRINCIPAL_REVIEW_SUBJECT = "athenz.notification.email.role_member.review.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailPrincipalReviewBody;
+        private final String emailPrincipalReviewBody;
 
         public RoleReviewPrincipalNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;
@@ -153,7 +153,7 @@ public class RoleMemberReviewNotificationTask implements NotificationTask {
         private static final String DOMAIN_MEMBER_REVIEW_SUBJECT = "athenz.notification.email.domain.role_member.review.subject";
 
         private final NotificationToEmailConverterCommon notificationToEmailConverterCommon;
-        private String emailDomainMemberReviewBody;
+        private final String emailDomainMemberReviewBody;
 
         public RoleReviewDomainNotificationToEmailConverter(NotificationToEmailConverterCommon notificationToEmailConverterCommon) {
             this.notificationToEmailConverterCommon = notificationToEmailConverterCommon;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/provider/ServiceProviderClient.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/provider/ServiceProviderClient.java
@@ -44,10 +44,12 @@ public class ServiceProviderClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceProviderClient.class);
 
-    public ServiceProviderClient(PrivateKeyStore keyStore, ServiceProviderManager serviceProviderManager, String homeDomainPrefix) throws KeyRefresherException, IOException, InterruptedException {
+    public ServiceProviderClient(PrivateKeyStore keyStore, String homeDomainPrefix)
+            throws KeyRefresherException, IOException, InterruptedException {
+
         SSLContext sslContext = getDomainDependencyProviderSSLContext(keyStore);
         if (sslContext != null) {
-            this.httpDriver = getHttpDriver(sslContext, serviceProviderManager);
+            this.httpDriver = getHttpDriver(sslContext);
             this.homeDomainPrefix = homeDomainPrefix;
         } else {
             this.httpDriver = null;
@@ -60,7 +62,10 @@ public class ServiceProviderClient {
         this.homeDomainPrefix = homeDomainPrefix;
     }
 
-    public DomainDependencyProviderResponse getDependencyStatus(ServiceProviderManager.DomainDependencyProvider domainDependencyProvider, String domain, String principal) {
+    public DomainDependencyProviderResponse getDependencyStatus(
+            ServiceProviderManager.DomainDependencyProvider domainDependencyProvider,
+            String domain, String principal) {
+
         if (this.httpDriver == null) {
             // ServiceProviderClient wasn't initialized. Do not enforce dependency check.
             DomainDependencyProviderResponse domainDependencyProviderResponse = new DomainDependencyProviderResponse();
@@ -95,14 +100,17 @@ public class ServiceProviderClient {
         }
     }
 
-    private SSLContext getDomainDependencyProviderSSLContext(PrivateKeyStore keyStore) throws KeyRefresherException, IOException, InterruptedException {
+    private SSLContext getDomainDependencyProviderSSLContext(PrivateKeyStore keyStore)
+            throws KeyRefresherException, IOException, InterruptedException {
+
         final String trustStore = System.getProperty(ZMSConsts.ZMS_PROP_PROVIDER_TRUST_STORE, "");
         final String trustStorePassword = System.getProperty(ZMSConsts.ZMS_PROP_PROVIDER_TRUST_STORE_PASSWORD, "");
         final String appName = System.getProperty(ZMSConsts.ZMS_PROP_PROVIDER_APP_NAME, "");
         final String certPath = System.getProperty(ZMSConsts.ZMS_PROP_PROVIDER_CERT_PATH, "");
         final String keyPath = System.getProperty(ZMSConsts.ZMS_PROP_PROVIDER_KEY_PATH, "");
 
-        if (StringUtil.isEmpty(trustStore) || StringUtil.isEmpty(certPath) || StringUtil.isEmpty(keyPath) || StringUtil.isEmpty(trustStorePassword)) {
+        if (StringUtil.isEmpty(trustStore) || StringUtil.isEmpty(certPath) ||
+                StringUtil.isEmpty(keyPath) || StringUtil.isEmpty(trustStorePassword)) {
             LOG.warn("ServiceProviderClient Configuration properties are missing. Providers will not be contacted when deleting domains.");
             return null;
         }
@@ -117,7 +125,7 @@ public class ServiceProviderClient {
                 keyRefresher.getTrustManagerProxy());
     }
 
-    private HttpDriver getHttpDriver(SSLContext sslContext, ServiceProviderManager serviceProviderManager) {
+    private HttpDriver getHttpDriver(SSLContext sslContext) {
 
         int maxPoolRoute = Integer.parseInt(System.getProperty(ZMS_PROP_PROVIDER_MAX_POOL_ROUTE, "45"));
         int maxPoolTotal = Integer.parseInt(System.getProperty(ZMS_PROP_PROVIDER_MAX_POOL_TOTAL, "50"));
@@ -136,9 +144,12 @@ public class ServiceProviderClient {
                 .build();
     }
 
-    private DomainDependencyProviderResponse getDependencyStatusFromProvider(ServiceProviderManager.DomainDependencyProvider domainDependencyProvider, String domain, String principal) throws IOException {
+    private DomainDependencyProviderResponse getDependencyStatusFromProvider(
+            ServiceProviderManager.DomainDependencyProvider domainDependencyProvider,
+            String domain, String principal) throws IOException {
+
         DomainDependencyProviderResponse domainDependencyProviderResponse = new DomainDependencyProviderResponse();
-        String url = getProviderEndpoint(domainDependencyProvider, domain);
+        String url = getProviderEndpoint(domainDependencyProvider);
 
         HttpPost httpPost = new HttpPost(url);
         httpPost.setHeader("Content-type", "application/json");
@@ -169,7 +180,7 @@ public class ServiceProviderClient {
         return domainDependencyProviderResponse;
     }
 
-    private String getProviderEndpoint(ServiceProviderManager.DomainDependencyProvider domainDependencyProvider, String domain) {
+    private String getProviderEndpoint(ServiceProviderManager.DomainDependencyProvider domainDependencyProvider) {
         String url = domainDependencyProvider.getProviderEndpoint();
         if (domainDependencyProvider.isInstanceProvider()) {
             if (!url.endsWith("/")) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/provider/ServiceProviderManager.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/provider/ServiceProviderManager.java
@@ -103,7 +103,8 @@ public class ServiceProviderManager {
             serviceProviders = Collections.emptyMap();
             return;
         }
-        Map<String, DomainDependencyProvider> serviceProvidersUpdatedMap = role.getRoleMembers().stream()
+
+        serviceProviders = role.getRoleMembers().stream()
                 .filter(roleMember -> !StringUtil.isEmpty(roleMember.getMemberName()))
                 .map(roleMember -> {
                     final String provider = roleMember.getMemberName();
@@ -119,8 +120,6 @@ public class ServiceProviderManager {
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toMap(DomainDependencyProvider::getProvider, Function.identity()));
-
-        serviceProviders = serviceProvidersUpdatedMap;
     }
 
     private boolean isServiceProviderAuthorizedLaunch(ServiceIdentity provSvcIdentity) {
@@ -134,11 +133,11 @@ public class ServiceProviderManager {
 
     /**
      * Checks if the given principal is an authorized service provider
-     * @param principal
+     * @param principal the service identity to check
      * @return True if principal is an authorized service provider. False otherwise
      */
     public boolean isServiceProvider(String principal) {
-        return !StringUtil.isEmpty(principal) && serviceProviders.keySet().contains(principal);
+        return !StringUtil.isEmpty(principal) && serviceProviders.containsKey(principal);
     }
 
     public void setServiceProviders(Map<String, DomainDependencyProvider> serviceProviders) {
@@ -149,13 +148,13 @@ public class ServiceProviderManager {
         return this.serviceProviders.entrySet()
                 .stream()
                 .filter(entry -> entry.getValue() != null && !StringUtil.isEmpty(entry.getValue().getProviderEndpoint()))
-                .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     public static class DomainDependencyProvider {
-        private String provider;
-        private String providerEndpoint;
-        private boolean isInstanceProvider;
+        private final String provider;
+        private final String providerEndpoint;
+        private final boolean isInstanceProvider;
 
         public DomainDependencyProvider(String provider, String providerEndpoint, boolean isInstanceProvider) {
             this.provider = provider;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/dynamodb/DynamoDBAuthHistoryStoreConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/dynamodb/DynamoDBAuthHistoryStoreConnection.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 
@@ -85,7 +86,7 @@ public class DynamoDBAuthHistoryStoreConnection implements AuthHistoryStoreConne
 
         return domainIndex.query(r -> r.queryConditional(queryConditional))
                 .stream()
-                .map(record -> record.items())
+                .map(Page::items)
                 .flatMap(List::stream)
                 .map(record -> {
                     AuthHistory authHistory = new AuthHistory();
@@ -105,8 +106,7 @@ public class DynamoDBAuthHistoryStoreConnection implements AuthHistoryStoreConne
             SimpleDateFormat formatter = new SimpleDateFormat("dd/MMM/yyyy:HH:mm:ss", Locale.ENGLISH);
             formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
             Date date = formatter.parse(authHistoryDynamoDBRecord.getTimestamp());
-            Timestamp timestamp = Timestamp.fromDate(date);
-            return timestamp;
+            return Timestamp.fromDate(date);
         } catch (ParseException e) {
             LOGGER.error("Error parsing timestamp for authHistoryDynamoDBRecord, timestamp will be empty: {}", authHistoryDynamoDBRecord);
             return null;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -25,6 +25,7 @@ import com.yahoo.rdl.JSON;
 import com.yahoo.rdl.Struct;
 import com.yahoo.rdl.Timestamp;
 import com.yahoo.rdl.UUID;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1104,7 +1105,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             throws SQLException {
 
         PreparedStatement ps;
-        if (prefix != null && prefix.length() > 0) {
+        if (!StringUtil.isEmpty(prefix)) {
             int len = prefix.length();
             char c = (char) (prefix.charAt(len - 1) + 1);
             String stop = prefix.substring(0, len - 1) + c;
@@ -1871,7 +1872,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             throws SQLException {
 
         PreparedStatement ps;
-        if (domainName != null && domainName.length() > 0) {
+        if (!StringUtils.isEmpty(domainName)) {
             final String principalPattern = domainName + ".%";
             ps = con.prepareStatement(SQL_LIST_PRINCIPAL_DOMAIN);
             ps.setString(1, principalPattern);
@@ -4404,7 +4405,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             throws SQLException {
 
         PreparedStatement ps;
-        if (action != null && action.length() > 0) {
+        if (!StringUtils.isEmpty(action)) {
             ps = con.prepareStatement(SQL_LIST_ROLE_ASSERTIONS + SQL_LIST_ROLE_ASSERTION_QUERY_ACTION);
             ps.setString(1, action);
         } else {

--- a/servers/zms/src/test/java/com/yahoo/athenz/common/messaging/MockDomainChangePublisher.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/common/messaging/MockDomainChangePublisher.java
@@ -35,7 +35,6 @@ public class MockDomainChangePublisher implements ChangePublisher<DomainChangeMe
 
     @Override
     public void close() {
-        
     }
 
     public static class Recorder {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalStateUpdaterTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalStateUpdaterTest.java
@@ -73,7 +73,7 @@ public class PrincipalStateUpdaterTest {
         Mockito.when(authority.getPrincipals(EnumSet.of(Principal.State.AUTHORITY_SYSTEM_SUSPENDED))).thenReturn(newSuspended);
 
         try {
-            PrincipalStateUpdater principalStateUpdater = new PrincipalStateUpdater(dbsvc, authority);
+            new PrincipalStateUpdater(dbsvc, authority);
         }catch (ResourceException rex){
             fail();
         }
@@ -98,7 +98,7 @@ public class PrincipalStateUpdaterTest {
         Mockito.when(authority.getPrincipals(EnumSet.of(Principal.State.AUTHORITY_SYSTEM_SUSPENDED))).thenReturn(Collections.emptyList());
         System.setProperty(ZMS_PROP_PRINCIPAL_STATE_UPDATER_DISABLE_TIMER, "true");
         try {
-            PrincipalStateUpdater principalStateUpdater = new PrincipalStateUpdater(dbsvc, authority);
+            new PrincipalStateUpdater(dbsvc, authority);
         }catch (ResourceException rex){
             fail();
         }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceExceptionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceExceptionTest.java
@@ -19,9 +19,6 @@ import static org.testng.Assert.*;
 
 import org.testng.annotations.Test;
 
-import com.yahoo.athenz.zms.ResourceException;
-
-
 public class ResourceExceptionTest {
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/TestUserPrincipalAuthority.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/TestUserPrincipalAuthority.java
@@ -1,6 +1,5 @@
 package com.yahoo.athenz.zms;
 
-import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.impl.PrincipalAuthority;
 
 class TestUserPrincipalAuthority extends PrincipalAuthority {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSServiceTagsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSServiceTagsTest.java
@@ -19,8 +19,6 @@
 package com.yahoo.athenz.zms;
 
 import com.yahoo.athenz.auth.util.AthenzUtils;
-import com.yahoo.athenz.zms.store.ObjectStoreConnection;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.*;
 
@@ -63,7 +61,7 @@ public class ZMSServiceTagsTest {
         void deleteAllCreatedServices() {
             ServiceIdentities serviceList = zmsImpl.getServiceIdentities(ctx, domainName, false, null,null, null);
             for (ServiceIdentity service : serviceList.getList()) {
-                String serviceName = service.getName().toString().replace(domainName + ".", "");
+                String serviceName = service.getName().replace(domainName + ".", "");
                     zmsImpl.deleteServiceIdentity(ctx, domainName, serviceName, "");
             }
         }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTagPolicyTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTagPolicyTest.java
@@ -1,271 +1,269 @@
-    /*
-     *
-     *  * Copyright The Athenz Authors
-     *  *
-     *  * Licensed under the Apache License, Version 2.0 (the "License");
-     *  * you may not use this file except in compliance with the License.
-     *  * You may obtain a copy of the License at
-     *  *
-     *  *     http://www.apache.org/licenses/LICENSE-2.0
-     *  *
-     *  * Unless required by applicable law or agreed to in writing, software
-     *  * distributed under the License is distributed on an "AS IS" BASIS,
-     *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     *  * See the License for the specific language governing permissions and
-     *  * limitations under the License.
-     *
-     */
+/*
+ *
+ *  * Copyright The Athenz Authors
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
 
+package com.yahoo.athenz.zms;
 
+import com.yahoo.athenz.zms.utils.ZMSUtils;
+import org.testng.Assert;
+import org.testng.annotations.*;
 
-    package com.yahoo.athenz.zms;
+import java.util.*;
 
-    import com.yahoo.athenz.zms.utils.ZMSUtils;
-    import org.testng.Assert;
-    import org.testng.annotations.*;
-
-    import java.util.*;
-
-    import static org.testng.Assert.*;
+import static org.testng.Assert.*;
 
 public class ZMSTagPolicyTest {
     
-        private final ZMSTestInitializer zmsTestInitializer = new ZMSTestInitializer();
-        private  ZMSImpl zmsImpl;
-        private  RsrcCtxWrapper ctx;
-        private final String domainName = "sys.auth";
-        private final int preDefinedPolicies = 1;
+    private final ZMSTestInitializer zmsTestInitializer = new ZMSTestInitializer();
+    private  ZMSImpl zmsImpl;
+    private  RsrcCtxWrapper ctx;
+    private final String domainName = "sys.auth";
 
-        @BeforeClass
-        public void startMemoryMySQL() {
-            zmsTestInitializer.startMemoryMySQL();
+    @BeforeClass
+    public void startMemoryMySQL() {
+        zmsTestInitializer.startMemoryMySQL();
+    }
+
+    @AfterClass
+    public void stopMemoryMySQL() {
+        zmsTestInitializer.stopMemoryMySQL();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        zmsTestInitializer.setUp();
+        zmsImpl = zmsTestInitializer.getZms();
+        ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        Role role = zmsTestInitializer.createRoleObject(domainName, "role1", null);
+        zmsImpl.putRole(ctx, domainName, "role1", zmsTestInitializer.getAuditRef(), false, role);
+        deleteAllCreatedPolicies();
+    }
+
+    @AfterMethod
+    public void clearConnections() {
+        zmsTestInitializer.clearConnections();
+        deleteAllCreatedPolicies();
+    }
+
+    void deleteAllCreatedPolicies() {
+        Policies policyList = zmsImpl.getPolicies(ctx, domainName, false, null,null, null);
+        for (Policy policy : policyList.getList()) {
+            String policyName = policy.getName().replace(domainName + ":policy.", "");
+            if (!policyName.contains("admin")) {
+                zmsImpl.deletePolicy(ctx, domainName, policyName, "");
+            }
+        }
+    }
+
+    @Test
+    public void testQueryPutPolicyWithTags() {
+
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // put policy with multiple tags
+        final String policyWithTags = "policyWithTags";
+        final String tagKey = "tag-key";
+        List<String> tagValues = Arrays.asList("val1", "val2");
+        Policy policy = zmsTestInitializer.createPolicyObject(domainName, policyWithTags, domainName + ":role.role1", false, "root",
+                "serivce:service1", AssertionEffect.ALLOW);
+        policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(tagValues)));
+        zmsImpl.putPolicy(ctx, domainName, policyWithTags, auditRef, false, policy);
+
+        // put policy with single tags
+        final String policiesingleTag = "policiesingleTag";
+        List<String> singleTagValue = Collections.singletonList("val1");
+        policy = zmsTestInitializer.createPolicyObject(domainName, policiesingleTag, domainName + ":role.role1", false, "root",
+                "service:service1", AssertionEffect.ALLOW);
+        policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(singleTagValue)));
+        zmsImpl.putPolicy(ctx, domainName, policiesingleTag, auditRef, false, policy);
+
+        //put policy without tags
+        final String noTagsPolicy = "noTagsPolicy";
+        policy = zmsTestInitializer.createPolicyObject(domainName, noTagsPolicy, domainName + ":role.role1", false, "root",
+                "service:service1", AssertionEffect.ALLOW);
+        zmsImpl.putPolicy(ctx, domainName, noTagsPolicy, auditRef, false, policy);
+
+        // get policies without tags query - both tags should be presented
+        Policies policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.FALSE, null,null, null);
+        hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
+        hasPolicyWithTags(policyList, policiesingleTag, domainName, tagKey, singleTagValue, 1);
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, null, null,0);
+
+        // get policies with exact tag value
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE ,tagKey, "val1");
+        hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
+        hasPolicyWithTags(policyList, policiesingleTag, domainName, tagKey, singleTagValue, 1);
+        // ensure there are no more policies
+        assertEquals(policyList.getList().size(), 2);
+
+        // get policies with exact tag value
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE, tagKey, "val2");
+        hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
+        // ensure there are no more policies
+        assertEquals(policyList.getList().size(), 1);
+
+        // get policies with only tag key
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE, tagKey, null);
+        hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
+        hasPolicyWithTags(policyList, policiesingleTag, domainName, tagKey, singleTagValue, 1);
+        // ensure there are no more policies
+        assertEquals(policyList.getList().size(), 2);
+    }
+
+    @Test
+    public void testPolicyTagsLimit() {
+
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // define limit of 3 policy tags
+        System.setProperty(ZMSConsts.ZMS_PROP_QUOTA_POLICY_TAG, "3");
+        ZMSImpl zmsTest = zmsTestInitializer.zmsInit();
+
+        final String policyName = "policyWithTagLimit";
+        final String tagKey = "tag-key";
+
+        //insert policy with 4 tags
+        List<String> tagValues = Arrays.asList("val1", "val2", "val3", "val4");
+        Policy policy = zmsTestInitializer.createPolicyObject(domainName, policyName, domainName + ":role.role1", false, "root",
+                "service:service1", AssertionEffect.ALLOW);
+        policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(tagValues)));
+        try {
+            zmsTest.putPolicy(ctx, domainName, policyName, auditRef, false, policy);
+            fail();
+        } catch(ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
+            assertTrue(ex.getMessage().contains("policy tag quota exceeded - limit: 3, current tags count: 0, new tags count: 4"));
         }
 
-        @AfterClass
-        public void stopMemoryMySQL() {
-            zmsTestInitializer.stopMemoryMySQL();
+        try {
+            // policy should not be created if fails to process tags.
+            zmsTest.getPolicy(ctx, domainName, policyName);
+            fail();
+        } catch(ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
-        @BeforeMethod
-        public void setUp() throws Exception {
-            zmsTestInitializer.setUp();
-            zmsImpl = zmsTestInitializer.getZms();
-            ctx = zmsTestInitializer.getMockDomRsrcCtx();
-            Role role = zmsTestInitializer.createRoleObject(domainName, "role1", null);
-            zmsImpl.putRole(ctx, domainName, "role1", zmsTestInitializer.getAuditRef(), false, role);
-            deleteAllCreatedPolicies();
-        }
+        System.clearProperty(ZMSConsts.ZMS_PROP_QUOTA_POLICY_TAG);
+    }
 
-        @AfterMethod
-        public void clearConnections() {
-            zmsTestInitializer.clearConnections();
-            deleteAllCreatedPolicies();
-        }
 
-        void deleteAllCreatedPolicies() {
-            Policies policyList = zmsImpl.getPolicies(ctx, domainName, false, null,null, null);
-            for (Policy policy : policyList.getList()) {
-                String policyName = policy.getName().toString().replace(domainName + ":policy.", "");
-                if (!policyName.contains("admin")) {
-                    zmsImpl.deletePolicy(ctx, domainName, policyName, "");
+    @Test
+    public void testQueryUpdatePolicyWithTags() {
+
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+
+        final String tagKey = "tag-key-update";
+        //put policy without tags
+        final String noTagsPolicy = "noTagsPolicy";
+        Policy policy = zmsTestInitializer.createPolicyObject(domainName, noTagsPolicy, domainName + ":role.role1", false, "root",
+                "service:service1", AssertionEffect.ALLOW);
+        zmsImpl.putPolicy(ctx, domainName, noTagsPolicy, auditRef, false, policy);
+
+        // assert there are no tags
+        Policies policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, null, null);
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, null, null,0);
+
+        // update tag list
+        List<String> tagValues = Arrays.asList("val1", "val2", "val3");
+        policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(tagValues)));
+        zmsImpl.putPolicy(ctx, domainName, noTagsPolicy, auditRef, false, policy);
+
+        // 1 tags should be presented
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, null,null);
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
+
+        // get policies with exact tag value
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.FALSE, null, tagKey, "val1");
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
+        assertEquals(policyList.getList().size(), 1);
+
+        // get policies with only tag key
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, tagKey, null);
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues , 3);
+        assertEquals(policyList.getList().size(), 1);
+
+        // now create a different tags Map, part is from tagValues
+        String newPolicyName = "newPolicy";
+        Map<String, TagValueList> tagsMap = new HashMap<>();
+        List<String> newTagValues1 = Arrays.asList("val1", "new-val");
+        String newTagKey = "newTagKey";
+        List<String> newTagValues2 = Arrays.asList("val4", "val5", "val6");
+        tagsMap.put(tagKey, new TagValueList().setList(newTagValues1));
+        tagsMap.put(newTagKey, new TagValueList().setList(newTagValues2));
+        Policy newPolicy = zmsTestInitializer.createPolicyObject(domainName, newPolicyName, domainName + ":role.role1", false, "root",
+                "service:service1", AssertionEffect.ALLOW);
+        newPolicy.setTags(tagsMap);
+        zmsImpl.putPolicy(ctx, domainName, newPolicyName, auditRef, false, newPolicy);
+
+        // 3 tags should be presented there is 1 initial policy in the sys.auth domain
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, null, null);
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
+        hasPolicyWithTags(policyList, newPolicyName, domainName, tagKey, newTagValues1, 2);
+        hasPolicyWithTags(policyList, newPolicyName, domainName, newTagKey, newTagValues2, 3);
+        int preDefinedPolicies = 1;
+        assertEquals(policyList.getList().size(), 2 + preDefinedPolicies);
+
+        // get policies with exact tag value
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, tagKey, "val1");
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
+        hasPolicyWithTags(policyList, newPolicyName, domainName, tagKey, newTagValues1, 2);
+        hasPolicyWithTags(policyList, newPolicyName, domainName, newTagKey, newTagValues2, 3);
+        assertEquals(policyList.getList().size(), 2);
+
+        // get policies with non-existent tag value
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, tagKey, "val2");
+        hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
+        assertEquals(policyList.getList().size(), 1);
+
+        // get policies with new tag key
+        policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, newTagKey, null);
+        hasPolicyWithTags(policyList, newPolicyName, domainName, newTagKey, newTagValues2, 3);
+        assertEquals(policyList.getList().size(), 1);
+    }
+
+    private void hasPolicyWithTags(Policies policyList, String policyName, String domainName, String tagKey, List<String> tagValues, int tagValuesLength) {
+        Policy policy = getPolicy(policyList, policyName, domainName);
+        Assert.assertNotNull(policy);
+        if (tagKey != null) {
+            if (tagValues != null) {
+                Assert.assertEquals(policy.getTags().get(tagKey).getList().size(), tagValuesLength);
+                for (String tagValue : tagValues) {
+                    Assert.assertTrue(hasTag(policy, tagKey, tagValue));
                 }
+            } else {
+                Assert.assertTrue(hasTag(policy, tagKey, null));
             }
         }
+    }
 
-        @Test
-        public void testQueryPutPolicyWithTags() {
-
-            final String auditRef = zmsTestInitializer.getAuditRef();
-
-            // put policy with multiple tags
-            final String policyWithTags = "policyWithTags";
-            final String tagKey = "tag-key";
-            List<String> tagValues = Arrays.asList("val1", "val2");
-            Policy policy = zmsTestInitializer.createPolicyObject(domainName, policyWithTags, domainName + ":role.role1", false, "root",
-                    "serivce:service1", AssertionEffect.ALLOW);
-            policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(tagValues)));
-            zmsImpl.putPolicy(ctx, domainName, policyWithTags, auditRef, false, policy);
-
-            // put policy with single tags
-            final String policiesingleTag = "policiesingleTag";
-            List<String> singleTagValue = Collections.singletonList("val1");
-            policy = zmsTestInitializer.createPolicyObject(domainName, policiesingleTag, domainName + ":role.role1", false, "root",
-                    "service:service1", AssertionEffect.ALLOW);
-            policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(singleTagValue)));
-            zmsImpl.putPolicy(ctx, domainName, policiesingleTag, auditRef, false, policy);
-
-            //put policy without tags
-            final String noTagsPolicy = "noTagsPolicy";
-            policy = zmsTestInitializer.createPolicyObject(domainName, noTagsPolicy, domainName + ":role.role1", false, "root",
-                    "service:service1", AssertionEffect.ALLOW);
-            zmsImpl.putPolicy(ctx, domainName, noTagsPolicy, auditRef, false, policy);
-
-            // get policies without tags query - both tags should be presented
-            Policies policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.FALSE, null,null, null);
-            hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
-            hasPolicyWithTags(policyList, policiesingleTag, domainName, tagKey, singleTagValue, 1);
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, null, null,0);
-
-            // get policies with exact tag value
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE ,tagKey, "val1");
-            hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
-            hasPolicyWithTags(policyList, policiesingleTag, domainName, tagKey, singleTagValue, 1);
-            // ensure there are no more policies
-            assertEquals(policyList.getList().size(), 2);
-
-            // get policies with exact tag value
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE, tagKey, "val2");
-            hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
-            // ensure there are no more policies
-            assertEquals(policyList.getList().size(), 1);
-
-            // get policies with only tag key
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE, tagKey, null);
-            hasPolicyWithTags(policyList, policyWithTags, domainName, tagKey, tagValues, 2);
-            hasPolicyWithTags(policyList, policiesingleTag, domainName, tagKey, singleTagValue, 1);
-            // ensure there are no more policies
-            assertEquals(policyList.getList().size(), 2);
+    private boolean hasTag(Policy policy, String tagKey, String tagValue) {
+        TagValueList tagValues = policy.getTags().get(tagKey);
+        if (tagValue != null) {
+            return tagValues.getList().contains(tagValue);
         }
+        return !tagValues.getList().isEmpty();
+    }
 
-        @Test
-        public void testPolicyTagsLimit() {
-
-            final String auditRef = zmsTestInitializer.getAuditRef();
-
-            // define limit of 3 policy tags
-            System.setProperty(ZMSConsts.ZMS_PROP_QUOTA_POLICY_TAG, "3");
-            ZMSImpl zmsTest = zmsTestInitializer.zmsInit();
-
-            final String policyName = "policyWithTagLimit";
-            final String tagKey = "tag-key";
-
-            //insert policy with 4 tags
-            List<String> tagValues = Arrays.asList("val1", "val2", "val3", "val4");
-            Policy policy = zmsTestInitializer.createPolicyObject(domainName, policyName, domainName + ":role.role1", false, "root",
-                    "service:service1", AssertionEffect.ALLOW);
-            policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(tagValues)));
-            try {
-                zmsTest.putPolicy(ctx, domainName, policyName, auditRef, false, policy);
-                fail();
-            } catch(ResourceException ex) {
-                assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
-                assertTrue(ex.getMessage().contains("policy tag quota exceeded - limit: 3, current tags count: 0, new tags count: 4"));
-            }
-
-            try {
-                // policy should not be created if fails to process tags.
-                zmsTest.getPolicy(ctx, domainName, policyName);
-                fail();
-            } catch(ResourceException ex) {
-                assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
-            }
-
-            System.clearProperty(ZMSConsts.ZMS_PROP_QUOTA_POLICY_TAG);
-        }
-
-
-        @Test
-        public void testQueryUpdatePolicyWithTags() {
-
-            final String auditRef = zmsTestInitializer.getAuditRef();
-
-
-            final String tagKey = "tag-key-update";
-            //put policy without tags
-            final String noTagsPolicy = "noTagsPolicy";
-            Policy policy = zmsTestInitializer.createPolicyObject(domainName, noTagsPolicy, domainName + ":role.role1", false, "root",
-                    "service:service1", AssertionEffect.ALLOW);
-            zmsImpl.putPolicy(ctx, domainName, noTagsPolicy, auditRef, false, policy);
-
-            // assert there are no tags
-            Policies policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, null, null);
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, null, null,0);
-
-            // update tag list
-            List<String> tagValues = Arrays.asList("val1", "val2", "val3");
-            policy.setTags(Collections.singletonMap(tagKey, new TagValueList().setList(tagValues)));
-            zmsImpl.putPolicy(ctx, domainName, noTagsPolicy, auditRef, false, policy);
-
-            // 1 tags should be presented
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, null,null);
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
-
-            // get policies with exact tag value
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.FALSE, null, tagKey, "val1");
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
-            assertEquals(policyList.getList().size(), 1);
-
-            // get policies with only tag key
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, tagKey, null);
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues , 3);
-            assertEquals(policyList.getList().size(), 1);
-
-            // now create a different tags Map, part is from tagValues
-            String newPolicyName = "newPolicy";
-            Map<String, TagValueList> tagsMap = new HashMap<>();
-            List<String> newTagValues1 = Arrays.asList("val1", "new-val");
-            String newTagKey = "newTagKey";
-            List<String> newTagValues2 = Arrays.asList("val4", "val5", "val6");
-            tagsMap.put(tagKey, new TagValueList().setList(newTagValues1));
-            tagsMap.put(newTagKey, new TagValueList().setList(newTagValues2));
-            Policy newPolicy = zmsTestInitializer.createPolicyObject(domainName, newPolicyName, domainName + ":role.role1", false, "root",
-                    "service:service1", AssertionEffect.ALLOW);
-            newPolicy.setTags(tagsMap);
-            zmsImpl.putPolicy(ctx, domainName, newPolicyName, auditRef, false, newPolicy);
-
-            // 3 tags should be presented there is 1 initial policy in the sys.auth domain
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, null, null);
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
-            hasPolicyWithTags(policyList, newPolicyName, domainName, tagKey, newTagValues1, 2);
-            hasPolicyWithTags(policyList, newPolicyName, domainName, newTagKey, newTagValues2, 3);
-            assertEquals(policyList.getList().size(), 2 + preDefinedPolicies);
-
-            // get policies with exact tag value
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, tagKey, "val1");
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
-            hasPolicyWithTags(policyList, newPolicyName, domainName, tagKey, newTagValues1, 2);
-            hasPolicyWithTags(policyList, newPolicyName, domainName, newTagKey, newTagValues2, 3);
-            assertEquals(policyList.getList().size(), 2);
-
-            // get policies with non-existent tag value
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, tagKey, "val2");
-            hasPolicyWithTags(policyList, noTagsPolicy, domainName, tagKey, tagValues, 3);
-            assertEquals(policyList.getList().size(), 1);
-
-            // get policies with new tag key
-            policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, null, newTagKey, null);
-            hasPolicyWithTags(policyList, newPolicyName, domainName, newTagKey, newTagValues2, 3);
-            assertEquals(policyList.getList().size(), 1);
-        }
-
-        private void hasPolicyWithTags(Policies policyList, String policyName, String domainName, String tagKey, List<String> tagValues, int tagValuesLength) {
-            Policy policy = getPolicy(policyList, policyName, domainName);
-            Assert.assertNotNull(policy);
-            if (tagKey != null) {
-                if (tagValues != null) {
-                    Assert.assertEquals(policy.getTags().get(tagKey).getList().size(), tagValuesLength);
-                    for (String tagValue : tagValues) {
-                        Assert.assertTrue(hasTag(policy, tagKey, tagValue));
-                    }
-                } else {
-                    Assert.assertTrue(hasTag(policy, tagKey, null));
-                }
-            }
-        }
-
-        private boolean hasTag(Policy policy, String tagKey, String tagValue) {
-            TagValueList tagValues = policy.getTags().get(tagKey);
-            if (tagValue != null) {
-                return tagValues.getList().contains(tagValue);
-            }
-            return !tagValues.getList().isEmpty();
-        }
-
-        private Policy getPolicy(Policies policyList, String policyName, String domainName) {
-            return policyList.getList().stream()
-                    .filter(g -> ZMSUtils.extractPolicyName(domainName, g.getName()).equalsIgnoreCase(policyName))
-                    .findFirst()
-                    .get();
-        }
+    private Policy getPolicy(Policies policyList, String policyName, String domainName) {
+        return policyList.getList().stream()
+                .filter(g -> ZMSUtils.extractPolicyName(domainName, g.getName()).equalsIgnoreCase(policyName))
+                .findFirst()
+                .get();
+    }
 }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestInitializer.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestInitializer.java
@@ -44,7 +44,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 import static com.yahoo.athenz.common.ServerCommonConsts.METRIC_DEFAULT_FACTORY_CLASS;
 import static com.yahoo.athenz.zms.ZMSConsts.*;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/config/AllowedOperationTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/config/AllowedOperationTest.java
@@ -35,16 +35,15 @@ public class AllowedOperationTest {
         assertEquals(gottenName, name);
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testSetItems() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("key", item);
             }
@@ -70,16 +69,15 @@ public class AllowedOperationTest {
         assertTrue(op.isOperationAllowedOn("opItemType", "opItemValue", AllowedOperation.MatchType.EQUALS));
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testIsOperationAllowedOnOpItemTypeIsNull() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("key", item);
             }
@@ -88,16 +86,15 @@ public class AllowedOperationTest {
         assertFalse(op.isOperationAllowedOn(null, "opItemValue", AllowedOperation.MatchType.EQUALS));
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testIsOperationAllowedOnOpItemValueIsNull() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("key", item);
             }
@@ -106,16 +103,15 @@ public class AllowedOperationTest {
         assertFalse(op.isOperationAllowedOn("opItemType", null, AllowedOperation.MatchType.EQUALS));
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testIsOperationAllowedOnOpItemTypeIsNotDefined() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("key", item);
             }
@@ -124,16 +120,15 @@ public class AllowedOperationTest {
         assertFalse(op.isOperationAllowedOn("opItemType", "opItemValue", AllowedOperation.MatchType.EQUALS));
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testIsOperationAllowedOnOpItemValueIsNotAllowed() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("key", item);
             }
@@ -142,16 +137,15 @@ public class AllowedOperationTest {
         assertFalse(op.isOperationAllowedOn("key", "opItemValue", AllowedOperation.MatchType.EQUALS));
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testIsOperationAllowedOnOpItemValueIsAllowed() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("key", item);
             }
@@ -216,16 +210,15 @@ public class AllowedOperationTest {
         assertFalse(op1.equals(op2));
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testEqualsSameHashCode() {
         AllowedOperation op1 = new AllowedOperation();
-        Set<String> item1 = new HashSet<String>() {
+        Set<String> item1 = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items1 = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items1 = new HashMap<>() {
             {
                 put("key", item1);
             }
@@ -233,12 +226,12 @@ public class AllowedOperationTest {
         op1.setItems(items1);
 
         AllowedOperation op2 = new AllowedOperation();
-        Set<String> item2 = new HashSet<String>() {
+        Set<String> item2 = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items2 = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items2 = new HashMap<>() {
             {
                 put("key", item2);
             }
@@ -248,16 +241,15 @@ public class AllowedOperationTest {
         assertEquals(op1.hashCode(), op2.hashCode());
     }
 
-    @SuppressWarnings("serial")
     @Test
     public void testEqualsDifferentHashCode() {
         AllowedOperation op1 = new AllowedOperation();
-        Set<String> item1 = new HashSet<String>() {
+        Set<String> item1 = new HashSet<>() {
             {
                 add("hoge");
             }
         };
-        Map<String, Set<String>> items1 = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items1 = new HashMap<>() {
             {
                 put("key", item1);
             }
@@ -265,12 +257,12 @@ public class AllowedOperationTest {
         op1.setItems(items1);
 
         AllowedOperation op2 = new AllowedOperation();
-        Set<String> item2 = new HashSet<String>() {
+        Set<String> item2 = new HashSet<>() {
             {
                 add("fuga");
             }
         };
-        Map<String, Set<String>> items2 = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items2 = new HashMap<>() {
             {
                 put("key", item2);
             }
@@ -283,13 +275,13 @@ public class AllowedOperationTest {
     @Test
     public void testIsOperationAllowedStartsWith() {
         AllowedOperation op = new AllowedOperation();
-        Set<String> item = new HashSet<String>() {
+        Set<String> item = new HashSet<>() {
             {
                 add("config.reader.");
                 add("config.writer.");
             }
         };
-        Map<String, Set<String>> items = new HashMap<String, Set<String>>() {
+        Map<String, Set<String>> items = new HashMap<>() {
             {
                 put("cfg", item);
             }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/DomainRoleMembersFetcherTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/DomainRoleMembersFetcherTest.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
@@ -20,7 +20,6 @@ import com.yahoo.athenz.common.server.notification.*;
 import com.yahoo.athenz.zms.*;
 import com.yahoo.athenz.zms.store.AthenzDomain;
 import com.yahoo.rdl.Timestamp;
-import org.checkerframework.checker.units.qual.C;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/MockNotificationServiceFactory.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/MockNotificationServiceFactory.java
@@ -21,7 +21,7 @@ import com.yahoo.athenz.common.server.notification.NotificationServiceFactory;
 
 public class MockNotificationServiceFactory implements NotificationServiceFactory {
 
-    private NotificationService notificationService = new MockNotificationService();
+    private final NotificationService notificationService = new MockNotificationService();
 
     @Override
     public NotificationService create() {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingGroupMembershipApprovalNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingGroupMembershipApprovalNotificationTaskTest.java
@@ -22,7 +22,6 @@ import com.yahoo.athenz.zms.ZMSTestUtils;
 import com.yahoo.rdl.Timestamp;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
-import org.testng.internal.junit.ArrayAsserts;
 
 import java.util.*;
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
@@ -22,7 +22,6 @@ import com.yahoo.athenz.zms.store.AthenzDomain;
 import com.yahoo.rdl.Timestamp;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.*;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationManagerTest.java
@@ -20,7 +20,6 @@ import com.yahoo.athenz.common.server.notification.*;
 import com.yahoo.athenz.zms.*;
 import com.yahoo.athenz.zms.store.AthenzDomain;
 import com.yahoo.rdl.Timestamp;
-import org.checkerframework.checker.units.qual.N;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -40,7 +39,7 @@ public class ZMSNotificationManagerTest {
 
     @BeforeClass
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @BeforeMethod

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/provider/ServiceProviderClientTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/provider/ServiceProviderClientTest.java
@@ -91,7 +91,7 @@ public class ServiceProviderClientTest {
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8))
                 .lines()
                 .collect(Collectors.joining("\n"));
-        assertEquals(text, "" +
+        assertEquals(text,
                 "{" +
                 "\"operation\":\"delete\"," +
                 "\"domainName\":\"test.domain\"," +
@@ -190,8 +190,7 @@ public class ServiceProviderClientTest {
         System.clearProperty(ZMS_PROP_PROVIDER_TRUST_STORE);
         System.clearProperty(ZMS_PROP_PROVIDER_TRUST_STORE_PASSWORD);
         PrivateKeyStore privateKeyStore = Mockito.mock(PrivateKeyStore.class);
-        ServiceProviderManager serviceProviderManager = Mockito.mock(ServiceProviderManager.class);
-        ServiceProviderClient serviceProviderClient = new ServiceProviderClient(privateKeyStore, serviceProviderManager, "home.");
+        ServiceProviderClient serviceProviderClient = new ServiceProviderClient(privateKeyStore, "home.");
         String provider = "provider-test";
         String providerEndpoint = "https://provider-endpoint:12345";
         ServiceProviderManager.DomainDependencyProvider domainDependencyProvider = new ServiceProviderManager.DomainDependencyProvider(provider, providerEndpoint, false);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/provider/ServiceProviderManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/provider/ServiceProviderManagerTest.java
@@ -23,8 +23,6 @@ import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.auth.impl.SimplePrincipal;
 import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.zms.*;
-import com.yahoo.athenz.zms.notification.MockNotificationService;
-import com.yahoo.athenz.zms.utils.ZMSUtils;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,8 +110,8 @@ public class ServiceProviderManagerTest {
         }
         List<Future<Boolean>> futures = executor.invokeAll(assertServiceProviderTasks);
         executor.shutdown();
-        for (int i = 0; i < futures.size(); ++i) {
-            if (!futures.get(i).get()) {
+        for (Future<Boolean> future : futures) {
+            if (!future.get()) {
                 fail();
             }
         }
@@ -137,7 +135,7 @@ public class ServiceProviderManagerTest {
         return testRole;
     }
 
-    public class AssertServiceProviderTask implements Callable<Boolean> {
+    public static class AssertServiceProviderTask implements Callable<Boolean> {
         final int threadNumber;
         final ServiceProviderManager serviceProviderManager;
         final long fetchFrequency;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/purge/PurgeResourcesEnumTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/purge/PurgeResourcesEnumTest.java
@@ -1,6 +1,5 @@
 package com.yahoo.athenz.zms.purge;
 
-import com.yahoo.athenz.zms.notification.DisableNotificationEnum;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactoryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactoryTest.java
@@ -56,7 +56,7 @@ public class AWSObjectStoreFactoryTest {
     @Test
     public void testCreate() {
 
-        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
+        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_PRIMARY_INSTANCE, "instance");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_USER, "rds-user");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "1");
 
@@ -76,7 +76,7 @@ public class AWSObjectStoreFactoryTest {
     @Test
     public void testOriginalMethods() {
 
-        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
+        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_PRIMARY_INSTANCE, "instance");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_USER, "rds-user");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "30000");
 
@@ -103,7 +103,7 @@ public class AWSObjectStoreFactoryTest {
     @Test
     public void testCreateWithReplica() {
 
-        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
+        System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_PRIMARY_INSTANCE, "instance");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_REPLICA_INSTANCE, "replica");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_USER, "rds-user");
         System.setProperty(ZMSConsts.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "30000");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactoryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactoryTest.java
@@ -17,9 +17,7 @@ package com.yahoo.athenz.zms.store.impl;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
-import com.amazonaws.services.rds.auth.GetIamAuthTokenRequest;
 import com.amazonaws.services.rds.auth.RdsIamAuthTokenGenerator;
-import com.amazonaws.util.EC2MetadataUtils;
 import com.yahoo.athenz.zms.ZMSConsts;
 import com.yahoo.athenz.zms.store.ObjectStore;
 import org.mockito.Mockito;
@@ -29,7 +27,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class AWSObjectStoreFactoryTest {
 
-    class TestAWSObjectStoreFactory extends AWSObjectStoreFactory {
+    static class TestAWSObjectStoreFactory extends AWSObjectStoreFactory {
 
         @Override
         InstanceProfileCredentialsProvider getNewInstanceCredentialsProvider() {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCObjectStoreTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCObjectStoreTest.java
@@ -22,7 +22,6 @@ import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
-import com.yahoo.athenz.zms.store.impl.jdbc.JDBCObjectStore;
 
 import static org.testng.Assert.*;
 


### PR DESCRIPTION
Changes include:
- replace deprecated calls
- mark fields as final when possible
- remove unused imports, fields, arguments
- replace function references with lambdas when possible
- replace size() > 0 calls with isEmpty()