### PR TITLE
skip loading on parent component for msd edit

### DIFF
--- a/ui/src/components/microsegmentation/AddSegmentation.js
+++ b/ui/src/components/microsegmentation/AddSegmentation.js
@@ -1664,7 +1664,8 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = (dispatch) => ({
     addRole: (roleName, role, auditRef, _csrf) =>
         dispatch(addRole(roleName, auditRef, role, _csrf)),
-    getRole: (domainName, roleName) => dispatch(getRole(domainName, roleName, false)),
+    getRole: (domainName, roleName) =>
+        dispatch(getRole(domainName, roleName, false)),
     deleteRole: (roleName, auditRef, _csrf) =>
         dispatch(deleteRole(roleName, auditRef, _csrf)),
     getPolicy: (domainName, policyName) =>
@@ -1746,7 +1747,8 @@ const mapDispatchToProps = (dispatch) => ({
                 assertionChanged,
                 assertionConditionChanged,
                 updatedData,
-                _csrf
+                _csrf,
+                false
             )
         ),
     getAssertionId: (domain, policyName, roleName, resource, action, effect) =>

--- a/ui/src/redux/thunks/microsegmentation.js
+++ b/ui/src/redux/thunks/microsegmentation.js
@@ -64,11 +64,12 @@ export const editMicrosegmentation =
         assertionChanged,
         assertionConditionChanged,
         data,
-        _csrf
+        _csrf,
+        showLoader = true
     ) =>
     async (dispatch, getState) => {
         try {
-            dispatch(loadingInProcess('editMicrosegmentation'));
+            showLoader && dispatch(loadingInProcess('editMicrosegmentation'));
             await editMicrosegmentationHandler(
                 domainName,
                 roleChanged,
@@ -79,7 +80,7 @@ export const editMicrosegmentation =
                 dispatch,
                 getState()
             );
-            dispatch(loadingSuccess('editMicrosegmentation'));
+            showLoader && dispatch(loadingSuccess('editMicrosegmentation'));
             return Promise.resolve();
         } catch (e) {
             return Promise.reject(e);


### PR DESCRIPTION
Problem: after quick debug, found the same issue from previous add msd policy where the parent component is loading form child component redux call.

Solution: apply the same [fix](https://github.com/AthenZ/athenz/pull/2317) for edit msd call