### PR TITLE
change the athenz-zpe-java-client jacoco coverage threshold from 0.8711 to 0.8702

### DIFF
--- a/clients/java/zpe/pom.xml
+++ b/clients/java/zpe/pom.xml
@@ -31,7 +31,7 @@
     <mock.server.version>5.15.0</mock.server.version>
     <commons.io.version>2.13.0</commons.io.version>
     <uberjar.name>benchmarks</uberjar.name>
-    <code.coverage.min>0.8711</code.coverage.min>
+    <code.coverage.min>0.8702</code.coverage.min>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
# description
After addressing https://github.com/AthenZ/athenz/pull/2323, we found that the total number of code steps in AuthZpeClient has decreased, which led to not meeting the jacoco threshold. Therefore, we have made the necessary modifications.

https://cd.screwdriver.cd/pipelines/6606/builds/902642/steps/build


# issue
https://github.com/AthenZ/athenz/issues/2340