### PR TITLE
fix - show add msd policy err

### DIFF
--- a/ui/src/components/microsegmentation/RulesList.js
+++ b/ui/src/components/microsegmentation/RulesList.js
@@ -177,9 +177,7 @@ class RulesList extends React.Component {
             this.props.data.outbound?.length > 0 &&
             this.state.tabularView;
 
-        return this.props.isLoading.length !== 0 ? (
-            <ReduxPageLoader message={'Loading microsegmentation data'} />
-        ) : (
+        return (
             <MembersSectionDiv data-testid='segmentation-data-list'>
                 {addSegmentationButton}
 


### PR DESCRIPTION
Problem: when user attempts to add policy via the microsegmentation tab in athenz ui ([example link](https://dev-ui.athenz.ouryahoo.com/domain/home.jtsang01/microsegmentation)), the add msd modal does not display the error caught.

Solution: make sure parent component only renders child component once
<img width="1340" alt="image" src="https://github.com/AthenZ/athenz/assets/25251812/3b1a762c-b476-486d-9b6d-7bc2ae046257">
