### PR TITLE
log x509 cert serial number in the access log files

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/ServerCommonConsts.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/ServerCommonConsts.java
@@ -40,8 +40,12 @@ public final class ServerCommonConsts {
     public static final String ZTS_PROP_FILE_NAME           = "athenz.zts.prop_file";
     public static final String PROP_DATA_STORE_SUBDIR = "athenz.server_common.data_store_subdir";
 
-    public static final String REQUEST_PRINCIPAL    = "com.yahoo.athenz.auth.principal";
-    public static final String REQUEST_AUTHORITY_ID = "com.yahoo.athenz.auth.authority_id";
+    public static final String REQUEST_PRINCIPAL      = "com.yahoo.athenz.auth.principal";
+    public static final String REQUEST_AUTHORITY_ID   = "com.yahoo.athenz.auth.authority_id";
+    public static final String REQUEST_X509_SERIAL    = "com.yahoo.athenz.auth.principal_x509_serial";
+    public static final String REQUEST_URI_SKIP_QUERY = "com.yahoo.athenz.uri.skip_query";
+    public static final String REQUEST_URI_ADDL_QUERY = "com.yahoo.athenz.uri.addl_query";
+    public static final String REQUEST_SSL_SESSION    = "org.eclipse.jetty.servlet.request.ssl_session";
 
     public static final String METRIC_DEFAULT_FACTORY_CLASS = "com.yahoo.athenz.common.metrics.impl.NoOpMetricFactory";
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
@@ -15,6 +15,7 @@
  */
 package com.yahoo.athenz.common.server.log.jetty;
 
+import com.yahoo.athenz.common.ServerCommonConsts;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.server.*;
 import org.mockito.Mockito;
@@ -34,12 +35,6 @@ import java.util.Locale;
 import static org.testng.Assert.*;
 
 public class AthenzRequestLogTest {
-
-    private static final String REQUEST_PRINCIPAL      = "com.yahoo.athenz.auth.principal";
-    private static final String REQUEST_AUTHORITY_ID   = "com.yahoo.athenz.auth.authority_id";
-    private static final String REQUEST_URI_SKIP_QUERY = "com.yahoo.athenz.uri.skip_query";
-    private static final String REQUEST_URI_ADDL_QUERY = "com.yahoo.athenz.uri.addl_query";
-    private static final String REQUEST_SSL_SESSION    = "org.eclipse.jetty.servlet.request.ssl_session";
 
     private static final String TEST_FILE = "./unit-test-athenz.log";
 
@@ -99,7 +94,7 @@ public class AthenzRequestLogTest {
         final String data = new String(Files.readAllBytes(file.toPath()));
 
         assertTrue(data.startsWith("10.10.11.12 - - [01/Jan/1970:00:00:00 +0000] \"GET /original-uri HTTP/1.1\" -1 1234 \"-\" \"-\" -"), data);
-        assertTrue(data.endsWith("Auth-None - -\n"), data);
+        assertTrue(data.endsWith("Auth-None - - -\n"), data);
 
         Files.delete(file.toPath());
     }
@@ -143,7 +138,7 @@ public class AthenzRequestLogTest {
         final String data = new String(Files.readAllBytes(file.toPath()));
 
         assertTrue(data.startsWith("10.11.12.13 - - [01/Jan/1970:00:00:00 +0000] \"GET /original-uri HTTP/1.1\" 401 100 \"-\" \"-\" 10"), data);
-        assertTrue(data.endsWith("Auth-None - -\n"), data);
+        assertTrue(data.endsWith("Auth-None - - -\n"), data);
 
         Files.delete(file.toPath());
     }
@@ -187,7 +182,7 @@ public class AthenzRequestLogTest {
         final String data = new String(Files.readAllBytes(file.toPath()));
 
         assertTrue(data.startsWith("2001:0db8:85a3:0000:0000:8a2e:0370:7334 - - [01/Jan/1970:00:00:00 +0000] \"GET /original-uri HTTP/1.1\" 401 5 \"-\" \"-\" 3"), data);
-        assertTrue(data.endsWith("Auth-None - -\n"), data);
+        assertTrue(data.endsWith("Auth-None - - -\n"), data);
 
         Files.delete(file.toPath());
     }
@@ -205,12 +200,13 @@ public class AthenzRequestLogTest {
         Response response = Mockito.mock(Response.class);
 
         Mockito.when(request.getHeader(HttpHeader.X_FORWARDED_FOR.toString())).thenReturn("10.10.11.13");
-        Mockito.when(request.getAttribute(REQUEST_PRINCIPAL)).thenReturn("athenz.zts");
-        Mockito.when(request.getAttribute(REQUEST_AUTHORITY_ID)).thenReturn("Auth-X509");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_PRINCIPAL)).thenReturn("athenz.zts");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_AUTHORITY_ID)).thenReturn("Auth-X509");
 
