### PR TITLE
Extract and export ClientTLSConfigFromPEM.

### DIFF
--- a/libs/go/athenzutils/zmsclient.go
+++ b/libs/go/athenzutils/zmsclient.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 )
 
 // ZmsClient creates and returns a ZMS client instance.
@@ -27,7 +28,7 @@ func ZmsClient(zmsURL, keyFile, certFile, caCertFile string, proxy bool) (*zms.Z
 			return nil, err
 		}
 	}
-	config, err := tlsConfiguration(keypem, certpem, cacertpem)
+	config, err := config.ClientTLSConfigFromPEM(keypem, certpem, cacertpem)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/go/athenzutils/ztsclient.go
+++ b/libs/go/athenzutils/ztsclient.go
@@ -4,8 +4,6 @@
 package athenzutils
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"net/http"
 	"net/url"
 	"os"
@@ -13,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/AthenZ/athenz/clients/go/zts"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 )
 
 // ZtsClient creates and returns a ZTS client instance.
@@ -32,7 +31,7 @@ func ZtsClient(ztsURL, keyFile, certFile, caCertFile string, proxy bool) (*zts.Z
 			return nil, err
 		}
 	}
-	config, err := tlsConfiguration(keypem, certpem, cacertpem)
+	config, err := config.ClientTLSConfigFromPEM(keypem, certpem, cacertpem)
 	if err != nil {
 		return nil, err
 	}
@@ -44,24 +43,6 @@ func ZtsClient(ztsURL, keyFile, certFile, caCertFile string, proxy bool) (*zts.Z
 	}
 	client := zts.NewClient(ztsURL, tr)
 	return &client, nil
-}
-
-func tlsConfiguration(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
-	config := &tls.Config{}
-	if certpem != nil && keypem != nil {
-		mycert, err := tls.X509KeyPair(certpem, keypem)
-		if err != nil {
-			return nil, err
-		}
-		config.Certificates = make([]tls.Certificate, 1)
-		config.Certificates[0] = mycert
-	}
-	if cacertpem != nil {
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(cacertpem)
-		config.RootCAs = certPool
-	}
-	return config, nil
 }
 
 // GenerateAccessTokenRequestString generates and urlencodes an access token string.

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/athenz/libs/go/sia/futil"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 )
 
 // CertReqDetails - struct with details to generate a certificate CSR
@@ -186,29 +187,7 @@ func tlsConfiguration(keyfile, certfile, cafile string) (*tls.Config, error) {
 			return nil, err
 		}
 	}
-	return tlsConfigurationFromPEM(keypem, certpem, capem)
-}
-
-func tlsConfigurationFromPEM(keypem, certpem, capem []byte) (*tls.Config, error) {
-	config := &tls.Config{}
-
-	if capem != nil {
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(capem) {
-			return nil, fmt.Errorf("failed to append certs to pool")
-		}
-		config.RootCAs = certPool
-	}
-
-	if certpem != nil && keypem != nil {
-		mycert, err := tls.X509KeyPair(certpem, keypem)
-		if err != nil {
-			return nil, err
-		}
-		config.Certificates = make([]tls.Certificate, 1)
-		config.Certificates[0] = mycert
-	}
-	return config, nil
+	return config.ClientTLSConfigFromPEM(keypem, certpem, capem)
 }
 
 func GenerateX509CSR(key *rsa.PrivateKey, csrDetails CertReqDetails) (string, error) {

--- a/libs/go/tls/config/config.go
+++ b/libs/go/tls/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 )
 
 func GetTLSConfigFromFiles(certFile, keyFile string) (*tls.Config, error) {
@@ -12,6 +13,24 @@ func GetTLSConfigFromFiles(certFile, keyFile string) (*tls.Config, error) {
 	config := ClientTLSConfig()
 	config.Certificates = []tls.Certificate{cert}
 
+	return config, nil
+}
+
+func ClientTLSConfigFromPEM(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
+	config := &tls.Config{}
+	if certpem != nil && keypem != nil {
+		mycert, err := tls.X509KeyPair(certpem, keypem)
+		if err != nil {
+			return nil, err
+		}
+		config.Certificates = make([]tls.Certificate, 1)
+		config.Certificates[0] = mycert
+	}
+	if cacertpem != nil {
+		certPool := x509.NewCertPool()
+		certPool.AppendCertsFromPEM(cacertpem)
+		config.RootCAs = certPool
+	}
 	return config, nil
 }
 

--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -5,8 +5,6 @@ package zmscli
 
 import (
 	"bytes"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"gopkg.in/yaml.v2"
@@ -17,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 	"github.com/ardielle/ardielle-go/rdl"
 	"golang.org/x/net/proxy"
 )
@@ -3395,7 +3394,7 @@ func SetX509CertClient(cli *Zms, keyFile, certFile, caCertFile, socksProxy strin
 			return err
 		}
 	}
