### PR TITLE
clean-up hostname verifier support in zts java client

### DIFF
--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSRDLClientMock.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSRDLClientMock.java
@@ -503,7 +503,7 @@ public class ZTSRDLClientMock extends ZTSRDLGeneratedClient implements java.io.C
     @Override
     public RoleToken postRoleCertificateRequest(String domainName, String roleName, RoleCertificateRequest req) {
         if (domainName.equals("exc")) {
-            throw new ResourceException(400, "Invalid request");
+            throw new IllegalArgumentException();
         } if (roleName.equals("no-role")) {
             throw new ResourceException(403, "Forbidden");
         }
@@ -512,6 +512,11 @@ public class ZTSRDLClientMock extends ZTSRDLGeneratedClient implements java.io.C
 
     @Override
     public RoleCertificate postRoleCertificateRequestExt(RoleCertificateRequest req) {
+        if (req.getCsr().contains("exc")) {
+            throw new IllegalArgumentException();
+        } if (req.getCsr().contains("no-role")) {
+            throw new ResourceException(403, "Forbidden");
+        }
         return new RoleCertificate().setX509Certificate("x509cert");
     }
 

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/ProviderHostnameVerifier.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/ProviderHostnameVerifier.java
@@ -40,16 +40,10 @@ public class ProviderHostnameVerifier implements HostnameVerifier {
             certs = session.getPeerCertificates();
         } catch (SSLPeerUnverifiedException ignored) {
         }
-        if (certs == null) {
+        if (certs == null || certs.length == 0) {
             return false;
         }
-        
-        for (Certificate cert : certs) {
-            final X509Certificate x509Cert = (X509Certificate) cert;
-            if (serviceName.equals(Crypto.extractX509CertCommonName(x509Cert))) {
-                return true;
-            }
-        }
-        return false;
+
+        return serviceName.equals(Crypto.extractX509CertCommonName((X509Certificate) certs[0]));
     }
 }


### PR DESCRIPTION
# Description
we really don't need a hostname verifier in zts client, but for backward compatibility we can't really remove this functionality so just a minor cleanup to use functions from crypto class.
also includes some grammatical errors reported by IntelliJ.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