-        Mockito.when(request.getAttribute(REQUEST_URI_SKIP_QUERY)).thenReturn(Boolean.TRUE);
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_URI_SKIP_QUERY)).thenReturn(Boolean.TRUE);
         Mockito.when(request.getRequestURI()).thenReturn("/request-uri");
-        Mockito.when(request.getAttribute(REQUEST_URI_ADDL_QUERY)).thenReturn("query=true");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_URI_ADDL_QUERY)).thenReturn("query=true");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_X509_SERIAL)).thenReturn("777");
 
         Mockito.when(request.getMethod()).thenReturn("GET");
         Mockito.when(request.getProtocol()).thenReturn("HTTP/1.1");
@@ -228,7 +224,7 @@ public class AthenzRequestLogTest {
         Mockito.when(response.getHttpChannel()).thenReturn(httpChannel);
 
         SSLSession sslSession = Mockito.mock(SSLSession.class);
-        Mockito.when(request.getAttribute(REQUEST_SSL_SESSION)).thenReturn(sslSession);
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_SSL_SESSION)).thenReturn(sslSession);
         Mockito.when(sslSession.getProtocol()).thenReturn("TLSv1.2");
         Mockito.when(sslSession.getCipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
 
@@ -239,7 +235,7 @@ public class AthenzRequestLogTest {
         final String data = new String(Files.readAllBytes(file.toPath()));
 
         assertTrue(data.startsWith("10.10.11.13 - athenz.zts [01/Jan/1970:00:00:00 +0000] \"GET /request-uri?query=true HTTP/1.1\" 200 10240 \"-\" \"-\" 102400"), data);
-        assertTrue(data.endsWith("Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n"), data);
+        assertTrue(data.endsWith("Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 777\n"), data);
 
         Files.delete(file.toPath());
     }
@@ -259,12 +255,12 @@ public class AthenzRequestLogTest {
         Mockito.when(request.getHeader(HttpHeader.X_FORWARDED_FOR.toString())).thenReturn("10.10.11.13");
         Mockito.when(request.getRemoteAddr()).thenReturn("10.10.11.12");
 
-        Mockito.when(request.getAttribute(REQUEST_PRINCIPAL)).thenReturn("athenz.zts");
-        Mockito.when(request.getAttribute(REQUEST_AUTHORITY_ID)).thenReturn("Auth-X509");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_PRINCIPAL)).thenReturn("athenz.zts");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_AUTHORITY_ID)).thenReturn("Auth-X509");
 
-        Mockito.when(request.getAttribute(REQUEST_URI_SKIP_QUERY)).thenReturn(Boolean.TRUE);
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_URI_SKIP_QUERY)).thenReturn(Boolean.TRUE);
         Mockito.when(request.getRequestURI()).thenReturn("/request-uri");
-        Mockito.when(request.getAttribute(REQUEST_URI_ADDL_QUERY)).thenReturn("query=true");
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_URI_ADDL_QUERY)).thenReturn("query=true");
 
         Mockito.when(request.getMethod()).thenReturn("GET");
         Mockito.when(request.getProtocol()).thenReturn("HTTP/1.1");
