### PR TITLE
Fix the server side authorization for the msd api to return kubernetes network policy object

### DIFF
--- a/core/msd/src/main/java/com/yahoo/athenz/msd/MSDSchema.java
+++ b/core/msd/src/main/java/com/yahoo/athenz/msd/MSDSchema.java
@@ -808,7 +808,7 @@ public class MSDSchema {
             .input("request", "KubernetesNetworkPolicyRequest", "Struct representing input options based on the cluster context")
             .headerParam("If-None-Match", "matchingTag", "String", null, "Retrieved from the previous request, this timestamp specifies to the server to return any policies modified since this time")
             .output("ETag", "tag", "String", "The current latest modification timestamp is returned in this header")
-            .auth("read", "{domain}:service.{service}")
+            .auth("read", "{domainName}:service.{serviceName}")
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")
 

--- a/core/msd/src/main/rdl/KubernetesNetworkPolicy.rdli
+++ b/core/msd/src/main/rdl/KubernetesNetworkPolicy.rdli
@@ -9,7 +9,7 @@ resource KubernetesNetworkPolicyResponse POST "/domain/{domainName}/service/{ser
     DomainName domainName; //Name of the domain
     EntityName serviceName; //Name of the service
     KubernetesNetworkPolicyRequest request; //Struct representing input options based on the cluster context
-    authorize ("read", "{domain}:service.{service}");
+    authorize ("read", "{domainName}:service.{serviceName}");
     String matchingTag (header="If-None-Match"); //Retrieved from the previous request, this timestamp specifies to the server to return any policies modified since this time
     String tag (header="ETag", out); //The current latest modification timestamp is returned in this header
     expected OK, NOT_MODIFIED;


### PR DESCRIPTION


# Description
Fix the server side authorization for the msd api to return kubernetes network policy object

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