-	config, err := tlsConfiguration(keypem, certpem, cacertpem)
+	config, err := config.ClientTLSConfigFromPEM(keypem, certpem, cacertpem)
 	if err != nil {
 		return err
 	}
@@ -3422,22 +3421,4 @@ func SetX509CertClient(cli *Zms, keyFile, certFile, caCertFile, socksProxy strin
 func SetClient(cli *Zms, tr *http.Transport, authHeader, ntoken *string) {
 	cli.Zms = zms.NewClient(cli.ZmsUrl, tr)
 	cli.Zms.AddCredentials(*authHeader, *ntoken)
-}
-
-func tlsConfiguration(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
-	config := &tls.Config{}
-	if certpem != nil && keypem != nil {
-		mycert, err := tls.X509KeyPair(certpem, keypem)
-		if err != nil {
-			return nil, err
-		}
-		config.Certificates = make([]tls.Certificate, 1)
-		config.Certificates[0] = mycert
-	}
-	if cacertpem != nil {
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(cacertpem)
-		config.RootCAs = certPool
-	}
-	return config, nil
 }

--- a/utils/zts-svccert/zts-svccert.go
+++ b/utils/zts-svccert/zts-svccert.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/AthenZ/athenz/libs/go/athenzutils"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/athenz/libs/go/zmssvctoken"
@@ -515,7 +516,7 @@ func certClient(ztsURL string, keyBytes []byte, certfile, caCertFile string) (*z
 			return nil, err
 		}
 	}
-	config, err := tlsConfiguration(keyBytes, certpem, cacertpem)
+	config, err := config.ClientTLSConfigFromPEM(keyBytes, certpem, cacertpem)
 	if err != nil {
 		return nil, err
 	}
@@ -525,22 +526,4 @@ func certClient(ztsURL string, keyBytes []byte, certfile, caCertFile string) (*z
 	}
 	client := zts.NewClient(ztsURL, transport)
 	return &client, nil
-}
-
-func tlsConfiguration(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
-	config := &tls.Config{}
-	if certpem != nil && keypem != nil {
-		mycert, err := tls.X509KeyPair(certpem, keypem)
-		if err != nil {
-			return nil, err
-		}
-		config.Certificates = make([]tls.Certificate, 1)
-		config.Certificates[0] = mycert
-	}
-	if cacertpem != nil {
-		certPool := x509.NewCertPool()
-		certPool.AppendCertsFromPEM(cacertpem)
-		config.RootCAs = certPool
-	}
-	return config, nil
 }


### PR DESCRIPTION
Extract a reused function and export it
```
func tlsConfiguration(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
	config := &tls.Config{}
	if certpem != nil && keypem != nil {
		mycert, err := tls.X509KeyPair(certpem, keypem)
		if err != nil {
			return nil, err
		}
		config.Certificates = make([]tls.Certificate, 1)
		config.Certificates[0] = mycert
	}
	if cacertpem != nil {
		certPool := x509.NewCertPool()
		certPool.AppendCertsFromPEM(cacertpem)
		config.RootCAs = certPool
	}
	return config, nil
}
```