### PR TITLE
Make KeyRefresher's background thread more efficient

### DIFF
--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -216,11 +215,11 @@ public class KeyRefresher {
             return false;
         }
 
-        try (InputStream is = Files.newInputStream(path);
-             DigestInputStream digestInputStream = new DigestInputStream(is, md)) {
-            //noinspection StatementWithEmptyBody
-            while (digestInputStream.read() != -1) {
-                // do nothing, just read until the EoF
+        try (InputStream is = Files.newInputStream(path)) {
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = is.read(buffer)) > 0) {
+                md.update(buffer, 0, read);
             }
         } catch (IOException ex) {
             //this is best effort, if we couldn't read the file, assume it's the same


### PR DESCRIPTION
InputStream::read() reads only a single byte at a time; this results in many read() syscalls and inefficient single-byte updates to the MessageDigest.

It'd be most efficient to first do a `stat` call and compare file size and timestamps; that's a bigger change, however. (Using a [WatchService](https://docs.oracle.com/javase/8/docs/api/java/nio/file/WatchService.html) would be another option)