### PR TITLE
fix add/edit tags for policy and service

### DIFF
--- a/ui/src/__tests__/redux/reducers/policies.test.js
+++ b/ui/src/__tests__/redux/reducers/policies.test.js
@@ -318,7 +318,7 @@ describe('Polices Reducer', () => {
         const action = {
             type: UPDATE_TAGS_TO_STORE,
             payload: {
-                collectionName: 'dom:policy.policy1:1',
+                collectionName: 'dom:policy.policy1',
                 collectionWithTags: {
                     ...configStorePolicies['dom:policy.policy1:1'],
                     tags: { tag: { list: ['tag1', 'tag2'] } },
@@ -342,7 +342,7 @@ describe('Polices Reducer', () => {
         const action = {
             type: UPDATE_TAGS_TO_STORE,
             payload: {
-                collectionName: 'dom:policy.policy1:2',
+                collectionName: 'dom:policy.policy1',
                 collectionWithTags: {
                     ...configStorePolicies['dom:policy.policy1:2'],
                     tags: {
@@ -371,7 +371,7 @@ describe('Polices Reducer', () => {
         const action = {
             type: UPDATE_TAGS_TO_STORE,
             payload: {
-                collectionName: 'dom:policy.policy1:2',
+                collectionName: 'dom:policy.policy1',
                 collectionWithTags: {
                     ...configStorePolicies['dom:policy.policy1:2'],
                     tags: { tag: { list: ['tag1'] } },

--- a/ui/src/components/tag/TagList.js
+++ b/ui/src/components/tag/TagList.js
@@ -292,7 +292,11 @@ class TagList extends React.Component {
         const clonedTags = AppUtils.deepClone(this.props.tags || {});
         let categoryObject =
             this.state.category !== 'domain'
-                ? this.props.collectionName
+                ? this.props.category === 'policy'
+                    ? this.props.collectionName +
+                      ':' +
+                      this.props.collectionDetails?.version
+                    : this.props.collectionName
                 : this.props.domain;
 
         rows = Object.entries(clonedTags).map((item, i) => {

--- a/ui/src/pages/domain/[domain]/policy/[policy]/[version]/tags.js
+++ b/ui/src/pages/domain/[domain]/policy/[policy]/[version]/tags.js
@@ -186,13 +186,7 @@ class PolicyTagsPage extends React.Component {
                                     <TagList
                                         collectionDetails={policyDetails}
                                         domain={domainName}
-                                        collectionName={
-                                            policyDetails
-                                                ? policyName +
-                                                  ':' +
-                                                  policyDetails.version
-                                                : policyName
-                                        }
+                                        collectionName={policyName || ''}
                                         tags={policyTags}
                                         category={'policy'}
                                         _csrf={this.props._csrf}

--- a/ui/src/redux/reducers/policies.js
+++ b/ui/src/redux/reducers/policies.js
@@ -161,11 +161,14 @@ export const policies = (state = {}, action) => {
             const { collectionName, collectionWithTags, category } = payload;
             let newState = state;
             if (category === 'policy') {
+                let collectionNameWithVersion =
+                    collectionName + ':' + collectionWithTags.version;
                 newState = produce(state, (draft) => {
-                    draft.policies[collectionName]
-                        ? (draft.policies[collectionName].tags =
+                    draft.policies[collectionNameWithVersion]
+                        ? (draft.policies[collectionNameWithVersion].tags =
                               collectionWithTags.tags)
-                        : (draft.policies[collectionName] = collectionWithTags);
+                        : (draft.policies[collectionNameWithVersion] =
+                              collectionWithTags);
                 });
             }
             return newState;

--- a/ui/src/server/handlers/api.js
+++ b/ui/src/server/handlers/api.js
@@ -1514,24 +1514,36 @@ Fetchr.registerService({
                 break;
             }
             case 'policy': {
-                req.clients.zms.putPolicyVersion(
+                req.clients.zms.putPolicy(
                     {
                         domainName: params.domainName,
                         policyName: params.collectionName,
                         policy: params.detail,
                         auditRef: params.auditRef,
+                        returnObj: true,
                     },
                     responseHandler.bind({ caller: 'putPolicy', callback, req })
                 );
                 break;
             }
             case 'service': {
+                if (params.detail) {
+                    // Note: zms expects publicKeys to be an array but we store it as an object
+                    // Additionally, updating service tags should not modify existing public keys
+                    let publicKeysList = [];
+                    let publicKeysMap = params.detail.publicKeys || {};
+                    for (const [, value] of Object.entries(publicKeysMap)) {
+                        publicKeysList.push(value);
+                    }
+                    params.detail.publicKeys = publicKeysList;
+                }
                 req.clients.zms.putServiceIdentity(
                     {
                         domain: params.domainName,
                         service: params.collectionName,
                         auditRef: params.auditRef,
                         detail: params.detail,
+                        returnObj: true,
                     },
                     responseHandler.bind({
                         caller: 'putServiceIdentity',


### PR DESCRIPTION
# Description
Problem:

- Users cannot add/edit policy or service tags via UI
```
putServiceIdentity({
  ...
  detail: {
    ...
    publicKeys: {} // Culprit, zms rdl definition expects publicKeys to be of type Array
  }
});
```

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

