### PR TITLE
When user selects scope aws, disable report mode

### DIFF
--- a/ui/src/__tests__/components/microsegmentation/__snapshots__/AddSegmentation.test.js.snap
+++ b/ui/src/__tests__/components/microsegmentation/__snapshots__/AddSegmentation.test.js.snap
@@ -380,152 +380,10 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
 }
 
 .emotion-37 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-flex-flow: row nowrap;
-  -webkit-flex-flow: row nowrap;
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-}
-
-.emotion-37>* {
-  -webkit-flex: 1 0 auto;
-  -ms-flex: 1 0 auto;
-  flex: 1 0 auto;
-}
-
-.emotion-38 {
-  padding-top: 18px;
-  width: 26%;
-}
-
-.emotion-40 {
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  box-sizing: border-box;
-  display: inline-block;
-  height: 16px;
-  line-height: 16px;
-  margin: 3px;
-  outline: 0px;
-  position: relative;
-  vertical-align: bottom;
-}
-
-.emotion-40>input[type='radio'] {
-  box-sizing: border-box;
-  cursor: pointer;
-  display: inline-block;
-  position: absolute;
-  top: 0;
-  visibility: hidden;
-}
-
-.emotion-40>input[type='radio']+label {
-  box-sizing: border-box;
-  cursor: pointer;
-  font-family: Helvetica,Arial,sans-serif;
-  font-size: 14px;
-  font-weight: 300;
-  height: 16px;
-  line-height: 16px;
-  padding: 0 10px 0 0;
-  vertical-align: bottom;
-  white-space: nowrap;
-}
-
-.emotion-40>input[type='radio']+label:before {
-  background: #fff;
-  border: 2px solid rgba(54,151,242,0.5);
-  border-radius: 50%;
-  box-sizing: border-box;
-  content: '';
-  cursor: pointer;
-  display: inline-block;
-  height: 16px;
-  line-height: 16px;
-  margin: 0px 3px -3px 0px;
-  -webkit-transition: all 0.25s ease-in;
-  transition: all 0.25s ease-in;
-  width: 16px;
-}
-
-.emotion-40>input[type='radio']:hover+label:before {
-  border: 2px solid #3697f2;
-}
-
-.emotion-40>input[type='radio']:focus+label:before {
-  border: 2px solid rgba(54,151,242,0.5);
-}
-
-.emotion-40>input[type='radio']:checked+label:before {
-  border: 2px solid #3697f2;
-}
-
-.emotion-40>input[type='radio']:disabled+label {
-  color: #d5d5d5;
-  cursor: not-allowed;
-}
-
-.emotion-40>input[type='radio']:disabled+label:before {
-  border: 2px solid #d5d5d5;
-  cursor: not-allowed;
-}
-
-.emotion-40>input[type='radio']:checked+label:after {
-  background-color: #3697f2;
-  border-radius: 50%;
-  box-sizing: border-box;
-  content: '';
-  height: 8px;
-  line-height: 8px;
-  left: 4px;
-  position: absolute;
-  top: 4px;
-  -webkit-transition: all 0.2s ease-in;
-  transition: all 0.2s ease-in;
-  width: 8px;
-}
-
-.emotion-40>input[type='radio']:disabled:checked+label:after {
-  color: #d5d5d5;
-  border: 2px solid #d5d5d5;
-  background-color: #d5d5d5;
-  cursor: not-allowed;
-}
-
-.emotion-43 {
-  float: left;
-  font-size: 14px;
-  font-weight: 700;
-  padding-top: 12px;
-  width: 8%;
-}
-
-.emotion-46 {
-  width: 415px;
-  padding-top: 12px;
-}
-
-.emotion-48 {
-  margin-top: 5px;
-  margin-left: 10px;
-  padding-top: 12px;
-}
-
-.emotion-50 {
-  fill: #188fff;
-  cursor: pointer;
-  vertical-align: text-bottom;
-}
-
-.emotion-56 {
   padding-top: 15px;
 }
 
