### PR TITLE
update service provider manager test case

### DIFF
--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/provider/ServiceProviderManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/provider/ServiceProviderManagerTest.java
@@ -62,7 +62,7 @@ public class ServiceProviderManagerTest {
     public void testIsServiceProvider() throws InterruptedException, ExecutionException {
         String testDomainName = "test.domain";
         String testRoleName = "test_role";
-        long fetchFrequency = 5L; // For the test, fetch every second
+        long fetchFrequency = 5L; // For the test, fetch every 5 seconds
         int numberOfThreads = 10;
         System.setProperty(ZMS_PROP_SERVICE_PROVIDER_MANAGER_DOMAIN, testDomainName);
         System.setProperty(ZMS_PROP_SERVICE_PROVIDER_MANAGER_ROLE, testRoleName);


### PR DESCRIPTION
# Description
the test case sets up provider list update every second, but it's possible if the build system is slow, the 10 threads verifying the list don't finish within a second before the list is refreshed. now, it's set to 5 secs so plenty of time for threads to complete their tasks.
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

