### PR TITLE
Add projectNumber in options

### DIFF
--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -100,6 +100,14 @@ func GetProject(metaEndpoint string) (string, error) {
 	return string(projectBytes), nil
 }
 
+func GetProjectNumber(metaEndpoint string) (string, error) {
+	projectBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/project/numeric-project-id")
+	if err != nil {
+		return "", err
+	}
+	return string(projectBytes), nil
+}
+
 func GetService(metaEndpoint string) (string, error) {
 	serviceBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/service-accounts/default/email")
 	if err != nil {

--- a/libs/go/sia/gcp/meta/meta_test.go
+++ b/libs/go/sia/gcp/meta/meta_test.go
@@ -126,6 +126,24 @@ func TestGetProject(test *testing.T) {
 	}
 }
 
+func TestGetProjectNumber(test *testing.T) {
+	// Mock the metadata endpoints
+	router := httptreemux.New()
+	router.GET("/computeMetadata/v1/project/numeric-project-id", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		log.Println("Called /computeMetadata/v1/project/numeric-project-id")
+		io.WriteString(w, "123456789")
+	})
+
+	metaServer := &testServer{}
+	metaServer.start(router)
+	defer metaServer.stop()
+
+	projectNumber, _ := GetProjectNumber(metaServer.httpUrl())
+	if projectNumber != "123456789" {
+		test.Errorf("want projectNumber=123456789 got projectNumber=%s", projectNumber)
+	}
+}
+
 func TestGetService(test *testing.T) {
 	// Mock the metadata endpoints
 	router := httptreemux.New()

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -167,6 +167,7 @@ type Options struct {
 	Group               string            //the group name to chown the cert/key dirs to. If absent, then athenz
 	Domain              string            //name of the domain for the identity
 	Account             string            //name of the account
+	ProjectNumber       string            //project number of the gcp project
 	Service             string            //name of the service for the identity
 	Zts                 string            //the ZTS to contact
 	InstanceId          string            //instance id if ec2/vm, task id if running within eks/ecs/gke


### PR DESCRIPTION
1. Add projectNumber in options.
2. Add getProjectNumber function.
Tested with sia-gce on a gcp instance.