### PR TITLE
fetch verification key from server during access token validation

### DIFF
--- a/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestAuthZpe.java
+++ b/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestAuthZpe.java
@@ -1461,13 +1461,6 @@ public class TestAuthZpe {
     }
 
     @Test
-    public void testCanFetch() {
-        assertFalse(AuthZpeClient.canFetchLatestJwksFromZts());
-        AuthZpeClient.setMillisBetweenZtsCalls(0);
-        assertTrue(AuthZpeClient.canFetchLatestJwksFromZts());
-    }
-
-    @Test
     public void testMaxCacheTokenSize() throws IOException {
 
         // perform allowed access check

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/AuthorityConsts.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/AuthorityConsts.java
@@ -35,6 +35,8 @@ public final class AuthorityConsts {
 
     public static final String ZTS_CERT_PRINCIPAL_URI    = "athenz://principal/";
 
+    public static final String AUTH_PROP_MILLIS_BETWEEN_ZTS_CALLS = "athenz.auth.millis_between_zts_calls";
+
     // prevent object creation
     private AuthorityConsts() {
     }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolver.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolver.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.yahoo.athenz.auth.AuthorityConsts.AUTH_PROP_MILLIS_BETWEEN_ZTS_CALLS;
+
 public class JwtsSigningKeyResolver implements SigningKeyResolver {
 
     public static final String ZTS_PROP_ATHENZ_CONF           = "athenz.athenz_conf";
@@ -49,6 +51,10 @@ public class JwtsSigningKeyResolver implements SigningKeyResolver {
     private static long millisBetweenZtsCalls;
 
     ConcurrentHashMap<String, PublicKey> publicKeys;
+
+    static {
+        setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(AUTH_PROP_MILLIS_BETWEEN_ZTS_CALLS, "86400000")));
+    }
 
     static ObjectMapper initJsonMapper() {
         ObjectMapper mapper = new ObjectMapper();

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolver.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolver.java
@@ -45,7 +45,6 @@ public class JwtsSigningKeyResolver implements SigningKeyResolver {
     private static final ObjectMapper JSON_MAPPER = initJsonMapper();
     private final SSLContext sslContext;
     private final String jwksUri;
-    private final boolean skipConfig;
     private static long lastZtsJwkFetchTime;
     private static long millisBetweenZtsCalls;
 
@@ -64,7 +63,6 @@ public class JwtsSigningKeyResolver implements SigningKeyResolver {
     public JwtsSigningKeyResolver(final String jwksUri, final SSLContext sslContext, boolean skipConfig) {
         this.jwksUri = jwksUri;
         this.sslContext = sslContext;
-        this.skipConfig = skipConfig;
         this.publicKeys = new ConcurrentHashMap<>();
         if (!skipConfig) {
             loadPublicKeysFromConfig();

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/TestJwtsSigningKeyResolver.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/TestJwtsSigningKeyResolver.java
@@ -65,6 +65,15 @@ public class TestJwtsSigningKeyResolver {
     }
 
     @Test
+    public void testCanFetch() {
+        JwtsSigningKeyResolver.setMillisBetweenZtsCalls(1000);
+        JwtsSigningKeyResolver resolver = new JwtsSigningKeyResolver(null, null);
+        assertFalse(JwtsSigningKeyResolver.canFetchLatestJwksFromZts());
+        JwtsSigningKeyResolver.setMillisBetweenZtsCalls(-1);
+        assertTrue(JwtsSigningKeyResolver.canFetchLatestJwksFromZts());
+    }
+
+    @Test
     public void testLoadPublicKeysFromServerInvalidUri() {
 
         final String oldConf = System.setProperty(JwtsSigningKeyResolver.ZTS_PROP_ATHENZ_CONF,


### PR DESCRIPTION
# description
Currently, AuthZpeClient is limited to dynamically fetching public keys exclusively during RoleToken verifications.
We aim to expand this functionality to also dynamically retrieve public keys when verifying AccessToken.