-.emotion-58 {
+.emotion-39 {
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   box-sizing: border-box;
@@ -538,7 +396,7 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
   vertical-align: middle;
 }
 
-.emotion-58>input[type='checkbox'] {
+.emotion-39>input[type='checkbox'] {
   box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
@@ -547,7 +405,7 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
   visibility: hidden;
 }
 
-.emotion-58>input[type='checkbox']+label {
+.emotion-39>input[type='checkbox']+label {
   box-sizing: border-box;
   cursor: pointer;
   font-family: Helvetica,Arial,sans-serif;
@@ -560,7 +418,7 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
   white-space: nowrap;
 }
 
-.emotion-58>input[type='checkbox']+label:before {
+.emotion-39>input[type='checkbox']+label:before {
   background: #fff;
   border: 2px solid rgba(54,151,242,0.5);
   border-radius: 2px;
@@ -576,33 +434,33 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
   width: 16px;
 }
 
-.emotion-58>input[type='checkbox']:hover+label:before {
+.emotion-39>input[type='checkbox']:hover+label:before {
   border: 2px solid #3697f2;
 }
 
-.emotion-58>input[type='checkbox']:focus+label:before {
+.emotion-39>input[type='checkbox']:focus+label:before {
   border: 2px solid rgba(54,151,242,0.5);
 }
 
-.emotion-58>input[type='checkbox'][data-partial='true']+label:before,
-.emotion-58>input[type='checkbox']:checked+label:before {
+.emotion-39>input[type='checkbox'][data-partial='true']+label:before,
+.emotion-39>input[type='checkbox']:checked+label:before {
   border: 2px solid #3697f2;
 }
 
-.emotion-58>input[type='checkbox']:disabled+label {
+.emotion-39>input[type='checkbox']:disabled+label {
   color: #d5d5d5;
   cursor: not-allowed;
 }
 
-.emotion-58>input[type='checkbox']:disabled+label:before {
+.emotion-39>input[type='checkbox']:disabled+label:before {
   border: 2px solid #d5d5d5;
 }
 
-.emotion-58>input[type='checkbox']:checked:not([data-partial='true'])+label:before {
+.emotion-39>input[type='checkbox']:checked:not([data-partial='true'])+label:before {
   background: #3697f2;
 }
 
-.emotion-58>input[type='checkbox'][data-partial='true']+label:after {
+.emotion-39>input[type='checkbox'][data-partial='true']+label:after {
   border: solid #3697f2;
   border-width: 2px 0 0 0;
   box-sizing: border-box;
@@ -617,7 +475,7 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
   width: 8px;
 }
 
-.emotion-58>input[type='checkbox']:checked:not([data-partial='true'])+label:after {
+.emotion-39>input[type='checkbox']:checked:not([data-partial='true'])+label:after {
   border: solid #fff;
   border-width: 0 2px 2px 0;
   box-sizing: border-box;
@@ -635,6 +493,148 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
   width: 4.5px;
+}
+
+.emotion-53 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-flex-flow: row nowrap;
+  -webkit-flex-flow: row nowrap;
+  -ms-flex-flow: row nowrap;
+  flex-flow: row nowrap;
+}
+
+.emotion-53>* {
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
+}
+
+.emotion-54 {
+  padding-top: 18px;
+  width: 26%;
+}
+
+.emotion-56 {
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+  box-sizing: border-box;
+  display: inline-block;
+  height: 16px;
+  line-height: 16px;
+  margin: 3px;
+  outline: 0px;
+  position: relative;
+  vertical-align: bottom;
+}
+
+.emotion-56>input[type='radio'] {
+  box-sizing: border-box;
+  cursor: pointer;
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  visibility: hidden;
+}
+
+.emotion-56>input[type='radio']+label {
+  box-sizing: border-box;
+  cursor: pointer;
+  font-family: Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 300;
+  height: 16px;
+  line-height: 16px;
+  padding: 0 10px 0 0;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.emotion-56>input[type='radio']+label:before {
+  background: #fff;
+  border: 2px solid rgba(54,151,242,0.5);
+  border-radius: 50%;
+  box-sizing: border-box;
+  content: '';
+  cursor: pointer;
+  display: inline-block;
+  height: 16px;
+  line-height: 16px;
+  margin: 0px 3px -3px 0px;
+  -webkit-transition: all 0.25s ease-in;
+  transition: all 0.25s ease-in;
+  width: 16px;
+}
+
+.emotion-56>input[type='radio']:hover+label:before {
+  border: 2px solid #3697f2;
+}
+
+.emotion-56>input[type='radio']:focus+label:before {
+  border: 2px solid rgba(54,151,242,0.5);
+}
+
+.emotion-56>input[type='radio']:checked+label:before {
+  border: 2px solid #3697f2;
+}
+
+.emotion-56>input[type='radio']:disabled+label {
+  color: #d5d5d5;
+  cursor: not-allowed;
+}
+
+.emotion-56>input[type='radio']:disabled+label:before {
+  border: 2px solid #d5d5d5;
+  cursor: not-allowed;
+}
+
+.emotion-56>input[type='radio']:checked+label:after {
+  background-color: #3697f2;
+  border-radius: 50%;
+  box-sizing: border-box;
+  content: '';
+  height: 8px;
+  line-height: 8px;
+  left: 4px;
+  position: absolute;
+  top: 4px;
+  -webkit-transition: all 0.2s ease-in;
+  transition: all 0.2s ease-in;
+  width: 8px;
+}
+
+.emotion-56>input[type='radio']:disabled:checked+label:after {
+  color: #d5d5d5;
+  border: 2px solid #d5d5d5;
+  background-color: #d5d5d5;
+  cursor: not-allowed;
+}
+
+.emotion-59 {
+  float: left;
+  font-size: 14px;
+  font-weight: 700;
+  padding-top: 12px;
+  width: 8%;
+}
+
+.emotion-62 {
+  width: 415px;
+  padding-top: 12px;
+}
+
+.emotion-64 {
+  margin-top: 5px;
+  margin-left: 10px;
+  padding-top: 12px;
+}
+
+.emotion-66 {
+  fill: #188fff;
+  cursor: pointer;
+  vertical-align: text-bottom;
 }
 
 .emotion-72 {
@@ -778,103 +778,13 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
         <label
           class="emotion-6 denali-input-label emotion-7 emotion-8"
         >
-          Policy Enforcement State
-        </label>
-        <div
-          class="emotion-37 denali-radiobutton-group emotion-38 emotion-39"
-          data-testid="radiobuttongroup"
-        >
-          <div
-            class="emotion-40 denali-radiobutton"
-            data-testid="radiobutton-wrapper"
-          >
-            <input
-              checked=""
-              id="radiobutton-enforcementStateRadioButton0-report"
-              name="enforcementStateRadioButton0"
-              type="radio"
-              value="report"
-            />
-            <label
-              for="radiobutton-enforcementStateRadioButton0-report"
-            >
-              Report
-            </label>
-          </div>
-          <div
-            class="emotion-40 denali-radiobutton"
-            data-testid="radiobutton-wrapper"
-          >
-            <input
-              id="radiobutton-enforcementStateRadioButton0-enforce"
-              name="enforcementStateRadioButton0"
-              type="radio"
-              value="enforce"
-            />
-            <label
-              for="radiobutton-enforcementStateRadioButton0-enforce"
-            >
-              Enforce
-            </label>
-          </div>
-        </div>
-        <label
-          class="emotion-6 denali-input-label emotion-43 emotion-295"
-        >
-          Hosts
-        </label>
-        <div
-          class="emotion-19 denali-input emotion-46 emotion-292"
-          data-testid="input-wrapper"
-        >
-          <input
-            autocomplete="off"
-            data-testid="input-node"
-            name="instances0"
-            placeholder="Comma separated list, Leave blank to apply to all hosts"
-            value=""
-          />
-          <div
-            class="message"
-            data-testid="message"
-          />
-        </div>
-        <div
-          class="emotion-48 emotion-291"
-        >
-          <svg
-            class="emotion-50"
-            data-testid="icon"
-            height="1.75em"
-            id=""
-            viewBox="0 0 1024 1024"
-            width="1.75em"
-          >
-            <title>
-              add-circle
-            </title>
-            <path
-              d="M512 42.667c-259.206 0-469.333 210.128-469.333 469.333s210.128 469.333 469.333 469.333c259.206 0 469.333-210.128 469.333-469.333v0c0.003-0.635 0.005-1.387 0.005-2.138 0-258.027-209.173-467.2-467.2-467.2-0.752 0-1.504 0.002-2.255 0.005l0.117-0zM512 896c-212.077 0-384-171.923-384-384s171.923-384 384-384c212.077 0 384 171.923 384 384v0c-1.203 211.592-172.408 382.797-383.885 383.999l-0.115 0.001z"
-            />
-            <path
-              d="M725.333 469.333h-170.667v-170.667c0-23.564-19.103-42.667-42.667-42.667s-42.667 19.103-42.667 42.667v0 170.667h-170.667c-23.564 0-42.667 19.103-42.667 42.667s19.103 42.667 42.667 42.667v0h170.667v170.667c0 23.564 19.103 42.667 42.667 42.667s42.667-19.103 42.667-42.667v0-170.667h170.667c23.564 0 42.667-19.103 42.667-42.667s-19.103-42.667-42.667-42.667v0z"
-            />
-          </svg>
-        </div>
-      </div>
-      <div
-        class="emotion-4 emotion-5"
-      >
-        <label
-          class="emotion-6 denali-input-label emotion-7 emotion-8"
-        >
           Scope
         </label>
         <div
-          class="emotion-56 emotion-297"
+          class="emotion-37 emotion-297"
         >
           <div
-            class="emotion-58 denali-checkbox emotion-59 emotion-60"
+            class="emotion-39 denali-checkbox emotion-40 emotion-41"
             data-testid="checkbox-wrapper"
           >
             <input
@@ -890,7 +800,7 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
             </label>
           </div>
           <div
-            class="emotion-58 denali-checkbox emotion-59 emotion-60"
+            class="emotion-39 denali-checkbox emotion-40 emotion-41"
             data-testid="checkbox-wrapper"
           >
             <input
@@ -907,7 +817,7 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
             </label>
           </div>
           <div
-            class="emotion-58 denali-checkbox emotion-59 emotion-60"
+            class="emotion-39 denali-checkbox emotion-40 emotion-41"
             data-testid="checkbox-wrapper"
           >
             <input
@@ -922,6 +832,96 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
               AWS
             </label>
           </div>
+        </div>
+      </div>
+      <div
+        class="emotion-4 emotion-5"
+      >
+        <label
+          class="emotion-6 denali-input-label emotion-7 emotion-8"
+        >
+          Policy Enforcement State
+        </label>
+        <div
+          class="emotion-53 denali-radiobutton-group emotion-54 emotion-55"
+          data-testid="radiobuttongroup"
+        >
+          <div
+            class="emotion-56 denali-radiobutton"
+            data-testid="radiobutton-wrapper"
+          >
+            <input
+              checked=""
+              id="radiobutton-enforcementStateRadioButton0-report"
+              name="enforcementStateRadioButton0"
+              type="radio"
+              value="report"
+            />
+            <label
+              for="radiobutton-enforcementStateRadioButton0-report"
+            >
+              Report (on prem only)
+            </label>
+          </div>
+          <div
+            class="emotion-56 denali-radiobutton"
+            data-testid="radiobutton-wrapper"
+          >
+            <input
+              id="radiobutton-enforcementStateRadioButton0-enforce"
+              name="enforcementStateRadioButton0"
+              type="radio"
+              value="enforce"
+            />
+            <label
+              for="radiobutton-enforcementStateRadioButton0-enforce"
+            >
+              Enforce
+            </label>
+          </div>
+        </div>
+        <label
+          class="emotion-6 denali-input-label emotion-59 emotion-295"
+        >
+          Hosts
+        </label>
+        <div
+          class="emotion-19 denali-input emotion-62 emotion-292"
+          data-testid="input-wrapper"
+        >
+          <input
+            autocomplete="off"
+            data-testid="input-node"
+            name="instances0"
+            placeholder="Comma separated list, Leave blank to apply to all hosts"
+            value=""
+          />
+          <div
+            class="message"
+            data-testid="message"
+          />
+        </div>
+        <div
+          class="emotion-64 emotion-291"
+        >
+          <svg
+            class="emotion-66"
+            data-testid="icon"
+            height="1.75em"
+            id=""
+            viewBox="0 0 1024 1024"
+            width="1.75em"
+          >
+            <title>
+              add-circle
+            </title>
+            <path
+              d="M512 42.667c-259.206 0-469.333 210.128-469.333 469.333s210.128 469.333 469.333 469.333c259.206 0 469.333-210.128 469.333-469.333v0c0.003-0.635 0.005-1.387 0.005-2.138 0-258.027-209.173-467.2-467.2-467.2-0.752 0-1.504 0.002-2.255 0.005l0.117-0zM512 896c-212.077 0-384-171.923-384-384s171.923-384 384-384c212.077 0 384 171.923 384 384v0c-1.203 211.592-172.408 382.797-383.885 383.999l-0.115 0.001z"
+            />
+            <path
+              d="M725.333 469.333h-170.667v-170.667c0-23.564-19.103-42.667-42.667-42.667s-42.667 19.103-42.667 42.667v0 170.667h-170.667c-23.564 0-42.667 19.103-42.667 42.667s19.103 42.667 42.667 42.667v0h170.667v170.667c0 23.564 19.103 42.667 42.667 42.667s42.667-19.103 42.667-42.667v0-170.667h170.667c23.564 0 42.667-19.103 42.667-42.667s-19.103-42.667-42.667-42.667v0z"
+            />
+          </svg>
         </div>
       </div>
     </div>
@@ -1086,10 +1086,10 @@ exports[`AddSegmentation should render fail to submit add-segmentation: destinat
         Validation
       </label>
       <div
-        class="emotion-56 emotion-297"
+        class="emotion-37 emotion-297"
       >
         <div
-          class="emotion-58 denali-checkbox emotion-59 emotion-60"
+          class="emotion-39 denali-checkbox emotion-40 emotion-41"
           data-testid="checkbox-wrapper"
         >
           <input

--- a/ui/src/components/microsegmentation/AddSegmentation.js
+++ b/ui/src/components/microsegmentation/AddSegmentation.js
@@ -258,6 +258,18 @@ class AddSegmentation extends React.Component {
             saving: 'todo',
             validationError: 'none',
             validationStatus: 'valid',
+            radioButtonInputs: [
+                {
+                    label: 'Report (on prem only)',
+                    value: 'report',
+                    disabled: false,
+                },
+                {
+                    label: 'Enforce',
+                    value: 'enforce',
+                    disabled: false,
+                },
+            ],
         };
     }
 
@@ -1191,10 +1203,20 @@ class AddSegmentation extends React.Component {
         }
     }
 
+    toggleDisableRadioButton(checked, list, index, inputs) {
+        if (checked) {
+            list[index]['enforcementstate'] = 'enforce';
+            inputs[0].disabled = true; // disable report mode when scope aws
+        } else {
+            inputs[0].disabled = false;
+        }
+    }
+
     handleInputChange(e, index) {
         const { name, value, checked } = e.target;
         const list = [...this.state.PESList];
         const checkedStr = checked ? 'true' : 'false';
+        let inputs = [...this.state.radioButtonInputs];
         if (name.includes('enforcementStateRadioButton')) {
             list[index]['enforcementstate'] = value;
             if (list.length == 2) {
@@ -1210,13 +1232,16 @@ class AddSegmentation extends React.Component {
             list[index]['scopeall'] = checkedStr;
             list[index]['scopeaws'] = 'false';
             list[index]['scopeonprem'] = 'false';
+            this.toggleDisableRadioButton(checked, list, index, inputs);
         } else if (name.includes('scopeonprem')) {
             list[index]['scopeonprem'] = checkedStr;
         } else if (name.includes('scopeaws')) {
             list[index]['scopeaws'] = checkedStr;
+            this.toggleDisableRadioButton(checked, list, index, inputs);
         }
         this.setState({
             PESList: list,
+            radioButtonInputs: inputs,
         });
     }
 
@@ -1250,17 +1275,6 @@ class AddSegmentation extends React.Component {
     }
 
     render() {
-        const inputs = [
-            {
-                label: 'Report',
-                value: 'report',
-            },
-            {
-                label: 'Enforce',
-                value: 'enforce',
-            },
-        ];
-
         let members = this.state.members
             ? this.state.members.map((item, idx) => {
                   // dummy place holder so that it can be be used in the form
@@ -1344,17 +1358,54 @@ class AddSegmentation extends React.Component {
                     return (
                         <div>
                             <SectionDiv>
+                                <StyledInputLabel>Scope</StyledInputLabel>
+                                <CheckBoxSectionDiv>
+                                    <StyledCheckBox
+                                        checked={x.scopeall === 'true'}
+                                        name={'scopeallCheckBox' + i}
+                                        id={'scopeallCheckBox' + i}
+                                        key={'scopeallCheckBox' + i}
+                                        label='All'
+                                        onChange={(e) =>
+                                            this.handleInputChange(e, i)
+                                        }
+                                    />
+                                    <StyledCheckBox
+                                        checked={x.scopeonprem === 'true'}
+                                        disabled={x.scopeall === 'true'}
+                                        name={'scopeonpremCheckBox' + i}
+                                        id={'scopeonpremCheckBox' + i}
+                                        key={'scopeonpremCheckBox' + i}
+                                        label='On-Prem'
+                                        onChange={(e) =>
+                                            this.handleInputChange(e, i)
+                                        }
+                                    />
+                                    <StyledCheckBox
+                                        checked={x.scopeaws === 'true'}
+                                        disabled={x.scopeall === 'true'}
+                                        name={'scopeawsCheckBox' + i}
+                                        id={'scopeawsCheckBox' + i}
+                                        key={'scopeawsCheckBox' + i}
+                                        label='AWS'
+                                        onChange={(e) =>
+                                            this.handleInputChange(e, i)
+                                        }
+                                    />
+                                </CheckBoxSectionDiv>
+                            </SectionDiv>
+                            <SectionDiv>
                                 <StyledInputLabel>
                                     Policy Enforcement State
                                 </StyledInputLabel>
                                 <StyledRadioButtonGroup
                                     name={'enforcementStateRadioButton' + i}
-                                    inputs={inputs}
+                                    inputs={this.state.radioButtonInputs}
                                     selectedValue={x.enforcementstate}
                                     onChange={(e) =>
                                         this.handleInputChange(e, i)
                                     }
-                                    disabled={i == 1}
+                                    disabled={i == 1 ? true : undefined}
                                 />
                                 <StyledInputLabelHost>
                                     Hosts
@@ -1398,43 +1449,6 @@ class AddSegmentation extends React.Component {
                                         />
                                     </RemoveCircleDiv>
                                 )}
-                            </SectionDiv>
-                            <SectionDiv>
-                                <StyledInputLabel>Scope</StyledInputLabel>
-                                <CheckBoxSectionDiv>
-                                    <StyledCheckBox
-                                        checked={x.scopeall === 'true'}
-                                        name={'scopeallCheckBox' + i}
-                                        id={'scopeallCheckBox' + i}
-                                        key={'scopeallCheckBox' + i}
-                                        label='All'
-                                        onChange={(e) =>
-                                            this.handleInputChange(e, i)
-                                        }
-                                    />
-                                    <StyledCheckBox
-                                        checked={x.scopeonprem === 'true'}
-                                        disabled={x.scopeall === 'true'}
-                                        name={'scopeonpremCheckBox' + i}
-                                        id={'scopeonpremCheckBox' + i}
-                                        key={'scopeonpremCheckBox' + i}
-                                        label='On-Prem'
-                                        onChange={(e) =>
-                                            this.handleInputChange(e, i)
-                                        }
-                                    />
-                                    <StyledCheckBox
-                                        checked={x.scopeaws === 'true'}
-                                        disabled={x.scopeall === 'true'}
-                                        name={'scopeawsCheckBox' + i}
-                                        id={'scopeawsCheckBox' + i}
-                                        key={'scopeawsCheckBox' + i}
-                                        label='AWS'
-                                        onChange={(e) =>
-                                            this.handleInputChange(e, i)
-                                        }
-                                    />
-                                </CheckBoxSectionDiv>
                             </SectionDiv>
                         </div>
                     );


### PR DESCRIPTION
Problem: Currently we don't support msd policies that are `scopeaws: 'true' && enforcementstate: 'report'`
Solution: 

- when user selects scope 'aws' OR 'all', disable the report mode radio button.
- when user deselects scope 'aws' enable the report mode radio button.

**Initial State of add msd policy modal**
<img width="1082" alt="image" src="https://github.com/AthenZ/athenz/assets/25251812/f53c0222-9d64-43cd-b011-0206fd499d15">
**User clicks on scope AWS - select**
<img width="1215" alt="image" src="https://github.com/AthenZ/athenz/assets/25251812/bc38418c-1852-41c0-870a-d3f1154f4258">
**User clicks on scope AWS - deselect**
<img width="1127" alt="image" src="https://github.com/AthenZ/athenz/assets/25251812/69a9dda8-a82d-4ec2-aa51-bfcd2e126aa3">
**User clicks on scope ALL**
<img width="1092" alt="image" src="https://github.com/AthenZ/athenz/assets/25251812/7f3f4fb7-2353-4120-ad8d-e0573da9987b">

