### PR TITLE
server common library code cleanup - replace deprecated calls, etc

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/filter/impl/AthenzZTSQoSFilter.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/filter/impl/AthenzZTSQoSFilter.java
@@ -31,7 +31,7 @@ import jakarta.servlet.http.HttpServletRequest;
 /**
  * AthenzZTSQoSFilter extends Jetty's QoSFilter to allow separate
  * handling of URIs for certificates and tokens
- *
+ * <p>
  * {@literal
  * <filter>
  *   <filter-name>AthenzZTSQoSFilterCerts</filter-name>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/pulsar/PulsarFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/pulsar/PulsarFactory.java
@@ -55,7 +55,7 @@ public class PulsarFactory<T> implements ChangePublisherFactory<T>, ChangeSubscr
     String serviceUrl = System.getProperty(PROP_MESSAGING_CLI_SERVICE_URL);
 
     if (serviceUrl == null) {
-      LOG.error("Pulsar client invalid service url: [{}]", serviceUrl);
+      LOG.error("Pulsar client null service url");
       throw new IllegalArgumentException("invalid pulsar service url");
     }
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/pulsar/client/AthenzPulsarClient.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/messaging/pulsar/client/AthenzPulsarClient.java
@@ -28,8 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -93,11 +91,7 @@ public class AthenzPulsarClient {
   
   private static ClientConfigurationData getClientConfiguration(TlsConfig tlsConfig) {
     ClientConfigurationData config = new ClientConfigurationData();
-    AuthenticationTls authenticationTls = new AuthenticationTls();
-    Map<String, String> authParams = new HashMap<>();
-    authParams.put("tlsKeyFile", tlsConfig.tlsKeyFilePath);
-    authParams.put("tlsCertFile", tlsConfig.tlsCertFilePath);
-    authenticationTls.configure(authParams);
+    AuthenticationTls authenticationTls = new AuthenticationTls(tlsConfig.tlsCertFilePath, tlsConfig.tlsKeyFilePath);
     config.setAuthentication(authenticationTls);
     config.setTlsAllowInsecureConnection(false);
     config.setTlsHostnameVerificationEnable(true);
@@ -110,9 +104,9 @@ public class AthenzPulsarClient {
     AthenzPulsarClient instance;
     String pulsarClientClassName = System.getProperty(PROP_ATHENZ_PULSAR_CLIENT_CLASS, PROP_ATHENZ_PULSAR_CLIENT_CLASS_DEFAULT);
     try {
-      instance = (AthenzPulsarClient) Class.forName(pulsarClientClassName).newInstance();
-    } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
-      throw new ExceptionInInitializerError(e);
+      instance = (AthenzPulsarClient) Class.forName(pulsarClientClassName).getDeclaredConstructor().newInstance();
+    } catch (Exception ex) {
+      throw new ExceptionInInitializerError(ex);
     }
     return instance;
   }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/AthenzDataSource.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/AthenzDataSource.java
@@ -34,8 +34,8 @@ public class AthenzDataSource extends PoolingDataSource<PoolableConnection> impl
     public static final String ATHENZ_PROP_DATASTORE_NETWORK_TIMEOUT = "athenz.datastore.network_timeout";
     public static final String ATHENZ_PROP_DATASTORE_TIMEOUT_THREADS = "athenz.datastore.timeout_threads";
 
-    private ScheduledExecutorService timeoutThreadPool;
-    private int networkTimeout;
+    private final ScheduledExecutorService timeoutThreadPool;
+    private final int networkTimeout;
 
     public AthenzDataSource(ObjectPool<PoolableConnection> pool) {
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/http/HttpDriver.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/http/HttpDriver.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLContext;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +68,7 @@ public class HttpDriver implements Closeable {
     private final int clientReadTimeoutMs;
 
     private CloseableHttpClient client;
-    private PoolingHttpClientConnectionManager connManager;
+    private final PoolingHttpClientConnectionManager connManager;
 
     public static class Builder {
         private final String baseUrl;
@@ -166,12 +165,13 @@ public class HttpDriver implements Closeable {
         client = httpClient;
     }
 
-    public static SSLContext createSSLContext(String trustorePath, char[] trustorePassword, String certPath,
-                                          String keyPath) throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
-        if (trustorePath == null) {
+    public static SSLContext createSSLContext(String trustStorePath, char[] trustStorePassword, String certPath, String keyPath)
+            throws IOException, InterruptedException, KeyRefresherException {
+
+        if (trustStorePath == null) {
             return null;
         }
-        KeyRefresher keyRefresher = Utils.generateKeyRefresher(trustorePath, trustorePassword,
+        KeyRefresher keyRefresher = Utils.generateKeyRefresher(trustStorePath, trustStorePassword,
                 certPath, keyPath);
         keyRefresher.startup();
         return Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(),

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/http/HttpDriverResponse.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/http/HttpDriverResponse.java
@@ -21,9 +21,9 @@ package com.yahoo.athenz.common.server.http;
 import org.apache.http.StatusLine;
 
 public class HttpDriverResponse {
-    private int statusCode;
-    private String message;
-    private StatusLine statusLine;
+    private final int statusCode;
+    private final String message;
+    private final StatusLine statusLine;
 
     public HttpDriverResponse(int statusCode, String message, StatusLine statusLine) {
         this.statusCode = statusCode;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/impl/DefaultAuditLogMsgBuilder.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/impl/DefaultAuditLogMsgBuilder.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.common.server.log.impl;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import com.fasterxml.uuid.EthernetAddress;
 import com.fasterxml.uuid.Generators;
@@ -370,10 +371,7 @@ public class DefaultAuditLogMsgBuilder implements AuditLogMsgBuilder {
 
     @Override
     public String whoFullName() {
-        if (this.whoFullName == null) {
-            return NULL_STR;
-        }
-        return this.whoFullName;
+        return Objects.requireNonNullElse(this.whoFullName, NULL_STR);
     }
 
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/ConnectionData.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/ConnectionData.java
@@ -29,17 +29,17 @@ import static com.yahoo.athenz.common.server.log.jetty.ExceptionCauseFetcher.get
 /**
  * The life-cycle of the SSL connection is made of 3 steps.
  * A {@link ConnectionData} instance is attached to every SSL connection, and is known at any step, as follows:
- *
+ * <p>
  *    1. {@link AthenzConnectionListener#onOpened} is called when the connection is opened (before the SSL handshake).
  *       At this point, extracts the {@link SSLEngine} instance from the {@link SslConnection} and create a new 
  *       {@link ConnectionData} instance. 
  *       it is accessible by the {@link SSLEngine} instances, using {@link AthenzConnectionListener#getConnectionDataBySslEngine}.
- *
+ * <p>
  *    2. {@link JettyConnectionLogger} implements the {@link org.eclipse.jetty.io.ssl.SslHandshakeListener} and provides the
  *       {@link JettyConnectionLogger#handshakeFailed} that is being called after a failed handshake.
  *       At this point, the {@link SSLEngine} instance is known and we are able to use it to get the {@link ConnectionData} from step-1
  *        (using {@link AthenzConnectionListener#getConnectionDataBySslEngine}).
- *
+ * <p>
  *    3. {@link AthenzConnectionListener#onClosed} is called when the connection is closed.
  *       At this point, extracts the {@link SSLEngine} instance from the {@link SslConnection} and 
  *       use it to remove the map entries from OPENED_SSL_ENGINES_MAP.

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLogger.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLogger.java
@@ -54,16 +54,14 @@ public class JettyConnectionLogger extends AbstractLifeCycle implements SslHands
     //
     @Override
     protected void doStop() {
-        handleListenerInvocation("AbstractLifeCycle", "doStop", "", Collections.emptyList(), () -> {
-            LOGGER.info("Jetty connection logger is stopped");
-        });
+        handleListenerInvocation("AbstractLifeCycle", "doStop", "", Collections.emptyList(),
+                () -> LOGGER.info("Jetty connection logger is stopped"));
     }
 
     @Override
     protected void doStart() {
-        handleListenerInvocation("AbstractLifeCycle", "doStart", "", Collections.emptyList(), () -> {
-            LOGGER.info("Jetty connection logger is started");
-        });
+        handleListenerInvocation("AbstractLifeCycle", "doStart", "", Collections.emptyList(),
+                () -> LOGGER.info("Jetty connection logger is started"));
     }
     //
     // AbstractLifeCycle methods stop

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLoggerFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLoggerFactory.java
@@ -43,10 +43,10 @@ public class JettyConnectionLoggerFactory {
 
         MetricFactory metricFactory;
         try {
-            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid MetricFactory class: {} error: {}", metricFactoryClass, e.getMessage());
-            throw new IllegalArgumentException("Invalid metric class");
+            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid MetricFactory class: {}", metricFactoryClass, ex);
+            throw new IllegalArgumentException("Invalid metric class", ex);
         }
 
         return metricFactory.create();
@@ -57,10 +57,11 @@ public class JettyConnectionLoggerFactory {
         final String sslConnectionLogFactoryClass = System.getProperty(ATHENZ_PROP_SSL_LOGGER_FACTORY_CLASS,
                 ATHENZ_SSL_LOGGER_FACTORY_CLASS);
         try {
-            sslConnectionLogFactory = (SSLConnectionLogFactory) Class.forName(sslConnectionLogFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid SSLConnectionLogFactory class: {} error: {}", sslConnectionLogFactoryClass, e.getMessage());
-            throw new IllegalArgumentException("Invalid SSLConnectionLogFactory");
+            sslConnectionLogFactory = (SSLConnectionLogFactory) Class.forName(
+                    sslConnectionLogFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid SSLConnectionLogFactory class: {}", sslConnectionLogFactoryClass, ex);
+            throw new IllegalArgumentException("Invalid SSLConnectionLogFactory", ex);
         }
         return sslConnectionLogFactory.create();
     }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/SSLConnectionLog.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/SSLConnectionLog.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 
 public class SSLConnectionLog implements ConnectionLog {
 
-    private JsonConnectionLogWriter jsonConnectionLogWriter = new JsonConnectionLogWriter();
+    private final JsonConnectionLogWriter jsonConnectionLogWriter = new JsonConnectionLogWriter();
     private static final Logger LOG = LoggerFactory.getLogger("SSLConnectionLog");
 
     @Override
     public void log(ConnectionLogEntry connectionLogEntry) {
         try {
             LOG.info(jsonConnectionLogWriter.logEntryToString(connectionLogEntry));
-        } catch (IOException exception) {
-            LOG.error("Failed to write connectionLogEntry. ex: {}", exception);
+        } catch (IOException ex) {
+            LOG.error("Failed to write connectionLogEntry", ex);
         }
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/MsdStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/MsdStore.java
@@ -22,20 +22,20 @@ public interface MsdStore {
      * of failure, a ResourceException is thrown.
      * @return MsdConnection object
      */