@@ -282,7 +278,7 @@ public class AthenzRequestLogTest {
         Mockito.when(response.getHttpChannel()).thenReturn(httpChannel);
 
         SSLSession sslSession = Mockito.mock(SSLSession.class);
-        Mockito.when(request.getAttribute(REQUEST_SSL_SESSION)).thenReturn(sslSession);
+        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_SSL_SESSION)).thenReturn(sslSession);
         Mockito.when(sslSession.getProtocol()).thenReturn("TLSv1.2");
         Mockito.when(sslSession.getCipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
 
@@ -293,7 +289,7 @@ public class AthenzRequestLogTest {
         final String data = new String(Files.readAllBytes(file.toPath()));
 
         assertTrue(data.startsWith("10.10.11.12 - athenz.zts [01/Jan/1970:00:00:00 +0000] \"GET /request-uri?query=true HTTP/1.1\" 200 10240 \"-\" \"-\" 102400"), data);
-        assertTrue(data.endsWith("Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\n"), data);
+        assertTrue(data.endsWith("Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 -\n"), data);
 
         Files.delete(file.toPath());
     }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
@@ -26,6 +26,7 @@ import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.messaging.DomainChangeMessage;
 import com.yahoo.athenz.common.server.rest.Http;
 
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -126,7 +127,15 @@ public class RsrcCtxWrapper implements ResourceContext {
         }
         ctx.request().setAttribute(ServerCommonConsts.REQUEST_PRINCIPAL, principalName);
         logAuthorityId(principal.getAuthority());
+        logCertificateSerialNumber(principal.getX509Certificate());
         return principalName;
+    }
+
+    public void logCertificateSerialNumber(X509Certificate x509Cert) {
+        if (x509Cert == null) {
+            return;
+        }
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_X509_SERIAL, x509Cert.getSerialNumber().toString());
     }
 
     public void logAuthorityId(Authority authority) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
