### PR TITLE
provide domain authz for expanded role lookup

### DIFF
--- a/core/zms/src/main/rdl/Role.rdli
+++ b/core/zms/src/main/rdl/Role.rdli
@@ -139,6 +139,7 @@ resource DomainRoleMembers GET "/domain/{domainName}/member" {
 // 1. authenticated principal is the same as the check principal
 // 2. system authorized ("access", "sys.auth:meta.role.lookup")
 // 3. service admin ("update", "{principal}")
+// 4. domain authorized ("access", "{domainName}:meta.role.lookup") if domainName is provided
 resource DomainRoleMember GET "/role?principal={principal}&domain={domainName}&expand={expand}" (name=getPrincipalRoles) {
     ResourceName principal (optional); //If not present, will return roles for the user making the call
     DomainName domainName (optional); //If not present, will return roles from all domains

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -1120,7 +1120,7 @@ public class ZMSResources {
     @GET
     @Path("/role")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Fetch all the roles across domains by either calling or specified principal The optional expand argument will include all direct and indirect roles, however, it will force authorization that you must be either the principal or for service accounts have update access to the service identity: 1. authenticated principal is the same as the check principal 2. system authorized (\"access\", \"sys.auth:meta.role.lookup\") 3. service admin (\"update\", \"{principal}\")")
+    @Operation(description = "Fetch all the roles across domains by either calling or specified principal The optional expand argument will include all direct and indirect roles, however, it will force authorization that you must be either the principal or for service accounts have update access to the service identity: 1. authenticated principal is the same as the check principal 2. system authorized (\"access\", \"sys.auth:meta.role.lookup\") 3. service admin (\"update\", \"{principal}\") 4. domain authorized (\"access\", \"{domainName}:meta.role.lookup\") if domainName is provided")
     public DomainRoleMember getPrincipalRoles(
         @Parameter(description = "If not present, will return roles for the user making the call", required = false) @QueryParam("principal") String principal,
         @Parameter(description = "If not present, will return roles from all domains", required = false) @QueryParam("domain") String domainName,


### PR DESCRIPTION
# Description

when executing expanded principal role lookup with the domain filter enabled, we now allow domain admins to specify what principals are authorized to carry out the expanded check:

("access", "{domainName}:meta.role.lookup")

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

