### PR TITLE
Fix gcp login initially loading error no roles incorrectly

### DIFF
--- a/ui/src/__tests__/pages/gcp/__snapshots__/login.test.js.snap
+++ b/ui/src/__tests__/pages/gcp/__snapshots__/login.test.js.snap
@@ -33,24 +33,7 @@ exports[`GCP Login Page should render error no gcp project when api returns no r
       <tt>
         gcp.*
       </tt>
-       
-      roles contain your user.
-      <br />
-      E.g., if your account is 'jdoe', then
-       
-      <tt>
-        gcp.fed.admin.user
-      </tt>
-       should have
-       
-      <tt>
-        user
-        .jdoe
-      </tt>
-       as a member.
-    </p>
-    <p>
-      If that does not work, please ask your Athenz domain admin for assistance.
+       roles contain your user. Your account should be in the configured federated roles that have access to the project. If that does not work, please ask your Athenz domain admin for assistance.
     </p>
   </div>
 </div>

--- a/ui/src/pages/gcp/login.js
+++ b/ui/src/pages/gcp/login.js
@@ -166,7 +166,6 @@ class GCPLoginPage extends React.Component {
             errorMessage: '',
             projectRoleMap: {},
             roleName: '',
-            isFetching: true,
         };
         this.getAssertionList = this.getAssertionList.bind(this);
         this.populateProjectRoleMap = this.populateProjectRoleMap.bind(this);
@@ -196,7 +195,6 @@ class GCPLoginPage extends React.Component {
         this.setState((prevState) => ({
             ...prevState,
             errorMessage: errorMessage,
-            isFetching: false,
         }));
     }
 
@@ -239,7 +237,6 @@ class GCPLoginPage extends React.Component {
         this.setState((prevState) => ({
             ...prevState,
             projectRoleMap,
-            isFetching: false,
         }));
     }
 
@@ -259,9 +256,6 @@ class GCPLoginPage extends React.Component {
         if (errorMessage) {
             return <Error err={errorMessage} />;
         }
-        if (this.state.isFetching) {
-            return <ReduxPageLoader message={'Loading GCP Projects'} />;
-        }
         let displayProjects = [];
         for (let pName in this.state.projectRoleMap) {
             let projectRoleNames = [];
@@ -276,7 +270,8 @@ class GCPLoginPage extends React.Component {
                                 value={projectObject.roleName}
                                 name={'project'}
                                 checked={
-                                    this.state.roleName === projectObject.roleName
+                                    this.state.roleName ===
+                                    projectObject.roleName
                                 }
                                 onChange={() =>
                                     this.handleRadioButton(projectObject)
@@ -303,62 +298,61 @@ class GCPLoginPage extends React.Component {
             );
         }
 
-        if (!displayProjects.length) {
-            return (
-                <CacheProvider value={this.cache}>
-                    <div data-testid='gcp-login-error'>
-                        <GcpHeader>
-                            <img src='/static/google-cloud.svg'></img>
-                        </GcpHeader>
-                        <ParentWrapperDiv>
-                            <h3>
-                                Error: There are no GCP project roles associated
-                                with your account.
-                            </h3>
-                            <p>
-                                Check to make sure that your <tt>gcp.*</tt>{' '}
-                                roles contain your user.
-                                <br />
-                                E.g., if your account is 'jdoe', then{' '}
-                                <tt>gcp.fed.admin.user</tt> should have{' '}
-                                <tt>{USER_DOMAIN}.jdoe</tt> as a member.
-                            </p>
-                            <p>
-                                If that does not work, please ask your Athenz
-                                domain admin for assistance.
-                            </p>
-                        </ParentWrapperDiv>
-                    </div>
-                </CacheProvider>
-            );
-        }
-
-        return (
+        let gcpLoginContainer = displayProjects.length ? (
+            <div data-testid='gcp-login'>
+                <GcpHeader>
+                    <img src='/static/google-cloud.svg'></img>
+                </GcpHeader>
+                <ParentWrapperDiv>
+                    <form action='/gcp/login/post' method='post'>
+                        <input
+                            type='hidden'
+                            name='_csrf'
+                            value={this.props._csrf}
+                        ></input>
+                        <input
+                            type='hidden'
+                            name='isAdmin'
+                            value={this.props.isAdmin}
+                        ></input>
+                        <StyledP>Select a role:</StyledP>
+                        {displayProjects}
+                        <SubmitContainer>
+                            <Button type={'submit'}>Submit</Button>
+                        </SubmitContainer>
+                    </form>
+                </ParentWrapperDiv>
+            </div>
+        ) : (
+            <div data-testid='gcp-login-error'>
+                <GcpHeader>
+                    <img src='/static/google-cloud.svg'></img>
+                </GcpHeader>
+                <ParentWrapperDiv>
+                    <h3>
+                        Error: There are no GCP project roles associated with
+                        your account.
+                    </h3>
+                    <p>
+                        Check to make sure that your <tt>gcp.*</tt> roles
+                        contain your user.
+                        <br />
+                        E.g., if your account is 'jdoe', then{' '}
+                        <tt>gcp.fed.admin.user</tt> should have{' '}
+                        <tt>{USER_DOMAIN}.jdoe</tt> as a member.
+                    </p>
+                    <p>
+                        If that does not work, please ask your Athenz domain
+                        admin for assistance.
+                    </p>
+                </ParentWrapperDiv>
+            </div>
+        );
+        return this.props.isLoading.length !== 0 ? (
+            <ReduxPageLoader message={'Loading microsegmentation data'} />
+        ) : (
             <CacheProvider value={this.cache}>
-                <div data-testid='gcp-login'>
-                    <GcpHeader>
-                        <img src='/static/google-cloud.svg'></img>
-                    </GcpHeader>
-                    <ParentWrapperDiv>
-                        <form action='/gcp/login/post' method='post'>
-                            <input
-                                type='hidden'
-                                name='_csrf'
-                                value={this.props._csrf}
-                            ></input>
-                            <input
-                                type='hidden'
-                                name='isAdmin'
-                                value={this.props.isAdmin}
-                            ></input>
-                            <StyledP>Select a role:</StyledP>
-                            {displayProjects}
-                            <SubmitContainer>
-                                <Button type={'submit'}>Submit</Button>
-                            </SubmitContainer>
-                        </form>
-                    </ParentWrapperDiv>
-                </div>
+                {gcpLoginContainer}
             </CacheProvider>
         );
     }

--- a/ui/src/pages/gcp/login.js
+++ b/ui/src/pages/gcp/login.js
@@ -335,21 +335,16 @@ class GCPLoginPage extends React.Component {
                     </h3>
                     <p>
                         Check to make sure that your <tt>gcp.*</tt> roles
-                        contain your user.
-                        <br />
-                        E.g., if your account is 'jdoe', then{' '}
-                        <tt>gcp.fed.admin.user</tt> should have{' '}
-                        <tt>{USER_DOMAIN}.jdoe</tt> as a member.
-                    </p>
-                    <p>
-                        If that does not work, please ask your Athenz domain
-                        admin for assistance.
+                        contain your user. Your account should be in the
+                        configured federated roles that have access to the
+                        project. If that does not work, please ask your Athenz
+                        domain admin for assistance.
                     </p>
                 </ParentWrapperDiv>
             </div>
         );
         return this.props.isLoading.length !== 0 ? (
-            <ReduxPageLoader message={'Loading microsegmentation data'} />
+            <ReduxPageLoader message={'Loading GCP Projects'} />
         ) : (
             <CacheProvider value={this.cache}>
                 {gcpLoginContainer}

--- a/ui/src/redux/thunks/user.js
+++ b/ui/src/redux/thunks/user.js
@@ -14,8 +14,12 @@
  *  limitations under the License.
  */
 
-import {getExpiryTime, isExpired} from '../utils';
-import {selectAllUsers, selectUserPendingMembers, selectUserResourceAccessList,} from '../selectors/user';
+import { getExpiryTime, isExpired } from '../utils';
+import {
+    selectAllUsers,
+    selectUserPendingMembers,
+    selectUserResourceAccessList,
+} from '../selectors/user';
 import API from '../../api';
 import {
     addUsersToStore,
@@ -23,6 +27,12 @@ import {
     loadUserResourceAccessList,
     returnUserResourceAccessList,
 } from '../actions/user';
+
+import {
+    loadingFailed,
+    loadingInProcess,
+    loadingSuccess,
+} from '../actions/loading';
 
 export const getUserPendingMembers = () => async (dispatch, getState) => {
     let userPendingMembers = selectUserPendingMembers(getState());
@@ -41,6 +51,7 @@ export const getUserResourceAccessList =
         let isUserResourceAccessListEmpty =
             Array.isArray(userResourceAccessList) &&
             userResourceAccessList.length < 1;
+        dispatch(loadingInProcess('getUserResourceAccessList'));
         if (isExpired(getState().user.expiry)) {
             try {
                 userResourceAccessList = await API().getResourceAccessList(
@@ -50,8 +61,10 @@ export const getUserResourceAccessList =
                 dispatch(
                     loadUserResourceAccessList(userResourceAccessList, expiry)
                 );
+                dispatch(loadingSuccess('getUserResourceAccessList'));
                 return Promise.resolve();
             } catch (e) {
+                dispatch(loadingFailed('getUserResourceAccessList'));
                 return Promise.reject(e);
             }
         } else if (!isUserResourceAccessListEmpty) {


### PR DESCRIPTION
Problem: gcp sso page was not processing the resourceAccessList fetch correctly thus initially showing "Error you don't have any gcp roles..."

Solution: dispatch loading, loading success, and loading failure in the redux `getResourceAccessList` and render the `ReduxLoader` 