### PR TITLE
simplify error messages for access tokens to avoid confusion

### DIFF
--- a/libs/go/sia/access/tokens/tokens.go
+++ b/libs/go/sia/access/tokens/tokens.go
@@ -240,7 +240,7 @@ func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrinci
 
 func NewTokenOptions(options *options.Options, ztsUrl string, userAgent string) (*config.TokenOptions, error) {
 	if options.AccessTokens == nil {
-		return nil, fmt.Errorf("access-token object is not presented")
+		return nil, fmt.Errorf("not configured to fetch access tokens")
 	}
 	dirs := []string{options.CertDir, options.KeyDir, options.BackupDir}
 	dirs = append(dirs, TokenDirs(options.TokenDir, options.AccessTokens)...)

--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -855,7 +855,7 @@ func tokenOptions(opts *options.Options, ztsUrl string) (*config.TokenOptions, e
 	userAgent := fmt.Sprintf("%s-%s", opts.Provider, opts.InstanceId)
 	tokenOpts, err := tokens.NewTokenOptions(options.LegacyOptions(opts), ztsUrl, userAgent)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create token options: %s", err.Error())
+		return nil, fmt.Errorf("processing access tokens: %s", err.Error())
 	}
 	if opts.StoreTokenOption != nil {
 		tokenOpts.StoreOptions = config.StoreTokenOptions(*opts.StoreTokenOption)

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -846,7 +846,7 @@ func tokenOptions(opts *options.Options, ztsUrl string) (*config.TokenOptions, e
 	userAgent := fmt.Sprintf("%s-%s", opts.Provider, opts.InstanceId)
 	tokenOpts, err := tokens.NewTokenOptions(opts, ztsUrl, userAgent)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create token options: %s", err.Error())
+		return nil, fmt.Errorf("processing access tokens: %s", err.Error())
 	}
 	if opts.StoreTokenOption != nil {
 		tokenOpts.StoreOptions = config.StoreTokenOptions(*opts.StoreTokenOption)


### PR DESCRIPTION
# Description
when the user does not have any access tokens configured for SIA, they see the following lines in syslog:

unable to create token options: access-token object is not presented

this is somewhat confusing and users think there are error. instead this will be replaced with:

processing access tokens: not configured to fetch access tokens

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

