### PR TITLE
bump awssdk from 2.20.162 to 2.21.6 for netty vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
   <properties>
     <apache.httpclient.version>4.5.14</apache.httpclient.version>
     <aws.version>1.12.567</aws.version>
-    <aws2.version>2.20.162</aws2.version>
+    <aws2.version>2.21.6</aws2.version>
     <gcp.bom.version>26.25.0</gcp.bom.version>
     <gcp.api-client.version>2.2.0</gcp.api-client.version>
     <bouncycastle.version>1.76</bouncycastle.version>


### PR DESCRIPTION
# Description
bump awssdk from 2.20.162 to 2.21.6 for netty vuln.

There is no particular problem with Athenz itself, but awssdk has a dependency on io.netty:netty-codec-http2, which triggers vulnerability detection when using the athenz-zts-java-client.

This issue has been resolved in awssdk version 2.21.4 or higher.
https://github.com/aws/aws-sdk-java-v2/blob/6edd247202a87d8370a2f50ec078d69856ec7170/.changes/2.21.4.json#L9

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