@@ -29,6 +29,8 @@ import org.testng.annotations.Test;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.math.BigInteger;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 import static com.yahoo.athenz.common.messaging.DomainChangeMessage.ObjectType.DOMAIN;
@@ -196,6 +198,10 @@ public class RsrcCtxWrapperTest {
         Authority authMock = Mockito.mock(Authority.class);
         SimplePrincipal principal = (SimplePrincipal) SimplePrincipal.create("hockey", "kings",
                 "v=S1,d=hockey;n=kings;s=sig", 0, new PrincipalAuthority());
+        assertNotNull(principal);
+        X509Certificate x509Certificate = Mockito.mock(X509Certificate.class);
+        Mockito.when(x509Certificate.getSerialNumber()).thenReturn(BigInteger.TEN);
+        principal.setX509Certificate(x509Certificate);
 
         Mockito.when(authMock.getHeader()).thenReturn("testheader");
         Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
@@ -214,6 +220,7 @@ public class RsrcCtxWrapperTest {
 
         Mockito.verify(reqMock, times(1)).setAttribute("com.yahoo.athenz.auth.principal", "hockey.kings");
         Mockito.verify(reqMock, times(1)).setAttribute("com.yahoo.athenz.auth.authority_id", "Auth-NTOKEN");
+        Mockito.verify(reqMock, times(1)).setAttribute("com.yahoo.athenz.auth.principal_x509_serial", "10");
     }
 
     @Test

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 public class RsrcCtxWrapper implements ResourceContext {
@@ -143,9 +145,17 @@ public class RsrcCtxWrapper implements ResourceContext {
         }
         logPrincipal(principalName);
         logAuthorityId(principal.getAuthority());
+        logCertificateSerialNumber(principal.getX509Certificate());
         return principalName;
     }
-    
+
+    public void logCertificateSerialNumber(X509Certificate x509Cert) {
+        if (x509Cert == null) {
+            return;
+        }
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_X509_SERIAL, x509Cert.getSerialNumber().toString());
+    }
+
     public void logPrincipal(final String principal) {
         if (principal == null) {
             return;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -27,6 +27,7 @@ import com.yahoo.athenz.auth.util.AthenzUtils;
 import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.athenz.auth.util.CryptoException;
 import com.yahoo.athenz.auth.util.StringUtils;
+import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.config.AuthzDetailsEntity;
 import com.yahoo.athenz.common.config.AuthzDetailsEntityList;
 import com.yahoo.athenz.common.metrics.Metric;
@@ -104,7 +105,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 
-import static com.yahoo.athenz.common.ServerCommonConsts.*;
 import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
 
 /**
@@ -200,7 +200,6 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     private static final String TYPE_EXTERNAL_CREDENTIALS_REQUEST = "ExternalCredentialsRequest";
 
     private static final String ZTS_ROLE_TOKEN_VERSION = "Z1";
-    private static final String ZTS_REQUEST_LOG_SKIP_QUERY = "com.yahoo.athenz.uri.skip_query";
 
     private static final long ZTS_NTOKEN_DEFAULT_EXPIRY = TimeUnit.SECONDS.convert(2, TimeUnit.HOURS);
     private static final long ZTS_NTOKEN_MAX_EXPIRY = TimeUnit.SECONDS.convert(7, TimeUnit.DAYS);
@@ -428,8 +427,8 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         jwkConfig = new AthenzJWKConfig();
 
-        ServiceIdentity ztsService = sysAuthService(ZTS_SERVICE);
-        ServiceIdentity zmsService = sysAuthService(ZMS_SERVICE);
+        ServiceIdentity ztsService = sysAuthService(ServerCommonConsts.ZTS_SERVICE);
+        ServiceIdentity zmsService = sysAuthService(ServerCommonConsts.ZMS_SERVICE);
 
         if (ztsService != null && zmsService != null) {
             updateAthenzJWK(ztsService, zmsService);
@@ -521,7 +520,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     }
 
     void loadSystemProperties() {
-        String propFile = System.getProperty(ZTS_PROP_FILE_NAME,
+        String propFile = System.getProperty(ServerCommonConsts.ZTS_PROP_FILE_NAME,
                 getRootDir() + "/conf/zts_server/zts.properties");
         CONFIG_MANAGER.addConfigSource(ConfigProviderFile.PROVIDER_DESCRIPTION_PREFIX + propFile);
     }
@@ -628,7 +627,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             authorizedProxyUsers = new HashSet<>(Arrays.asList(authorizedProxyUserList.split(",")));
         }
 
-        userDomain = System.getProperty(PROP_USER_DOMAIN, ZTSConsts.ATHENZ_USER_DOMAIN);
+        userDomain = System.getProperty(ServerCommonConsts.PROP_USER_DOMAIN, ZTSConsts.ATHENZ_USER_DOMAIN);
         userDomainPrefix = userDomain + ".";
 
         userDomainAlias = System.getProperty(ZTSConsts.ZTS_PROP_USER_DOMAIN_ALIAS);
@@ -778,7 +777,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     void loadMetricObject() {
 
         final String metricFactoryClass = System.getProperty(ZTSConsts.ZTS_PROP_METRIC_FACTORY_CLASS,
-                METRIC_DEFAULT_FACTORY_CLASS);
+                ServerCommonConsts.METRIC_DEFAULT_FACTORY_CLASS);
 
         MetricFactory metricFactory;
         try {
@@ -999,8 +998,10 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         if ((lastAthenzJWKUpdateTime == 0) || (lastAthenzJWKUpdateTime + millisBetweenAthenzJWKUpdates < System.currentTimeMillis())) {
             synchronized (updateJWKMutex) {
                 if (lastAthenzJWKUpdateTime == 0 || (lastAthenzJWKUpdateTime + millisBetweenAthenzJWKUpdates < System.currentTimeMillis())) {
-                    final ServiceIdentity ztsService = getServiceIdentity(ctx, ATHENZ_SYS_DOMAIN, ZTS_SERVICE);
-                    final ServiceIdentity zmsService = getServiceIdentity(ctx, ATHENZ_SYS_DOMAIN, ZMS_SERVICE);
+                    final ServiceIdentity ztsService = getServiceIdentity(ctx, ServerCommonConsts.ATHENZ_SYS_DOMAIN,
+                            ServerCommonConsts.ZTS_SERVICE);
+                    final ServiceIdentity zmsService = getServiceIdentity(ctx, ServerCommonConsts.ATHENZ_SYS_DOMAIN,
+                            ServerCommonConsts.ZMS_SERVICE);
 
                     if (hasNewJWKConfig(zmsService.getModified(), ztsService.getModified())) {
                         updateAthenzJWK(ztsService, zmsService);
@@ -3391,7 +3392,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         // our access log files so we're going to set the attribute
         // to skip the query parameters
 
-        ctx.request().setAttribute(ZTS_REQUEST_LOG_SKIP_QUERY, Boolean.TRUE);
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_URI_SKIP_QUERY, Boolean.TRUE);
 
         final String principalDomain = logPrincipalAndGetDomain(ctx);
         validateRequest(ctx.request(), principalDomain, caller);
@@ -3733,7 +3734,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         }
 
         final String serviceDnsSuffix = domainData.getCertDnsDomain();
-        final DataCache athenzSysDomainCache = dataStore.getDataCache(ATHENZ_SYS_DOMAIN);
+        final DataCache athenzSysDomainCache = dataStore.getDataCache(ServerCommonConsts.ATHENZ_SYS_DOMAIN);
 
         if (!certReq.validate(domain, service, provider, validCertSubjectOrgValues, athenzSysDomainCache,
                 serviceDnsSuffix, info.getHostname(), info.getHostCnames(), hostnameResolver,
@@ -4236,7 +4237,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         }
 
         final String serviceDnsSuffix = domainData.getCertDnsDomain();
-        final DataCache athenzSysDomainCache = dataStore.getDataCache(ATHENZ_SYS_DOMAIN);
+        final DataCache athenzSysDomainCache = dataStore.getDataCache(ServerCommonConsts.ATHENZ_SYS_DOMAIN);
 
         StringBuilder errorMsg = new StringBuilder(256);
         if (!certReq.validate(domain, service, provider, validCertSubjectOrgValues, athenzSysDomainCache,

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
@@ -35,6 +35,9 @@ import com.yahoo.athenz.common.metrics.Metric;
 
 import com.yahoo.athenz.common.server.rest.Http.AuthorityList;
 
+import java.math.BigInteger;
+import java.security.cert.X509Certificate;
+
 public class RsrcCtxWrapperTest {
 
     @Test
@@ -292,6 +295,10 @@ public class RsrcCtxWrapperTest {
 
         SimplePrincipal principal = (SimplePrincipal) SimplePrincipal.create("hockey", "kings",
                 "v=S1,d=hockey;n=kings;s=sig", 0, new PrincipalAuthority());
+        assertNotNull(principal);
+        X509Certificate x509Certificate = Mockito.mock(X509Certificate.class);
+        Mockito.when(x509Certificate.getSerialNumber()).thenReturn(BigInteger.TEN);
+        principal.setX509Certificate(x509Certificate);
 
         Mockito.when(authMock.getHeader()).thenReturn("testheader");
         Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
@@ -310,6 +317,7 @@ public class RsrcCtxWrapperTest {
 
         Mockito.verify(reqMock, times(1)).setAttribute("com.yahoo.athenz.auth.principal", "hockey.kings");
         Mockito.verify(reqMock, times(1)).setAttribute("com.yahoo.athenz.auth.authority_id", "Auth-NTOKEN");
+        Mockito.verify(reqMock, times(1)).setAttribute("com.yahoo.athenz.auth.principal_x509_serial", "10");
     }
 
     @Test
@@ -326,6 +334,7 @@ public class RsrcCtxWrapperTest {
 
         SimplePrincipal principal = (SimplePrincipal) SimplePrincipal.create("hockey", "kings",
                 "v=S1,d=hockey;n=kings;s=sig", 0, new PrincipalAuthority());
+        assertNotNull(principal);
         principal.setRolePrincipalName("athenz.role");
 
         Mockito.when(authMock.getHeader()).thenReturn("testheader");


### PR DESCRIPTION
this would allow system admins to run some checks where they can verify if access token requests are coming from a different set of IPs instead of the IP address where that certificate was fetched from. the values could be different if the host is behind a NAT gw with multiple addresses, but even then you should see that set only.

If the IPs are wildly different, it might indicate a possible incorrect use of the key/cert where it's shared across multiple workloads or even a possible compromise.