### PR TITLE
 support proxy principal spiffe uri in access token requests

### DIFF
--- a/libs/go/sia/access/config/config.go
+++ b/libs/go/sia/access/config/config.go
@@ -20,21 +20,23 @@ import "time"
 
 // Role models the configuration to be specified in sia_config
 type Role struct {
-	Service string   `json:"service,omitempty"`    // principal service with role access
-	Roles   []string `json:"roles,omitempty"`      // the roles in the domain in which principal is a member
-	Expiry  int      `json:"expires_in,omitempty"` // requested expiry time for access token in seconds
+	Service                  string   `json:"service,omitempty"`                     // principal service with role access
+	Roles                    []string `json:"roles,omitempty"`                       // the roles in the domain in which principal is a member
+	Expiry                   int      `json:"expires_in,omitempty"`                  // requested expiry time for access token in seconds
+	ProxyPrincipalSpiffeUris string   `json:"proxy_principal_spiffe_uris,omitempty"` // Proxy Principal Spiffe URIs to be included in the token
 }
 
 // AccessToken is the type that holds information AFTER processing the configuration
 type AccessToken struct {
-	FileName string   // FileName under /var/lib/sia/tokens
-	Service  string   // Principal service that is a member of the roles
-	Domain   string   // Domain in which principal is a member of
-	Roles    []string // Roles under the Domain for which access tokens are being requested
-	User     string   // Owner of the access token file on disc
-	Uid      int      // Uid of the Owner of file on disc
-	Gid      int      // Gid of the file on disc
-	Expiry   int      // Expiry of the access token
+	FileName                 string   // FileName under /var/lib/sia/tokens
+	Service                  string   // Principal service that is a member of the roles
+	Domain                   string   // Domain in which principal is a member of
+	Roles                    []string // Roles under the Domain for which access tokens are being requested
+	User                     string   // Owner of the access token file on disc
+	Uid                      int      // Uid of the Owner of file on disc
+	Gid                      int      // Gid of the file on disc
+	Expiry                   int      // Expiry of the access token
+	ProxyPrincipalSpiffeUris string   // Proxy Principal Spiffe URIs to be included in the token
 }
 
 type StoreTokenOptions int

--- a/libs/go/sia/access/tokens/tokens.go
+++ b/libs/go/sia/access/tokens/tokens.go
@@ -151,7 +151,7 @@ func Fetch(opts *config.TokenOptions) ([]string, []error) {
 		}
 		client.AddCredentials(UserAgent, opts.UserAgent)
 
-		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry)))
+		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris)))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("unable to post access token request for domain: %q, roles: %v, err: %v", t.Domain, t.Roles, err))
 			continue
@@ -215,10 +215,13 @@ func TokenDirs(root string, tokens []config.AccessToken) []string {
 	return dirs
 }
 
-func makeTokenRequest(domain string, roles []string, expiryTime int) string {
+func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string) string {
 	params := url.Values{}
 	params.Add("grant_type", "client_credentials")
 	params.Add("expires_in", strconv.Itoa(expiryTime))
+	if proxyPrincipalSpiffeUris != "" {
+		params.Add("proxy_principal_spiffe_uris", proxyPrincipalSpiffeUris)
+	}
 
 	var scope string
 	if roles[0] == "*" {

--- a/libs/go/sia/aws/options/data/sia_config.with-access-tokens
+++ b/libs/go/sia/aws/options/data/sia_config.with-access-tokens
@@ -34,7 +34,13 @@
 
     "athenz.demo/all": {
       "roles": ["*"]
-    }
+    },
+
+    "athenz.demo/spiffe": {
+       "roles": ["writer", "writer-admin"],
+       "expires_in": 10800,
+       "proxy_principal_spiffe_uris": "spiffe://athenz/sa/api,spiffe://athenz/sa/logger"
+     }
   },
   "accounts": [
        {

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -819,14 +819,15 @@ func processAccessTokens(config *Config, processedSvcs []Service) ([]ac.AccessTo
 		}
 
 		accessTokens = append(accessTokens, ac.AccessToken{
-			FileName: fileName,
-			Service:  service,
-			Domain:   domain,
-			Roles:    roles,
-			Expiry:   expiry,
-			User:     processedSvc.User,
-			Uid:      processedSvc.Uid,
-			Gid:      processedSvc.Gid,
+			FileName:                 fileName,
+			Service:                  service,
+			Domain:                   domain,
+			Roles:                    roles,
+			Expiry:                   expiry,
+			User:                     processedSvc.User,
+			Uid:                      processedSvc.Uid,
+			Gid:                      processedSvc.Gid,
+			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
 		})
 	}
 	return accessTokens, nil

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -529,58 +529,75 @@ func TestOptionsWithAccessToken(t *testing.T) {
 	a.Contains(serviceNames, "logger")
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "reader",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"reader"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "reader",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"reader"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "poweruser",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"reader-admin"},
-		Expiry:   10800,
-		User:     "nobody",
+		FileName:                 "poweruser",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"reader-admin"},
+		Expiry:                   10800,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "consumer",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"reader", "reader-admin"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "consumer",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"reader", "reader-admin"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "writer",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"writer", "writer-admin"},
-		Expiry:   10800,
-		User:     "nobody",
+		FileName:                 "writer",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"writer", "writer-admin"},
+		Expiry:                   10800,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "splunk",
-		Service:  "logger",
-		Domain:   "athenz.demo",
-		Roles:    []string{"splunk"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "splunk",
+		Service:                  "logger",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"splunk"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "all",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"*"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "all",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"*"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
+
+	a.True(assertToken(opts.AccessTokens, config.AccessToken{
+		FileName:                 "spiffe",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"writer", "writer-admin"},
+		Expiry:                   10800,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "spiffe://athenz/sa/api,spiffe://athenz/sa/logger",
+	}))
+
 	log.Print(opts)
 }
 
