### PR TITLE
Add accountId, projectNumber, launchTime in raw.Doc

### DIFF
--- a/libs/go/sia/host/hostdoc/README.md
+++ b/libs/go/sia/host/hostdoc/README.md
@@ -4,19 +4,24 @@ The Host Document is expected to contain the following JSON
 
 ```
 {
-        "provider": "value"
+        "provider": "value",
+	"account_id": "value",
+	"project_number": "value",
 	"uuid": “long hex value",
 	"domain": "value",
 	"service": "comma separated value",
 	"profile": "value”,
 	"zone": "openstack cluster",
         "ip": ["value"],
+        "launch_time": "RFC 3339",
 }
 ```
 
 
-The Json would be could be dropped into a file such as /var/lib/sia/host_document.
+The Json would be dropped into a file such as /var/lib/sia/host_document.
 
-Notes on Service:
+Notes:
 
 The service entry is a comma-separated value. The first one is the primary service name that can be used by tools when the service is not provided in the context.
+
+Stop/start an ec2 instance will update the launch_time.

--- a/libs/go/sia/host/hostdoc/raw/raw.go
+++ b/libs/go/sia/host/hostdoc/raw/raw.go
@@ -5,17 +5,16 @@ import "time"
 // JsonDoc is used mainly for unmarshalling the raw doc
 // it is used for backward compatibility to allow both service and services keys
 type Doc struct {
-	Provider          string   `json:"provider,omitempty"`
-	Domain            string   `json:"domain"`
-	Service           string   `json:"service"`
-	Services          string   `json:"services,omitempty"`
-	Profile           string   `json:"profile"`
-	ProfileRestrictTo string   `json:"profile_restrict_to,omitempty"`
-	AccountId         string   `json:"account_id,omitempty"`
-	ProjectNumber     string   `json:"project_number,omitempty"`
-	Uuid              string   `json:"uuid,omitempty"`
-	Ip                []string `json:"ip,omitempty"`
-	Zone              string   `json:"zone,omitempty"`
-	// stop/start an instance will update the LaunchTime
-	LaunchTime *time.Time `json:"launch_time,omitempty"`
+	Provider          string     `json:"provider,omitempty"`
+	Domain            string     `json:"domain"`
+	Service           string     `json:"service"`
+	Services          string     `json:"services,omitempty"`
+	Profile           string     `json:"profile"`
+	ProfileRestrictTo string     `json:"profile_restrict_to,omitempty"`
+	AccountId         string     `json:"account_id,omitempty"`
+	ProjectNumber     string     `json:"project_number,omitempty"`
+	Uuid              string     `json:"uuid,omitempty"`
+	Ip                []string   `json:"ip,omitempty"`
+	Zone              string     `json:"zone,omitempty"`
+	LaunchTime        *time.Time `json:"launch_time,omitempty"` // stop/start an instance will update the LaunchTime
 }

--- a/libs/go/sia/host/hostdoc/raw/raw.go
+++ b/libs/go/sia/host/hostdoc/raw/raw.go
@@ -1,5 +1,7 @@
 package raw
 
+import "time"
+
 // JsonDoc is used mainly for unmarshalling the raw doc
 // it is used for backward compatibility to allow both service and services keys
 type Doc struct {
@@ -9,7 +11,11 @@ type Doc struct {
 	Services          string   `json:"services,omitempty"`
 	Profile           string   `json:"profile"`
 	ProfileRestrictTo string   `json:"profile_restrict_to,omitempty"`
+	AccountId         string   `json:"account_id,omitempty"`
+	ProjectNumber     string   `json:"project_number,omitempty"`
 	Uuid              string   `json:"uuid,omitempty"`
 	Ip                []string `json:"ip,omitempty"`
 	Zone              string   `json:"zone,omitempty"`
+	// stop/start an instance will update the LaunchTime
+	LaunchTime *time.Time `json:"launch_time,omitempty"`
 }


### PR DESCRIPTION
Add accountId, projectNumber, launchTime in raw.Doc.
Calypso will read these new metadata from host_document and send them to ums.

Tested with sia_aws on an ec2 host with calypso. Both sia_aws and calypso ended successfully.
```
./siad -cmd refresh -nosyslog
...
2023/09/11 22:31:14 Identity successfully refreshed for services: ums
```

```
sudo /usr/sbin/calypso --ums $ums_url -nosyslog
2023/09/11 22:32:08 Migrating shadow content for cluster: us-west-2
2023/09/11 22:32:08 Calypso binary finished execution
```