-    default public MsdStoreConnection getConnection() {
+    default MsdStoreConnection getConnection() {
         return null;
-    };
+    }
 
     /**
      * Set the operation timeout in seconds
      * @param opTimeout timeout in seconds
      */
-    default public void setOperationTimeout(int opTimeout) {
-    };
+    default void setOperationTimeout(int opTimeout) {
+    }
 
     /**
      * Clear all connections to the msd store
      */
-    default public void clearConnections() {
+    default void clearConnections() {
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/MsdStoreConnection.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/MsdStoreConnection.java
@@ -33,7 +33,7 @@ public interface MsdStoreConnection extends Closeable {
      * @param workload static workload to be stored in the underlying storage
      */
     default void putStaticWorkload(StaticWorkload workload) {
-    };
+    }
 
     /**
      * deleteStaticWorkload deletes the Workload from the underlying storage that can be an RDMS or NoSQL
@@ -42,7 +42,7 @@ public interface MsdStoreConnection extends Closeable {
      * @param instanceId instance id
      */
     default void deleteStaticWorkload(String domainName, String serviceName, String instanceId) {
-    };
+    }
 
     /**
      * putDynamicWorkLoad stores the Workload value into the underlying storage that can be an RDMS or NoSQL
@@ -50,7 +50,7 @@ public interface MsdStoreConnection extends Closeable {
      * @param options workload options to be passed to the api
      */
     default void putDynamicWorkload(DynamicWorkload workload, WorkloadOptions options) {
-    };
+    }
 
     /**
      * deleteDynamicWorkLoad delete the Workload from the underlying storage that can be an RDMS or NoSQL
@@ -59,14 +59,14 @@ public interface MsdStoreConnection extends Closeable {
      * @param instanceId instance id
      */
     default void deleteDynamicWorkload(String domainName, String serviceName, String instanceId) {
-    };
+    }
 
     /**
      * putTransportPolicyValidationStatus stores the validation status into the underlying storage that can be an RDMS or NoSQL
      * @param validationResponse response object to be stored in the underlying storage
      */
     default void putTransportPolicyValidationStatus(TransportPolicyValidationResponse validationResponse) {
-    };
+    }
 
     /**
      * getWorkloadsBySvc looks up all workloads for the requested service in the MSD storage
@@ -131,17 +131,17 @@ public interface MsdStoreConnection extends Closeable {
     }
 
     default void commitChanges() {
-    };
+    }
 
     default void rollbackChanges() {
-    };
+    }
 
     /**
      * set timeout for operations with underlying storage
      * @param opTimout
      */
     default void setOperationTimeout(int opTimout) {
-    };
+    }
 
     /**
      * construct IP to Workload mapping for building cache
@@ -149,5 +149,5 @@ public interface MsdStoreConnection extends Closeable {
      */
     default InetWorkload buildIpToWorkload() {
         return new InetWorkload(new InetAddressMap<>(new TreeMap<>(), new TreeMap<>()), new InetAddressMap<>(new TreeMap<>(), new TreeMap<>()));
-    };
+    }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/NoOpTransportPolicyValidator.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/NoOpTransportPolicyValidator.java
@@ -25,8 +25,7 @@ public class NoOpTransportPolicyValidator implements TransportPolicyValidator {
 
     @Override
     public TransportPolicyValidationResponse validateTransportPolicy(TransportPolicyValidationRequest transportPolicy) {
-        TransportPolicyValidationResponse response = new TransportPolicyValidationResponse().setStatus(TransportPolicyValidationStatus.VALID);
-        return response;
+        return new TransportPolicyValidationResponse().setStatus(TransportPolicyValidationStatus.VALID);
     }
 
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/TransportPolicyValidator.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/msd/validator/TransportPolicyValidator.java
@@ -21,12 +21,12 @@ import com.yahoo.athenz.msd.TransportPolicyValidationResponse;
 
 public interface TransportPolicyValidator {
 
-    default public void init(MsdStore store) {
+    default void init(MsdStore store) {
     }
 
     /**
      * validateTransportPolicy validates the transport policy against other pre-defined policies
      * @param transportPolicy transport policy to be validated
      */
-    public TransportPolicyValidationResponse validateTransportPolicy(TransportPolicyValidationRequest transportPolicy);
+    TransportPolicyValidationResponse validateTransportPolicy(TransportPolicyValidationRequest transportPolicy);
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationEmail.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationEmail.java
@@ -20,9 +20,9 @@ import java.util.Objects;
 import java.util.Set;
 
 public class NotificationEmail {
-    private String subject;
-    private String body;
-    private Set<String> fullyQualifiedRecipientsEmail;
+    private final String subject;
+    private final String body;
+    private final Set<String> fullyQualifiedRecipientsEmail;
 
     public NotificationEmail(String subject, String body, Set<String> fullyQualifiedRecipientsEmail) {
         this.subject = subject;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationMetric.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationMetric.java
@@ -66,8 +66,8 @@ public class NotificationMetric {
         final int prime = 31;
         int result = 1;
 
-        for (int i = 0; i < attributes.size(); ++i) {
-            result = prime * result + Arrays.hashCode(attributes.get(i));
+        for (String[] attribute : attributes) {
+            result = prime * result + Arrays.hashCode(attribute);
         }
 
         return result;
@@ -76,12 +76,9 @@ public class NotificationMetric {
     @Override
     public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < attributes.size(); ++i) {
-            stringBuilder.append(String.join(",", attributes.get(i))).append(";");
+        for (String[] attribute : attributes) {
+            stringBuilder.append(String.join(",", attribute)).append(";");
         }
-
-        return "NotificationMetric{" +
-                "attributes=" + stringBuilder.toString() +
-                '}';
+        return "NotificationMetric{attributes=" + stringBuilder + "}";
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationToEmailConverterCommon.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationToEmailConverterCommon.java
@@ -90,9 +90,9 @@ public class NotificationToEmailConverterCommon {
 
         Authority authority;
         try {
-            authority = (Authority) Class.forName(className).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOGGER.error("Invalid Notification user Authority class: {} error: {}", className, e.getMessage());
+            authority = (Authority) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOGGER.error("Invalid Notification user Authority class: {}", className, ex);
             return null;
         }
         return authority;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
@@ -58,7 +58,7 @@ public class EmailNotificationService implements NotificationService {
     private final String emailDomainFrom;
     private final String from;
 
-    private byte[] logoImage;
+    private final byte[] logoImage;
 
     public EmailNotificationService(EmailProvider emailProvider) {
         this.emailProvider = emailProvider;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/MetricNotificationServiceFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/MetricNotificationServiceFactory.java
@@ -42,10 +42,10 @@ public class MetricNotificationServiceFactory implements NotificationServiceFact
                 METRIC_DEFAULT_FACTORY_CLASS);
         MetricFactory metricFactory;
         try {
-            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
-            LOG.error("Invalid MetricFactory class: {} error: {}", metricFactoryClass, e.getMessage());
-            throw new IllegalArgumentException("Invalid metric class");
+            metricFactory = (MetricFactory) Class.forName(metricFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            LOG.error("Invalid MetricFactory class: {}", metricFactoryClass, ex);
+            throw new IllegalArgumentException("Invalid metric class", ex);
         }
 
         LOG.info("Loaded MetricFactory for receiving notification metrics: {}", metricFactoryClass);

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/paramstore/AWSParameterStoreSyncer.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/paramstore/AWSParameterStoreSyncer.java
@@ -38,7 +38,7 @@ import java.util.concurrent.locks.StampedLock;
 /**
  * Periodically (configurable) loads all AWS Parameters Store and store it in memory.
  * Provides api to retrieve the parameters.
- *
+ * <p>
  * Required permissions: ssm:GetParameters, ssm:DescribeParameters
  */
 public class AWSParameterStoreSyncer implements DynamicParameterStore {
@@ -80,8 +80,8 @@ public class AWSParameterStoreSyncer implements DynamicParameterStore {
             return SsmClient.builder()
                 .region(Region.of(region))
                 .build();
-        } catch (Exception e) {
-            LOG.error("Failed to init aws ssm client. error: {}, {}", e.getMessage(), e);
+        } catch (Exception ex) {
+            LOG.error("Failed to init aws ssm client", ex);
         }
         return null;
     }
@@ -105,10 +105,9 @@ public class AWSParameterStoreSyncer implements DynamicParameterStore {
             return;
         }
         try {
-            List<ParameterMetadata> params = getParameterList();
-            storeParameters(params);
-        } catch (Exception e) {
-            LOG.error("Failed to reload AWS Parameters store. error: {}, {}", e.getMessage(), e);
+            storeParameters(getParameterList());
+        } catch (Exception ex) {
+            LOG.error("Failed to reload AWS Parameters store", ex);
         }
     }
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
@@ -159,7 +159,7 @@ public class Http {
         
         if (authErrMsg.length() > 0) {
             request.setAttribute(INVALID_CRED_ATTR, authErrMsg.toString());
-            LOG.error("authenticate: {}", authErrMsg.toString());
+            LOG.error("authenticate: {}", authErrMsg);
         } else {
             request.setAttribute(INVALID_CRED_ATTR, "No credentials provided");
             LOG.error("authenticate: No credentials provided");

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/status/StatusCheckException.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/status/StatusCheckException.java
@@ -20,8 +20,8 @@ import static com.yahoo.athenz.common.server.rest.ResourceException.INTERNAL_SER
 import static com.yahoo.athenz.common.server.rest.ResourceException.symbolForCode;
 
 public class StatusCheckException extends Exception {
-    private int httpCode;
-    private String msg;
+    private final int httpCode;
+    private final String msg;
 
     public StatusCheckException() {
         this.httpCode = INTERNAL_SERVER_ERROR;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/ChangeLogStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/ChangeLogStore.java
@@ -128,7 +128,7 @@ public interface ChangeLogStore {
      * the last modification time for the request. If data store
      * successfully updates the local entries in the cache then
      * it will call setLastModificationTimestamp with the same value
-     * @return Array of JWSDomain objects
+     * @return List of JWSDomain objects
      */
     default List<JWSDomain> getUpdatedJWSDomains(StringBuilder lastModTimeBuffer) {
         return null;

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/S3ChangeLogStore.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/S3ChangeLogStore.java
@@ -52,8 +52,8 @@ public class S3ChangeLogStore implements ChangeLogStore {
 
     private static final String NUMBER_OF_THREADS = "athenz.zts.bucket.threads";
     private static final String DEFAULT_TIMEOUT_SECONDS = "athenz.zts.bucket.threads.timeout";
-    private int nThreads = Integer.parseInt(System.getProperty(NUMBER_OF_THREADS, "10"));
-    private int defaultTimeoutSeconds = Integer.parseInt(System.getProperty(DEFAULT_TIMEOUT_SECONDS, "1800"));
+    private final int nThreads = Integer.parseInt(System.getProperty(NUMBER_OF_THREADS, "10"));
+    private final int defaultTimeoutSeconds = Integer.parseInt(System.getProperty(DEFAULT_TIMEOUT_SECONDS, "1800"));
     protected Map<String, SignedDomain> tempSignedDomainMap = new ConcurrentHashMap<>();
     protected Map<String, JWSDomain> tempJWSDomainMap = new ConcurrentHashMap<>();
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/config/ConfigManager.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/config/ConfigManager.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
  *  and (optionally) periodically reload them into the system-properties - possibly calling change-callbacks. <br>
  * These configs can then be accessed via {@link System#getProperty}, or directly from the ConfigManager -
  *  either via {@link #getConfigValue} or {@link #getAllConfigValues()}.
- *
+ * <p>
  * <h3>Simple usage example:</h3>
  * <pre>{@code
  *      new ConfigManager()

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/auth/impl/aws/AwsPrivateKeyStoreTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/auth/impl/aws/AwsPrivateKeyStoreTest.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import static org.mockito.BDDMockito.given;
@@ -227,7 +226,7 @@ public class AwsPrivateKeyStoreTest {
         S3Object s3ObjectKey = mock(S3Object.class);
         Mockito.when(s3.getObject(bucketName, algKeyName)).thenReturn(s3ObjectKey);
         File privKeyFile = new File("src/test/resources/unit_test_zts_private.pem");
-        final String privKey = new String(Files.readAllBytes(privKeyFile.toPath()), StandardCharsets.UTF_8);
+        final String privKey = Files.readString(privKeyFile.toPath());
         InputStream isKey = new ByteArrayInputStream( privKey.getBytes() );
         S3ObjectInputStream s3ObjectKeyInputStream = new S3ObjectInputStream(isKey, null);
         Mockito.when(s3ObjectKey.getObjectContent()).thenReturn(s3ObjectKeyInputStream);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/filter/impl/AthenzZTSQoSFilterTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/filter/impl/AthenzZTSQoSFilterTest.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.*;
 
 public class AthenzZTSQoSFilterTest {
 
-    private class QoSFilterChain implements FilterChain {
+    private static class QoSFilterChain implements FilterChain {
         @Override
         public void doFilter(ServletRequest request, ServletResponse servletResponse) {
             HttpServletResponse response = (HttpServletResponse) servletResponse;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/filter/impl/MockHttpServletResponse.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/filter/impl/MockHttpServletResponse.java
@@ -32,7 +32,7 @@ public class MockHttpServletResponse implements HttpServletResponse {
     private int contentLength = 0;
     private int status = 0;
     private final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-    private PrintWriter writer = new PrintWriter(byteOutputStream);
+    private final PrintWriter writer = new PrintWriter(byteOutputStream);
     
     public String getWriterData() throws IOException {
         writer.flush();

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/messaging/pulsar/PulsarChangeSubscriberTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/messaging/pulsar/PulsarChangeSubscriberTest.java
@@ -117,7 +117,7 @@ public class PulsarChangeSubscriberTest {
     }
 
     @Test
-    public void test_subscriber_creation() throws IOException, InterruptedException {
+    public void test_subscriber_creation() {
         System.setProperty(PROP_MESSAGING_CLI_SERVICE_URL, "some-service");
         PulsarChangeSubscriber<DomainChangeMessage> subscriber = new PulsarChangeSubscriber<>("service-url",
             "topic",

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/messaging/pulsar/client/MockAthenzPulsarClient.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/messaging/pulsar/client/MockAthenzPulsarClient.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.fail;
 
 public class MockAthenzPulsarClient extends AthenzPulsarClient {
 
-    protected PulsarClientImpl getPulsarClient(String serviceUrl, ClientConfigurationData config) throws PulsarClientException {
+    protected PulsarClientImpl getPulsarClient(String serviceUrl, ClientConfigurationData config) {
         try {
             CompletableFuture asyncProducerResult = null;
             if (serviceUrl == null || serviceUrl.isEmpty()) {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
@@ -21,9 +21,6 @@ import org.testng.annotations.Test;
 import com.yahoo.athenz.common.metrics.Metric;
 import com.yahoo.athenz.common.metrics.MetricFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class MetricsTest {
 
     @Test

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/DataSourceFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/DataSourceFactoryTest.java
@@ -17,6 +17,7 @@ package com.yahoo.athenz.common.server.db;
 
 import static org.testng.Assert.*;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import org.apache.commons.pool2.impl.BaseObjectPoolConfig;
@@ -88,9 +89,9 @@ public class DataSourceFactoryTest {
         assertEquals(config.getMaxTotal(), GenericObjectPoolConfig.DEFAULT_MAX_TOTAL);
         assertEquals(config.getMaxIdle(), GenericObjectPoolConfig.DEFAULT_MAX_IDLE);
         assertEquals(config.getMinIdle(), GenericObjectPoolConfig.DEFAULT_MIN_IDLE);
-        assertEquals(config.getMaxWaitMillis(), GenericObjectPoolConfig.DEFAULT_MAX_WAIT_MILLIS);
-        assertEquals(config.getMinEvictableIdleTimeMillis(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
-        assertEquals(config.getTimeBetweenEvictionRunsMillis(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+        assertEquals(config.getMaxWaitDuration(), GenericObjectPoolConfig.DEFAULT_MAX_WAIT);
+        assertEquals(config.getMinEvictableIdleDuration(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_DURATION);
+        assertEquals(config.getDurationBetweenEvictionRuns(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_DURATION);
         assertTrue(config.getTestWhileIdle());
         assertTrue(config.getTestOnBorrow());
     }
@@ -110,9 +111,9 @@ public class DataSourceFactoryTest {
         assertEquals(config.getMaxTotal(), 10);
         assertEquals(config.getMaxIdle(), 20);
         assertEquals(config.getMinIdle(), 30);
-        assertEquals(config.getMaxWaitMillis(), 40);
-        assertEquals(config.getMinEvictableIdleTimeMillis(), 50);
-        assertEquals(config.getTimeBetweenEvictionRunsMillis(), 60);
+        assertEquals(config.getMaxWaitDuration(), Duration.ofMillis(40));
+        assertEquals(config.getMinEvictableIdleDuration(), Duration.ofMillis(50));
+        assertEquals(config.getDurationBetweenEvictionRuns(), Duration.ofMillis(60));
         assertTrue(config.getTestWhileIdle());
         assertTrue(config.getTestOnBorrow());
         
@@ -140,9 +141,9 @@ public class DataSourceFactoryTest {
         assertEquals(config.getMaxTotal(), GenericObjectPoolConfig.DEFAULT_MAX_TOTAL);
         assertEquals(config.getMaxIdle(), GenericObjectPoolConfig.DEFAULT_MAX_IDLE);
         assertEquals(config.getMinIdle(), GenericObjectPoolConfig.DEFAULT_MIN_IDLE);
-        assertEquals(config.getMaxWaitMillis(), GenericObjectPoolConfig.DEFAULT_MAX_WAIT_MILLIS);
-        assertEquals(config.getMinEvictableIdleTimeMillis(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
-        assertEquals(config.getTimeBetweenEvictionRunsMillis(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS);
+        assertEquals(config.getMaxWaitDuration(), GenericObjectPoolConfig.DEFAULT_MAX_WAIT);
+        assertEquals(config.getMinEvictableIdleDuration(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_DURATION);
+        assertEquals(config.getDurationBetweenEvictionRuns(), BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_DURATION);
         assertTrue(config.getTestWhileIdle());
         assertTrue(config.getTestOnBorrow());
         
@@ -171,9 +172,9 @@ public class DataSourceFactoryTest {
         assertEquals(config.getMaxTotal(), -1);
         assertEquals(config.getMaxIdle(), -1);
         assertEquals(config.getMinIdle(), 0);
-        assertEquals(config.getMaxWaitMillis(), 0);
-        assertEquals(config.getMinEvictableIdleTimeMillis(), 0);
-        assertEquals(config.getTimeBetweenEvictionRunsMillis(), 0);
+        assertEquals(config.getMaxWaitDuration(), Duration.ofMillis(0));
+        assertEquals(config.getMinEvictableIdleDuration(), Duration.ofMillis(0));
+        assertEquals(config.getDurationBetweenEvictionRuns(), Duration.ofMillis(0));
         assertTrue(config.getTestWhileIdle());
         assertTrue(config.getTestOnBorrow());
         
@@ -248,9 +249,7 @@ public class DataSourceFactoryTest {
         props.setProperty("user", "user");
         props.setProperty("password", "password");
 
-        assertThrows(RuntimeException.class, () -> {
-            DataSourceFactory.create("jdbc:mysql:localhost:3306/athenz", props);
-        });
+        assertThrows(RuntimeException.class, () -> DataSourceFactory.create("jdbc:mysql:localhost:3306/athenz", props));
         System.clearProperty(DataSourceFactory.DRIVER_CLASS_NAME);
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/debug/DebugKerberosAuthorityTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/debug/DebugKerberosAuthorityTest.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 
 import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Principal;
-import com.yahoo.athenz.common.server.debug.DebugKerberosAuthority;
 
 import static org.testng.Assert.*;
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/debug/DebugPrincipalAuthorityTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/debug/DebugPrincipalAuthorityTest.java
@@ -17,9 +17,7 @@ package com.yahoo.athenz.common.server.debug;
 
 import org.testng.annotations.Test;
 
-import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Principal;
-import com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority;
 
 import static org.testng.Assert.*;
 
@@ -28,11 +26,11 @@ public class DebugPrincipalAuthorityTest {
     @Test
     public void testPrincipalAuthority() {
 
-        Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
+        DebugPrincipalAuthority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
         assertNotNull(principalAuthority);
         
         principalAuthority.initialize();
-        ((DebugPrincipalAuthority) principalAuthority).setKeyStore(null);
+        principalAuthority.setKeyStore(null);
         
         assertNull(principalAuthority.getDomain());
         assertEquals(principalAuthority.getHeader(), "Athenz-Principal-Auth");

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/debug/DebugRoleAuthorityTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/debug/DebugRoleAuthorityTest.java
@@ -19,9 +19,7 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
-import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Principal;
-import com.yahoo.athenz.common.server.debug.DebugRoleAuthority;
 
 import static org.testng.Assert.*;
 
@@ -29,12 +27,12 @@ public class DebugRoleAuthorityTest {
 
     @Test
     public void testRoleAuthority() {
-        
-        Authority roleAuthority = new com.yahoo.athenz.common.server.debug.DebugRoleAuthority();
+
+        DebugRoleAuthority roleAuthority = new com.yahoo.athenz.common.server.debug.DebugRoleAuthority();
         assertNotNull(roleAuthority);
         
         roleAuthority.initialize();
-        ((DebugRoleAuthority) roleAuthority).setKeyStore(null);
+        roleAuthority.setKeyStore(null);
         
         assertNull(roleAuthority.getDomain());
         assertEquals(roleAuthority.getHeader(), "Athenz-Role-Auth");

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/dns/HostnameResolverTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/dns/HostnameResolverTest.java
@@ -27,7 +27,7 @@ import static org.testng.Assert.assertFalse;
 
 public class HostnameResolverTest {
 
-    class TestHostnameResolver implements HostnameResolver {
+    static class TestHostnameResolver implements HostnameResolver {
     }
 
     @Test

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/http/HttpDriverTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/http/HttpDriverTest.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
 public class HttpDriverTest {
-    private ClassLoader classLoader = this.getClass().getClassLoader();
+    private final ClassLoader classLoader = this.getClass().getClassLoader();
 
     @Test
     public void testDriverThrowsException() throws IllegalArgumentException {
@@ -136,7 +136,6 @@ public class HttpDriverTest {
     @Test
     public void testDoGetException() throws IOException {
         CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-        CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
 
         Mockito.when(httpClient.execute(Mockito.any(HttpGet.class))).thenThrow(new IOException("Unknown error"));
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/impl/AuditLogMsgBuilderTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/impl/AuditLogMsgBuilderTest.java
@@ -154,13 +154,13 @@ public class AuditLogMsgBuilderTest {
     @Test
     public void testSetReplaceMethods() {
         AuditLogMsgBuilder msgBldr = starter("testBuild");
-        Assert.assertTrue(msgBldr.whatDetails("testWhatDetails") instanceof AuditLogMsgBuilder);
+        Assert.assertNotNull(msgBldr.whatDetails("testWhatDetails"));
         Assert.assertEquals(msgBldr.whatDetails(), "testWhatDetails");
 
-        Assert.assertTrue(msgBldr.uuId("testUUID") instanceof AuditLogMsgBuilder);
+        Assert.assertNotNull(msgBldr.uuId("testUUID"));
         Assert.assertEquals(msgBldr.uuId(), "testUUID");
 
-        Assert.assertTrue(msgBldr.whoFullName("testWhoFullName") instanceof AuditLogMsgBuilder);
+        Assert.assertNotNull(msgBldr.whoFullName("testWhoFullName"));
         Assert.assertEquals(msgBldr.whoFullName(), "testWhoFullName");
     }
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/JsonConnectionLogWriterTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/JsonConnectionLogWriterTest.java
@@ -36,7 +36,7 @@ public class JsonConnectionLogWriterTest {
                 .withPeerPort(1234)
                 .build();
         String expectedJson = "{" +
-                "\"id\":\""+id.toString()+"\"," +
+                "\"id\":\""+ id +"\"," +
                 "\"timestamp\":\"2021-01-13T12:12:12Z\"," +
                 "\"peerPort\":1234" +
                 "}";
@@ -58,7 +58,7 @@ public class JsonConnectionLogWriterTest {
                 .withDuration(5)
                 .build();
         String expectedJson = "{" +
-                "\"id\":\""+id.toString()+"\"," +
+                "\"id\":\""+ id +"\"," +
                 "\"timestamp\":\"2021-01-13T12:12:12Z\"," +
                 "\"duration\":5.000," +
                 "\"peerPort\":1234," +

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/MsdStoreConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/MsdStoreConnectionTest.java
@@ -28,7 +28,7 @@ import static org.testng.Assert.*;
 
 public class MsdStoreConnectionTest {
 
-    class TestMsdStorageConnection implements MsdStoreConnection {
+    static class TestMsdStorageConnection implements MsdStoreConnection {
     }
 
     @Test

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/MsdStoreFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/MsdStoreFactoryTest.java
@@ -20,8 +20,6 @@ import com.yahoo.athenz.auth.PrivateKeyStore;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
-import java.security.PrivateKey;
-
 import static org.testng.Assert.assertNotNull;
 
 public class MsdStoreFactoryTest {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/net/InetAddressMapTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/net/InetAddressMapTest.java
@@ -17,14 +17,12 @@
 package com.yahoo.athenz.common.server.msd.net;
 
 import com.yahoo.athenz.msd.DynamicWorkload;
-import com.yahoo.athenz.msd.StaticWorkload;
 import org.testng.annotations.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.NavigableMap;
 import java.util.TreeMap;
 
 import static org.testng.Assert.*;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/net/InetComparatorTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/net/InetComparatorTest.java
@@ -17,11 +17,8 @@
 package com.yahoo.athenz.common.server.msd.net;
 
 import com.yahoo.athenz.msd.DynamicWorkload;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import java.lang.invoke.MethodHandles;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.*;
@@ -29,7 +26,6 @@ import java.util.*;
 import static org.testng.Assert.*;
 
 public class InetComparatorTest {
-    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Test
     public void testCompare() throws UnknownHostException {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/NoOpStaticWorkloadValidatorTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/NoOpStaticWorkloadValidatorTest.java
@@ -31,7 +31,7 @@ public class NoOpStaticWorkloadValidatorTest {
     @Test
     public void testNoOpValidator() {
 
-        StaticWorkloadDataRepository<String> repository = new StaticWorkloadDataRepository<String>() {
+        StaticWorkloadDataRepository<String> repository = new StaticWorkloadDataRepository<>() {
             @Override
             public void initialize(PrivateKeyStore privateKeyStore, HostnameResolver hostnameResolver, MsdStore msdStore) {
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/NoOpTransportPolicyValidatorTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/NoOpTransportPolicyValidatorTest.java
@@ -17,8 +17,6 @@
 
 package com.yahoo.athenz.common.server.msd.validator;
 
-import com.yahoo.athenz.common.server.msd.MsdStore;
-import com.yahoo.athenz.common.server.msd.MsdStoreConnection;
 import com.yahoo.athenz.msd.TransportPolicyValidationRequest;
 import com.yahoo.athenz.msd.TransportPolicyValidationStatus;
 import org.testng.annotations.Test;
@@ -29,14 +27,8 @@ public class NoOpTransportPolicyValidatorTest {
 
     @Test
     public void testNoOpValidator() {
-        MsdStore store = new MsdStore() {
-            @Override
-            public MsdStoreConnection getConnection() {
-                return MsdStore.super.getConnection();
-            }
-        };
 
-        TransportPolicyValidatorFactory factory = () -> new NoOpTransportPolicyValidator();
+        TransportPolicyValidatorFactory factory = NoOpTransportPolicyValidator::new;
         TransportPolicyValidator validator = factory.create();
         assertTrue(validator instanceof NoOpTransportPolicyValidator);
         TransportPolicyValidationRequest request = new TransportPolicyValidationRequest();

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/TransportPolicyValidatorFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/validator/TransportPolicyValidatorFactoryTest.java
@@ -15,8 +15,6 @@
  */
 package com.yahoo.athenz.common.server.msd.validator;
 
-import com.yahoo.athenz.common.server.msd.MsdStore;
-import com.yahoo.athenz.common.server.msd.MsdStoreConnection;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -25,12 +23,6 @@ import static org.testng.Assert.assertNotNull;
 public class TransportPolicyValidatorFactoryTest {
     @Test
     public void createTest() {
-        MsdStore store = new MsdStore() {
-            @Override
-            public MsdStoreConnection getConnection() {
-                return MsdStore.super.getConnection();
-            }
-        };
 
         TransportPolicyValidator mockTransportPolicyValidator = Mockito.mock(TransportPolicyValidator.class);
         TransportPolicyValidatorFactory factory = () -> mockTransportPolicyValidator;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationManagerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationManagerTest.java
@@ -39,7 +39,7 @@ public class NotificationManagerTest {
 
     @BeforeClass
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
     }
 
     @BeforeMethod
@@ -251,7 +251,6 @@ public class NotificationManagerTest {
     @Test
     public void testNotificationManagerFail() {
         System.setProperty(NOTIFICATION_PROP_SERVICE_FACTORY_CLASS, "aa");
-        RolesProvider rolesProvider = Mockito.mock(RolesProvider.class);
 
         NotificationManager notificationManager = getNotificationManager(null);
         assertNotNull(notificationManager);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationMetricTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationMetricTest.java
@@ -16,7 +16,6 @@
 
 package com.yahoo.athenz.common.server.notification;
 
-import com.yahoo.athenz.common.metrics.Metric;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationToMetricConverterCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationToMetricConverterCommonTest.java
@@ -34,10 +34,6 @@ public class NotificationToMetricConverterCommonTest {
         Timestamp yesterdayTimeStamp = Timestamp.fromMillis(1601828361000L);
         Timestamp monthFromNowTimeStamp = Timestamp.fromMillis(1604594993000L);
 
-        System.out.println("current: " + currentTimeStamp.toString());
-        System.out.println("tomorrow: " + tomorrowTimeStamp.toString());
-        System.out.println("yesterday: " + yesterdayTimeStamp.toString());
-
         assertEquals("0", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), currentTimeStamp.toString()));
         assertEquals("1", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), tomorrowTimeStamp.toString()));
         assertEquals("-1", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), yesterdayTimeStamp.toString()));

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationServiceTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationServiceTest.java
@@ -17,16 +17,10 @@
 package com.yahoo.athenz.common.server.notification.impl;
 
 import com.yahoo.athenz.common.server.notification.EmailProvider;
-import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.util.*;
-
-import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/paramstore/AWSParameterStoreSyncerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/paramstore/AWSParameterStoreSyncerTest.java
@@ -22,7 +22,6 @@ import org.joda.time.DateTime;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.ParameterMetadata;
 
 import java.lang.reflect.Field;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHCertRecordTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHCertRecordTest.java
@@ -15,11 +15,9 @@
  */
 package com.yahoo.athenz.common.server.ssh;
 
-import com.yahoo.athenz.common.server.ssh.SSHCertRecord;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class SSHCertRecordTest {
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/MockS3ChangeLogStore.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/MockS3ChangeLogStore.java
@@ -18,10 +18,8 @@ package com.yahoo.athenz.common.server.store.impl;
 import static org.mockito.Mockito.mock;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.yahoo.athenz.zms.SignedDomain;
 import org.mockito.Mockito;
 
-import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 
 class MockS3ChangeLogStore extends S3ChangeLogStore {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/MockZMSFileChangeLogStore.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/MockZMSFileChangeLogStore.java
@@ -25,8 +25,6 @@ import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.mockito.Mockito;
-
 import com.yahoo.athenz.zms.DomainList;
 import com.yahoo.athenz.zms.SignedDomains;
 import com.yahoo.athenz.zms.ZMSClient;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/MockZMSFileMTLSChangeLogStore.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/MockZMSFileMTLSChangeLogStore.java
@@ -17,7 +17,6 @@ package com.yahoo.athenz.common.server.store.impl;
 
 import com.oath.auth.KeyRefresherException;
 import com.yahoo.athenz.zms.*;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/S3ChangeLogStoreTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/S3ChangeLogStoreTest.java
@@ -174,7 +174,7 @@ public class S3ChangeLogStoreTest {
         try {
             when(store.executorService.awaitTermination(defaultTimeoutSeconds, TimeUnit.SECONDS)).thenThrow(new InterruptedException());
             assertFalse(store.getAllDomains(temp));
-            assertTrue(store.getLocalDomainList().size() > 0);
+            assertFalse(store.getLocalDomainList().isEmpty());
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/ZMSFileChangeLogStoreCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/ZMSFileChangeLogStoreCommonTest.java
@@ -23,7 +23,6 @@ import com.yahoo.rdl.JSON;
 import com.yahoo.rdl.Struct;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -38,7 +37,6 @@ import java.util.*;
 
 import static com.yahoo.athenz.common.ServerCommonConsts.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 public class ZMSFileChangeLogStoreCommonTest {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/ConfigManagerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/ConfigManagerTest.java
@@ -75,7 +75,7 @@ public class ConfigManagerTest {
         assertEquals("mock://aAb2d4", mockSource2.sourceDescription);
 
         assertEquals(2, changesCount);
-        assertConfigManagerState(configManager, "" +
+        assertConfigManagerState(configManager,
                 "config-test-a -> value-1\n" +
                 "config-test-b -> value-2\n" +
                 "config-test-c -> value-3\n" +
@@ -87,7 +87,7 @@ public class ConfigManagerTest {
         assertFalse(configManager.removeConfigSource("mock://a1b2c3"));
 
         assertEquals(3, changesCount);
-        assertConfigManagerState(configManager, "" +
+        assertConfigManagerState(configManager,
                 "config-test-a -> value-A\n" +
                 "config-test-b -> value-2\n" +
                 "config-test-d -> value-4");
@@ -97,7 +97,7 @@ public class ConfigManagerTest {
         mockSource1 = (MockConfigProvider.MockConfigSource) configManager.getConfigSources()[1];
 
         assertEquals(4, changesCount);
-        assertConfigManagerState(configManager, "" +
+        assertConfigManagerState(configManager,
                 "config-test-a -> value-A\n" +
                 "config-test-b -> value-2\n" +
                 "config-test-c -> value-3\n" +
@@ -110,7 +110,7 @@ public class ConfigManagerTest {
         mockSource1.keysAndValues = "a1c3eE".toCharArray();
         configManager.reloadAllConfigs();
         assertEquals(5, changesCount);
-        assertConfigManagerState(configManager, "" +
+        assertConfigManagerState(configManager,
                 "config-test-a -> value-1\n" +
                 "config-test-c -> value-3\n" +
                 "config-test-d -> value-4\n" +
@@ -125,7 +125,7 @@ public class ConfigManagerTest {
         mockSource2.shouldThrow = true;
         configManager.reloadAllConfigs();
         assertEquals(5, changesCount);
-        assertConfigManagerState(configManager, "" +
+        assertConfigManagerState(configManager,
                 "config-test-a -> value-1\n" +
                 "config-test-c -> value-3\n" +
                 "config-test-d -> value-4\n" +

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/DynamicConfigTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/DynamicConfigTest.java
@@ -46,7 +46,7 @@ public class DynamicConfigTest {
 
         File configFile = File.createTempFile("ConfigProviderFileTest.testStatic", ".conf");
 
-        writeFile(configFile, "" +
+        writeFile(configFile,
                 "string-key-ok: string-value\n" +
                 "\n" +
                 "int-key-ok: 100\n" +

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/providers/ConfigProviderFileTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/providers/ConfigProviderFileTest.java
@@ -31,8 +31,7 @@ public class ConfigProviderFileTest {
 
         File configFile = File.createTempFile("ConfigProviderFileTest", ".conf");
         try (PrintWriter out = new PrintWriter(configFile)) {
-            out.print("" +
-                    "  ConfigProviderFileTest-1 : value-1 \n" +
+            out.print("  ConfigProviderFileTest-1 : value-1 \n" +
                     "  # remark \n" +
                     "  ConfigProviderFileTest-2 : value-2 \n");
         }


### PR DESCRIPTION
Changes include:
- replace deprecated calls
- mark fields as final when possible
- remove unused imports, fields, arguments
- replace function references with lambdas when possible
- replace size() > 0 calls with isEmpty()