@@ -631,7 +648,8 @@ func assertToken(tokens []config.AccessToken, token config.AccessToken) bool {
 			t.Domain == token.Domain &&
 			reflect.DeepEqual(t.Roles, token.Roles) &&
 			t.Expiry == token.Expiry &&
-			t.User == token.User {
+			t.User == token.User &&
+			t.ProxyPrincipalSpiffeUris == token.ProxyPrincipalSpiffeUris {
 			return true
 		}
 	}

--- a/libs/go/sia/options/data/sia_config.with-access-tokens
+++ b/libs/go/sia/options/data/sia_config.with-access-tokens
@@ -34,6 +34,12 @@
 
     "athenz.demo/all": {
       "roles": ["*"]
+    },
+
+    "athenz.demo/spiffe": {
+      "roles": ["writer", "writer-admin"],
+      "expires_in": 10800,
+      "proxy_principal_spiffe_uris": "spiffe://athenz/sa/api,spiffe://athenz/sa/logger"
     }
   },
   "domain": "athenz",

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -888,14 +888,15 @@ func processAccessTokens(config *Config, processedSvcs []Service) ([]ac.AccessTo
 		}
 
 		accessTokens = append(accessTokens, ac.AccessToken{
-			FileName: fileName,
-			Service:  service,
-			Domain:   domain,
-			Roles:    roles,
-			Expiry:   expiry,
-			User:     processedSvc.User,
-			Uid:      processedSvc.Uid,
-			Gid:      processedSvc.Gid,
+			FileName:                 fileName,
+			Service:                  service,
+			Domain:                   domain,
+			Roles:                    roles,
+			Expiry:                   expiry,
+			User:                     processedSvc.User,
+			Uid:                      processedSvc.Uid,
+			Gid:                      processedSvc.Gid,
+			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
 		})
 	}
 	return accessTokens, nil

--- a/libs/go/sia/options/options_test.go
+++ b/libs/go/sia/options/options_test.go
@@ -533,58 +533,75 @@ func TestOptionsWithAccessToken(t *testing.T) {
 	a.Contains(serviceNames, "logger")
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "reader",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"reader"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "reader",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"reader"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "poweruser",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"reader-admin"},
-		Expiry:   10800,
-		User:     "nobody",
+		FileName:                 "poweruser",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"reader-admin"},
+		Expiry:                   10800,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "consumer",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"reader", "reader-admin"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "consumer",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"reader", "reader-admin"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "writer",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"writer", "writer-admin"},
-		Expiry:   10800,
-		User:     "nobody",
+		FileName:                 "writer",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"writer", "writer-admin"},
+		Expiry:                   10800,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "splunk",
-		Service:  "logger",
-		Domain:   "athenz.demo",
-		Roles:    []string{"splunk"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "splunk",
+		Service:                  "logger",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"splunk"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
 
 	a.True(assertToken(opts.AccessTokens, config.AccessToken{
-		FileName: "all",
-		Service:  "api",
-		Domain:   "athenz.demo",
-		Roles:    []string{"*"},
-		Expiry:   DefaultTokenExpiry,
-		User:     "nobody",
+		FileName:                 "all",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"*"},
+		Expiry:                   DefaultTokenExpiry,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "",
 	}))
+
+	a.True(assertToken(opts.AccessTokens, config.AccessToken{
+		FileName:                 "spiffe",
+		Service:                  "api",
+		Domain:                   "athenz.demo",
+		Roles:                    []string{"writer", "writer-admin"},
+		Expiry:                   10800,
+		User:                     "nobody",
+		ProxyPrincipalSpiffeUris: "spiffe://athenz/sa/api,spiffe://athenz/sa/logger",
+	}))
+
 	log.Print(opts)
 }
 
@@ -635,7 +652,8 @@ func assertToken(tokens []config.AccessToken, token config.AccessToken) bool {
 			t.Domain == token.Domain &&
 			reflect.DeepEqual(t.Roles, token.Roles) &&
 			t.Expiry == token.Expiry &&
-			t.User == token.User {
+			t.User == token.User &&
+			t.ProxyPrincipalSpiffeUris == token.ProxyPrincipalSpiffeUris {
 			return true
 		}
 	}


### PR DESCRIPTION
# Description
expose "proxy_principal_spiffe_uris" field in the sia_config file so the clients can request access tokens with the specified comma separated values of spiffe Uris

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

