### PR TITLE
libs/go/zmscli: fix dropped errors

### DIFF
--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -379,6 +379,9 @@ func (cli Zms) SystemBackup(dir string) (*string, error) {
 		if err == nil && data != nil {
 			s := *data
 			err = os.WriteFile(filename, []byte(s), 0644)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	cli.Verbose = verbose

--- a/libs/go/zmscli/import.go
+++ b/libs/go/zmscli/import.go
@@ -146,10 +146,11 @@ func (cli Zms) importRoles(dn string, lstRoles []*zms.Role, existingRoles *zms.R
 		if len(role.RoleMembers) > 0 {
 			roleMembers := make([]*zms.RoleMember, 0)
 			var err error
+			var adminRole *zms.Role
 			if rn == "admin" && validatedAdmins != nil {
 				// need to retrieve the current admin role
 				// and make sure to remove any existing admin
-				adminRole, err := cli.Zms.GetRole(zms.DomainName(dn), "admin", nil, nil, nil)
+				adminRole, err = cli.Zms.GetRole(zms.DomainName(dn), "admin", nil, nil, nil)
 				if err != nil {
 					return err
 				}
@@ -213,10 +214,11 @@ func (cli Zms) importRolesOld(dn string, lstRoles []interface{}, validatedAdmins
 			mem := val.([]interface{})
 			roleMembers := make([]*zms.RoleMember, 0)
 			var err error
+			var role *zms.Role
 			if rn == "admin" && validatedAdmins != nil {
 				// need to retrieve the current admin role
 				// and make sure to remove any existing admin
-				role, err := cli.Zms.GetRole(zms.DomainName(dn), "admin", nil, nil, nil)
+				role, err = cli.Zms.GetRole(zms.DomainName(dn), "admin", nil, nil, nil)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This fixes three dropped `err` variables in the `libs/go/zmscli` package.