### PR TITLE
Fix service tags tab hiding other tabs

### DIFF
--- a/ui/src/__tests__/components/header/ServiceTabs.test.js
+++ b/ui/src/__tests__/components/header/ServiceTabs.test.js
@@ -15,11 +15,10 @@
  */
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import RoleTabs from '../../../components/header/RoleTabs';
 import ServiceTabs from '../../../components/header/ServiceTabs';
 
 describe('Service Tabs', () => {
-    it('should render', () => {
+    it('should render with feature flag turned on', () => {
         const api = {
             getStatus() {
                 return new Promise((resolve, reject) => {
@@ -36,12 +35,39 @@ describe('Service Tabs', () => {
                 service={service}
                 selectedName='dynamic'
                 api={api}
+                featureFlag={true}
             />
         );
         const tabs = getByTestId('tabgroup');
         const tab = tabs.querySelectorAll('.denali-tab');
         fireEvent.click(tab[0]);
         fireEvent.click(tab[1]);
+        expect(tabs).toMatchSnapshot();
+    });
+
+    it('should render only one tab without feature flag', () => {
+        const api = {
+            getStatus() {
+                return new Promise((resolve, reject) => {
+                    resolve([]);
+                });
+            },
+        };
+
+        let domain = 'home.jtsang01';
+        let service = 'openstack';
+        const { getByTestId } = render(
+            <ServiceTabs
+                domain={domain}
+                service={service}
+                selectedName='dynamic'
+                api={api}
+                featureFlag={false}
+            />
+        );
+        const tabs = getByTestId('tabgroup');
+        const tab = tabs.querySelectorAll('.denali-tab');
+        fireEvent.click(tab[0]);
         expect(tabs).toMatchSnapshot();
     });
 });

--- a/ui/src/__tests__/components/header/__snapshots__/ServiceTabs.test.js.snap
+++ b/ui/src/__tests__/components/header/__snapshots__/ServiceTabs.test.js.snap
@@ -1,6 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Service Tabs should render 1`] = `
+exports[`Service Tabs should render only one tab without feature flag 1`] = `
+.emotion-0 {
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  background: #f5f8fe;
+  border-radius: 2px;
+  box-sizing: border-box;
+  display: inline-grid;
+  grid-template-columns: repeat(1, 1fr);
+  margin-top: 0;
+  min-width: 80px;
+  position: relative;
+}
+
+.emotion-0.vertical {
+  background: #f5f8fe;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  height: 100%;
+  min-width: 300px;
+  overflow-y: scroll;
+  padding: 12px 0px 40px 0px;
+  width: 300px;
+}
+
+.emotion-1 {
+  font-family: Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 300;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background: #f5f8fe;
+  color: #3697f2;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  padding: 8px 20px;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.emotion-1:hover {
+  color: #3570f4;
+}
+
+.emotion-1.active {
+  background: #fff;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  color: #303030;
+  cursor: initial;
+}
+
+.emotion-1.active:hover {
+  color: #303030;
+}
+
+.emotion-1.vertical {
+  background: #f5f8fe;
+  border-left: solid 4px #f5f8fe;
+  height: 24px;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  padding: 12px 0px 12px 26px;
+  text-align: left;
+}
+
+.emotion-1.vertical.active {
+  background: #fff;
+  border-left: solid 4px #3697f2;
+  color: #303030;
+}
+
+.emotion-1.vertical.active:hover {
+  color: #303030;
+}
+
+<div
+  class="emotion-0 denali-tab-group"
+  data-testid="tabgroup"
+>
+  <div
+    class="emotion-1 denali-tab"
+    data-active="false"
+  >
+    Tags
+  </div>
+</div>
+`;
+
+exports[`Service Tabs should render with feature flag turned on 1`] = `
 .emotion-0 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/microsegmentation.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/microsegmentation.test.js.snap
@@ -554,7 +554,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
   border-radius: 2px;
   box-sizing: border-box;
   display: inline-grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   margin-top: 0;
   min-width: 80px;
   position: relative;
@@ -638,11 +638,11 @@ exports[`Service Microsegmentation Page should render 1`] = `
   color: #303030;
 }
 
-.emotion-47 {
+.emotion-44 {
   margin: 20px;
 }
 
-.emotion-49 {
+.emotion-46 {
   padding-bottom: 20px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -662,11 +662,11 @@ exports[`Service Microsegmentation Page should render 1`] = `
   float: right;
 }
 
-.emotion-51 {
+.emotion-48 {
   margin-right: 10px;
 }
 
-.emotion-53 {
+.emotion-50 {
   border: none;
   border-radius: 2px;
   box-shadow: 0 0 0 1px transparent inset,0 0 0 0 #d5d5d5 inset;
@@ -692,25 +692,25 @@ exports[`Service Microsegmentation Page should render 1`] = `
   color: #3697f2;
 }
 
-.emotion-53:first-of-type {
+.emotion-50:first-of-type {
   margin-left: 0;
 }
 
-.emotion-53:disabled {
+.emotion-50:disabled {
   background: rgba(48,48,48,0.1);
   color: rgba(48,48,48,0.2);
   cursor: not-allowed;
 }
 
-.emotion-53:disabled {
+.emotion-50:disabled {
   box-shadow: 0 0 0 1px rgba(48,48,48,0.1) inset;
 }
 
-.emotion-53:hover:not(:disabled) {
+.emotion-50:hover:not(:disabled) {
   background: #d7e2fd;
 }
 
-.emotion-54 {
+.emotion-51 {
   width: 100%;
   border-spacing: 0;
   display: table;
@@ -727,7 +727,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
   height: 50px;
 }
 
-.emotion-56 {
+.emotion-53 {
   height: 25px;
   margin-left: 10px;
   margin-top: 10px;
@@ -739,18 +739,18 @@ exports[`Service Microsegmentation Page should render 1`] = `
   font-weight: lighter;
 }
 
-.emotion-58 {
+.emotion-55 {
   margin-right: 10px;
   verticalalign: bottom;
 }
 
-.emotion-60 {
+.emotion-57 {
   fill: #188fff;
   cursor: pointer;
   vertical-align: text-bottom;
 }
 
-.emotion-61 {
+.emotion-58 {
   text-align: left;
   border-bottom: 2px solid #d5d5d5;
   color: #9a9a9a;
@@ -763,7 +763,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
   word-break: break-all;
 }
 
-.emotion-65 {
+.emotion-62 {
   text-align: left;
   border-bottom: 2px solid #d5d5d5;
   color: #9a9a9a;
@@ -776,7 +776,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
   word-break: break-all;
 }
 
-.emotion-73 {
+.emotion-70 {
   text-align: center;
   border-bottom: 2px solid #d5d5d5;
   color: #9a9a9a;
@@ -789,7 +789,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
   word-break: break-all;
 }
 
-.emotion-81 {
+.emotion-78 {
   background-color: #3570f40D;
   text-align: left;
   padding: 5px 0 5px 15px;
@@ -797,9 +797,19 @@ exports[`Service Microsegmentation Page should render 1`] = `
   word-break: break-all;
 }
 
-.emotion-87 {
+.emotion-84 {
   background-color: #3570f40D;
   text-align: left;
+  padding: 5px 0 5px 15px;
+  vertical-align: middle;
+  word-break: break-all;
+  -webkit-text-decoration: dashed underline;
+  text-decoration: dashed underline;
+}
+
+.emotion-91 {
+  background-color: #3570f40D;
+  text-align: center;
   padding: 5px 0 5px 15px;
   vertical-align: middle;
   word-break: break-all;
@@ -813,27 +823,26 @@ exports[`Service Microsegmentation Page should render 1`] = `
   padding: 5px 0 5px 15px;
   vertical-align: middle;
   word-break: break-all;
+}
+
+.emotion-102 {
+  text-align: left;
+  padding: 5px 0 5px 15px;
+  vertical-align: middle;
+  word-break: break-all;
+}
+
+.emotion-108 {
+  text-align: left;
+  padding: 5px 0 5px 15px;
+  vertical-align: middle;
+  word-break: break-all;
   -webkit-text-decoration: dashed underline;
   text-decoration: dashed underline;
 }
 
-.emotion-97 {
-  background-color: #3570f40D;
+.emotion-115 {
   text-align: center;
-  padding: 5px 0 5px 15px;
-  vertical-align: middle;
-  word-break: break-all;
-}
-
-.emotion-105 {
-  text-align: left;
-  padding: 5px 0 5px 15px;
-  vertical-align: middle;
-  word-break: break-all;
-}
-
-.emotion-111 {
-  text-align: left;
   padding: 5px 0 5px 15px;
   vertical-align: middle;
   word-break: break-all;
@@ -846,18 +855,9 @@ exports[`Service Microsegmentation Page should render 1`] = `
   padding: 5px 0 5px 15px;
   vertical-align: middle;
   word-break: break-all;
-  -webkit-text-decoration: dashed underline;
-  text-decoration: dashed underline;
 }
 
-.emotion-121 {
-  text-align: center;
-  padding: 5px 0 5px 15px;
-  vertical-align: middle;
-  word-break: break-all;
-}
-
-.emotion-176 {
+.emotion-173 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -883,13 +883,13 @@ exports[`Service Microsegmentation Page should render 1`] = `
   width: 20px;
 }
 
-.emotion-178 {
+.emotion-175 {
   fill: #303030;
   cursor: inherit;
   vertical-align: text-bottom;
 }
 
-.emotion-179 {
+.emotion-176 {
   margin-right: 0;
   border-left: 1px solid #d5d5d5;
   -webkit-flex: 0 0 350px;
@@ -904,7 +904,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
   width: 350px;
 }
 
-.emotion-181 {
+.emotion-178 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -923,28 +923,28 @@ exports[`Service Microsegmentation Page should render 1`] = `
   padding: 20px 30px 20px 15px;
 }
 
-.emotion-183 {
+.emotion-180 {
   font-size: 16px;
   font-weight: 600;
 }
 
-.emotion-185 {
+.emotion-182 {
   color: #3570f4;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
 }
 
-.emotion-187 {
+.emotion-184 {
   padding: 0 5px;
   color: #d5d5d5;
 }
 
-.emotion-191 {
+.emotion-188 {
   padding: 0 30px 0 15px;
 }
 
-.emotion-193 {
+.emotion-190 {
   padding: 10px 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -952,12 +952,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
   display: flex;
 }
 
-.emotion-195 {
+.emotion-192 {
   font-size: 1.25em;
   margin-right: 5px;
 }
 
-.emotion-197 {
+.emotion-194 {
   fill: #303030;
   cursor: inherit;
   vertical-align: baseline;
@@ -1143,37 +1143,19 @@ exports[`Service Microsegmentation Page should render 1`] = `
                 class="emotion-43 denali-tab"
                 data-active="false"
               >
-                Static Instances
-              </div>
-              <div
-                class="emotion-43 denali-tab"
-                data-active="false"
-              >
-                Dynamic Instances
-              </div>
-              <div
-                class="emotion-43 denali-tab"
-                data-active="false"
-              >
                 Tags
-              </div>
-              <div
-                class="emotion-43 denali-tab active"
-                data-active="true"
-              >
-                Microsegmentation
               </div>
             </div>
           </div>
           <div
-            class="emotion-47 emotion-48"
+            class="emotion-44 emotion-45"
             data-testid="segmentation-data-list"
           >
             <div
-              class="emotion-49 emotion-50"
+              class="emotion-46 emotion-47"
             >
               <div
-                class="emotion-51 emotion-52"
+                class="emotion-48 emotion-49"
               >
                 <div
                   class="toggle is-small"
@@ -1205,26 +1187,26 @@ exports[`Service Microsegmentation Page should render 1`] = `
               </div>
               <div>
                 <button
-                  class="emotion-53 denali-button"
+                  class="emotion-50 denali-button"
                 >
                   Add ACL Policy
                 </button>
               </div>
             </div>
             <table
-              class="emotion-54 emotion-55"
+              class="emotion-51 emotion-52"
               data-testid="segmentation-rule-table"
             >
               <thead>
                 <tr>
                   <th
-                    class="emotion-56 emotion-57"
+                    class="emotion-53 emotion-54"
                   >
                     <span
-                      class="emotion-58 emotion-59"
+                      class="emotion-55 emotion-56"
                     >
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1244,47 +1226,47 @@ exports[`Service Microsegmentation Page should render 1`] = `
                 </tr>
                 <tr>
                   <th
-                    class="emotion-61 emotion-62"
+                    class="emotion-58 emotion-59"
                   >
                     Identifier
                   </th>
                   <th
-                    class="emotion-61 emotion-62"
+                    class="emotion-58 emotion-59"
                   >
                     Destination Service
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Destination Port
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Source Service
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Source Port
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Layer
                   </th>
                   <th
-                    class="emotion-73 emotion-66"
+                    class="emotion-70 emotion-63"
                   >
                     Enforcement State
                   </th>
                   <th
-                    class="emotion-73 emotion-66"
+                    class="emotion-70 emotion-63"
                   >
                     Edit
                   </th>
                   <th
-                    class="emotion-73 emotion-66"
+                    class="emotion-70 emotion-63"
                   >
                     Delete
                   </th>
@@ -1292,34 +1274,34 @@ exports[`Service Microsegmentation Page should render 1`] = `
               </thead>
               <tbody>
                 <tr
-                  class="emotion-79 emotion-80"
+                  class="emotion-76 emotion-77"
                   data-testid="segmentation-row"
                 >
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     test1
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     openhouse
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     4443
                   </td>
                   <td
-                    class="emotion-87 emotion-88"
+                    class="emotion-84 emotion-85"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1339,24 +1321,24 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     1024-65535
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     TCP
                   </td>
                   <td
-                    class="emotion-94 emotion-88"
+                    class="emotion-91 emotion-85"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1382,12 +1364,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-97 emotion-82"
+                    class="emotion-94 emotion-79"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1404,12 +1386,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-97 emotion-82"
+                    class="emotion-94 emotion-79"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1430,34 +1412,34 @@ exports[`Service Microsegmentation Page should render 1`] = `
                   </td>
                 </tr>
                 <tr
-                  class="emotion-79 emotion-80"
+                  class="emotion-76 emotion-77"
                   data-testid="segmentation-row"
                 >
                   <td
-                    class="emotion-105 emotion-82"
+                    class="emotion-102 emotion-79"
                     color=""
                   >
                     test2
                   </td>
                   <td
-                    class="emotion-105 emotion-82"
+                    class="emotion-102 emotion-79"
                     color=""
                   >
                     openhouse
                   </td>
                   <td
-                    class="emotion-105 emotion-82"
+                    class="emotion-102 emotion-79"
                     color=""
                   >
                     8443-8444
                   </td>
                   <td
-                    class="emotion-111 emotion-88"
+                    class="emotion-108 emotion-85"
                     color=""
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1477,24 +1459,24 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-105 emotion-82"
+                    class="emotion-102 emotion-79"
                     color=""
                   >
                     1024-65535
                   </td>
                   <td
-                    class="emotion-105 emotion-82"
+                    class="emotion-102 emotion-79"
                     color=""
                   >
                     TCP
                   </td>
                   <td
-                    class="emotion-118 emotion-88"
+                    class="emotion-115 emotion-85"
                     color=""
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1520,12 +1502,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-121 emotion-82"
+                    class="emotion-118 emotion-79"
                     color=""
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1542,12 +1524,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-121 emotion-82"
+                    class="emotion-118 emotion-79"
                     color=""
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1571,19 +1553,19 @@ exports[`Service Microsegmentation Page should render 1`] = `
             </table>
             <br />
             <table
-              class="emotion-54 emotion-55"
+              class="emotion-51 emotion-52"
               data-testid="segmentation-rule-table"
             >
               <thead>
                 <tr>
                   <th
-                    class="emotion-56 emotion-57"
+                    class="emotion-53 emotion-54"
                   >
                     <span
-                      class="emotion-58 emotion-59"
+                      class="emotion-55 emotion-56"
                     >
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1603,47 +1585,47 @@ exports[`Service Microsegmentation Page should render 1`] = `
                 </tr>
                 <tr>
                   <th
-                    class="emotion-61 emotion-62"
+                    class="emotion-58 emotion-59"
                   >
                     Identifier
                   </th>
                   <th
-                    class="emotion-61 emotion-62"
+                    class="emotion-58 emotion-59"
                   >
                     Source Service
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Source Port
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Destination Service
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Destination Port
                   </th>
                   <th
-                    class="emotion-65 emotion-66"
+                    class="emotion-62 emotion-63"
                   >
                     Layer
                   </th>
                   <th
-                    class="emotion-73 emotion-66"
+                    class="emotion-70 emotion-63"
                   >
                     Enforcement State
                   </th>
                   <th
-                    class="emotion-73 emotion-66"
+                    class="emotion-70 emotion-63"
                   >
                     Edit
                   </th>
                   <th
-                    class="emotion-73 emotion-66"
+                    class="emotion-70 emotion-63"
                   >
                     Delete
                   </th>
@@ -1651,34 +1633,34 @@ exports[`Service Microsegmentation Page should render 1`] = `
               </thead>
               <tbody>
                 <tr
-                  class="emotion-79 emotion-80"
+                  class="emotion-76 emotion-77"
                   data-testid="segmentation-row"
                 >
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     test2
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     openhouse
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     1024-65535
                   </td>
                   <td
-                    class="emotion-87 emotion-88"
+                    class="emotion-84 emotion-85"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1698,24 +1680,24 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     4443
                   </td>
                   <td
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                     color="#3570f40D"
                   >
                     TCP
                   </td>
                   <td
-                    class="emotion-94 emotion-88"
+                    class="emotion-91 emotion-85"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1732,12 +1714,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-97 emotion-82"
+                    class="emotion-94 emotion-79"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1754,12 +1736,12 @@ exports[`Service Microsegmentation Page should render 1`] = `
                     </span>
                   </td>
                   <td
-                    class="emotion-97 emotion-82"
+                    class="emotion-94 emotion-79"
                     color="#3570f40D"
                   >
                     <span>
                       <svg
-                        class="emotion-60"
+                        class="emotion-57"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1788,11 +1770,11 @@ exports[`Service Microsegmentation Page should render 1`] = `
         data-testid="user-domains"
       >
         <div
-          class="emotion-176 emotion-177"
+          class="emotion-173 emotion-174"
           data-testid="toggle-domain"
         >
           <svg
-            class="emotion-178"
+            class="emotion-175"
             data-testid="icon"
             height="1em"
             id=""
@@ -1808,45 +1790,45 @@ exports[`Service Microsegmentation Page should render 1`] = `
           </svg>
         </div>
         <div
-          class="emotion-179 emotion-180"
+          class="emotion-176 emotion-177"
         >
           <div
-            class="emotion-181 emotion-182"
+            class="emotion-178 emotion-179"
           >
             <div
-              class="emotion-183 emotion-184"
+              class="emotion-180 emotion-181"
             >
               My Domains
             </div>
             <div>
               <a
-                class="emotion-185 emotion-186"
+                class="emotion-182 emotion-183"
               >
                 Create
               </a>
               <span
-                class="emotion-187 emotion-188"
+                class="emotion-184 emotion-185"
               >
                  | 
               </span>
               <a
-                class="emotion-185 emotion-186"
+                class="emotion-182 emotion-183"
               >
                 Manage
               </a>
             </div>
           </div>
           <div
-            class="emotion-191 emotion-192"
+            class="emotion-188 emotion-189"
           >
             <div
-              class="emotion-193 emotion-194"
+              class="emotion-190 emotion-191"
             >
               <div
-                class="emotion-195 emotion-196"
+                class="emotion-192 emotion-193"
               >
                 <svg
-                  class="emotion-197"
+                  class="emotion-194"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1868,19 +1850,19 @@ exports[`Service Microsegmentation Page should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-185 emotion-186"
+                class="emotion-182 emotion-183"
               >
                 athens
               </a>
             </div>
             <div
-              class="emotion-193 emotion-194"
+              class="emotion-190 emotion-191"
             >
               <div
-                class="emotion-195 emotion-196"
+                class="emotion-192 emotion-193"
               >
                 <svg
-                  class="emotion-197"
+                  class="emotion-194"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1902,7 +1884,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-185 emotion-186"
+                class="emotion-182 emotion-183"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/tags.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/tags.test.js.snap
@@ -554,7 +554,7 @@ exports[`Service Tag Page should render 1`] = `
   border-radius: 2px;
   box-sizing: border-box;
   display: inline-grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   margin-top: 0;
   min-width: 80px;
   position: relative;
@@ -638,11 +638,11 @@ exports[`Service Tag Page should render 1`] = `
   color: #303030;
 }
 
-.emotion-47 {
+.emotion-44 {
   margin: 20px;
 }
 
-.emotion-49 {
+.emotion-46 {
   padding-bottom: 20px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -662,7 +662,7 @@ exports[`Service Tag Page should render 1`] = `
   float: right;
 }
 
-.emotion-51 {
+.emotion-48 {
   border: none;
   border-radius: 2px;
   box-shadow: 0 0 0 1px transparent inset,0 0 0 0 #d5d5d5 inset;
@@ -688,25 +688,25 @@ exports[`Service Tag Page should render 1`] = `
   color: #3697f2;
 }
 
-.emotion-51:first-of-type {
+.emotion-48:first-of-type {
   margin-left: 0;
 }
 
-.emotion-51:disabled {
+.emotion-48:disabled {
   background: rgba(48,48,48,0.1);
   color: rgba(48,48,48,0.2);
   cursor: not-allowed;
 }
 
-.emotion-51:disabled {
+.emotion-48:disabled {
   box-shadow: 0 0 0 1px rgba(48,48,48,0.1) inset;
 }
 
-.emotion-51:hover:not(:disabled) {
+.emotion-48:hover:not(:disabled) {
   background: #d7e2fd;
 }
 
-.emotion-52 {
+.emotion-49 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -732,13 +732,13 @@ exports[`Service Tag Page should render 1`] = `
   width: 20px;
 }
 
-.emotion-54 {
+.emotion-51 {
   fill: #303030;
   cursor: inherit;
   vertical-align: text-bottom;
 }
 
-.emotion-55 {
+.emotion-52 {
   margin-right: 0;
   border-left: 1px solid #d5d5d5;
   -webkit-flex: 0 0 350px;
@@ -753,7 +753,7 @@ exports[`Service Tag Page should render 1`] = `
   width: 350px;
 }
 
-.emotion-57 {
+.emotion-54 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -772,28 +772,28 @@ exports[`Service Tag Page should render 1`] = `
   padding: 20px 30px 20px 15px;
 }
 
-.emotion-59 {
+.emotion-56 {
   font-size: 16px;
   font-weight: 600;
 }
 
-.emotion-61 {
+.emotion-58 {
   color: #3570f4;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
 }
 
-.emotion-63 {
+.emotion-60 {
   padding: 0 5px;
   color: #d5d5d5;
 }
 
-.emotion-67 {
+.emotion-64 {
   padding: 0 30px 0 15px;
 }
 
-.emotion-69 {
+.emotion-66 {
   padding: 10px 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -801,12 +801,12 @@ exports[`Service Tag Page should render 1`] = `
   display: flex;
 }
 
-.emotion-71 {
+.emotion-68 {
   font-size: 1.25em;
   margin-right: 5px;
 }
 
-.emotion-73 {
+.emotion-70 {
   fill: #303030;
   cursor: inherit;
   vertical-align: baseline;
@@ -989,41 +989,23 @@ exports[`Service Tag Page should render 1`] = `
               data-testid="tabgroup"
             >
               <div
-                class="emotion-43 denali-tab"
-                data-active="false"
-              >
-                Static Instances
-              </div>
-              <div
-                class="emotion-43 denali-tab"
-                data-active="false"
-              >
-                Dynamic Instances
-              </div>
-              <div
                 class="emotion-43 denali-tab active"
                 data-active="true"
               >
                 Tags
               </div>
-              <div
-                class="emotion-43 denali-tab"
-                data-active="false"
-              >
-                Microsegmentation
-              </div>
             </div>
           </div>
           <div
-            class="emotion-47 emotion-48"
+            class="emotion-44 emotion-45"
             data-testid="tag-list"
           >
             <div
-              class="emotion-49 emotion-50"
+              class="emotion-46 emotion-47"
             >
               <div>
                 <button
-                  class="emotion-51 denali-button"
+                  class="emotion-48 denali-button"
                 >
                   Add Tag
                 </button>
@@ -1037,11 +1019,11 @@ exports[`Service Tag Page should render 1`] = `
         data-testid="user-domains"
       >
         <div
-          class="emotion-52 emotion-53"
+          class="emotion-49 emotion-50"
           data-testid="toggle-domain"
         >
           <svg
-            class="emotion-54"
+            class="emotion-51"
             data-testid="icon"
             height="1em"
             id=""
@@ -1057,45 +1039,45 @@ exports[`Service Tag Page should render 1`] = `
           </svg>
         </div>
         <div
-          class="emotion-55 emotion-56"
+          class="emotion-52 emotion-53"
         >
           <div
-            class="emotion-57 emotion-58"
+            class="emotion-54 emotion-55"
           >
             <div
-              class="emotion-59 emotion-60"
+              class="emotion-56 emotion-57"
             >
               My Domains
             </div>
             <div>
               <a
-                class="emotion-61 emotion-62"
+                class="emotion-58 emotion-59"
               >
                 Create
               </a>
               <span
-                class="emotion-63 emotion-64"
+                class="emotion-60 emotion-61"
               >
                  | 
               </span>
               <a
-                class="emotion-61 emotion-62"
+                class="emotion-58 emotion-59"
               >
                 Manage
               </a>
             </div>
           </div>
           <div
-            class="emotion-67 emotion-68"
+            class="emotion-64 emotion-65"
           >
             <div
-              class="emotion-69 emotion-70"
+              class="emotion-66 emotion-67"
             >
               <div
-                class="emotion-71 emotion-72"
+                class="emotion-68 emotion-69"
               >
                 <svg
-                  class="emotion-73"
+                  class="emotion-70"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1117,19 +1099,19 @@ exports[`Service Tag Page should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-61 emotion-62"
+                class="emotion-58 emotion-59"
               >
                 athens
               </a>
             </div>
             <div
-              class="emotion-69 emotion-70"
+              class="emotion-66 emotion-67"
             >
               <div
-                class="emotion-71 emotion-72"
+                class="emotion-68 emotion-69"
               >
                 <svg
-                  class="emotion-73"
+                  class="emotion-70"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1151,7 +1133,7 @@ exports[`Service Tag Page should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-61 emotion-62"
+                class="emotion-58 emotion-59"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/dynamic.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/dynamic.test.js.snap
@@ -572,7 +572,7 @@ exports[`DynamicInstancePage should render 1`] = `
   border-radius: 2px;
   box-sizing: border-box;
   display: inline-grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   margin-top: 0;
   min-width: 80px;
   position: relative;
@@ -656,11 +656,11 @@ exports[`DynamicInstancePage should render 1`] = `
   color: #303030;
 }
 
-.emotion-62 {
+.emotion-59 {
   margin: 20px;
 }
 
-.emotion-64 {
+.emotion-61 {
   padding-bottom: 20px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -679,11 +679,11 @@ exports[`DynamicInstancePage should render 1`] = `
   flex-flow: row nowrap;
 }
 
-.emotion-66 {
+.emotion-63 {
   width: 50%;
 }
 
-.emotion-68 {
+.emotion-65 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -691,21 +691,21 @@ exports[`DynamicInstancePage should render 1`] = `
   width: 100%;
 }
 
-.emotion-70 {
+.emotion-67 {
   background: #ffffff;
   width: 35%;
 }
 
-.emotion-72 {
+.emotion-69 {
   position: relative;
   width: 100%;
 }
 
-.emotion-72 input {
+.emotion-69 input {
   cursor: pointer;
 }
 
-.emotion-73 {
+.emotion-70 {
   box-sizing: border-box;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -722,7 +722,7 @@ exports[`DynamicInstancePage should render 1`] = `
   width: 100%;
 }
 
-.emotion-73 input {
+.emotion-70 input {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -748,42 +748,42 @@ exports[`DynamicInstancePage should render 1`] = `
   width: 100%;
 }
 
-.emotion-73.animated input {
+.emotion-70.animated input {
   -webkit-transition: background-color 0.2s ease-in-out,color 0.2s ease-in-out,border 0.2s ease-in-out;
   transition: background-color 0.2s ease-in-out,color 0.2s ease-in-out,border 0.2s ease-in-out;
 }
 
-.emotion-73 input::-webkit-input-placeholder {
+.emotion-70 input::-webkit-input-placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-73 input::-moz-placeholder {
+.emotion-70 input::-moz-placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-73 input:-ms-input-placeholder {
+.emotion-70 input:-ms-input-placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-73 input::placeholder {
+.emotion-70 input::placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-73 input.focused,
-.emotion-73 input:active,
-.emotion-73 input:focus {
+.emotion-70 input.focused,
+.emotion-70 input:active,
+.emotion-70 input:focus {
   background: rgba(53,112,244,0.05);
   border-bottom: 2px solid #3570f4;
   color: #303030;
 }
 
-.emotion-73 input:invalid {
+.emotion-70 input:invalid {
   background: rgba(53,112,244,0.05);
   border-bottom: 2px solid #d01111;
   color: #303030;
 }
 
-.emotion-73 .message {
+.emotion-70 .message {
   font-size: 12px;
   left: 0;
   line-height: 1.8;
@@ -791,22 +791,22 @@ exports[`DynamicInstancePage should render 1`] = `
   top: 2.571rem;
 }
 
-.emotion-73.error input,
-.emotion-73.error input.focused,
-.emotion-73.error input:active,
-.emotion-73.error input:focus {
+.emotion-70.error input,
+.emotion-70.error input.focused,
+.emotion-70.error input:active,
+.emotion-70.error input:focus {
   border-bottom: 2px solid #d01111;
 }
 
-.emotion-73.error .message {
+.emotion-70.error .message {
   color: #d01111;
 }
 
-.emotion-73 input {
+.emotion-70 input {
   padding-right: 36px;
 }
 
-.emotion-73 .input-icon {
+.emotion-70 .input-icon {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -820,19 +820,19 @@ exports[`DynamicInstancePage should render 1`] = `
   right: 6px;
 }
 
-.emotion-74 {
+.emotion-71 {
   fill: #d5d5d5;
   cursor: pointer;
   vertical-align: text-bottom;
 }
 
-.emotion-75 {
+.emotion-72 {
   background: #ffffff;
   width: 65%;
   margin-left: 5px;
 }
 
-.emotion-79 {
+.emotion-76 {
   width: 100%;
   border-spacing: 0 15px;
   display: table;
@@ -840,7 +840,7 @@ exports[`DynamicInstancePage should render 1`] = `
   border-color: grey;
 }
 
-.emotion-81 {
+.emotion-78 {
   text-align: left;
   border-bottom: 2px solid #d5d5d5;
   color: #9a9a9a;
@@ -851,7 +851,7 @@ exports[`DynamicInstancePage should render 1`] = `
   padding: 5px 0 5px 25px;
 }
 
-.emotion-95 {
+.emotion-92 {
   box-sizing: border-box;
   margin-top: 10px;
   box-shadow: 0 1px 4px #d9d9d9;
@@ -863,13 +863,13 @@ exports[`DynamicInstancePage should render 1`] = `
   padding: 5px 0 5px 15px;
 }
 
-.emotion-97 {
+.emotion-94 {
   text-align: left;
   padding: 5px 0 5px 15px;
   vertical-align: middle;
 }
 
-.emotion-99 {
+.emotion-96 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -880,19 +880,19 @@ exports[`DynamicInstancePage should render 1`] = `
   padding-bottom: 10px;
 }
 
-.emotion-111 {
+.emotion-108 {
   text-align: center;
   padding: 5px 0 5px 15px;
   vertical-align: middle;
 }
 
-.emotion-113 {
+.emotion-110 {
   fill: #188fff;
   cursor: pointer;
   vertical-align: text-bottom;
 }
 
-.emotion-114 {
+.emotion-111 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -918,13 +918,13 @@ exports[`DynamicInstancePage should render 1`] = `
   width: 20px;
 }
 
-.emotion-116 {
+.emotion-113 {
   fill: #303030;
   cursor: inherit;
   vertical-align: text-bottom;
 }
 
-.emotion-117 {
+.emotion-114 {
   margin-right: 0;
   border-left: 1px solid #d5d5d5;
   -webkit-flex: 0 0 350px;
@@ -939,7 +939,7 @@ exports[`DynamicInstancePage should render 1`] = `
   width: 350px;
 }
 
-.emotion-119 {
+.emotion-116 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -958,28 +958,28 @@ exports[`DynamicInstancePage should render 1`] = `
   padding: 20px 30px 20px 15px;
 }
 
-.emotion-121 {
+.emotion-118 {
   font-size: 16px;
   font-weight: 600;
 }
 
-.emotion-123 {
+.emotion-120 {
   color: #3570f4;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
 }
 
-.emotion-125 {
+.emotion-122 {
   padding: 0 5px;
   color: #d5d5d5;
 }
 
-.emotion-129 {
+.emotion-126 {
   padding: 0 30px 0 15px;
 }
 
-.emotion-131 {
+.emotion-128 {
   padding: 10px 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -987,12 +987,12 @@ exports[`DynamicInstancePage should render 1`] = `
   display: flex;
 }
 
-.emotion-133 {
+.emotion-130 {
   font-size: 1.25em;
   margin-right: 5px;
 }
 
-.emotion-135 {
+.emotion-132 {
   fill: #303030;
   cursor: inherit;
   vertical-align: baseline;
@@ -1259,54 +1259,36 @@ exports[`DynamicInstancePage should render 1`] = `
                 class="emotion-58 denali-tab"
                 data-active="false"
               >
-                Static Instances
-              </div>
-              <div
-                class="emotion-58 denali-tab active"
-                data-active="true"
-              >
-                Dynamic Instances
-              </div>
-              <div
-                class="emotion-58 denali-tab"
-                data-active="false"
-              >
                 Tags
-              </div>
-              <div
-                class="emotion-58 denali-tab"
-                data-active="false"
-              >
-                Microsegmentation
               </div>
             </div>
           </div>
           <div
-            class="emotion-62 emotion-63"
+            class="emotion-59 emotion-60"
             data-testid="instancelist"
           >
             <div
-              class="emotion-64 emotion-65"
+              class="emotion-61 emotion-62"
             >
               <div
-                class="emotion-66 emotion-67"
+                class="emotion-63 emotion-64"
               >
                 <div
-                  class="emotion-68 emotion-69"
+                  class="emotion-65 emotion-66"
                 >
                   <div
-                    class="emotion-70 emotion-71"
+                    class="emotion-67 emotion-68"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="emotion-72 denali-input-dropdown"
+                      class="emotion-69 denali-input-dropdown"
                       data-testid="input-dropdown"
                       role="combobox"
                     >
                       <div
-                        class="emotion-73 denali-input animated"
+                        class="emotion-70 denali-input animated"
                         data-testid="input-wrapper"
                       >
                         <input
@@ -1326,7 +1308,7 @@ exports[`DynamicInstancePage should render 1`] = `
                           class="input-icon"
                         >
                           <svg
-                            class="emotion-74"
+                            class="emotion-71"
                             data-testid="icon"
                             height="24px"
                             id=""
@@ -1349,10 +1331,10 @@ exports[`DynamicInstancePage should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="emotion-75 emotion-76"
+                    class="emotion-72 emotion-73"
                   >
                     <div
-                      class="emotion-73 denali-input animated"
+                      class="emotion-70 denali-input animated"
                       data-testid="input-wrapper"
                     >
                       <input
@@ -1391,7 +1373,7 @@ exports[`DynamicInstancePage should render 1`] = `
               </div>
             </div>
             <table
-              class="emotion-79 emotion-80"
+              class="emotion-76 emotion-77"
               data-testid="instancetable"
             >
               <colgroup>
@@ -1420,37 +1402,37 @@ exports[`DynamicInstancePage should render 1`] = `
               <thead>
                 <tr>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     Instance
                   </th>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     Hostname
                   </th>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     Provider
                   </th>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     ID
                   </th>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     Expires On
                   </th>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     Last Certificate Refresh
                   </th>
                   <th
-                    class="emotion-81 emotion-82"
+                    class="emotion-78 emotion-79"
                   >
                     Delete
                   </th>
@@ -1458,52 +1440,52 @@ exports[`DynamicInstancePage should render 1`] = `
               </thead>
               <tbody>
                 <tr
-                  class="emotion-95 emotion-96"
+                  class="emotion-92 emotion-93"
                   data-testid="instance-row"
                 >
                   <td
-                    class="emotion-97 emotion-98"
+                    class="emotion-94 emotion-95"
                     color=""
                   >
                     <div
-                      class="emotion-99 emotion-100"
+                      class="emotion-96 emotion-97"
                     />
                   </td>
                   <td
-                    class="emotion-97 emotion-98"
+                    class="emotion-94 emotion-95"
                     color=""
                   />
                   <td
-                    class="emotion-97 emotion-98"
+                    class="emotion-94 emotion-95"
                     color=""
                   >
                     Static
                   </td>
                   <td
-                    class="emotion-97 emotion-98"
+                    class="emotion-94 emotion-95"
                     color=""
                   >
                     10.1.1.1
                   </td>
                   <td
-                    class="emotion-97 emotion-98"
+                    class="emotion-94 emotion-95"
                     color=""
                   >
                     Invalid date
                   </td>
                   <td
-                    class="emotion-97 emotion-98"
+                    class="emotion-94 emotion-95"
                     color=""
                   >
                     2021-05-15 01:17 UTC
                   </td>
                   <td
-                    class="emotion-111 emotion-98"
+                    class="emotion-108 emotion-95"
                     color=""
                   >
                     <span>
                       <svg
-                        class="emotion-113"
+                        class="emotion-110"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1532,11 +1514,11 @@ exports[`DynamicInstancePage should render 1`] = `
         data-testid="user-domains"
       >
         <div
-          class="emotion-114 emotion-115"
+          class="emotion-111 emotion-112"
           data-testid="toggle-domain"
         >
           <svg
-            class="emotion-116"
+            class="emotion-113"
             data-testid="icon"
             height="1em"
             id=""
@@ -1552,45 +1534,45 @@ exports[`DynamicInstancePage should render 1`] = `
           </svg>
         </div>
         <div
-          class="emotion-117 emotion-118"
+          class="emotion-114 emotion-115"
         >
           <div
-            class="emotion-119 emotion-120"
+            class="emotion-116 emotion-117"
           >
             <div
-              class="emotion-121 emotion-122"
+              class="emotion-118 emotion-119"
             >
               My Domains
             </div>
             <div>
               <a
-                class="emotion-123 emotion-124"
+                class="emotion-120 emotion-121"
               >
                 Create
               </a>
               <span
-                class="emotion-125 emotion-126"
+                class="emotion-122 emotion-123"
               >
                  | 
               </span>
               <a
-                class="emotion-123 emotion-124"
+                class="emotion-120 emotion-121"
               >
                 Manage
               </a>
             </div>
           </div>
           <div
-            class="emotion-129 emotion-130"
+            class="emotion-126 emotion-127"
           >
             <div
-              class="emotion-131 emotion-132"
+              class="emotion-128 emotion-129"
             >
               <div
-                class="emotion-133 emotion-134"
+                class="emotion-130 emotion-131"
               >
                 <svg
-                  class="emotion-135"
+                  class="emotion-132"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1612,19 +1594,19 @@ exports[`DynamicInstancePage should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-123 emotion-124"
+                class="emotion-120 emotion-121"
               >
                 athens
               </a>
             </div>
             <div
-              class="emotion-131 emotion-132"
+              class="emotion-128 emotion-129"
             >
               <div
-                class="emotion-133 emotion-134"
+                class="emotion-130 emotion-131"
               >
                 <svg
-                  class="emotion-135"
+                  class="emotion-132"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1646,7 +1628,7 @@ exports[`DynamicInstancePage should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-123 emotion-124"
+                class="emotion-120 emotion-121"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/static.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/static.test.js.snap
@@ -572,7 +572,7 @@ exports[`StaticInstancePage should render 1`] = `
   border-radius: 2px;
   box-sizing: border-box;
   display: inline-grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   margin-top: 0;
   min-width: 80px;
   position: relative;
@@ -656,11 +656,11 @@ exports[`StaticInstancePage should render 1`] = `
   color: #303030;
 }
 
-.emotion-53 {
+.emotion-50 {
   margin: 20px;
 }
 
-.emotion-55 {
+.emotion-52 {
   padding-bottom: 20px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -679,11 +679,11 @@ exports[`StaticInstancePage should render 1`] = `
   flex-flow: row nowrap;
 }
 
-.emotion-57 {
+.emotion-54 {
   width: 50%;
 }
 
-.emotion-59 {
+.emotion-56 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -691,13 +691,13 @@ exports[`StaticInstancePage should render 1`] = `
   width: 100%;
 }
 
-.emotion-61 {
+.emotion-58 {
   background: #ffffff;
   width: 65%;
   margin-left: 5px;
 }
 
-.emotion-63 {
+.emotion-60 {
   box-sizing: border-box;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -714,7 +714,7 @@ exports[`StaticInstancePage should render 1`] = `
   width: 100%;
 }
 
-.emotion-63 input {
+.emotion-60 input {
   -webkit-appearance: none;
   -moz-appearance: none;
   -ms-appearance: none;
@@ -740,42 +740,42 @@ exports[`StaticInstancePage should render 1`] = `
   width: 100%;
 }
 
-.emotion-63.animated input {
+.emotion-60.animated input {
   -webkit-transition: background-color 0.2s ease-in-out,color 0.2s ease-in-out,border 0.2s ease-in-out;
   transition: background-color 0.2s ease-in-out,color 0.2s ease-in-out,border 0.2s ease-in-out;
 }
 
-.emotion-63 input::-webkit-input-placeholder {
+.emotion-60 input::-webkit-input-placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-63 input::-moz-placeholder {
+.emotion-60 input::-moz-placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-63 input:-ms-input-placeholder {
+.emotion-60 input:-ms-input-placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-63 input::placeholder {
+.emotion-60 input::placeholder {
   color: rgba(48,48,48,0.6);
 }
 
-.emotion-63 input.focused,
-.emotion-63 input:active,
-.emotion-63 input:focus {
+.emotion-60 input.focused,
+.emotion-60 input:active,
+.emotion-60 input:focus {
   background: rgba(53,112,244,0.05);
   border-bottom: 2px solid #3570f4;
   color: #303030;
 }
 
-.emotion-63 input:invalid {
+.emotion-60 input:invalid {
   background: rgba(53,112,244,0.05);
   border-bottom: 2px solid #d01111;
   color: #303030;
 }
 
-.emotion-63 .message {
+.emotion-60 .message {
   font-size: 12px;
   left: 0;
   line-height: 1.8;
@@ -783,22 +783,22 @@ exports[`StaticInstancePage should render 1`] = `
   top: 2.571rem;
 }
 
-.emotion-63.error input,
-.emotion-63.error input.focused,
-.emotion-63.error input:active,
-.emotion-63.error input:focus {
+.emotion-60.error input,
+.emotion-60.error input.focused,
+.emotion-60.error input:active,
+.emotion-60.error input:focus {
   border-bottom: 2px solid #d01111;
 }
 
-.emotion-63.error .message {
+.emotion-60.error .message {
   color: #d01111;
 }
 
-.emotion-63 input {
+.emotion-60 input {
   padding-right: 36px;
 }
 
-.emotion-63 .input-icon {
+.emotion-60 .input-icon {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -812,7 +812,7 @@ exports[`StaticInstancePage should render 1`] = `
   right: 6px;
 }
 
-.emotion-65 {
+.emotion-62 {
   border: none;
   border-radius: 2px;
   box-shadow: 0 0 0 1px transparent inset,0 0 0 0 #d5d5d5 inset;
@@ -838,25 +838,25 @@ exports[`StaticInstancePage should render 1`] = `
   color: #3697f2;
 }
 
-.emotion-65:first-of-type {
+.emotion-62:first-of-type {
   margin-left: 0;
 }
 
-.emotion-65:disabled {
+.emotion-62:disabled {
   background: rgba(48,48,48,0.1);
   color: rgba(48,48,48,0.2);
   cursor: not-allowed;
 }
 
-.emotion-65:disabled {
+.emotion-62:disabled {
   box-shadow: 0 0 0 1px rgba(48,48,48,0.1) inset;
 }
 
-.emotion-65:hover:not(:disabled) {
+.emotion-62:hover:not(:disabled) {
   background: #d7e2fd;
 }
 
-.emotion-66 {
+.emotion-63 {
   width: 100%;
   border-spacing: 0 15px;
   display: table;
@@ -864,7 +864,7 @@ exports[`StaticInstancePage should render 1`] = `
   border-color: grey;
 }
 
-.emotion-68 {
+.emotion-65 {
   text-align: left;
   border-bottom: 2px solid #d5d5d5;
   color: #9a9a9a;
@@ -875,7 +875,7 @@ exports[`StaticInstancePage should render 1`] = `
   padding: 5px 0 5px 25px;
 }
 
-.emotion-76 {
+.emotion-73 {
   box-sizing: border-box;
   margin-top: 10px;
   box-shadow: 0 1px 4px #d9d9d9;
@@ -887,13 +887,13 @@ exports[`StaticInstancePage should render 1`] = `
   padding: 5px 0 5px 15px;
 }
 
-.emotion-78 {
+.emotion-75 {
   text-align: left;
   padding: 5px 0 5px 15px;
   vertical-align: middle;
 }
 
-.emotion-80 {
+.emotion-77 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -904,19 +904,19 @@ exports[`StaticInstancePage should render 1`] = `
   padding-bottom: 10px;
 }
 
-.emotion-86 {
+.emotion-83 {
   text-align: center;
   padding: 5px 0 5px 15px;
   vertical-align: middle;
 }
 
-.emotion-88 {
+.emotion-85 {
   fill: #188fff;
   cursor: pointer;
   vertical-align: text-bottom;
 }
 
-.emotion-89 {
+.emotion-86 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -942,13 +942,13 @@ exports[`StaticInstancePage should render 1`] = `
   width: 20px;
 }
 
-.emotion-91 {
+.emotion-88 {
   fill: #303030;
   cursor: inherit;
   vertical-align: text-bottom;
 }
 
-.emotion-92 {
+.emotion-89 {
   margin-right: 0;
   border-left: 1px solid #d5d5d5;
   -webkit-flex: 0 0 350px;
@@ -963,7 +963,7 @@ exports[`StaticInstancePage should render 1`] = `
   width: 350px;
 }
 
-.emotion-94 {
+.emotion-91 {
   -webkit-align-items: baseline;
   -webkit-box-align: baseline;
   -ms-flex-align: baseline;
@@ -982,28 +982,28 @@ exports[`StaticInstancePage should render 1`] = `
   padding: 20px 30px 20px 15px;
 }
 
-.emotion-96 {
+.emotion-93 {
   font-size: 16px;
   font-weight: 600;
 }
 
-.emotion-98 {
+.emotion-95 {
   color: #3570f4;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
 }
 
-.emotion-100 {
+.emotion-97 {
   padding: 0 5px;
   color: #d5d5d5;
 }
 
-.emotion-104 {
+.emotion-101 {
   padding: 0 30px 0 15px;
 }
 
-.emotion-106 {
+.emotion-103 {
   padding: 10px 0;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1011,12 +1011,12 @@ exports[`StaticInstancePage should render 1`] = `
   display: flex;
 }
 
-.emotion-108 {
+.emotion-105 {
   font-size: 1.25em;
   margin-right: 5px;
 }
 
-.emotion-110 {
+.emotion-107 {
   fill: #303030;
   cursor: inherit;
   vertical-align: baseline;
@@ -1242,49 +1242,31 @@ exports[`StaticInstancePage should render 1`] = `
               data-testid="tabgroup"
             >
               <div
-                class="emotion-49 denali-tab active"
-                data-active="true"
-              >
-                Static Instances
-              </div>
-              <div
-                class="emotion-49 denali-tab"
-                data-active="false"
-              >
-                Dynamic Instances
-              </div>
-              <div
                 class="emotion-49 denali-tab"
                 data-active="false"
               >
                 Tags
               </div>
-              <div
-                class="emotion-49 denali-tab"
-                data-active="false"
-              >
-                Microsegmentation
-              </div>
             </div>
           </div>
           <div
-            class="emotion-53 emotion-54"
+            class="emotion-50 emotion-51"
             data-testid="instancelist"
           >
             <div
-              class="emotion-55 emotion-56"
+              class="emotion-52 emotion-53"
             >
               <div
-                class="emotion-57 emotion-58"
+                class="emotion-54 emotion-55"
               >
                 <div
-                  class="emotion-59 emotion-60"
+                  class="emotion-56 emotion-57"
                 >
                   <div
-                    class="emotion-61 emotion-62"
+                    class="emotion-58 emotion-59"
                   >
                     <div
-                      class="emotion-63 denali-input animated"
+                      class="emotion-60 denali-input animated"
                       data-testid="input-wrapper"
                     >
                       <input
@@ -1323,14 +1305,14 @@ exports[`StaticInstancePage should render 1`] = `
               </div>
               <div>
                 <button
-                  class="emotion-65 denali-button"
+                  class="emotion-62 denali-button"
                 >
                   Add Static Instance
                 </button>
               </div>
             </div>
             <table
-              class="emotion-66 emotion-67"
+              class="emotion-63 emotion-64"
               data-testid="instancetable"
             >
               <colgroup>
@@ -1350,22 +1332,22 @@ exports[`StaticInstancePage should render 1`] = `
               <thead>
                 <tr>
                   <th
-                    class="emotion-68 emotion-69"
+                    class="emotion-65 emotion-66"
                   >
                     Instance
                   </th>
                   <th
-                    class="emotion-68 emotion-69"
+                    class="emotion-65 emotion-66"
                   >
                     Type
                   </th>
                   <th
-                    class="emotion-68 emotion-69"
+                    class="emotion-65 emotion-66"
                   >
                     Date Added
                   </th>
                   <th
-                    class="emotion-68 emotion-69"
+                    class="emotion-65 emotion-66"
                   >
                     Delete
                   </th>
@@ -1373,34 +1355,34 @@ exports[`StaticInstancePage should render 1`] = `
               </thead>
               <tbody>
                 <tr
-                  class="emotion-76 emotion-77"
+                  class="emotion-73 emotion-74"
                   data-testid="instance-row"
                 >
                   <td
-                    class="emotion-78 emotion-79"
+                    class="emotion-75 emotion-76"
                     color=""
                   >
                     <div
-                      class="emotion-80 emotion-81"
+                      class="emotion-77 emotion-78"
                     />
                   </td>
                   <td
-                    class="emotion-78 emotion-79"
+                    class="emotion-75 emotion-76"
                     color=""
                   />
                   <td
-                    class="emotion-78 emotion-79"
+                    class="emotion-75 emotion-76"
                     color=""
                   >
                     2021-05-15 01:17 UTC
                   </td>
                   <td
-                    class="emotion-86 emotion-79"
+                    class="emotion-83 emotion-76"
                     color=""
                   >
                     <span>
                       <svg
-                        class="emotion-88"
+                        class="emotion-85"
                         data-testid="icon"
                         height="1.25em"
                         id=""
@@ -1429,11 +1411,11 @@ exports[`StaticInstancePage should render 1`] = `
         data-testid="user-domains"
       >
         <div
-          class="emotion-89 emotion-90"
+          class="emotion-86 emotion-87"
           data-testid="toggle-domain"
         >
           <svg
-            class="emotion-91"
+            class="emotion-88"
             data-testid="icon"
             height="1em"
             id=""
@@ -1449,45 +1431,45 @@ exports[`StaticInstancePage should render 1`] = `
           </svg>
         </div>
         <div
-          class="emotion-92 emotion-93"
+          class="emotion-89 emotion-90"
         >
           <div
-            class="emotion-94 emotion-95"
+            class="emotion-91 emotion-92"
           >
             <div
-              class="emotion-96 emotion-97"
+              class="emotion-93 emotion-94"
             >
               My Domains
             </div>
             <div>
               <a
-                class="emotion-98 emotion-99"
+                class="emotion-95 emotion-96"
               >
                 Create
               </a>
               <span
-                class="emotion-100 emotion-101"
+                class="emotion-97 emotion-98"
               >
                  | 
               </span>
               <a
-                class="emotion-98 emotion-99"
+                class="emotion-95 emotion-96"
               >
                 Manage
               </a>
             </div>
           </div>
           <div
-            class="emotion-104 emotion-105"
+            class="emotion-101 emotion-102"
           >
             <div
-              class="emotion-106 emotion-107"
+              class="emotion-103 emotion-104"
             >
               <div
-                class="emotion-108 emotion-109"
+                class="emotion-105 emotion-106"
               >
                 <svg
-                  class="emotion-110"
+                  class="emotion-107"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1509,19 +1491,19 @@ exports[`StaticInstancePage should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-98 emotion-99"
+                class="emotion-95 emotion-96"
               >
                 athens
               </a>
             </div>
             <div
-              class="emotion-106 emotion-107"
+              class="emotion-103 emotion-104"
             >
               <div
-                class="emotion-108 emotion-109"
+                class="emotion-105 emotion-106"
               >
                 <svg
-                  class="emotion-110"
+                  class="emotion-107"
                   data-testid="icon"
                   height="1em"
                   id=""
@@ -1543,7 +1525,7 @@ exports[`StaticInstancePage should render 1`] = `
                 </svg>
               </div>
               <a
-                class="emotion-98 emotion-99"
+                class="emotion-95 emotion-96"
               >
                 athens.ci
               </a>

--- a/ui/src/components/constants/constants.js
+++ b/ui/src/components/constants/constants.js
@@ -28,6 +28,8 @@ export const DISPLAY_SPACE = '\u23b5';
 
 export const SERVICE_TYPE_DYNAMIC = 'dynamic';
 export const SERVICE_TYPE_STATIC = 'static';
+export const SERVICE_TYPE_MICROSEGMENTATION = 'microsegmentation';
+export const SERVICE_TYPE_MICROSEGMENTATION_LABEL = 'Microsegmentation';
 export const SERVICE_TYPE_DYNAMIC_LABEL = 'Dynamic Instances';
 export const SERVICE_TYPE_STATIC_LABEL = 'Static Instances';
 export const SEGMENTATION_TYPE_OUTBOUND = 'outbound';
@@ -68,8 +70,8 @@ export const SERVICE_TABS = [
         name: 'tags',
     },
     {
-        label: 'Microsegmentation',
-        name: 'microsegmentation',
+        label: SERVICE_TYPE_MICROSEGMENTATION_LABEL,
+        name: SERVICE_TYPE_MICROSEGMENTATION,
     },
 ];
 

--- a/ui/src/components/header/ServiceTabs.js
+++ b/ui/src/components/header/ServiceTabs.js
@@ -19,6 +19,7 @@ import { withRouter } from 'next/router';
 import {
     SERVICE_TABS,
     SERVICE_TYPE_DYNAMIC,
+    SERVICE_TYPE_MICROSEGMENTATION,
     SERVICE_TYPE_STATIC,
 } from '../constants/constants';
 
@@ -63,9 +64,11 @@ class ServiceTabs extends React.Component {
     }
 
     render() {
+        let shouldShowAllServiceTabs = this.props.featureFlag;
+        let serviceTabs = shouldShowAllServiceTabs ?  SERVICE_TABS : SERVICE_TABS.filter((tab) => tab.name === 'tags');
         return (
             <TabGroup
-                tabs={SERVICE_TABS}
+                tabs={serviceTabs}
                 selectedName={this.props.selectedName}
                 onClick={this.tabClicked}
                 noanim

--- a/ui/src/components/header/ServiceTabs.js
+++ b/ui/src/components/header/ServiceTabs.js
@@ -65,15 +65,7 @@ class ServiceTabs extends React.Component {
     render() {
         return (
             <TabGroup
-                tabs={
-                    this.props.featureFlag
-                        ? SERVICE_TABS.filter(
-                              (tab) =>
-                                  tab.name !== SERVICE_TYPE_STATIC &&
-                                  tab.name !== SERVICE_TYPE_DYNAMIC
-                          )
-                        : SERVICE_TABS
-                }
+                tabs={SERVICE_TABS}
                 selectedName={this.props.selectedName}
                 onClick={this.tabClicked}
                 noanim

--- a/ui/src/pages/domain/[domain]/service/[service]/instance/dynamic.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/instance/dynamic.js
@@ -37,6 +37,7 @@ import {
 } from '../../../../../../redux/selectors/services';
 import InstanceList from '../../../../../../components/service/InstanceList';
 import { selectIsLoading } from '../../../../../../redux/selectors/loading';
+import { selectFeatureFlag } from '../../../../../../redux/selectors/domains';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { ReduxPageLoader } from '../../../../../../components/denali/ReduxPageLoader';
@@ -197,6 +198,7 @@ class DynamicInstancePage extends React.Component {
                                             categoryType={SERVICE_TYPE_DYNAMIC}
                                         />
                                         <ServiceTabs
+                                            featureFlag={this.props.featureFlag}
                                             domain={domainName}
                                             service={serviceName}
                                             selectedName={SERVICE_TYPE_DYNAMIC}
@@ -249,6 +251,7 @@ const mapStateToProps = (state, props) => {
             props.service
         ),
         isLoading: selectIsLoading(state),
+        featureFlag: selectFeatureFlag(state),
     };
 };
 

--- a/ui/src/pages/domain/[domain]/service/[service]/instance/static.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/instance/static.js
@@ -34,6 +34,7 @@ import {
     selectInstancesWorkLoadMeta,
     selectStaticServiceHeaderDetails,
 } from '../../../../../../redux/selectors/services';
+import { selectFeatureFlag } from '../../../../../../redux/selectors/domains';
 import { getServiceHeaderAndInstances } from '../../../../../../redux/thunks/services';
 import InstanceList from '../../../../../../components/service/InstanceList';
 import { selectIsLoading } from '../../../../../../redux/selectors/loading';
@@ -197,6 +198,7 @@ class StaticInstancePage extends React.Component {
                                             categoryType={SERVICE_TYPE_STATIC}
                                         />
                                         <ServiceTabs
+                                            featureFlag={this.props.featureFlag}
                                             domain={domainName}
                                             service={serviceName}
                                             selectedName={SERVICE_TYPE_STATIC}
@@ -249,6 +251,7 @@ const mapStateToProps = (state, props) => {
             props.service
         ),
         isLoading: selectIsLoading(state),
+        featureFlag: selectFeatureFlag(state),
     };
 };
 

--- a/ui/src/pages/domain/[domain]/service/[service]/microsegmentation.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/microsegmentation.js
@@ -34,6 +34,7 @@ import ServiceTabs from '../../../../../components/header/ServiceTabs';
 import {getInboundOutbound} from "../../../../../redux/thunks/microsegmentation";
 import RulesList from "../../../../../components/microsegmentation/RulesList";
 import Alert from "../../../../../components/denali/Alert";
+import { selectFeatureFlag } from '../../../../../redux/selectors/domains';
 
 const AppContainerDiv = styled.div`
     align-items: stretch;
@@ -217,6 +218,7 @@ const mapStateToProps = (state, props) => {
     return {
         ...props,
         isLoading: selectIsLoading(state),
+        featureFlag: selectFeatureFlag(state),
         serviceDetails: selectService(
             state,
             props.domainName,

--- a/ui/src/pages/domain/[domain]/service/[service]/tags.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/tags.js
@@ -170,7 +170,6 @@ class ServiceTagsPage extends React.Component {
                                             _csrf={_csrf}
                                         />
                                         <ServiceTabs
-                                            featureFlag={this.props.featureFlag}
                                             domain={domainName}
                                             service={serviceName}
                                             selectedName={'tags'}

--- a/ui/src/pages/domain/[domain]/service/[service]/tags.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/tags.js
@@ -170,6 +170,7 @@ class ServiceTagsPage extends React.Component {
                                             _csrf={_csrf}
                                         />
                                         <ServiceTabs
+                                            featureFlag={this.props.featureFlag}
                                             domain={domainName}
                                             service={serviceName}
                                             selectedName={'tags'}


### PR DESCRIPTION
# Description
Problem: currently selecting the service tags tab results in all other service tabs (static instances / dynamic instances / microsegmentation ) hidden.
Solution: feature flag on -> show all tabs, feature flag off -> show only tags tab

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

