### PR TITLE
new store-token-option to store access token without quotes

### DIFF
--- a/libs/go/sia/access/config/config.go
+++ b/libs/go/sia/access/config/config.go
@@ -40,8 +40,9 @@ type AccessToken struct {
 type StoreTokenOptions int
 
 const (
-	ZtsResponse     StoreTokenOptions = iota // Default - store the entire AccessTokenResponse from ZTS
-	AccessTokenProp                          // Store only the access_token property
+	ZtsResponse                  StoreTokenOptions = iota // Default - store the entire AccessTokenResponse from ZTS
+	AccessTokenProp                                       // Store only the access_token property
+	AccessTokenWithoutQuotesProp                          // Store only the access_token without enclosing in quotes
 )
 
 // TokenService service definition with key/cert filenames

--- a/libs/go/sia/access/tokens/tokens.go
+++ b/libs/go/sia/access/tokens/tokens.go
@@ -162,6 +162,8 @@ func Fetch(opts *config.TokenOptions) ([]string, []error) {
 		tokenBytesToStore := func(res *zts.AccessTokenResponse, opts *config.TokenOptions) ([]byte, error) {
 			if opts.StoreOptions == config.ZtsResponse {
 				return json.Marshal(res)
+			} else if opts.StoreOptions == config.AccessTokenWithoutQuotesProp {
+				return []byte(res.Access_token), nil
 			} else {
 				return json.Marshal(res.Access_token)
 			}

--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -857,7 +857,11 @@ func tokenOptions(opts *options.Options, ztsUrl string) (*config.TokenOptions, e
 	if err != nil {
 		return nil, fmt.Errorf("unable to create token options: %s", err.Error())
 	}
-	tokenOpts.StoreOptions = config.AccessTokenProp
+	if opts.StoreTokenOption != nil {
+		tokenOpts.StoreOptions = config.StoreTokenOptions(*opts.StoreTokenOption)
+	} else {
+		tokenOpts.StoreOptions = config.AccessTokenProp
+	}
 
 	log.Printf("token options created successfully")
 	return tokenOpts, nil

--- a/libs/go/sia/agent/agent_test.go
+++ b/libs/go/sia/agent/agent_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/ssh/hostkey"
 	"k8s.io/utils/strings/slices"
 	"log"
 	"net"
@@ -30,10 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AthenZ/athenz/libs/go/sia/access/config"
 	"github.com/AthenZ/athenz/libs/go/sia/agent/devel/ztsmock"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
 	"github.com/AthenZ/athenz/libs/go/sia/options"
+	"github.com/AthenZ/athenz/libs/go/sia/ssh/hostkey"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
 
 	"github.com/stretchr/testify/assert"
@@ -475,6 +476,34 @@ func TestNilTokenOptions(test *testing.T) {
 	token, err := tokenOptions(opts, "")
 	assert.Nil(test, token, "should not create token")
 	assert.NotNil(test, err, "token is not presented")
+}
+
+func TestTokenStoreOptions(test *testing.T) {
+	opts := &options.Options{
+		Domain: "athenz",
+		AccessTokens: []config.AccessToken{
+			{
+				FileName: "reader",
+				Domain:   "athenz",
+				Service:  "api",
+			},
+		},
+		TokenDir:  "/tmp",
+		CertDir:   "/tmp",
+		KeyDir:    "/tmp",
+		BackupDir: "/tmp",
+	}
+	token, err := tokenOptions(opts, "")
+	assert.Nil(test, err)
+	assert.Equal(test, token.StoreOptions, config.AccessTokenProp)
+
+	// set the token option value
+	tokenOption := 2
+	opts.StoreTokenOption = &tokenOption
+
+	token, err = tokenOptions(opts, "")
+	assert.Nil(test, err)
+	assert.Equal(test, token.StoreOptions, config.AccessTokenWithoutQuotesProp)
 }
 
 func TestGetServiceHostname(test *testing.T) {

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -848,7 +848,11 @@ func tokenOptions(opts *options.Options, ztsUrl string) (*config.TokenOptions, e
 	if err != nil {
 		return nil, fmt.Errorf("unable to create token options: %s", err.Error())
 	}
-	tokenOpts.StoreOptions = config.AccessTokenProp
+	if opts.StoreTokenOption != nil {
+		tokenOpts.StoreOptions = config.StoreTokenOptions(*opts.StoreTokenOption)
+	} else {
+		tokenOpts.StoreOptions = config.AccessTokenProp
+	}
 
 	log.Printf("token options created successfully")
 	return tokenOpts, nil

--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AthenZ/athenz/libs/go/sia/access/config"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/agent/devel/ztsmock"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/attestation"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/options"
@@ -491,6 +492,34 @@ func TestNilTokenOptions(test *testing.T) {
 	token, err := tokenOptions(opts, "")
 	assert.Nil(test, token, "should not create token")
 	assert.NotNil(test, err, "token is not presented")
+}
+
+func TestTokenStoreOptions(test *testing.T) {
+	opts := &options.Options{
+		Domain: "athenz",
+		AccessTokens: []config.AccessToken{
+			{
+				FileName: "reader",
+				Domain:   "athenz",
+				Service:  "api",
+			},
+		},
+		TokenDir:  "/tmp",
+		CertDir:   "/tmp",
+		KeyDir:    "/tmp",
+		BackupDir: "/tmp",
+	}
+	token, err := tokenOptions(opts, "")
+	assert.Nil(test, err)
+	assert.Equal(test, token.StoreOptions, config.AccessTokenProp)
+
+	// set the token option value
+	tokenOption := 2
+	opts.StoreTokenOption = &tokenOption
+
+	token, err = tokenOptions(opts, "")
+	assert.Nil(test, err)
+	assert.Equal(test, token.StoreOptions, config.AccessTokenWithoutQuotesProp)
 }
 
 func TestGetServiceHostname(test *testing.T) {

--- a/libs/go/sia/aws/options/data/sia_config_threshold_role
+++ b/libs/go/sia/aws/options/data/sia_config_threshold_role
@@ -25,5 +25,6 @@
             }
         }
     ],
-    "fail_count_for_exit": 5
+    "fail_count_for_exit": 5,
+    "store_token_option": 2
 }

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -305,6 +305,7 @@ func TestOptionsWithRoleThreshold(t *testing.T) {
 	assert.Equal(t, 1440, opts.RefreshInterval)
 	assert.Empty(t, opts.ZTSRegion)
 	assert.Equal(t, 5, opts.FailCountForExit)
+	assert.Equal(t, 2, *opts.StoreTokenOption)
 
 	// Make sure profile is correct
 	assert.Equal(t, "zts-profile", opts.Profile)
@@ -675,6 +676,7 @@ func TestInitEnvConfig(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
 	os.Setenv("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", "10")
 	os.Setenv("ATHENZ_SIA_SPIFFE_TRUST_DOMAIN", "athenz.io")
+	os.Setenv("ATHENZ_SIA_STORE_TOKEN_OPTION", "2")
 
 	cfg, cfgAccount, err := InitEnvConfig(nil)
 	require.Nilf(t, err, "error should be empty, error: %v", err)
@@ -711,6 +713,7 @@ func TestInitEnvConfig(t *testing.T) {
 	assert.Equal(t, 2, len(cfgAccount.Roles))
 	assert.Equal(t, "host1.athenz.io", cfg.SshPrincipals)
 	assert.Equal(t, 10, cfg.FailCountForExit)
+	assert.Equal(t, 2, *cfg.StoreTokenOption)
 
 	os.Clearenv()
 }

--- a/libs/go/sia/options/data/sia_config_threshold_role
+++ b/libs/go/sia/options/data/sia_config_threshold_role
@@ -27,5 +27,6 @@
             }
         }
     ],
-    "fail_count_for_exit": 5
+    "fail_count_for_exit": 5,
+    "store_token_option": 2
 }

--- a/libs/go/sia/options/options_test.go
+++ b/libs/go/sia/options/options_test.go
@@ -309,6 +309,7 @@ func TestOptionsWithRoleThreshold(t *testing.T) {
 	assert.Equal(t, 1440, opts.RefreshInterval)
 	assert.Empty(t, opts.ZTSRegion)
 	assert.Equal(t, 5, opts.FailCountForExit)
+	assert.Equal(t, 2, *opts.StoreTokenOption)
 
 	// Make sure profile is correct
 	assert.Equal(t, "zts-profile", opts.Profile)
@@ -679,6 +680,7 @@ func TestInitEnvConfig(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
 	os.Setenv("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", "10")
 	os.Setenv("ATHENZ_SIA_SPIFFE_TRUST_DOMAIN", "athenz.io")
+	os.Setenv("ATHENZ_SIA_STORE_TOKEN_OPTION", "2")
 
 	provider := MockAWSProvider{
 		Name:     fmt.Sprintf("athenz.aws.us-west-2"),
@@ -719,6 +721,7 @@ func TestInitEnvConfig(t *testing.T) {
 	assert.Equal(t, 2, len(cfgAccount.Roles))
 	assert.Equal(t, "host1.athenz.io", cfg.SshPrincipals)
 	assert.Equal(t, 10, cfg.FailCountForExit)
+	assert.Equal(t, 2, *cfg.StoreTokenOption)
 
 	os.Clearenv()
 }


### PR DESCRIPTION
provide a new config option "store_token_option" in the config file that would specify if the access token should be saved in the configured file with quotes (existing default behavior) or not.

If "store_token_option: 2" is included in the sia_config file, the token will be saved without any surrounding quotes.