### PR TITLE
fix membership approval email view in gmail

### DIFF
--- a/servers/zms/src/main/resources/messages/group-membership-approval.html
+++ b/servers/zms/src/main/resources/messages/group-membership-approval.html
@@ -12,7 +12,7 @@
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>
         <div class="hdr">Group Membership Approval Details</div>
-        <div class="bt">Group Membership request has been submitted with the following details:</div>
+        <div class="bt">Please visit the <a href="{6}/workflow/domain?domain={0}">Athenz Membership Review Page</a> to act on this request that has been submitted with the following details:</div>
         <hr>
         <div class="divScroll">
             <table id="t01">
@@ -23,8 +23,6 @@
                 <tr><td class="ch">REQUESTER</td><td class="cv">{4}</td></tr>
             </table>
         </div>
-        <hr>
-        <div class="bt">Please visit the <a href="{5}">Athenz Workflow Screen</a> to act on the request.</div>
     </div>
     <div class="footer-container">
         <div class="footer">This is a generated email from <a href="{6}">Athenz</a>. Please do not respond.</div>

--- a/servers/zms/src/main/resources/messages/membership-approval.html
+++ b/servers/zms/src/main/resources/messages/membership-approval.html
@@ -12,7 +12,7 @@
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>
         <div class="hdr">Membership Approval Details</div>
-        <div class="bt">Membership request has been submitted with the following details:</div>
+        <div class="bt">Please visit the <a href="{6}/workflow/domain?domain={0}">Athenz Membership Review Page</a> to act on this request that has been submitted with the following details:</div>
         <hr>
         <div class="divScroll">
             <table id="t01">
@@ -23,8 +23,6 @@
                 <tr><td class="ch">REQUESTER</td><td class="cv">{4}</td></tr>
             </table>
         </div>
-        <hr>
-        <div class="bt">Please visit the <a href="{5}">Athenz Workflow Screen</a> to act on the request.</div>
     </div>
     <div class="footer-container">
         <div class="footer">This is a generated email from <a href="{6}">Athenz</a>. Please do not respond.</div>

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
@@ -419,6 +419,7 @@ public class PutGroupMembershipNotificationTaskTest {
         System.setProperty("athenz.notification_workflow_url", "https://athenz.example.com/workflow");
         System.setProperty("athenz.notification_support_text", "#Athenz slack channel");
         System.setProperty("athenz.notification_support_url", "https://link.to.athenz.channel.com");
+        System.setProperty("athenz.notification_athenz_ui_url", "https://athenz.example.com");
 
         Map<String, String> details = new HashMap<>();
         details.put("domain", "dom1");
@@ -440,7 +441,7 @@ public class PutGroupMembershipNotificationTaskTest {
         assertTrue(body.contains("user.member1"));
         assertTrue(body.contains("test reason"));
         assertTrue(body.contains("user.requester"));
-        assertTrue(body.contains("https://athenz.example.com/workflow"));
+        assertTrue(body.contains("https://athenz.example.com/workflow/domain?domain=dom1"));
 
         // Make sure support text and url do not appear
 
@@ -448,8 +449,9 @@ public class PutGroupMembershipNotificationTaskTest {
         assertFalse(body.contains("link.to.athenz.channel.com"));
 
         System.clearProperty("athenz.notification_workflow_url");
-        System.clearProperty("notification_support_text");
-        System.clearProperty("notification_support_url");
+        System.clearProperty("athenz.notification_support_text");
+        System.clearProperty("athenz.notification_support_url");
+        System.clearProperty("athenz.notification_athenz_ui_url");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTaskTest.java
@@ -411,6 +411,7 @@ public class PutRoleMembershipNotificationTaskTest {
         System.setProperty("athenz.notification_workflow_url", "https://athenz.example.com/workflow");
         System.setProperty("athenz.notification_support_text", "#Athenz slack channel");
         System.setProperty("athenz.notification_support_url", "https://link.to.athenz.channel.com");
+        System.setProperty("athenz.notification_athenz_ui_url", "https://athenz.example.com");
 
         Map<String, String> details = new HashMap<>();
         details.put("domain", "dom1");
@@ -431,7 +432,7 @@ public class PutRoleMembershipNotificationTaskTest {
         assertTrue(body.contains("user.member1"));
         assertTrue(body.contains("test reason"));
         assertTrue(body.contains("user.requester"));
-        assertTrue(body.contains("https://athenz.example.com/workflow"));
+        assertTrue(body.contains("https://athenz.example.com/workflow/domain?domain=dom1"));
 
         // Make sure support text and url do not appear
 
@@ -439,8 +440,9 @@ public class PutRoleMembershipNotificationTaskTest {
         assertFalse(body.contains("link.to.athenz.channel.com"));
 
         System.clearProperty("athenz.notification_workflow_url");
-        System.clearProperty("notification_support_text");
-        System.clearProperty("notification_support_url");
+        System.clearProperty("athenz.notification_support_text");
+        System.clearProperty("athenz.notification_support_url");
+        System.clearProperty("athenz.notification_athenz_ui_url");
     }
 
     @Test


### PR DESCRIPTION
# Description

Moved the workflow link to the top of the message for better visibility. We also directly put the user in the domain view for the requested domain so that if the user has large number of requests from multiple domains, it's automatically filtered for them.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

