### PR TITLE
auth-core library code cleanup - replace deprecated calls, etc

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/ServerPrivateKey.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/ServerPrivateKey.java
@@ -24,9 +24,9 @@ public class ServerPrivateKey {
     public static final String RSA   = "RSA";
     public static final String ECDSA = "ECDSA";
 
-    private String id;
-    private PrivateKey key;
-    private SignatureAlgorithm algorithm;
+    private final String id;
+    private final PrivateKey key;
+    private final SignatureAlgorithm algorithm;
 
     public ServerPrivateKey(final PrivateKey key, final String id) {
 

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/CertificateAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/CertificateAuthority.java
@@ -40,7 +40,7 @@ public class CertificateAuthority implements Authority {
     private static final String ATHENZ_AUTH_CHALLENGE = "AthenzX509Certificate realm=\"athenz\"";
 
     private CertificateIdentityParser certificateIdentityParser = null;
-    private GlobStringsMatcher globStringsMatcher = new GlobStringsMatcher(ATHENZ_PROP_RESTRICTED_OU);
+    private final GlobStringsMatcher globStringsMatcher = new GlobStringsMatcher(ATHENZ_PROP_RESTRICTED_OU);
 
     @Override
     public void initialize() {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/KerberosAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/KerberosAuthority.java
@@ -61,8 +61,8 @@ public class KerberosAuthority implements Authority {
     private String  servicePrincipal; // ex: HTTP/localhost@LOCALHOST
     private String  keyTabConfFile;
     private String  jaasConfigSection;
-    private String  loginCallbackHandler;
-    private AtomicReference<Subject> serviceSubject = new AtomicReference<>();
+    private final String  loginCallbackHandler;
+    private final AtomicReference<Subject> serviceSubject = new AtomicReference<>();
     private Exception initState = null;
 
     private long lastLogin   = 0; // last time logged in in millisecs
@@ -77,11 +77,7 @@ public class KerberosAuthority implements Authority {
         if (keyTabConfFile != null && !keyTabConfFile.isEmpty()) {
             this.keyTabConfFile = keyTabConfFile;
         }
-        if (jaasConfigSection == null) {
-            this.jaasConfigSection = "";
-        } else {
-            this.jaasConfigSection = jaasConfigSection;
-        }
+        this.jaasConfigSection = Objects.requireNonNullElse(jaasConfigSection, "");
     }
 
     public KerberosAuthority() {
@@ -268,7 +264,7 @@ public class KerberosAuthority implements Authority {
             errMsg.append("KerberosAuthority:authenticate: Invalid token: exc=").
                    append(ex.getMessage()).append(" : credential=").
                    append(creds);
-            LOG.error("KerberosAuthority:authenticate: {}", errMsg.toString());
+            LOG.error("KerberosAuthority:authenticate: {}", errMsg);
             return null;
         }
 
@@ -293,9 +289,9 @@ public class KerberosAuthority implements Authority {
     }
 
     static class LoginConfig extends Configuration {
-        private String keyTabConfFile;
-        private String servicePrincipalName;
-        private boolean debugKrbEnabled;
+        private final String keyTabConfFile;
+        private final String servicePrincipalName;
+        private final boolean debugKrbEnabled;
 
         public LoginConfig(String keyTabConfFile, String servicePrincipalName) {
             this.keyTabConfFile       = keyTabConfFile;

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/LDAPAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/LDAPAuthority.java
@@ -37,13 +37,14 @@ public class LDAPAuthority implements Authority {
     static final String ATHENZ_PROP_LDAP_PORT = "athenz.auth.ldap.port";
     static final String ATHENZ_AUTH_CHALLENGE = "LDAPAuthentication realm=\"athenz\"";
     static final String ATHENZ_PROP_HOSTNAME = "athenz.auth.ldap.hostname";
-    private String baseDN, portNumber, hostName, providerURL;
+    private String baseDN;
+    private String providerURL;
 
     @Override
     public void initialize() {
         baseDN = System.getProperty(ATHENZ_PROP_LDAP_BASE_DN, "o=Athenz");
-        portNumber = System.getProperty(ATHENZ_PROP_LDAP_PORT, "389");
-        hostName = System.getProperty(ATHENZ_PROP_HOSTNAME, "localhost");
+        final String portNumber = System.getProperty(ATHENZ_PROP_LDAP_PORT, "389");
+        final String hostName = System.getProperty(ATHENZ_PROP_HOSTNAME, "localhost");
         providerURL = "ldap://" + hostName + ":" + portNumber;
     }
 
@@ -131,7 +132,7 @@ public class LDAPAuthority implements Authority {
     }
 
     DirContext getDirContext(String finalDN, String password) throws NamingException {
-        Hashtable env = new Hashtable();
+        Hashtable<String, String> env = new Hashtable<>();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
         env.put(Context.PROVIDER_URL, providerURL);
         env.put(Context.SECURITY_AUTHENTICATION, "simple");
@@ -141,8 +142,7 @@ public class LDAPAuthority implements Authority {
     }
 
     SimplePrincipal getSimplePrincipal(String creds, String username) {
-        SimplePrincipal simplePrincipal = (SimplePrincipal) SimplePrincipal.create(getDomain(),
+        return (SimplePrincipal) SimplePrincipal.create(getDomain(),
                 username.toLowerCase(), creds, this);
-        return simplePrincipal;
     }
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/PrincipalAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/PrincipalAuthority.java
@@ -54,7 +54,7 @@ public class PrincipalAuthority implements Authority, AuthorityKeyStore {
     private int allowedOffset;
     IpCheckMode ipCheckMode;
     final String userDomain;
-    private String headerName;
+    private final String headerName;
     
     public PrincipalAuthority() {
         allowedOffset = Integer.parseInt(System.getProperty(ATHENZ_PROP_TOKEN_OFFSET, "300"));

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimplePrincipal.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimplePrincipal.java
@@ -76,7 +76,7 @@ public class SimplePrincipal implements Principal {
      * @return a Principal for the given set of roles in a domain
      */
     public static Principal create(String domain, String creds, List<String> roles, String rolePrincipalName, Authority authority) {
-        if (roles == null || roles.size() == 0) {
+        if (roles == null || roles.isEmpty()) {
             LOG.error("createRolePrincipal: zero roles");
             return null;
         }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimpleServiceIdentityProvider.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimpleServiceIdentityProvider.java
@@ -34,11 +34,11 @@ public class SimpleServiceIdentityProvider implements ServiceIdentityProvider {
 
     private static final Authority PRINCIPAL_AUTHORITY = new PrincipalAuthority();
 
-    private String domain;
-    private String service;
-    private PrivateKey key;
+    private final String domain;
+    private final String service;
+    private final PrivateKey key;
     private long tokenTimeout;
-    private String keyId;
+    private final String keyId;
     private String host = null;
     private Authority authority;
     

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParser.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParser.java
@@ -32,7 +32,7 @@ public class DefaultOAuthJwtAccessTokenParser implements OAuthJwtAccessTokenPars
 
     public static final int ALLOWED_CLOCK_SKEW_SECONDS = 60;
 
-    protected JwtParser parser = null;
+    protected JwtParser parser;
 
     /**
      * Create parser for DefaultOAuthJwtAccessToken
@@ -54,7 +54,7 @@ public class DefaultOAuthJwtAccessTokenParser implements OAuthJwtAccessTokenPars
 
     @Override
     public OAuthJwtAccessToken parse(String jwtString) throws OAuthJwtAccessTokenException {
-        OAuthJwtAccessToken accessToken = null;
+        OAuthJwtAccessToken accessToken;
         try {
             Jws<Claims> jws = this.parser.parseClaimsJws(jwtString);
             accessToken = new DefaultOAuthJwtAccessToken(jws);

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserFactory.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserFactory.java
@@ -25,9 +25,8 @@ public class DefaultOAuthJwtAccessTokenParserFactory implements OAuthJwtAccessTo
 
     public static final String SYSTEM_PROP_PREFIX = "athenz.auth.oauth.jwt.parser.";
     public static final String JWKS_URL = "jwks_url";
-    public static final BiFunction<String, String, String> GET_PROPERTY = (String key, String def) -> {
-        return System.getProperty(SYSTEM_PROP_PREFIX + key, def);
-    };
+    public static final BiFunction<String, String, String> GET_PROPERTY =
+            (String key, String def) -> System.getProperty(SYSTEM_PROP_PREFIX + key, def);
 
     @Override
     public OAuthJwtAccessTokenParser create(KeyStore keyStore) throws IllegalArgumentException {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/KeyStoreJwkKeyResolver.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/KeyStoreJwkKeyResolver.java
@@ -37,8 +37,8 @@ public class KeyStoreJwkKeyResolver implements SigningKeyResolver {
 
     private static final String SYS_AUTH_DOMAIN = "sys.auth";
 
-    private KeyStore keyStore = null;
-    private SigningKeyResolver jwksResolver = null;
+    private final KeyStore keyStore;
+    private final SigningKeyResolver jwksResolver;
 
     /**
      * @param  keyStore key store get the JWT public keys
@@ -56,7 +56,6 @@ public class KeyStoreJwkKeyResolver implements SigningKeyResolver {
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
     public Key resolveSigningKey(JwsHeader header, Claims claims) {
         String keyId = header.getKeyId();
         if (keyId == null || keyId.isEmpty()) {
@@ -104,7 +103,6 @@ public class KeyStoreJwkKeyResolver implements SigningKeyResolver {
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
     public Key resolveSigningKey(JwsHeader header, String plaintext) {
         // JSON Web Encryption (JWE) not supported
         return null;

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/OAuthJwtAccessTokenParser.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/OAuthJwtAccessTokenParser.java
@@ -29,5 +29,5 @@ public interface OAuthJwtAccessTokenParser {
      * @return                              OAuthJwtAccessToken
      * @throws OAuthJwtAccessTokenException parse error
      */
-    public OAuthJwtAccessToken parse(String jwtString) throws OAuthJwtAccessTokenException;
+    OAuthJwtAccessToken parse(String jwtString) throws OAuthJwtAccessTokenException;
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/OAuthJwtAccessTokenParserFactory.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/OAuthJwtAccessTokenParserFactory.java
@@ -27,5 +27,5 @@ public interface OAuthJwtAccessTokenParserFactory {
      * @param keyStore keyStore
      * @return OAuthJwtAccessTokenParser instance
      */
-    public OAuthJwtAccessTokenParser create(KeyStore keyStore) throws IllegalArgumentException;
+    OAuthJwtAccessTokenParser create(KeyStore keyStore) throws IllegalArgumentException;
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/token/DefaultOAuthJwtAccessToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/token/DefaultOAuthJwtAccessToken.java
@@ -74,7 +74,7 @@ public class DefaultOAuthJwtAccessToken implements OAuthJwtAccessToken {
                 LOG.debug("DefaultOAuthJwtAccessToken:getAudiences treat audience as string, err: {}", e.getMessage());
             }
             // found but class mismatch
-            audiences = Arrays.asList(new String[]{ this.body.getAudience() });
+            audiences = Arrays.asList(this.body.getAudience());
         }
         return audiences;
     }
@@ -87,7 +87,7 @@ public class DefaultOAuthJwtAccessToken implements OAuthJwtAccessToken {
     @Override
     public String getCertificateThumbprint() {
         // https://github.com/jwtk/jjwt/issues/404, custom model class not supported
-        LinkedHashMap<?, ?> certConf = null;
+        LinkedHashMap<?, ?> certConf;
         try {
             certConf = this.body.get(OAuthJwtAccessToken.CLAIM_CONFIRM, LinkedHashMap.class);
             if (certConf == null) {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/token/OAuthJwtAccessToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/token/OAuthJwtAccessToken.java
@@ -28,53 +28,53 @@ import java.util.List;
 public interface OAuthJwtAccessToken {
 
     // claims
-    public static final String CLAIM_CONFIRM = "cnf";
-    public static final String CLAIM_CONFIRM_X509_HASH = "x5t#S256";
-    public static final String CLAIM_SCOPE = "scope";
-    public static final String CLAIM_CLIENT_ID = "client_id";
+    String CLAIM_CONFIRM = "cnf";
+    String CLAIM_CONFIRM_X509_HASH = "x5t#S256";
+    String CLAIM_SCOPE = "scope";
+    String CLAIM_CLIENT_ID = "client_id";
 
     // delimiters
-    public static final String SCOPE_DELIMITER = " ";
+    String SCOPE_DELIMITER = " ";
 
     /**
      * @return JWT subject (sub)
      */
-    public String getSubject();
+    String getSubject();
 
     /**
      * @return JWT issuer (iss)
      */
-    public String getIssuer();
+    String getIssuer();
 
     /**
      * @return JWT audience (aud)
      */
-    public String getAudience();
+    String getAudience();
 
     /**
      * @return JWT audiences (aud) as list
      */
-    public List<String> getAudiences();
+    List<String> getAudiences();
 
     /**
      * @return JWT client ID (client_id)
      */
-    public String getClientId();
+    String getClientId();
 
     /**
      * @return JWT certificate thumbprint (cnf['x5t#S256'])
      */
-    public String getCertificateThumbprint();
+    String getCertificateThumbprint();
 
     /**
      * @return JWT scope (scope)
      */
-    public String getScope();
+    String getScope();
 
     /**
      * @return JWT scopes (scope) as List
      */
-    public default List<String> getScopes() {
+    default List<String> getScopes() {
         if (this.getScope() == null) {
             return null;
         }
@@ -84,21 +84,21 @@ public interface OAuthJwtAccessToken {
     /**
      * @return JWT issued at (iat)
      */
-    public long getIssuedAt();
+    long getIssuedAt();
 
     /**
      * @return JWT expiration time (exp)
      */
-    public long getExpiration();
+    long getExpiration();
 
     /**
      * @return JWT getSignature
      */
-    public String getSignature();
+    String getSignature();
 
     /**
      * @return JWT as string in JAVA format
      */
-    public String toString();
+    String toString();
 
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/util/OAuthAuthorityUtils.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/util/OAuthAuthorityUtils.java
@@ -33,7 +33,7 @@ public class OAuthAuthorityUtils {
      * @param  def default value
      * @return     system property value set
      */
-    public static final String getProperty(String key, String def) {
+    public static String getProperty(String key, String def) {
         return System.getProperty(OAuthAuthorityConsts.SYSTEM_PROP_PREFIX + key, def);
     }
 
@@ -43,11 +43,11 @@ public class OAuthAuthorityUtils {
      * @param  delimiter CSV delimiter
      * @return           corresponding Set object of the CSV string, or null if CSV is null or empty
      */
-    public static final Set<String> csvToSet(String csv, String delimiter) {
+    public static Set<String> csvToSet(String csv, String delimiter) {
         if (csv == null || csv.isEmpty()) {
             return null;
         }
-        Set<String> set = new HashSet<String>();
+        Set<String> set = new HashSet<>();
         if (delimiter == null || delimiter.isEmpty()) {
             set.add(csv);
         } else {
@@ -62,7 +62,7 @@ public class OAuthAuthorityUtils {
      * @param request the request
      * @return        the token, or null if no OAuth authorization header was supplied
      */
-    public static final String extractHeaderToken(HttpServletRequest request) {
+    public static String extractHeaderToken(HttpServletRequest request) {
         Enumeration<String> headers = request.getHeaders(OAuthAuthorityConsts.AUTH_HEADER);
         while (headers.hasMoreElements()) {
             // typically there is only one (most servers enforce that)

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/validator/DefaultOAuthJwtAccessTokenValidator.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/validator/DefaultOAuthJwtAccessTokenValidator.java
@@ -27,10 +27,10 @@ import com.yahoo.athenz.auth.oauth.token.OAuthJwtAccessTokenException;
  */
 public class DefaultOAuthJwtAccessTokenValidator implements OAuthJwtAccessTokenValidator {
 
-    private String trustedIssuer = null;
-    private Set<String> requiredAudiences = null;
-    private Set<String> requiredScopes = null;
-    private Map<String, Set<String>> authorizedClientIds = null;
+    private final String trustedIssuer;
+    private final Set<String> requiredAudiences;
+    private final Set<String> requiredScopes;
+    private final Map<String, Set<String>> authorizedClientIds;
 
     /**
      * create DefaultOAuthJwtAccessTokenValidator
@@ -68,6 +68,7 @@ public class DefaultOAuthJwtAccessTokenValidator implements OAuthJwtAccessTokenV
             throw new OAuthJwtAccessTokenException("iss not trusted: got=" + issuer);
         }
     }
+
     private void verifyAudiences(OAuthJwtAccessToken jwt) throws OAuthJwtAccessTokenException {
         List<String> audiences = jwt.getAudiences();
         if (audiences == null || !(new HashSet<>(audiences)).containsAll(this.requiredAudiences)) {
@@ -76,6 +77,7 @@ public class DefaultOAuthJwtAccessTokenValidator implements OAuthJwtAccessTokenV
             throw new OAuthJwtAccessTokenException("required aud not found: got=" + got);
         }
     }
+
     private void verifyScopes(OAuthJwtAccessToken jwt) throws OAuthJwtAccessTokenException {
         List<String> scopes = jwt.getScopes();
         if (scopes == null || !(new HashSet<>(scopes)).containsAll(this.requiredScopes)) {
@@ -83,17 +85,19 @@ public class DefaultOAuthJwtAccessTokenValidator implements OAuthJwtAccessTokenV
             throw new OAuthJwtAccessTokenException("required scope not found: got=" + jwt.getScope());
         }
     }
+
     private void verifyCertificateThumbprint(OAuthJwtAccessToken jwt, String certificateThumbprint) throws OAuthJwtAccessTokenException {
         String certThumbprint = jwt.getCertificateThumbprint();
-        if (certificateThumbprint == certThumbprint) {
+        if (certificateThumbprint == null && certThumbprint == null) {
             // skip when both null
             return;
         }
-        if (certificateThumbprint == null || certThumbprint == null || !certificateThumbprint.equals(certThumbprint)) {
+        if (certificateThumbprint == null || !certificateThumbprint.equals(certThumbprint)) {
             // certificate thumbprint NOT match with JWT
             throw new OAuthJwtAccessTokenException(String.format("client certificate thumbprint (%s) not match: got=%s", certificateThumbprint, certThumbprint));
         }
     }
+
     private void verifyClientId(OAuthJwtAccessToken jwt, String certificatePrincipal) throws OAuthJwtAccessTokenException {
         String clientId = jwt.getClientId();
         Set<String> validClientIds = this.authorizedClientIds.get(certificatePrincipal);

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/validator/OAuthJwtAccessTokenValidator.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/validator/OAuthJwtAccessTokenValidator.java
@@ -33,7 +33,7 @@ public interface OAuthJwtAccessTokenValidator {
      * @param  jwt                          jwt object
      * @throws OAuthJwtAccessTokenException throws when the JWT is invalid
      */
-    public void validate(OAuthJwtAccessToken jwt) throws OAuthJwtAccessTokenException;
+    void validate(OAuthJwtAccessToken jwt) throws OAuthJwtAccessTokenException;
 
     /**
      * validate client ID claim
@@ -41,7 +41,7 @@ public interface OAuthJwtAccessTokenValidator {
      * @param  clientId                     expected client ID
      * @throws OAuthJwtAccessTokenException throws when the client ID in the JWT is invalid
      */
-    public void validateClientId(OAuthJwtAccessToken jwt, String clientId) throws OAuthJwtAccessTokenException;
+    void validateClientId(OAuthJwtAccessToken jwt, String clientId) throws OAuthJwtAccessTokenException;
 
     /**
      * validate certificate binding of the JWT
@@ -49,7 +49,7 @@ public interface OAuthJwtAccessTokenValidator {
      * @param  certificateThumbprint        expected certificate thumbprint
      * @throws OAuthJwtAccessTokenException throws when the certificate thumbprint in the JWT is invalid
      */
-    public void validateCertificateBinding(OAuthJwtAccessToken jwt, String certificateThumbprint) throws OAuthJwtAccessTokenException;
+    void validateCertificateBinding(OAuthJwtAccessToken jwt, String certificateThumbprint) throws OAuthJwtAccessTokenException;
 
     /**
      * validate certificate binding of the JWT
@@ -57,7 +57,7 @@ public interface OAuthJwtAccessTokenValidator {
      * @param  x509Certificate              the bound certificate
      * @throws OAuthJwtAccessTokenException throws when the certificate thumbprint in the JWT is invalid
      */
-    default public void validateCertificateBinding(OAuthJwtAccessToken jwt, X509Certificate x509Certificate) throws OAuthJwtAccessTokenException {
+    default void validateCertificateBinding(OAuthJwtAccessToken jwt, X509Certificate x509Certificate) throws OAuthJwtAccessTokenException {
         String certificateThumbprint;
         try {
             certificateThumbprint = this.getX509CertificateThumbprint(x509Certificate);
@@ -73,7 +73,7 @@ public interface OAuthJwtAccessTokenValidator {
      * @return X.509 certificate common name
      * @throws NullPointerException on null
      */
-    default public String getX509CertificateCommonName(X509Certificate x509Certificate) {
+    default String getX509CertificateCommonName(X509Certificate x509Certificate) {
         return Crypto.extractX509CertCommonName(x509Certificate);
     }
 
@@ -86,7 +86,7 @@ public interface OAuthJwtAccessTokenValidator {
      * @throws NullPointerException         on null
      * @see <a href="https://tools.ietf.org/html/draft-ietf-oauth-mtls-17#section-3.1" target="_top">draft-ietf-oauth-mtls-17</a>
      */
-    default public String getX509CertificateThumbprint(X509Certificate x509Certificate) throws CertificateEncodingException, CryptoException {
+    default String getX509CertificateThumbprint(X509Certificate x509Certificate) throws CertificateEncodingException, CryptoException {
         byte[] encodedCert = Crypto.sha256(x509Certificate.getEncoded());
         return Base64.getUrlEncoder().withoutPadding().encodeToString(encodedCert);
     }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/KerberosToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/KerberosToken.java
@@ -39,7 +39,7 @@ public class KerberosToken extends Token {
     private static final String ATHENZ_PROP_KRB_USER_DOMAIN = "athenz.auth.kerberos.krb_user_domain";
     private static final String ATHENZ_PROP_KRB_USER_REALM = "athenz.auth.kerberos.krb_user_realm";
 
-    private String krbPrivActionClass = System.getProperty(KRB_PROP_TOKEN_PRIV_ACTION);
+    private final String krbPrivActionClass = System.getProperty(KRB_PROP_TOKEN_PRIV_ACTION);
     private String userName = null;
     
     public static final String USER_DOMAIN = System.getProperty(ATHENZ_PROP_USER_DOMAIN, "user");

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/PrincipalToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/PrincipalToken.java
@@ -41,9 +41,9 @@ public class PrincipalToken extends Token {
     public static class Builder {
 
         // required attributes
-        private String domain;
-        private String name;
-        private String version;
+        private final String domain;
+        private final String name;
+        private final String version;
         
         // optional attributes with default values
         private String salt = Crypto.randomSalt();

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/RoleToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/RoleToken.java
@@ -35,9 +35,9 @@ public class RoleToken extends Token {
     public static class Builder {
 
         // required attributes
-        private String domain;
-        private List<String> roles;
-        private String version;
+        private final String domain;
+        private final List<String> roles;
+        private final String version;
         private String principal = null;
         private String proxyUser = null;
         private boolean domainCompleteRoleSet = false;

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolver.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolver.java
@@ -154,7 +154,7 @@ public class JwtsSigningKeyResolver implements SigningKeyResolver {
                 }
                 publicKeys.put(id, Crypto.loadPublicKey(Crypto.ybase64DecodeString(key)));
             }
-            if (publicKeys.size() == 0) {
+            if (publicKeys.isEmpty()) {
                 LOGGER.error("No valid public json web keys in conf file: {}", confFileName);
             }
         } catch (IOException ex) {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/GlobStringsMatcher.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/GlobStringsMatcher.java
@@ -30,7 +30,7 @@ public class GlobStringsMatcher {
 
     public GlobStringsMatcher(String systemProperty) {
         List<String> globList = AthenzUtils.splitCommaSeparatedSystemProperty(systemProperty);
-        patterns = globList.stream().map(glob -> StringUtils.patternFromGlob(glob)).collect(Collectors.toList());
+        patterns = globList.stream().map(StringUtils::patternFromGlob).collect(Collectors.toList());
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("Property: %s, Regex List: %s", systemProperty, Arrays.toString(patterns.toArray())));
         }
@@ -38,11 +38,11 @@ public class GlobStringsMatcher {
 
     public boolean isEmptyPatternsList() {
         return (patterns == null ||
-                patterns.size() == 0 ||
+                patterns.isEmpty() ||
                 (patterns.size() == 1 && patterns.get(0).equals("^$")));
     }
 
     public boolean isMatch(String value) {
-        return patterns.stream().anyMatch(pattern -> value.matches(pattern));
+        return patterns.stream().anyMatch(value::matches);
     }
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Validate.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Validate.java
@@ -26,8 +26,8 @@ public class Validate {
     private static final String PRINCIPAL_REGEX = "((([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*):)?(([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)";
     private static final String DOMAIN_REGEX = "([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*";
     
-    private static Pattern principalPattern = Pattern.compile(PRINCIPAL_REGEX);
-    private static Pattern domainPattern = Pattern.compile(DOMAIN_REGEX);
+    private static final Pattern PRINCIPAL_PATTERN = Pattern.compile(PRINCIPAL_REGEX);
+    private static final Pattern DOMAIN_PATTERN = Pattern.compile(DOMAIN_REGEX);
 
     /**
      * @param name a principal name to validate
@@ -37,7 +37,7 @@ public class Validate {
         if (name == null || name.isEmpty()) {
             return false;
         }
-        Matcher matcher = principalPattern.matcher(name);
+        Matcher matcher = PRINCIPAL_PATTERN.matcher(name);
         return matcher.matches();
     }
 
@@ -49,7 +49,7 @@ public class Validate {
         if (name == null || name.isEmpty()) {
             return false;
         }
-        Matcher matcher = domainPattern.matcher(name);
+        Matcher matcher = DOMAIN_PATTERN.matcher(name);
         return matcher.matches();
     }
 }

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateAuthorityTest.java
@@ -21,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.List;
 
 import org.testng.annotations.Test;
 

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateAuthorityValidatorTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateAuthorityValidatorTest.java
@@ -3,7 +3,6 @@ package com.yahoo.athenz.auth.impl;
 import org.testng.annotations.Test;
 
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.CertificateException;

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateIdentityParserTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateIdentityParserTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class CertificateIdentityParserTest {
 
     private final ClassLoader classLoader = this.getClass().getClassLoader();
-    private final X509Certificate readCert(String resourceName) throws Exception {
+    private X509Certificate readCert(String resourceName) throws Exception {
         try (FileInputStream certIs = new FileInputStream(this.classLoader.getResource(resourceName).getFile())) {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             return (X509Certificate) cf.generateCertificate(certIs);
@@ -57,7 +57,7 @@ public class CertificateIdentityParserTest {
         for (Field f : parser.getClass().getDeclaredFields()) {
             switch (f.getName()) {
             case "excludedPrincipalSet":
-                assertEquals(getFieldValue.apply(f, parser), null);
+                assertNull(getFieldValue.apply(f, parser));
                 break;
             case "excludeRoleCertificates":
                 assertEquals(getFieldValue.apply(f, parser), false);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateIdentityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateIdentityTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 public class CertificateIdentityTest {
 
     private final ClassLoader classLoader = this.getClass().getClassLoader();
-    private final X509Certificate readCert(String resourceName) throws Exception {
+    private X509Certificate readCert(String resourceName) throws Exception {
         try (FileInputStream certIs = new FileInputStream(this.classLoader.getResource(resourceName).getFile())) {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             return (X509Certificate) cf.generateCertificate(certIs);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/KeyStoreMock.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/KeyStoreMock.java
@@ -24,11 +24,11 @@ import com.yahoo.athenz.auth.KeyStore;
 
 public class KeyStoreMock implements KeyStore {
 
-    private String servicePublicKeyStringK0;
-    private String servicePublicKeyStringK1;
-    private String ztsPublicKeyStringK0;
-    private String ztsPublicKeyStringK1;
-    private String hostPublic;
+    private final String servicePublicKeyStringK0;
+    private final String servicePublicKeyStringK1;
+    private final String ztsPublicKeyStringK0;
+    private final String ztsPublicKeyStringK1;
+    private final String hostPublic;
 
     public KeyStoreMock() throws IOException {
         Path path = Paths.get("./src/test/resources/fantasy_public_k0.key");

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/MockPrivExcAction.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/MockPrivExcAction.java
@@ -22,7 +22,7 @@ import com.yahoo.athenz.auth.token.KerberosToken;
 public class MockPrivExcAction implements PrivilegedExceptionAction<String> {
 
     private byte[] kerberosTicket;
-    private String realm = System.getProperty(KerberosToken.KRB_PROP_TOKEN_PRIV_ACTION + "_TEST_REALM",
+    private final String realm = System.getProperty(KerberosToken.KRB_PROP_TOKEN_PRIV_ACTION + "_TEST_REALM",
             KerberosToken.KRB_USER_REALM);
 
     public MockPrivExcAction(String kerberosTicket) {

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/PrincipalAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/PrincipalAuthorityTest.java
@@ -98,7 +98,7 @@ public class PrincipalAuthorityTest {
 
         return "v=" + version + ";d=" + domain
                 + ";n=" + name + ";h=" + host + ";a=" + salt + ";t="
-                + Long.toString(timestamp) + ";e=" + Long.toString(expiryTime)
+                + timestamp + ";e=" + expiryTime
                 + ";s=" + signature;
     }
 
@@ -175,7 +175,7 @@ public class PrincipalAuthorityTest {
 
         // Service Authority should return null when authenticate() fails
         assertNull(principal);
-        assertTrue(!errMsg.toString().isEmpty());
+        assertFalse(errMsg.toString().isEmpty());
         assertTrue(errMsg.toString().contains("authenticate"));
 
         principal = serviceAuthority.authenticate(

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/RoleAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/RoleAuthorityTest.java
@@ -47,7 +47,7 @@ public class RoleAuthorityTest {
     private String ztsPrivateKeyStringK1 = null;
     private static final String ZMS_USER_DOMAIN = "athenz.user_domain";
 
-    private static String userDomain = System.getProperty(ZMS_USER_DOMAIN, "user");
+    private static final String userDomain = System.getProperty(ZMS_USER_DOMAIN, "user");
     
     @BeforeTest
     private void loadKeys() throws IOException {
@@ -103,8 +103,8 @@ public class RoleAuthorityTest {
         }
 
         return "v=" + version + ";d=" + domain
-                + ";r=" + flattenedRoles + ";t=" + Long.toString(timestamp)
-                + ";e=" + Long.toString(expiryTime) + ";s=" + signature;
+                + ";r=" + flattenedRoles + ";t=" + timestamp
+                + ";e=" + expiryTime + ";s=" + signature;
     }
 
     @Test
@@ -211,7 +211,7 @@ public class RoleAuthorityTest {
 
         // Role Authority should return null when authenticate() fails
         assertNull(principal);
-        assertTrue(!errMsg.toString().isEmpty());
+        assertFalse(errMsg.toString().isEmpty());
         assertTrue(errMsg.toString().contains("authenticate"));
 
         principal = rollAuthority.authenticate(tamperWithRoleToken(tokenToTamper),
@@ -256,7 +256,7 @@ public class RoleAuthorityTest {
         // Create and sign token with keyVersion = 0
         RoleToken roleToken = new RoleToken.Builder(rolVersion, svcDomain, roles)
             .salt(salt).ip("127.0.0.1").expirationWindow(expirationTime)
-            .principal("" + userDomain + ".joe").keyId(testKeyVersionK0).build();
+            .principal(userDomain + ".joe").keyId(testKeyVersionK0).build();
         roleToken.sign(ztsPrivateKeyStringK0);
 
         // mismatch IP but should be OK since it's not write operation
@@ -280,7 +280,7 @@ public class RoleAuthorityTest {
         // Create and sign token with keyVersion = 0
         RoleToken roleToken = new RoleToken.Builder(rolVersion, svcDomain, roles)
             .salt(salt).ip("127.0.0.1").expirationWindow(expirationTime)
-            .principal("" + userDomain + ".joe").keyId(testKeyVersionK0).build();
+            .principal(userDomain + ".joe").keyId(testKeyVersionK0).build();
         roleToken.sign(ztsPrivateKeyStringK0);
 
         // mismatch IP should fail
@@ -289,7 +289,7 @@ public class RoleAuthorityTest {
                 "127.0.0.2", "DELETE", errMsg);
 
         assertNull(principal);
-        assertTrue(!errMsg.toString().isEmpty());
+        assertFalse(errMsg.toString().isEmpty());
         assertTrue(errMsg.toString().contains("authenticate"));
         
         errMsg = new StringBuilder(); // get a fresh one
@@ -297,7 +297,7 @@ public class RoleAuthorityTest {
                 "127.0.0.2", "PUT", errMsg);
 
         assertNull(principal);
-        assertTrue(!errMsg.toString().isEmpty());
+        assertFalse(errMsg.toString().isEmpty());
         assertTrue(errMsg.toString().contains("authenticate"));
         
         // final check should be ok with valid IP

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/SimplePrincipalTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/SimplePrincipalTest.java
@@ -230,7 +230,7 @@ public class SimplePrincipalTest {
 
         Principal p3 = SimplePrincipal.create("user", "jdoe1", fakeCreds, 101, userAuthority);
         assertFalse(p.equals(p3));
-        assertTrue(p.hashCode() != p3.hashCode());
+        assertNotEquals(p.hashCode(), p3.hashCode());
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/OAuthCertBoundJwtAccessTokenAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/OAuthCertBoundJwtAccessTokenAuthorityTest.java
@@ -24,12 +24,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import com.yahoo.athenz.auth.Authority.CredSource;
@@ -88,13 +84,13 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
     }
 
     @Test
-    public void testGetCredSource() throws Exception {
+    public void testGetCredSource() {
         OAuthCertBoundJwtAccessTokenAuthority authority = new OAuthCertBoundJwtAccessTokenAuthority();
         assertEquals(authority.getCredSource(), CredSource.REQUEST);
     }
 
     @Test
-    public void testGetAuthenticateChallenge() throws Exception {
+    public void testGetAuthenticateChallenge() {
         OAuthCertBoundJwtAccessTokenAuthority authority = new OAuthCertBoundJwtAccessTokenAuthority();
         assertEquals(authority.getAuthenticateChallenge(), "Bearer realm=\"athenz.io\"");
     }
@@ -102,19 +98,19 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
     @Test
     public void testGetDomain() throws Exception {
         OAuthCertBoundJwtAccessTokenAuthority authority = new OAuthCertBoundJwtAccessTokenAuthority();
-        assertEquals(authority.getDomain(), null);
+        assertNull(authority.getDomain());
     }
 
     @Test
-    public void testGetHeader() throws Exception {
+    public void testGetHeader() {
         OAuthCertBoundJwtAccessTokenAuthority authority = new OAuthCertBoundJwtAccessTokenAuthority();
         assertEquals(authority.getHeader(), "Authorization");
     }
 
     @Test
-    public void testAuthenticateWithHeader() throws Exception {
+    public void testAuthenticateWithHeader() {
         OAuthCertBoundJwtAccessTokenAuthority authority = new OAuthCertBoundJwtAccessTokenAuthority();
-        assertEquals(authority.authenticate(null, null, null, null), null);
+        assertNull(authority.authenticate(null, null, null, null));
     }
 
     @Test
@@ -126,8 +122,6 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         Map<String, String> authorizedServices = new HashMap<>();
 
         // empty args
-        authorizedClientIds.clear();
-        authorizedServices.clear();
         processAuthorizedClientIds.invoke(authority, null, authorizedClientIds, authorizedServices);
         assertEquals(authorizedClientIds.size(), 0);
         assertEquals(authorizedServices.size(), 0);
@@ -157,13 +151,13 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         authorizedServices.clear();
         Map<String, Set<String>> expectedAuthorizedClientIds = new HashMap<>();
         Map<String, String> expectedAuthorizedServices = new HashMap<>();
-        expectedAuthorizedClientIds.put("ui_principal_11", new HashSet<>(Arrays.asList(new String[]{"client_id_11","client_id_12"})));
+        expectedAuthorizedClientIds.put("ui_principal_11", new HashSet<>(Arrays.asList("client_id_11","client_id_12")));
         expectedAuthorizedServices.put("ui_principal_11", "authorized_service_11");
-        expectedAuthorizedClientIds.put("ui_principal_21", new HashSet<>(Arrays.asList(new String[]{"client_id_21"})));
+        expectedAuthorizedClientIds.put("ui_principal_21", new HashSet<>(List.of("client_id_21")));
         expectedAuthorizedServices.put("ui_principal_21", "authorized_service_21");
-        expectedAuthorizedClientIds.put("ui_principal_31", new HashSet<>(Arrays.asList(new String[]{"client_id_31"})));
+        expectedAuthorizedClientIds.put("ui_principal_31", new HashSet<>(Arrays.asList("client_id_31")));
         expectedAuthorizedServices.put("ui_principal_31", "authorized_service_31");
-        expectedAuthorizedClientIds.put("ui_principal_41", new HashSet<>(Arrays.asList(new String[]{"client_id_41","trailing_comma"})));
+        expectedAuthorizedClientIds.put("ui_principal_41", new HashSet<>(Arrays.asList("client_id_41","trailing_comma")));
         expectedAuthorizedServices.put("ui_principal_41", "authorized_service_41");
         processAuthorizedClientIds.invoke(authority, this.classLoader.getResource("authorized_client_ids.txt").getPath(), authorizedClientIds, authorizedServices);
         assertEquals(authorizedClientIds, expectedAuthorizedClientIds);
@@ -172,7 +166,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
 
     static final class OAuthCertBoundJwtAccessTokenAuthorityTestParser implements OAuthJwtAccessTokenParser {
         @Override
-        public OAuthJwtAccessToken parse(String jwtString) throws OAuthJwtAccessTokenException {
+        public OAuthJwtAccessToken parse(String jwtString) {
             return null;
         }
     }
@@ -200,8 +194,6 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         assertEquals(authenticateChallengeField.get(authority), "Bearer realm=\"https://athenz.io\"");
 
         // certificateIdentityParser
-        CertificateIdentityParser certParser = null;
-        Field excludeRoleCertificatesField = null, excludedPrincipalsField = null;
         Field certificateIdentityParserField = authority.getClass().getDeclaredField("certificateIdentityParser");
         certificateIdentityParserField.setAccessible(true);
 
@@ -210,13 +202,13 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         authority.initialize();
         System.clearProperty("athenz.auth.oauth.jwt.cert.exclude_role_certificates");
         System.clearProperty("athenz.auth.oauth.jwt.cert.excluded_principals");
-        certParser = (CertificateIdentityParser) certificateIdentityParserField.get(authority);
-        excludeRoleCertificatesField  = certParser.getClass().getDeclaredField("excludeRoleCertificates");
-        excludedPrincipalsField  = certParser.getClass().getDeclaredField("excludedPrincipalSet");
+        CertificateIdentityParser certParser = (CertificateIdentityParser) certificateIdentityParserField.get(authority);
+        Field excludeRoleCertificatesField  = certParser.getClass().getDeclaredField("excludeRoleCertificates");
+        Field excludedPrincipalsField  = certParser.getClass().getDeclaredField("excludedPrincipalSet");
         excludeRoleCertificatesField.setAccessible(true);
         excludedPrincipalsField.setAccessible(true);
         assertEquals(excludeRoleCertificatesField.get(certParser), true);
-        assertEquals(excludedPrincipalsField.get(certParser), new HashSet<>(Arrays.asList(new String[]{ "principals_1", "principals_2" })));
+        assertEquals(excludedPrincipalsField.get(certParser), new HashSet<>(Arrays.asList("principals_1", "principals_2")));
 
         System.clearProperty("athenz.auth.oauth.jwt.cert.exclude_role_certificates");
         System.clearProperty("athenz.auth.oauth.jwt.cert.excluded_principals");
@@ -227,14 +219,14 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         excludeRoleCertificatesField.setAccessible(true);
         excludedPrincipalsField.setAccessible(true);
         assertEquals(excludeRoleCertificatesField.get(certParser), false);
-        assertEquals(excludedPrincipalsField.get(certParser), (Set<String>) null);
+        assertNull(excludedPrincipalsField.get(certParser));
 
         // parser
         Field parserField = authority.getClass().getDeclaredField("parser");
         parserField.setAccessible(true);
 
         System.setProperty("athenz.auth.oauth.jwt.parser_factory_class", "invalid_class");
-        assertThrows(IllegalArgumentException.class, () -> authority.initialize());
+        assertThrows(IllegalArgumentException.class, authority::initialize);
         System.clearProperty("athenz.auth.oauth.jwt.parser_factory_class");
 
         System.setProperty("athenz.auth.oauth.jwt.parser_factory_class", OAuthCertBoundJwtAccessTokenAuthorityTestParserFactory.class.getName());
@@ -259,8 +251,6 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         assertEquals(shouldVerifyCertThumbprintField.get(authority), false);
 
         // authorizedServices & validator
-        DefaultOAuthJwtAccessTokenValidator validator = null;
-        Field trustedIssuerField = null, requiredAudiencesField = null, requiredScopesField = null, authorizedClientIdsField = null;
         Field authorizedServicesField = authority.getClass().getDeclaredField("authorizedServices");
         authorizedServicesField.setAccessible(true);
         Field validatorField = authority.getClass().getDeclaredField("validator");
@@ -270,7 +260,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         System.setProperty("athenz.auth.oauth.jwt.claim.iss", "");
         System.setProperty("athenz.auth.oauth.jwt.claim.aud", "");
         System.setProperty("athenz.auth.oauth.jwt.claim.scope", "");
-        assertThrows(IllegalArgumentException.class, () -> authority.initialize());
+        assertThrows(IllegalArgumentException.class, authority::initialize);
         System.clearProperty("athenz.auth.oauth.jwt.authorized_client_ids_path");
         System.clearProperty("athenz.auth.oauth.jwt.claim.iss");
         System.clearProperty("athenz.auth.oauth.jwt.claim.aud");
@@ -279,7 +269,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         Map<String, String> expectedAuthorizedServices = new HashMap<>();
         Map<String, Set<String>> expectedAuthorizedClientIds = new HashMap<>();
         expectedAuthorizedServices.put("ui.athenz.io", "sys.auth.ui");
-        expectedAuthorizedClientIds.put("ui.athenz.io", new HashSet<>(Arrays.asList(new String[]{"client_id_1","client_id_2","ui.athenz.io"})));
+        expectedAuthorizedClientIds.put("ui.athenz.io", new HashSet<>(Arrays.asList("client_id_1","client_id_2","ui.athenz.io")));
         System.setProperty("athenz.auth.oauth.jwt.authorized_client_ids_path", this.classLoader.getResource("authorized_client_ids.single.txt").getPath());
         System.setProperty("athenz.auth.oauth.jwt.claim.iss", "iss");
         System.setProperty("athenz.auth.oauth.jwt.claim.aud", "aud_1,aud_2");
@@ -290,18 +280,18 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         System.clearProperty("athenz.auth.oauth.jwt.claim.aud");
         System.clearProperty("athenz.auth.oauth.jwt.claim.scope");
         assertEquals(authorizedServicesField.get(authority), expectedAuthorizedServices);
-        validator = (DefaultOAuthJwtAccessTokenValidator) validatorField.get(authority);
-        trustedIssuerField = validator.getClass().getDeclaredField("trustedIssuer");
-        requiredAudiencesField = validator.getClass().getDeclaredField("requiredAudiences");
-        requiredScopesField = validator.getClass().getDeclaredField("requiredScopes");
-        authorizedClientIdsField = validator.getClass().getDeclaredField("authorizedClientIds");
+        DefaultOAuthJwtAccessTokenValidator validator = (DefaultOAuthJwtAccessTokenValidator) validatorField.get(authority);
+        Field trustedIssuerField = validator.getClass().getDeclaredField("trustedIssuer");
+        Field requiredAudiencesField = validator.getClass().getDeclaredField("requiredAudiences");
+        Field requiredScopesField = validator.getClass().getDeclaredField("requiredScopes");
+        Field authorizedClientIdsField = validator.getClass().getDeclaredField("authorizedClientIds");
         trustedIssuerField.setAccessible(true);
         requiredAudiencesField.setAccessible(true);
         requiredScopesField.setAccessible(true);
         authorizedClientIdsField.setAccessible(true);
         assertEquals(trustedIssuerField.get(validator), "iss");
-        assertEquals(requiredAudiencesField.get(validator), new HashSet<>(Arrays.asList(new String[]{"aud_1", "aud_2"})));
-        assertEquals(requiredScopesField.get(validator), new HashSet<>(Arrays.asList(new String[]{"scope_1", "scope_2"})));
+        assertEquals(requiredAudiencesField.get(validator), new HashSet<>(Arrays.asList("aud_1", "aud_2")));
+        assertEquals(requiredScopesField.get(validator), new HashSet<>(Arrays.asList("scope_1", "scope_2")));
         assertEquals(authorizedClientIdsField.get(validator), expectedAuthorizedClientIds);
 
         System.clearProperty("athenz.auth.oauth.jwt.authorized_client_ids_path");
@@ -320,8 +310,8 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         requiredScopesField.setAccessible(true);
         authorizedClientIdsField.setAccessible(true);
         assertEquals(trustedIssuerField.get(validator), "https://athenz.io");
-        assertEquals(requiredAudiencesField.get(validator), new HashSet<>(Arrays.asList(new String[]{"https://zms.athenz.io"})));
-        assertEquals(requiredScopesField.get(validator), new HashSet<>(Arrays.asList(new String[]{"sys.auth:role.admin"})));
+        assertEquals(requiredAudiencesField.get(validator), new HashSet<>(Arrays.asList("https://zms.athenz.io")));
+        assertEquals(requiredScopesField.get(validator), new HashSet<>(Arrays.asList("sys.auth:role.admin")));
         assertEquals(authorizedClientIdsField.get(validator), new HashMap<String, String>());
     }
 
@@ -332,7 +322,6 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         String noCnfJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleUlkIn0.eyJzdWIiOiJ1c2VyLmFkbWluIiwiaXNzIjoic3lzLmF1dGgudGVzdElkUCIsImF1ZCI6Imh0dHBzOi8vem1zLmF0aGVuei5pbyIsInNjb3BlIjoic3lzLmF1dGg6cm9sZS5hZG1pbiIsImNsaWVudF9pZCI6InVpLmF0aGVuei5pbyIsImlhdCI6MTUxNjIzOTAyMiwiZXhwIjo5OTkwMDA5OTk5fQ.uE-SsyDGb0a1QU1Clv0WmwZqIm1HXc0pJy_rGofpIeo5jOsz3wj1ZVjGslgLV56hW9zvnwOh5ur8ChgQrYfDN1meM6loiu4py9mAU9bfaiPkecqGA5zmWQjhl9206MbVKxFXbVlt5FrQJaM5corSkIH4MIpxS4vU2dZBC4Emtc8hZXRg5BOKr6xRA-vTLbWNa3FTh8dhehTXngQ_bnJfU5MxoTMlrBCrajKjnzSYzZ6vutJKDZKGdbmRrM982wjuDyEzhViKVDBsNqUa0LUblBoUtVx2FnPCUlBWnyqm4aaf6FtqV8z2KolcH1DA_3PaWv1R_txFD0B4pRm1GA77LGCgAdNzZ4KMBN300K0DzBhbYS4fmbr0faAIUtYWRTI3PwkSQGUwZTS4FZbK6RQ-kUkx68BhLP3R33E06EGsb7qvdcPELFjMh8HtbUPUZdJnq0z5Q6EJrWE4h3_7c6JDCm5IIJ9GDN8u20l0BFQe1SCmcYAVutuuGX_79B73r2sQdm8-6LVoOZXtDFLlbadcXUHybUgZYYSlehKD1Vdt4JQqeVStdUM0q7Otfe9dhfrDHwJrEN9iGNWVItxlP86K8SrTRzaa8b1Qs6E-qXx_6XFF3taFU9jWS3I571WrXo1qkJp6QQknqEFa1JJkh28UDjonkgRSzeProQxbF_7T5VE";
         String invalidSubjectJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleUlkIn0.eyJzdWIiOiJ1c2VyYWRtaW4iLCJpc3MiOiJzeXMuYXV0aC50ZXN0SWRQIiwiYXVkIjoiaHR0cHM6Ly96bXMuYXRoZW56LmlvIiwic2NvcGUiOiJzeXMuYXV0aDpyb2xlLmFkbWluIiwiY2xpZW50X2lkIjoidWkuYXRoZW56LmlvIiwiaWF0IjoxNTE2MjM5MDIyLCJjbmYiOnsieDV0I1MyNTYiOiJ6bGt4eW9YOTVsZS1OdjdPSTBCeGNqVE9vZ3Z5OVBHSC12X0NCcl9Ec0VrIn0sImV4cCI6OTk5MDAwOTk5OX0.HhCeOzNcDtR6GmPvlARwn5NSNPK3QhLw_LSsyg8LIq35vu8BoBsgX-Dw8GuFXc84e9gFdV5LTPOpOM78Ktc_L-eQ27j3u_UggCGwxkZHknRprLzBDx8A-bM3VyPyxTpokNFyrmrDbUn7pE8QwDRuPxOHjZUG1Wca2kY9YtgxnvYmh8w6TRH_uKdCPlbdo6FgQFbpSXZWbm0_UOQXpsSLH-q9vwz52D2wuDM_kGigLf1GKueshj-4Rzmrgh1nT-Zb6JQtBKdsnJRjQi9O9gQFwAdUcFFLVXd8IQKpgJc6ZvesGBwJmEOrE-THFHaGPdiRbqgMc8ha_0uknVeOwgiIflQfXi2Tid6aXBWBLDnABJuzlpSs7cXto3Fu-RAQLCQ16YJnFfeaCpmRkkjqTIupgRUy3_rqBNDUgg62kGjb6Sz_Q9lC1rdvx19i2lZqlvxgX1Q0_tbkqfCXm4mgU8b70OJ2oVGE6fq4hXDIKl-v7YAtDQdfqz3OmN6epRdOXCi3ZdgE5QzJS1TVbu-IgGrNgkfl8QzS02mSoIUpJAWZfE_21oYvLNjtYuOC2r9q3CSTwUHQJu45HupZnr0dLq7dIV-y_PAanHpz2IRJrhbZBicbR2P0sBsx-FxPUIGCK4II3Gsx5LehYNWYHSNnzdaGZC56x41VTzo2g7KNqLNYUBk";
         String customJwt = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImtleUlkIn0.eyJzdWIiOiJ1c2VyLmFkbWluIiwiaXNzIjoic3lzLmF1dGgudGVzdElkUCIsImF1ZCI6WyJjdXN0b21fYXVkXzEiLCJjdXN0b21fYXVkXzIiXSwic2NvcGUiOiJjdXN0b21fc2NvcGVfMSBjdXN0b21fc2NvcGVfMiIsImNsaWVudF9pZCI6InVpLmF0aGVuei5pbyIsImlhdCI6MTUxNjIzOTAyMiwiY25mIjp7Ing1dCNTMjU2IjoiemxreHlvWDk1bGUtTnY3T0kwQnhjalRPb2d2eTlQR0gtdl9DQnJfRHNFayJ9LCJleHAiOjk5OTAwMDk5OTl9.HCc0RCeV06gtgUKPoSDGhFySDxsCujmpzbge-oe1YQv43sRBTJfvJ4JIDnuPCosPugw8R9l9Bj3VM_sKSLHpJGhDRcQPamlawdes7bHSSL8VDoQIPLIzTdQUXc81OJqKSTMBjChdPzHSKF3VpwnrMpuFuBLvPs7PyN7xXxzDlEANPYx6-9pnd_z_eB4hABj0Q_fyX9pcm9wyXPyW3eEDo0m_R80fa6CUaEGt6FseVyZp7WimCXF-IongjXJLy3BLppVIUHg5U_rVmvoe81pE7-tJe7NiS5suUWLq-kMBNhmGBulGNLbH8VT4jOVDTpzS8a3jHL18xtHlij9Zbg4zpBbo4Z8O0Az37SS1vrGwTMPAW9uhjVRqAJB1MM5YZ5Rr8XRy6hduF-FbDmOP27jE_n0Hk2oQ2yfaB2oAY0wjpSLukV_CNzaDWrBBu_j25ld1OsvKeHXTBtf8EhjIcWrktu48SJvoDNQZZskeDXAt7gabFv7y2Gbe4JG4AF43-ewRuFzoMBJsLgzjvd7f1v71leTV519AD4ScjJNp17PakSc8BFu3E9--yr2jLFsJ1cC3VtezdOV2Jssh00WiklsB-mdcHi2WOXr3XONuix6ZvS2DehQCKEFtGEQcWe3oLjZmE5QDJNvuCbU1GbtAXiAbbEuqKaUKUf9HZW2KVfUSgqI";
-        HttpServletRequest requestMock = null;
         StringBuilder errMsg = new StringBuilder();
         OAuthCertBoundJwtAccessTokenAuthority authority = new OAuthCertBoundJwtAccessTokenAuthority();
         System.setProperty("athenz.auth.oauth.jwt.claim.iss", "sys.auth.testIdP");
@@ -341,39 +330,38 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         KeyStore jwtKeyStore = Mockito.spy(baseKeyStore);
         Mockito.when(jwtKeyStore.getPublicKey("sys.auth", "testidp", "keyId")).thenReturn(this.jwtPublicKey);
         authority.setKeyStore(jwtKeyStore);
-        Principal principal = null;
 
         // empty token, skip
-        requestMock = Mockito.mock(HttpServletRequestWrapper.class);
+        HttpServletRequest requestMock = Mockito.mock(HttpServletRequestWrapper.class);
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList()));
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertEquals(errMsg.length(), 0);
 
         // no certificate error
         requestMock = Mockito.mock(HttpServletRequestWrapper.class);
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer dummy_access_token")));
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertEquals(errMsg.toString(), "OAuthCertBoundJwtAccessTokenAuthority:authenticate: invalid certificate: No certificate available in request");
 
         // null errMsg, no errors
         requestMock = Mockito.mock(HttpServletRequestWrapper.class);
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer dummy_access_token_1")));
-        assertEquals(authority.authenticate(requestMock, null), null);
+        assertNull(authority.authenticate(requestMock, null));
 
         // parse JWT error
         requestMock = Mockito.mock(HttpServletRequestWrapper.class);
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer invalid_access_token")));
         Mockito.when(requestMock.getAttribute(CertificateIdentityParser.JAVAX_CERT_ATTR)).thenReturn(clientCertChain);
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertEquals(errMsg.toString(), "OAuthCertBoundJwtAccessTokenAuthority:authenticate: invalid JWT: io.jsonwebtoken.MalformedJwtException: JWT strings must contain exactly 2 period characters. Found: 0");
         requestMock = Mockito.mock(HttpServletRequestWrapper.class);
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer " + expiredJwt)));
         Mockito.when(requestMock.getAttribute(CertificateIdentityParser.JAVAX_CERT_ATTR)).thenReturn(clientCertChain);
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertTrue(errMsg.toString().startsWith("OAuthCertBoundJwtAccessTokenAuthority:authenticate: invalid JWT: io.jsonwebtoken.ExpiredJwtException: JWT expired at 2018-01-18T01:30:22Z. Current time: "));
 
         // invalid JWT
@@ -381,13 +369,13 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer " + noExpJwt)));
         Mockito.when(requestMock.getAttribute(CertificateIdentityParser.JAVAX_CERT_ATTR)).thenReturn(clientCertChain);
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertEquals(errMsg.toString(), "OAuthCertBoundJwtAccessTokenAuthority:authenticate: invalid JWT: exp is empty");
         requestMock = Mockito.mock(HttpServletRequestWrapper.class);
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer " + noCnfJwt)));
         Mockito.when(requestMock.getAttribute(CertificateIdentityParser.JAVAX_CERT_ATTR)).thenReturn(clientCertChain);
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertEquals(errMsg.toString(), "OAuthCertBoundJwtAccessTokenAuthority:authenticate: invalid JWT: NO mapping of authorized client IDs for certificate principal (ui.athenz.io)");
 
         // skip cert thumbprint verification
@@ -402,7 +390,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer " + noCnfJwt)));
         Mockito.when(requestMock.getAttribute(CertificateIdentityParser.JAVAX_CERT_ATTR)).thenReturn(clientCertChain);
         errMsg.setLength(0);
-        principal = authority.authenticate(requestMock, errMsg);
+        Principal principal = authority.authenticate(requestMock, errMsg);
         assertNotNull(principal);
         assertEquals(errMsg.toString(), "");
         assertEquals(principal.getDomain(), "user");
@@ -410,7 +398,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         assertEquals(principal.getCredentials(), noCnfJwt);
         assertEquals(principal.getIssueTime(), 1516239022L);
         assertEquals(principal.getX509Certificate(), clientCertChain[0]);
-        assertEquals(principal.getRoles(), null);
+        assertNull(principal.getRoles());
         assertEquals(principal.getApplicationId(), "ui.athenz.io");
         assertEquals(principal.getAuthorizedService(), "sys.auth.ui");
         System.setProperty("athenz.auth.oauth.jwt.claim.iss", "sys.auth.testIdP");
@@ -427,7 +415,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         Mockito.when(requestMock.getHeaders("Authorization")).thenReturn(Collections.enumeration(Arrays.asList("Bearer " + invalidSubjectJwt)));
         Mockito.when(requestMock.getAttribute(CertificateIdentityParser.JAVAX_CERT_ATTR)).thenReturn(clientCertChain);
         errMsg.setLength(0);
-        assertEquals(authority.authenticate(requestMock, errMsg), null);
+        assertNull(authority.authenticate(requestMock, errMsg));
         assertEquals(errMsg.toString(), "OAuthCertBoundJwtAccessTokenAuthority:authenticate: sub is not a valid service identity: got=useradmin");
 
         // verify non-default JWT
@@ -454,7 +442,7 @@ public class OAuthCertBoundJwtAccessTokenAuthorityTest {
         assertEquals(principal.getCredentials(), customJwt);
         assertEquals(principal.getIssueTime(), 1516239022L);
         assertEquals(principal.getX509Certificate(), clientCertChain[0]);
-        assertEquals(principal.getRoles(), null);
+        assertNull(principal.getRoles());
         assertEquals(principal.getApplicationId(), "ui.athenz.io");
         assertEquals(principal.getAuthorizedService(), "sys.auth.ui");
         System.setProperty("athenz.auth.oauth.jwt.claim.iss", "sys.auth.testIdP");

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserFactoryTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserFactoryTest.java
@@ -25,23 +25,17 @@ import org.testng.annotations.Test;
 public class DefaultOAuthJwtAccessTokenParserFactoryTest {
 
     private final ClassLoader classLoader = this.getClass().getClassLoader();
-    private final KeyStore baseKeyStore = new KeyStore() {
-        @Override
-        public String getPublicKey(String domain, String service, String keyId) {
-            return null;
-        }
-    };
+    private final KeyStore baseKeyStore = (domain, service, keyId) -> null;
 
     @Test
     public void testCreate() throws OAuthJwtAccessTokenException {
-        OAuthJwtAccessTokenParser parser = null;
         DefaultOAuthJwtAccessTokenParserFactory factory = new DefaultOAuthJwtAccessTokenParserFactory();
 
         // check internal
         assertThrows(IllegalArgumentException.class, () -> factory.create(null));
 
         // check default
-        parser = factory.create(baseKeyStore);
+        OAuthJwtAccessTokenParser parser = factory.create(baseKeyStore);
         assertNotNull(parser);
 
         // check custom property

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserTest.java
@@ -33,12 +33,7 @@ import io.jsonwebtoken.JwtParser;
 public class DefaultOAuthJwtAccessTokenParserTest {
 
     private final ClassLoader classLoader = this.getClass().getClassLoader();
-    private final KeyStore baseKeyStore = new KeyStore() {
-        @Override
-        public String getPublicKey(String domain, String service, String keyId) {
-            return null;
-        }
-    };
+    private final KeyStore baseKeyStore = (domain, service, keyId) -> null;
 
     @Test
     public void testDefaultOAuthJwtAccessTokenParser() {
@@ -50,13 +45,12 @@ public class DefaultOAuthJwtAccessTokenParserTest {
                 throw new RuntimeException(e);
             }
         };
-        DefaultOAuthJwtAccessTokenParser parser = null;
 
         // new error
         assertThrows(IllegalArgumentException.class, () -> new DefaultOAuthJwtAccessTokenParser(null, null));
 
         // new with null/empty URL
-        parser = new DefaultOAuthJwtAccessTokenParser(baseKeyStore, null);
+        DefaultOAuthJwtAccessTokenParser parser = new DefaultOAuthJwtAccessTokenParser(baseKeyStore, null);
         assertNotNull(parser);
         for (Field f : parser.getClass().getDeclaredFields()) {
             switch (f.getName()) {
@@ -114,9 +108,14 @@ public class DefaultOAuthJwtAccessTokenParserTest {
 
         // parse success
         String jwtString = "dummy-jwt-string";
-        Jws<Claims> jws = new Jws<Claims>() {
-            public JwsHeader getHeader() { return null; }
-            public Claims getBody() { return null; }
+        Jws<Claims> jws = new Jws<>() {
+            public JwsHeader getHeader() {
+                return null;
+            }
+
+            public Claims getBody() {
+                return null;
+            }
 
             @Override
             public String getSignature() {

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/parser/KeyStoreJwkKeyResolverTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/parser/KeyStoreJwkKeyResolverTest.java
@@ -18,7 +18,6 @@ package com.yahoo.athenz.auth.oauth.parser;
 import static org.testng.Assert.*;
 import java.io.FileReader;
 import java.lang.reflect.Field;
-import java.net.MalformedURLException;
 import java.security.Key;
 import java.security.KeyFactory;
 import java.security.PublicKey;
@@ -55,8 +54,8 @@ public class KeyStoreJwkKeyResolverTest {
     };
 
     @Test
-    public void testKeyStoreJwkKeyResolver() throws MalformedURLException {
-        KeyStoreJwkKeyResolver resolver = null; BiFunction<Field, KeyStoreJwkKeyResolver, Object> getFieldValue = (f, object) -> {
+    public void testKeyStoreJwkKeyResolver() {
+        BiFunction<Field, KeyStoreJwkKeyResolver, Object> getFieldValue = (f, object) -> {
             try {
                 f.setAccessible(true);
                 return f.get(object);
@@ -65,7 +64,7 @@ public class KeyStoreJwkKeyResolverTest {
             }
         };
 
-        resolver = new KeyStoreJwkKeyResolver(null, null, null);
+        KeyStoreJwkKeyResolver resolver = new KeyStoreJwkKeyResolver(null, null, null);
         assertNotNull(resolver);
         for (Field f : resolver.getClass().getDeclaredFields()) {
             switch (f.getName()) {
@@ -157,7 +156,7 @@ public class KeyStoreJwkKeyResolverTest {
         assertSame(resolver.resolveSigningKey(jwsHeader, claims), pk24);
 
         // 3. found in key store, skip JWKS
-        PublicKey pk31 = null;
+        PublicKey pk31;
 
         try (PemReader reader = new PemReader(new FileReader(this.classLoader.getResource("jwt_public.key").getFile()))) {
             pk31 = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(reader.readPemObject().getContent()));
@@ -205,7 +204,7 @@ public class KeyStoreJwkKeyResolverTest {
     }
 
     @Test
-    public void testResolveSigningKeyForJwe() throws MalformedURLException {
+    public void testResolveSigningKeyForJwe() {
         KeyStoreJwkKeyResolver resolver = new KeyStoreJwkKeyResolver(null, "file:///", null);
         assertNull(resolver.resolveSigningKey(null, (String) null));
         assertNull(resolver.resolveSigningKey(null, ""));

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/token/DefaultOAuthJwtAccessTokenTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/token/DefaultOAuthJwtAccessTokenTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 
@@ -39,7 +38,7 @@ public class DefaultOAuthJwtAccessTokenTest {
 
     @BeforeMethod
     public void initialize() throws Exception {
-        PublicKey pub = null;
+        PublicKey pub;
         try (PemReader reader = new PemReader(new FileReader(this.getClass().getClassLoader().getResource("jwt_public.key").getFile()))) {
             pub = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(reader.readPemObject().getContent()));
         }
@@ -54,7 +53,6 @@ public class DefaultOAuthJwtAccessTokenTest {
     @Test
     public void testDefaultOAuthJwtAccessToken() {
         BiFunction<Field, DefaultOAuthJwtAccessToken, Object> getFieldValue = (f, object) -> {
-            JwtBuilder b = Jwts.builder().setSubject("Bob");
             try {
                 f.setAccessible(true);
                 return f.get(object);
@@ -104,10 +102,10 @@ public class DefaultOAuthJwtAccessTokenTest {
         assertEquals(at.getIssuer(), "https://athenz.io");
         assertEquals(at.getAudience(), "[https://zms.athenz.io, https://zts.athenz.io]");
         assertEquals(at.getAudiences(), Arrays.asList("https://zms.athenz.io", "https://zts.athenz.io"));
-        assertEquals(at.getClientId(), null);
-        assertEquals(at.getCertificateThumbprint(), null);
-        assertEquals(at.getScope(), null);
-        assertEquals(at.getScopes(), null);
+        assertNull(at.getClientId());
+        assertNull(at.getCertificateThumbprint());
+        assertNull(at.getScope());
+        assertNull(at.getScopes());
         assertEquals(at.getIssuedAt(), 1470000000L);
         assertEquals(at.getExpiration(), 9990009999L);
 
@@ -119,14 +117,14 @@ public class DefaultOAuthJwtAccessTokenTest {
     @Test
     public void testGettersOnEmptyJwt() {
         DefaultOAuthJwtAccessToken at = new DefaultOAuthJwtAccessToken(this.parser.parseClaimsJws(emptyJwtString));
-        assertEquals(at.getSubject(), null);
-        assertEquals(at.getIssuer(), null);
-        assertEquals(at.getAudience(), null);
-        assertEquals(at.getAudiences(), null);
-        assertEquals(at.getClientId(), null);
-        assertEquals(at.getCertificateThumbprint(), null);
-        assertEquals(at.getScope(), null);
-        assertEquals(at.getScopes(), null);
+        assertNull(at.getSubject());
+        assertNull(at.getIssuer());
+        assertNull(at.getAudience());
+        assertNull(at.getAudiences());
+        assertNull(at.getClientId());
+        assertNull(at.getCertificateThumbprint());
+        assertNull(at.getScope());
+        assertNull(at.getScopes());
         assertEquals(at.getIssuedAt(), 0L);
         assertEquals(at.getExpiration(), 0L);
 

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/util/OAuthAuthorityUtilsTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/util/OAuthAuthorityUtilsTest.java
@@ -32,12 +32,11 @@ public class OAuthAuthorityUtilsTest {
 
     @Test
     public void testGetProperty() {
-        String propValue = null;
 
         // prop not set
         System.clearProperty("athenz.auth.oauth.jwt.test_prop");
-        propValue = OAuthAuthorityUtils.getProperty("test_prop", null);
-        assertEquals(propValue, null);
+        String propValue = OAuthAuthorityUtils.getProperty("test_prop", null);
+        assertNull(propValue);
         propValue = OAuthAuthorityUtils.getProperty("test_prop", "");
         assertEquals(propValue, "");
         propValue = OAuthAuthorityUtils.getProperty("test_prop", "default_value");
@@ -56,10 +55,9 @@ public class OAuthAuthorityUtilsTest {
 
     @Test
     public void testCsvToSet() {
-        Set<String> propValue = null;
 
         // empty csv
-        propValue = OAuthAuthorityUtils.csvToSet(null, ",");
+        Set<String> propValue = OAuthAuthorityUtils.csvToSet(null, ",");
         assertNull(propValue);
         propValue = OAuthAuthorityUtils.csvToSet("", ",");
         assertNull(propValue);
@@ -84,14 +82,12 @@ public class OAuthAuthorityUtilsTest {
 
     @Test
     public void testExtractHeaderToken() {
-        String tokenString = null;
-        Enumeration<String> headers = null;
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
         // strict bearer token
-        headers = Collections.enumeration(Arrays.asList("Bearer dummy_access_token_1"));
+        Enumeration<String> headers = Collections.enumeration(Arrays.asList("Bearer dummy_access_token_1"));
         Mockito.when(request.getHeaders("Authorization")).thenReturn(headers);
-        tokenString = OAuthAuthorityUtils.extractHeaderToken(request);
+        String tokenString = OAuthAuthorityUtils.extractHeaderToken(request);
         assertEquals(tokenString, "dummy_access_token_1");
 
         // case-insensitive bearer token
@@ -109,13 +105,13 @@ public class OAuthAuthorityUtilsTest {
         // empty header
         Mockito.when(request.getHeaders("Authorization")).thenReturn(Collections.emptyEnumeration());
         tokenString = OAuthAuthorityUtils.extractHeaderToken(request);
-        assertEquals(tokenString, null);
+        assertNull(tokenString);
 
         // non-bearer header
         headers = Collections.enumeration(Arrays.asList("Basic encoded_password"));
         Mockito.when(request.getHeaders("Authorization")).thenReturn(headers);
         tokenString = OAuthAuthorityUtils.extractHeaderToken(request);
-        assertEquals(tokenString, null);
+        assertNull(tokenString);
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/validator/DefaultOAuthJwtAccessTokenValidatorTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/validator/DefaultOAuthJwtAccessTokenValidatorTest.java
@@ -96,27 +96,13 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
             }
             fail("assertThrowable: does not throw");
         };
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator(null, this.requiredAudiences, this.requiredScopes, this.authorizedClientIds);
-        }, "trusted issuers must be configured");
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator("", this.requiredAudiences, this.requiredScopes, this.authorizedClientIds);
-        }, "trusted issuers must be configured");
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, null, this.requiredScopes, this.authorizedClientIds);
-        }, "required audiences must be configured");
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, new HashSet<>(), this.requiredScopes, this.authorizedClientIds);
-        }, "required audiences must be configured");
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, this.requiredAudiences, null, this.authorizedClientIds);
-        }, "required scopes must be configured");
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, this.requiredAudiences, new HashSet<>(), this.authorizedClientIds);
-        }, "required scopes must be configured");
-        assertThrowable.accept(() -> {
-            return new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, this.requiredAudiences, this.requiredScopes, null);
-        }, "client ID mapping must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator(null, this.requiredAudiences, this.requiredScopes, this.authorizedClientIds), "trusted issuers must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator("", this.requiredAudiences, this.requiredScopes, this.authorizedClientIds), "trusted issuers must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, null, this.requiredScopes, this.authorizedClientIds), "required audiences must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, new HashSet<>(), this.requiredScopes, this.authorizedClientIds), "required audiences must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, this.requiredAudiences, null, this.authorizedClientIds), "required scopes must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, this.requiredAudiences, new HashSet<>(), this.authorizedClientIds), "required scopes must be configured");
+        assertThrowable.accept(() -> new DefaultOAuthJwtAccessTokenValidator(this.trustedIssuer, this.requiredAudiences, this.requiredScopes, null), "client ID mapping must be configured");
 
         // actual value
         BiFunction<Field, DefaultOAuthJwtAccessTokenValidator, Object> getFieldValue = (f, object) -> {
@@ -157,35 +143,19 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
 
         // null JWT issuer
         Mockito.doReturn(null).when(mock).getIssuer();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "iss not trusted: got=null");
+        assertThrowable.accept(() -> validator.validate(mock), "iss not trusted: got=null");
 
         // empty
         Mockito.doReturn("").when(mock).getIssuer();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "iss not trusted: got=");
+        assertThrowable.accept(() -> validator.validate(mock), "iss not trusted: got=");
 
         // not match
         Mockito.doReturn("untrusty_issuer").when(mock).getIssuer();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "iss not trusted: got=untrusty_issuer");
+        assertThrowable.accept(() -> validator.validate(mock), "iss not trusted: got=untrusty_issuer");
 
         // match
         Mockito.doReturn("trustedIssuer").when(mock).getIssuer();
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validate(mock));
     }
 
     @Test
@@ -198,35 +168,19 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
 
         // null JWT issuer
         Mockito.doReturn(null).when(mock).getAudiences();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "required aud not found: got=null");
+        assertThrowable.accept(() -> validator.validate(mock), "required aud not found: got=null");
 
         // empty
         Mockito.doReturn(new ArrayList<>()).when(mock).getAudiences();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "required aud not found: got=");
+        assertThrowable.accept(() -> validator.validate(mock), "required aud not found: got=");
 
         // not match
         Mockito.doReturn(Arrays.asList("aud_1", "unknown_aud")).when(mock).getAudiences();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "required aud not found: got=aud_1, unknown_aud");
+        assertThrowable.accept(() -> validator.validate(mock), "required aud not found: got=aud_1, unknown_aud");
 
         // match
         Mockito.doReturn(Arrays.asList("aud_3", "aud_2", "aud_1")).when(mock).getAudiences();
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validate(mock));
     }
 
     @Test
@@ -239,35 +193,19 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
 
         // null JWT issuer
         Mockito.doReturn(null).when(mock).getScope();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "required scope not found: got=null");
+        assertThrowable.accept(() -> validator.validate(mock), "required scope not found: got=null");
 
         // empty
         Mockito.doReturn("").when(mock).getScope();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "required scope not found: got=");
+        assertThrowable.accept(() -> validator.validate(mock), "required scope not found: got=");
 
         // not match
         Mockito.doReturn("scope_1 unknown_scope").when(mock).getScope();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "required scope not found: got=scope_1 unknown_scope");
+        assertThrowable.accept(() -> validator.validate(mock), "required scope not found: got=scope_1 unknown_scope");
 
         // match
         Mockito.doReturn("scope_3 scope_2 scope_1").when(mock).getScope();
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validate(mock));
     }
 
     @Test
@@ -280,27 +218,15 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
 
         // zero exp
         Mockito.doReturn(0L).when(mock).getExpiration();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "exp is empty");
+        assertThrowable.accept(() -> validator.validate(mock), "exp is empty");
 
         // -ve exp
         Mockito.doReturn(-1L).when(mock).getExpiration();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        }, "exp is empty");
+        assertThrowable.accept(() -> validator.validate(mock), "exp is empty");
 
         // +ve exp
         Mockito.doReturn(1L).when(mock).getExpiration();
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validate(mock);
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validate(mock));
     }
 
     @Test
@@ -310,90 +236,42 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
         Mockito.doReturn(null).when(mock).getClientId();
 
         // null JWT client ID, null CN, invalid
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, null);
-            }
-        }, "NO mapping of authorized client IDs for certificate principal (null)");
+        assertThrowable.accept(() -> validator.validateClientId(mock, null), "NO mapping of authorized client IDs for certificate principal (null)");
         // null JWT client ID ONLY, no mapping
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "no_mapping_1");
-            }
-        }, "NO mapping of authorized client IDs for certificate principal (no_mapping_1)");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "no_mapping_1"), "NO mapping of authorized client IDs for certificate principal (no_mapping_1)");
         // null JWT client ID ONLY, mapped
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "client_cert_common_name");
-            }
-        }, "client_id is not authorized for certificate principal (client_cert_common_name): got=null");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "client_cert_common_name"), "client_id is not authorized for certificate principal (client_cert_common_name): got=null");
 
         Mockito.doReturn("jwt_client_id").when(mock).getClientId();
 
         // null expected client ID ONLY, no mapping
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, null);
-            }
-        }, "NO mapping of authorized client IDs for certificate principal (null)");
+        assertThrowable.accept(() -> validator.validateClientId(mock, null), "NO mapping of authorized client IDs for certificate principal (null)");
         // null expected client ID ONLY, mapped
         authorizedClientIds.put(null, new HashSet<>(Arrays.asList("null_1, null_2")));
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, null);
-            }
-        }, "client_id is not authorized for certificate principal (null): got=jwt_client_id");
+        assertThrowable.accept(() -> validator.validateClientId(mock, null), "client_id is not authorized for certificate principal (null): got=jwt_client_id");
         authorizedClientIds.remove(null);
 
         // not match, no mapping
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "no_mapping_2");
-            }
-        }, "NO mapping of authorized client IDs for certificate principal (no_mapping_2)");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "no_mapping_2"), "NO mapping of authorized client IDs for certificate principal (no_mapping_2)");
         // not match, mapped
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "client_cert_common_name");
-            }
-        }, "client_id is not authorized for certificate principal (client_cert_common_name): got=jwt_client_id");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "client_cert_common_name"), "client_id is not authorized for certificate principal (client_cert_common_name): got=jwt_client_id");
 
         // match, no mapping
         Mockito.doReturn("match.principal.1").when(mock).getClientId();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "match.principal.1");
-            }
-        }, "NO mapping of authorized client IDs for certificate principal (match.principal.1)");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "match.principal.1"), "NO mapping of authorized client IDs for certificate principal (match.principal.1)");
         // match, mapped
         Mockito.doReturn("client_id_1").when(mock).getClientId();
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "client_cert_common_name");
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validateClientId(mock, "client_cert_common_name"));
 
         // no mapping, case-insensitive, match, invalid
         Mockito.doReturn("match.principal.PPP").when(mock).getClientId();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "match.principal.ppp");
-            }
-        }, "NO mapping of authorized client IDs for certificate principal (match.principal.ppp)");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "match.principal.ppp"), "NO mapping of authorized client IDs for certificate principal (match.principal.ppp)");
         // mapped, case-sensitive, match
         Mockito.doReturn("CLIENT_ID_2").when(mock).getClientId();
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "client_cert_common_name");
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validateClientId(mock, "client_cert_common_name"));
         // mapped, case-sensitive, not match
         Mockito.doReturn("client_id_2").when(mock).getClientId();
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateClientId(mock, "client_cert_common_name");
-            }
-        }, "client_id is not authorized for certificate principal (client_cert_common_name): got=client_id_2");
+        assertThrowable.accept(() -> validator.validateClientId(mock, "client_cert_common_name"), "client_id is not authorized for certificate principal (client_cert_common_name): got=client_id_2");
     }
 
     @Test
@@ -403,40 +281,22 @@ public class DefaultOAuthJwtAccessTokenValidatorTest {
         Mockito.doReturn(null).when(mock).getCertificateThumbprint();
 
         // null JWT thumbprint, null expected certificate thumbprint
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateCertificateBinding(mock, (String) null);
-            }
-        });
+        assertDoesNotThrow.accept(() -> validator.validateCertificateBinding(mock, (String) null));
 
         // null JWT thumbprint ONLY
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateCertificateBinding(mock, "certificate_thumbprint");
-            }
-        }, "client certificate thumbprint (certificate_thumbprint) not match: got=null");
+        assertThrowable.accept(() -> validator.validateCertificateBinding(mock, "certificate_thumbprint"), "client certificate thumbprint (certificate_thumbprint) not match: got=null");
 
         Mockito.doReturn("certificate_thumbprint").when(mock).getCertificateThumbprint();
 
         // null expected certificate thumbprint ONLY
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateCertificateBinding(mock, (String) null);
-            }
-        }, "client certificate thumbprint (null) not match: got=certificate_thumbprint");
+        assertThrowable.accept(() -> validator.validateCertificateBinding(mock, (String) null), "client certificate thumbprint (null) not match: got=certificate_thumbprint");
 
         // not match
-        assertThrowable.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateCertificateBinding(mock, "not_match");
-            }
-        }, "client certificate thumbprint (not_match) not match: got=certificate_thumbprint");
+        assertThrowable.accept(() -> validator.validateCertificateBinding(mock, "not_match"), "client certificate thumbprint (not_match) not match: got=certificate_thumbprint");
 
         // match
-        assertDoesNotThrow.accept(new ThrowingRunnable() {
-            public void run() throws Throwable {
-                validator.validateCertificateBinding(mock, new String("certificate_thumbprint")); // for coverage
-            }
+        assertDoesNotThrow.accept(() -> {
+            validator.validateCertificateBinding(mock, "certificate_thumbprint"); // for coverage
         });
     }
 

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/validator/OAuthJwtAccessTokenValidatorTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/oauth/validator/OAuthJwtAccessTokenValidatorTest.java
@@ -33,7 +33,7 @@ public class OAuthJwtAccessTokenValidatorTest {
 
     private final ClassLoader classLoader = this.getClass().getClassLoader();
     private OAuthJwtAccessTokenValidator baseValidator = null;
-    private final X509Certificate readCert(String resourceName) throws Exception {
+    private X509Certificate readCert(String resourceName) throws Exception {
         try (FileInputStream certIs = new FileInputStream(this.classLoader.getResource(resourceName).getFile())) {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             return (X509Certificate) cf.generateCertificate(certIs);
@@ -43,9 +43,9 @@ public class OAuthJwtAccessTokenValidatorTest {
     @BeforeMethod
     public void initialize() throws Exception {
         this.baseValidator = new OAuthJwtAccessTokenValidator() {
-            public void validate(OAuthJwtAccessToken jwt) throws OAuthJwtAccessTokenException {}
-            public void validateClientId(OAuthJwtAccessToken jwt, String clientId) throws OAuthJwtAccessTokenException {}
-            public void validateCertificateBinding(OAuthJwtAccessToken jwt, String certificateThumbprint) throws OAuthJwtAccessTokenException {}
+            public void validate(OAuthJwtAccessToken jwt) {}
+            public void validateClientId(OAuthJwtAccessToken jwt, String clientId) {}
+            public void validateCertificateBinding(OAuthJwtAccessToken jwt, String certificateThumbprint) {}
         };
     }
 

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/TokenTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/TokenTest.java
@@ -44,7 +44,6 @@ public class TokenTest {
     private String servicePrivateKeyStringK0 = null;
     private String servicePrivateKeyStringK1 = null;
     private String servicePublicKeyStringK0 = null;
-    private String servicePublicKeyStringK1 = null;
 
     @BeforeTest
     private void loadKeys() throws IOException {
@@ -57,11 +56,7 @@ public class TokenTest {
         
         path = Paths.get("./src/test/resources/unit_test_fantasy_private_k1.key");
         servicePrivateKeyStringK1 = new String(Files.readAllBytes(path));
-
-        path = Paths.get("./src/test/resources/fantasy_public_k1.key");
-        servicePublicKeyStringK1 = new String(Files.readAllBytes(path));
     }
-
     
     @Test
     public void testTokenValidateNullSignature() throws CryptoException {
@@ -73,7 +68,7 @@ public class TokenTest {
 
         StringBuilder errMsg = new StringBuilder();
         assertFalse(token.validate(servicePublicKeyStringK0, 3600, false, errMsg));
-        assertTrue(!errMsg.toString().isEmpty());
+        assertFalse(errMsg.toString().isEmpty());
     }
     
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -1334,9 +1334,7 @@ public class CryptoTest {
 
         // now null out the p1363 signature
 
-        for (int i = 0; i < p1363Signature.length; i++) {
-            p1363Signature[i] = 0;
-        }
+        Arrays.fill(p1363Signature, (byte) 0);
         testDerSignature = Crypto.convertSignatureFromP1363ToDERFormat(p1363Signature, Crypto.SHA256);
         assertFalse(Crypto.verify(serviceToken.getBytes(StandardCharsets.UTF_8), keyPair.getPublic(),
                 testDerSignature, Crypto.SHA256));

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/YBase64Test.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/YBase64Test.java
@@ -157,7 +157,6 @@ public class YBase64Test {
 
     @Test
     public void testRandom() {
-        YBase64 temp = new YBase64();
-
+        new YBase64();
     }
 }


### PR DESCRIPTION
Changes include:
- replace deprecated calls
- mark fields as final when possible
- remove unused imports, fields, arguments
- replace function references with lambdas when possible
- replace size() > 0 calls with isEmpty()