### PR TITLE
Add GetZone from meta endpoint for gcp

### DIFF
--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -84,6 +84,28 @@ func getRegionFromMeta(metaEndPoint string) string {
 	return region
 }
 
+func GetZone(metaEndPoint string) string {
+	var zone string
+	zone = getZoneFromMeta(metaEndPoint)
+	if zone == "" {
+		log.Println("No zone information available. Defaulting to us-west1")
+		zone = "us-west1"
+	}
+	return zone
+}
+
+func getZoneFromMeta(metaEndPoint string) string {
+	var zone string
+	log.Println("Trying to determine zone from metadata server ...")
+	fullOutput, err := GetData(metaEndPoint, "/computeMetadata/v1/instance/zone")
+	if err == nil {
+		if idx := strings.LastIndex(string(fullOutput), "/"); idx > 0 {
+			zone = string(fullOutput[idx+1:])
+		}
+	}
+	return zone
+}
+
 func GetDomain(metaEndpoint string) (string, error) {
 	domainBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/project/attributes/athenz-domain")
 	if err != nil {

--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -71,16 +71,11 @@ func GetRegion(metaEndPoint string) string {
 
 func getRegionFromMeta(metaEndPoint string) string {
 	var region string
-	log.Println("Trying to determine region from metadata server ...")
-	fullOutput, err := GetData(metaEndPoint, "/computeMetadata/v1/instance/zone")
-	if err == nil {
-		if idx := strings.LastIndex(string(fullOutput), "/"); idx > 0 {
-			zone := string(fullOutput[idx+1:])
-			if idx := strings.LastIndex(zone, "-"); idx > 0 {
-				region = zone[:idx]
-			}
-		}
+	zone := getZoneFromMeta(metaEndPoint)
+	if idx := strings.LastIndex(zone, "-"); idx > 0 {
+		region = zone[:idx]
 	}
+
 	return region
 }
 

--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -88,8 +88,8 @@ func GetZone(metaEndPoint string) string {
 	var zone string
 	zone = getZoneFromMeta(metaEndPoint)
 	if zone == "" {
-		log.Println("No zone information available. Defaulting to us-west1")
-		zone = "us-west1"
+		log.Println("No zone information available. Defaulting to us-west1-a")
+		zone = "us-west1-a"
 	}
 	return zone
 }

--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -61,17 +61,7 @@ func processHttpRequest(base, path, method string, headers map[string]string) ([
 // GetRegion get current region from identity document
 func GetRegion(metaEndPoint string) string {
 	var region string
-	region = getRegionFromMeta(metaEndPoint)
-	if region == "" {
-		log.Println("No region information available. Defaulting to us-west1")
-		region = "us-west1"
-	}
-	return region
-}
-
-func getRegionFromMeta(metaEndPoint string) string {
-	var region string
-	zone := getZoneFromMeta(metaEndPoint)
+	zone := GetZone(metaEndPoint)
 	if idx := strings.LastIndex(zone, "-"); idx > 0 {
 		region = zone[:idx]
 	}

--- a/libs/go/sia/gcp/meta/meta_test.go
+++ b/libs/go/sia/gcp/meta/meta_test.go
@@ -90,6 +90,24 @@ func TestGetRegion(test *testing.T) {
 	}
 }
 
+func TestGetZone(test *testing.T) {
+	// Mock the metadata endpoints
+	router := httptreemux.New()
+	router.GET("/computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request, params map[string]string) {
+		log.Println("Called /computeMetadata/v1/instance/zone")
+		io.WriteString(w, "projects/1001234567890/zones/us-west2-a")
+	})
+
+	metaServer := &testServer{}
+	metaServer.start(router)
+	defer metaServer.stop()
+
+	zone := GetZone(metaServer.httpUrl())
+	if zone != "us-west2-a" {
+		test.Errorf("Unable to match expected zone: %s", zone)
+	}
+}
+
 func TestGetDomain(test *testing.T) {
 	// Mock the metadata endpoints
 	router := httptreemux.New()


### PR DESCRIPTION
# Description
Add GetZone from meta endpoint for gcp.
GetRegion returns "us-west1".
To get launch time for sia-gce, we need "us-west1-a"

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**


