### PR TITLE
Add account, startTime to raw.Doc

### DIFF
--- a/libs/go/sia/host/hostdoc/README.md
+++ b/libs/go/sia/host/hostdoc/README.md
@@ -4,15 +4,15 @@ The Host Document is expected to contain the following JSON
 
 ```
 {
-    "provider": "value"
+        "provider": "value"
 	"uuid": “long hex value",
 	"account": "value",
 	"domain": "value",
 	"service": "comma separated value",
 	"profile": "value”,
 	"zone": "openstack cluster",
-    "ip": ["value"],
-    "start_time": "RFC 3339",
+        "ip": ["value"],
+        "start_time": "RFC 3339",
 }
 ```
 

--- a/libs/go/sia/host/hostdoc/README.md
+++ b/libs/go/sia/host/hostdoc/README.md
@@ -4,18 +4,20 @@ The Host Document is expected to contain the following JSON
 
 ```
 {
-        "provider": "value"
+    "provider": "value"
 	"uuid": “long hex value",
+	"account": "value",
 	"domain": "value",
 	"service": "comma separated value",
 	"profile": "value”,
 	"zone": "openstack cluster",
-        "ip": ["value"],
+    "ip": ["value"],
+    "start_time": "RFC 3339",
 }
 ```
 
 
-The Json would be could be dropped into a file such as /var/lib/sia/host_document.
+The Json would be dropped into a file such as /var/lib/sia/host_document.
 
 Notes on Service:
 

--- a/libs/go/sia/host/hostdoc/raw/raw.go
+++ b/libs/go/sia/host/hostdoc/raw/raw.go
@@ -1,15 +1,19 @@
 package raw
 
+import "time"
+
 // JsonDoc is used mainly for unmarshalling the raw doc
 // it is used for backward compatibility to allow both service and services keys
 type Doc struct {
-	Provider          string   `json:"provider,omitempty"`
-	Domain            string   `json:"domain"`
-	Service           string   `json:"service"`
-	Services          string   `json:"services,omitempty"`
-	Profile           string   `json:"profile"`
-	ProfileRestrictTo string   `json:"profile_restrict_to,omitempty"`
-	Uuid              string   `json:"uuid,omitempty"`
-	Ip                []string `json:"ip,omitempty"`
-	Zone              string   `json:"zone,omitempty"`
+	Provider          string     `json:"provider,omitempty"`
+	Domain            string     `json:"domain"`
+	Service           string     `json:"service"`
+	Services          string     `json:"services,omitempty"`
+	Profile           string     `json:"profile"`
+	ProfileRestrictTo string     `json:"profile_restrict_to,omitempty"`
+	Account           string     `json:"account,omitempty"`
+	Uuid              string     `json:"uuid,omitempty"`
+	Ip                []string   `json:"ip,omitempty"`
+	Zone              string     `json:"zone,omitempty"`
+	StartTime         *time.Time `json:"start_time,omitempty"`
 }


### PR DESCRIPTION
Add account, startTime to raw.Doc.
Calypso will read these new metadata from host_document and send them to ums.

Tested with sia_aws on an ec2 host with calypso. Both sia_aws and calypso ended successfully.

```
/usr/sbin/siad -cmd refresh -nosyslog
2023/09/11 20:34:29 Identity successfully refreshed for services: ums
```
```
sudo /usr/sbin/calypso --ums https://ums.calypso.ouryahoo.com:4443/ums/v1 -nosyslog
Touch YubiKey:
2023/09/11 20:42:16 Migrating shadow content for cluster: us-west-2
2023/09/11 20:42:16 Calypso binary finished execution
```


