### PR TITLE
Add new fields to hostdoc.Doc

### DIFF
--- a/libs/go/sia/host/hostdoc/hostdoc.go
+++ b/libs/go/sia/host/hostdoc/hostdoc.go
@@ -52,7 +52,7 @@ type Doc struct {
 	Ip                map[string]bool
 	Zone              string
 	Bytes             []byte
-	LaunchTime        *time.Time
+	LaunchTime        time.Time
 }
 
 // NewPlainDoc returns Doc, the provider string from the host_document, and an error

--- a/libs/go/sia/host/hostdoc/hostdoc.go
+++ b/libs/go/sia/host/hostdoc/hostdoc.go
@@ -19,11 +19,12 @@ package hostdoc
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/host/hostdoc/raw"
 	"net"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/AthenZ/athenz/libs/go/sia/host/hostdoc/raw"
 	"github.com/AthenZ/athenz/libs/go/sia/host/provider"
 )
 
@@ -45,10 +46,13 @@ type Doc struct {
 	Profile           string
 	ProfileRestrictTo string
 	Services          []string
+	AccountId         string
+	ProjectNumber     string
 	Uuid              string
 	Ip                map[string]bool
 	Zone              string
 	Bytes             []byte
+	LaunchTime        *time.Time
 }
 
 // NewPlainDoc returns Doc, the provider string from the host_document, and an error
@@ -92,10 +96,13 @@ func NewPlainDoc(bytes []byte) (*Doc, string, error) {
 		Services:          strings.Split(svcs, ","),
 		Profile:           d.Profile,
 		ProfileRestrictTo: d.ProfileRestrictTo,
+		AccountId:         d.AccountId,
+		ProjectNumber:     d.ProjectNumber,
 		Uuid:              uuid,
 		Zone:              d.Zone,
 		Ip:                ip,
 		Bytes:             bytes,
+		LaunchTime:        d.LaunchTime,
 	}, d.Provider, nil
 }
 

--- a/libs/go/sia/host/hostdoc/raw/raw.go
+++ b/libs/go/sia/host/hostdoc/raw/raw.go
@@ -5,16 +5,16 @@ import "time"
 // JsonDoc is used mainly for unmarshalling the raw doc
 // it is used for backward compatibility to allow both service and services keys
 type Doc struct {
-	Provider          string     `json:"provider,omitempty"`
-	Domain            string     `json:"domain"`
-	Service           string     `json:"service"`
-	Services          string     `json:"services,omitempty"`
-	Profile           string     `json:"profile"`
-	ProfileRestrictTo string     `json:"profile_restrict_to,omitempty"`
-	AccountId         string     `json:"account_id,omitempty"`
-	ProjectNumber     string     `json:"project_number,omitempty"`
-	Uuid              string     `json:"uuid,omitempty"`
-	Ip                []string   `json:"ip,omitempty"`
-	Zone              string     `json:"zone,omitempty"`
-	LaunchTime        *time.Time `json:"launch_time,omitempty"` // stop/start an instance will update the LaunchTime
+	Provider          string    `json:"provider,omitempty"`
+	Domain            string    `json:"domain"`
+	Service           string    `json:"service"`
+	Services          string    `json:"services,omitempty"`
+	Profile           string    `json:"profile"`
+	ProfileRestrictTo string    `json:"profile_restrict_to,omitempty"`
+	AccountId         string    `json:"account_id,omitempty"`
+	ProjectNumber     string    `json:"project_number,omitempty"`
+	Uuid              string    `json:"uuid,omitempty"`
+	Ip                []string  `json:"ip,omitempty"`
+	Zone              string    `json:"zone,omitempty"`
+	LaunchTime        time.Time `json:"launch_time,omitempty"` // stop/start an instance will update the LaunchTime
 }


### PR DESCRIPTION
Add new fields to hostdoc.Doc.
Calypso will use the NewPlainDoc method to read and parse the new fields from host_document.
Tested with Calypso.