### PR TITLE
new role/group/domain attributes - no implementation

### DIFF
--- a/clients/go/msd/msd_schema.go
+++ b/clients/go/msd/msd_schema.go
@@ -830,7 +830,7 @@ func init() {
 	mPostKubernetesNetworkPolicyRequest.Input("request", "KubernetesNetworkPolicyRequest", false, "", "", false, nil, "Struct representing input options based on the cluster context")
 	mPostKubernetesNetworkPolicyRequest.Input("matchingTag", "String", false, "", "If-None-Match", false, nil, "Retrieved from the previous request, this timestamp specifies to the server to return any policies modified since this time")
 	mPostKubernetesNetworkPolicyRequest.Output("tag", "String", "ETag", false, "The current latest modification timestamp is returned in this header")
-	mPostKubernetesNetworkPolicyRequest.Auth("read", "{domain}:service.{service}", false, "")
+	mPostKubernetesNetworkPolicyRequest.Auth("read", "{domainName}:service.{serviceName}", false, "")
 	mPostKubernetesNetworkPolicyRequest.Exception("BAD_REQUEST", "ResourceError", "")
 	mPostKubernetesNetworkPolicyRequest.Exception("FORBIDDEN", "ResourceError", "")
 	mPostKubernetesNetworkPolicyRequest.Exception("NOT_FOUND", "ResourceError", "")

--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -278,6 +278,12 @@ type DomainMeta struct {
 	// features enabled per domain (system attribute)
 	//
 	FeatureFlags *int32 `json:"featureFlags,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
+	// a single value
+	//
+	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 }
 
 // NewDomainMeta - creates an initialized DomainMeta instance, returns a pointer to it
@@ -528,6 +534,12 @@ type Domain struct {
 	// features enabled per domain (system attribute)
 	//
 	FeatureFlags *int32 `json:"featureFlags,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
+	// a single value
+	//
+	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// the common name to be referred to, the symbolic id. It is immutable
@@ -1275,6 +1287,22 @@ type RoleMeta struct {
 	// last review timestamp of the role
 	//
 	LastReviewedDate *rdl.Timestamp `json:"lastReviewedDate,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Flag indicates whether to allow expired members to renew their membership
+	//
+	SelfRenewEnabled *bool `json:"selfRenewEnabled,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Number of minutes members can renew their membership if self review option
+	// is enabled
+	//
+	SelfRenewMins *int32 `json:"selfRenewMins,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Maximum number of members allowed in the group
+	//
+	MaxMembers *int32 `json:"maxMembers,omitempty" rdl:"optional" yaml:",omitempty"`
 }
 
 // NewRoleMeta - creates an initialized RoleMeta instance, returns a pointer to it
@@ -1445,6 +1473,22 @@ type Role struct {
 	// last review timestamp of the role
 	//
 	LastReviewedDate *rdl.Timestamp `json:"lastReviewedDate,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Flag indicates whether to allow expired members to renew their membership
+	//
+	SelfRenewEnabled *bool `json:"selfRenewEnabled,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Number of minutes members can renew their membership if self review option
+	// is enabled
+	//
+	SelfRenewMins *int32 `json:"selfRenewMins,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Maximum number of members allowed in the group
+	//
+	MaxMembers *int32 `json:"maxMembers,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the role
@@ -3666,6 +3710,12 @@ type TopLevelDomain struct {
 	FeatureFlags *int32 `json:"featureFlags,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
+	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
+	// a single value
+	//
+	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
 	// name of the domain
 	//
 	Name SimpleName `json:"name"`
@@ -3938,6 +3988,12 @@ type SubDomain struct {
 	// features enabled per domain (system attribute)
 	//
 	FeatureFlags *int32 `json:"featureFlags,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
+	// a single value
+	//
+	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the domain
@@ -4226,6 +4282,12 @@ type UserDomain struct {
 	// features enabled per domain (system attribute)
 	//
 	FeatureFlags *int32 `json:"featureFlags,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
+	// a single value
+	//
+	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// user id which will be the domain name
@@ -5405,6 +5467,22 @@ type GroupMeta struct {
 	// last review timestamp of the group
 	//
 	LastReviewedDate *rdl.Timestamp `json:"lastReviewedDate,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Flag indicates whether to allow expired members to renew their membership
+	//
+	SelfRenewEnabled *bool `json:"selfRenewEnabled,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Number of minutes members can renew their membership if self review option
+	// is enabled
+	//
+	SelfRenewMins *int32 `json:"selfRenewMins,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Maximum number of members allowed in the group
+	//
+	MaxMembers *int32 `json:"maxMembers,omitempty" rdl:"optional" yaml:",omitempty"`
 }
 
 // NewGroupMeta - creates an initialized GroupMeta instance, returns a pointer to it
@@ -5517,6 +5595,22 @@ type Group struct {
 	// last review timestamp of the group
 	//
 	LastReviewedDate *rdl.Timestamp `json:"lastReviewedDate,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Flag indicates whether to allow expired members to renew their membership
+	//
+	SelfRenewEnabled *bool `json:"selfRenewEnabled,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Number of minutes members can renew their membership if self review option
+	// is enabled
+	//
+	SelfRenewMins *int32 `json:"selfRenewMins,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// Maximum number of members allowed in the group
+	//
+	MaxMembers *int32 `json:"maxMembers,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the group
@@ -6698,6 +6792,12 @@ type DomainData struct {
 	// features enabled per domain (system attribute)
 	//
 	FeatureFlags *int32 `json:"featureFlags,omitempty" rdl:"optional" yaml:",omitempty"`
+
+	//
+	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
+	// a single value
+	//
+	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the domain

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -161,6 +161,7 @@ func init() {
 	tDomainMeta.Field("memberPurgeExpiryDays", "Int32", true, nil, "purge role/group members with expiry date configured days in the past")
 	tDomainMeta.Field("productId", "String", true, nil, "associated product id (system attribute - uniqueness check - if enabled)")
 	tDomainMeta.Field("featureFlags", "Int32", true, nil, "features enabled per domain (system attribute)")
+	tDomainMeta.MapField("contacts", "SimpleName", "MemberName", true, "list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value")
 	sb.AddType(tDomainMeta.Build())
 
 	tDomain := rdl.NewStructTypeBuilder("DomainMeta", "Domain")
@@ -246,6 +247,9 @@ func init() {
 	tRoleMeta.Field("auditEnabled", "Bool", true, false, "Flag indicates whether or not role updates should be approved by GRC. If true, the auditRef parameter must be supplied(not empty) for any API defining it.")
 	tRoleMeta.Field("deleteProtection", "Bool", true, false, "If true, ask for delete confirmation in audit and review enabled roles.")
 	tRoleMeta.Field("lastReviewedDate", "Timestamp", true, nil, "last review timestamp of the role")
+	tRoleMeta.Field("selfRenewEnabled", "Bool", true, false, "Flag indicates whether to allow expired members to renew their membership")
+	tRoleMeta.Field("selfRenewMins", "Int32", true, nil, "Number of minutes members can renew their membership if self review option is enabled")
+	tRoleMeta.Field("maxMembers", "Int32", true, nil, "Maximum number of members allowed in the group")
 	sb.AddType(tRoleMeta.Build())
 
 	tRole := rdl.NewStructTypeBuilder("RoleMeta", "Role")
@@ -588,6 +592,9 @@ func init() {
 	tGroupMeta.Field("auditEnabled", "Bool", true, false, "Flag indicates whether or not group updates should require GRC approval. If true, the auditRef parameter must be supplied(not empty) for any API defining it")
 	tGroupMeta.Field("deleteProtection", "Bool", true, false, "If true, ask for delete confirmation in audit and review enabled groups.")
 	tGroupMeta.Field("lastReviewedDate", "Timestamp", true, nil, "last review timestamp of the group")
+	tGroupMeta.Field("selfRenewEnabled", "Bool", true, false, "Flag indicates whether to allow expired members to renew their membership")
+	tGroupMeta.Field("selfRenewMins", "Int32", true, nil, "Number of minutes members can renew their membership if self review option is enabled")
+	tGroupMeta.Field("maxMembers", "Int32", true, nil, "Maximum number of members allowed in the group")
 	sb.AddType(tGroupMeta.Build())
 
 	tGroup := rdl.NewStructTypeBuilder("GroupMeta", "Group")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/Domain.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/Domain.java
@@ -90,6 +90,9 @@ public class Domain {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Integer featureFlags;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> contacts;
     public String name;
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -266,6 +269,13 @@ public class Domain {
     public Integer getFeatureFlags() {
         return featureFlags;
     }
+    public Domain setContacts(Map<String, String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
     public Domain setName(String name) {
         this.name = name;
         return this;
@@ -365,6 +375,9 @@ public class Domain {
                 return false;
             }
             if (featureFlags == null ? a.featureFlags != null : !featureFlags.equals(a.featureFlags)) {
+                return false;
+            }
+            if (contacts == null ? a.contacts != null : !contacts.equals(a.contacts)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/DomainData.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/DomainData.java
@@ -86,6 +86,9 @@ public class DomainData {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Integer featureFlags;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> contacts;
     public String name;
     public List<Role> roles;
     public SignedPolicies policies;
@@ -262,6 +265,13 @@ public class DomainData {
     public Integer getFeatureFlags() {
         return featureFlags;
     }
+    public DomainData setContacts(Map<String, String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
     public DomainData setName(String name) {
         this.name = name;
         return this;
@@ -389,6 +399,9 @@ public class DomainData {
                 return false;
             }
             if (featureFlags == null ? a.featureFlags != null : !featureFlags.equals(a.featureFlags)) {
+                return false;
+            }
+            if (contacts == null ? a.contacts != null : !contacts.equals(a.contacts)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/DomainMeta.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/DomainMeta.java
@@ -86,6 +86,9 @@ public class DomainMeta {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Integer featureFlags;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> contacts;
 
     public DomainMeta setDescription(String description) {
         this.description = description;
@@ -255,6 +258,13 @@ public class DomainMeta {
     public Integer getFeatureFlags() {
         return featureFlags;
     }
+    public DomainMeta setContacts(Map<String, String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -333,6 +343,9 @@ public class DomainMeta {
                 return false;
             }
             if (featureFlags == null ? a.featureFlags != null : !featureFlags.equals(a.featureFlags)) {
+                return false;
+            }
+            if (contacts == null ? a.contacts != null : !contacts.equals(a.contacts)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/Group.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/Group.java
@@ -47,6 +47,15 @@ public class Group {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Timestamp lastReviewedDate;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Boolean selfRenewEnabled;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer selfRenewMins;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer maxMembers;
     public String name;
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -135,6 +144,27 @@ public class Group {
     public Timestamp getLastReviewedDate() {
         return lastReviewedDate;
     }
+    public Group setSelfRenewEnabled(Boolean selfRenewEnabled) {
+        this.selfRenewEnabled = selfRenewEnabled;
+        return this;
+    }
+    public Boolean getSelfRenewEnabled() {
+        return selfRenewEnabled;
+    }
+    public Group setSelfRenewMins(Integer selfRenewMins) {
+        this.selfRenewMins = selfRenewMins;
+        return this;
+    }
+    public Integer getSelfRenewMins() {
+        return selfRenewMins;
+    }
+    public Group setMaxMembers(Integer maxMembers) {
+        this.maxMembers = maxMembers;
+        return this;
+    }
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
     public Group setName(String name) {
         this.name = name;
         return this;
@@ -202,6 +232,15 @@ public class Group {
                 return false;
             }
             if (lastReviewedDate == null ? a.lastReviewedDate != null : !lastReviewedDate.equals(a.lastReviewedDate)) {
+                return false;
+            }
+            if (selfRenewEnabled == null ? a.selfRenewEnabled != null : !selfRenewEnabled.equals(a.selfRenewEnabled)) {
+                return false;
+            }
+            if (selfRenewMins == null ? a.selfRenewMins != null : !selfRenewMins.equals(a.selfRenewMins)) {
+                return false;
+            }
+            if (maxMembers == null ? a.maxMembers != null : !maxMembers.equals(a.maxMembers)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/GroupMeta.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/GroupMeta.java
@@ -47,6 +47,15 @@ public class GroupMeta {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Timestamp lastReviewedDate;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Boolean selfRenewEnabled;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer selfRenewMins;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer maxMembers;
 
     public GroupMeta setSelfServe(Boolean selfServe) {
         this.selfServe = selfServe;
@@ -125,6 +134,27 @@ public class GroupMeta {
     public Timestamp getLastReviewedDate() {
         return lastReviewedDate;
     }
+    public GroupMeta setSelfRenewEnabled(Boolean selfRenewEnabled) {
+        this.selfRenewEnabled = selfRenewEnabled;
+        return this;
+    }
+    public Boolean getSelfRenewEnabled() {
+        return selfRenewEnabled;
+    }
+    public GroupMeta setSelfRenewMins(Integer selfRenewMins) {
+        this.selfRenewMins = selfRenewMins;
+        return this;
+    }
+    public Integer getSelfRenewMins() {
+        return selfRenewMins;
+    }
+    public GroupMeta setMaxMembers(Integer maxMembers) {
+        this.maxMembers = maxMembers;
+        return this;
+    }
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -164,6 +194,15 @@ public class GroupMeta {
                 return false;
             }
             if (lastReviewedDate == null ? a.lastReviewedDate != null : !lastReviewedDate.equals(a.lastReviewedDate)) {
+                return false;
+            }
+            if (selfRenewEnabled == null ? a.selfRenewEnabled != null : !selfRenewEnabled.equals(a.selfRenewEnabled)) {
+                return false;
+            }
+            if (selfRenewMins == null ? a.selfRenewMins != null : !selfRenewMins.equals(a.selfRenewMins)) {
+                return false;
+            }
+            if (maxMembers == null ? a.maxMembers != null : !maxMembers.equals(a.maxMembers)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/Role.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/Role.java
@@ -77,6 +77,15 @@ public class Role {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Timestamp lastReviewedDate;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Boolean selfRenewEnabled;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer selfRenewMins;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer maxMembers;
     public String name;
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -227,6 +236,27 @@ public class Role {
     public Timestamp getLastReviewedDate() {
         return lastReviewedDate;
     }
+    public Role setSelfRenewEnabled(Boolean selfRenewEnabled) {
+        this.selfRenewEnabled = selfRenewEnabled;
+        return this;
+    }
+    public Boolean getSelfRenewEnabled() {
+        return selfRenewEnabled;
+    }
+    public Role setSelfRenewMins(Integer selfRenewMins) {
+        this.selfRenewMins = selfRenewMins;
+        return this;
+    }
+    public Integer getSelfRenewMins() {
+        return selfRenewMins;
+    }
+    public Role setMaxMembers(Integer maxMembers) {
+        this.maxMembers = maxMembers;
+        return this;
+    }
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
     public Role setName(String name) {
         this.name = name;
         return this;
@@ -332,6 +362,15 @@ public class Role {
                 return false;
             }
             if (lastReviewedDate == null ? a.lastReviewedDate != null : !lastReviewedDate.equals(a.lastReviewedDate)) {
+                return false;
+            }
+            if (selfRenewEnabled == null ? a.selfRenewEnabled != null : !selfRenewEnabled.equals(a.selfRenewEnabled)) {
+                return false;
+            }
+            if (selfRenewMins == null ? a.selfRenewMins != null : !selfRenewMins.equals(a.selfRenewMins)) {
+                return false;
+            }
+            if (maxMembers == null ? a.maxMembers != null : !maxMembers.equals(a.maxMembers)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/RoleMeta.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/RoleMeta.java
@@ -71,6 +71,15 @@ public class RoleMeta {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Timestamp lastReviewedDate;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Boolean selfRenewEnabled;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer selfRenewMins;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer maxMembers;
 
     public RoleMeta setSelfServe(Boolean selfServe) {
         this.selfServe = selfServe;
@@ -205,6 +214,27 @@ public class RoleMeta {
     public Timestamp getLastReviewedDate() {
         return lastReviewedDate;
     }
+    public RoleMeta setSelfRenewEnabled(Boolean selfRenewEnabled) {
+        this.selfRenewEnabled = selfRenewEnabled;
+        return this;
+    }
+    public Boolean getSelfRenewEnabled() {
+        return selfRenewEnabled;
+    }
+    public RoleMeta setSelfRenewMins(Integer selfRenewMins) {
+        this.selfRenewMins = selfRenewMins;
+        return this;
+    }
+    public Integer getSelfRenewMins() {
+        return selfRenewMins;
+    }
+    public RoleMeta setMaxMembers(Integer maxMembers) {
+        this.maxMembers = maxMembers;
+        return this;
+    }
+    public Integer getMaxMembers() {
+        return maxMembers;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -268,6 +298,15 @@ public class RoleMeta {
                 return false;
             }
             if (lastReviewedDate == null ? a.lastReviewedDate != null : !lastReviewedDate.equals(a.lastReviewedDate)) {
+                return false;
+            }
+            if (selfRenewEnabled == null ? a.selfRenewEnabled != null : !selfRenewEnabled.equals(a.selfRenewEnabled)) {
+                return false;
+            }
+            if (selfRenewMins == null ? a.selfRenewMins != null : !selfRenewMins.equals(a.selfRenewMins)) {
+                return false;
+            }
+            if (maxMembers == null ? a.maxMembers != null : !maxMembers.equals(a.maxMembers)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/SubDomain.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/SubDomain.java
@@ -86,6 +86,9 @@ public class SubDomain {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Integer featureFlags;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> contacts;
     public String name;
     public List<String> adminUsers;
     @RdlOptional
@@ -261,6 +264,13 @@ public class SubDomain {
     public Integer getFeatureFlags() {
         return featureFlags;
     }
+    public SubDomain setContacts(Map<String, String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
     public SubDomain setName(String name) {
         this.name = name;
         return this;
@@ -367,6 +377,9 @@ public class SubDomain {
                 return false;
             }
             if (featureFlags == null ? a.featureFlags != null : !featureFlags.equals(a.featureFlags)) {
+                return false;
+            }
+            if (contacts == null ? a.contacts != null : !contacts.equals(a.contacts)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/TopLevelDomain.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/TopLevelDomain.java
@@ -87,6 +87,9 @@ public class TopLevelDomain {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Integer featureFlags;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> contacts;
     public String name;
     public List<String> adminUsers;
     @RdlOptional
@@ -261,6 +264,13 @@ public class TopLevelDomain {
     public Integer getFeatureFlags() {
         return featureFlags;
     }
+    public TopLevelDomain setContacts(Map<String, String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
     public TopLevelDomain setName(String name) {
         this.name = name;
         return this;
@@ -360,6 +370,9 @@ public class TopLevelDomain {
                 return false;
             }
             if (featureFlags == null ? a.featureFlags != null : !featureFlags.equals(a.featureFlags)) {
+                return false;
+            }
+            if (contacts == null ? a.contacts != null : !contacts.equals(a.contacts)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/UserDomain.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/UserDomain.java
@@ -86,6 +86,9 @@ public class UserDomain {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Integer featureFlags;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Map<String, String> contacts;
     public String name;
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -259,6 +262,13 @@ public class UserDomain {
     public Integer getFeatureFlags() {
         return featureFlags;
     }
+    public UserDomain setContacts(Map<String, String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+    public Map<String, String> getContacts() {
+        return contacts;
+    }
     public UserDomain setName(String name) {
         this.name = name;
         return this;
@@ -351,6 +361,9 @@ public class UserDomain {
                 return false;
             }
             if (featureFlags == null ? a.featureFlags != null : !featureFlags.equals(a.featureFlags)) {
+                return false;
+            }
+            if (contacts == null ? a.contacts != null : !contacts.equals(a.contacts)) {
                 return false;
             }
             if (name == null ? a.name != null : !name.equals(a.name)) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -137,7 +137,8 @@ public class ZMSSchema {
             .field("businessService", "String", true, "associated business service with domain")
             .field("memberPurgeExpiryDays", "Int32", true, "purge role/group members with expiry date configured days in the past")
             .field("productId", "String", true, "associated product id (system attribute - uniqueness check - if enabled)")
-            .field("featureFlags", "Int32", true, "features enabled per domain (system attribute)");
+            .field("featureFlags", "Int32", true, "features enabled per domain (system attribute)")
+            .mapField("contacts", "SimpleName", "MemberName", true, "list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value");
 
         sb.structType("Domain", "DomainMeta")
             .comment("A domain is an independent partition of users, roles, and resources. Its name represents the definition of a namespace; the only way a new namespace can be created, from the top, is by creating Domains. Administration of a domain is governed by the parent domain (using reverse-DNS namespaces). The top level domains are governed by the special \"sys.auth\" domain.")
@@ -213,7 +214,10 @@ public class ZMSSchema {
             .field("description", "String", true, "a description of the role")
             .field("auditEnabled", "Bool", true, "Flag indicates whether or not role updates should be approved by GRC. If true, the auditRef parameter must be supplied(not empty) for any API defining it.", false)
             .field("deleteProtection", "Bool", true, "If true, ask for delete confirmation in audit and review enabled roles.", false)
-            .field("lastReviewedDate", "Timestamp", true, "last review timestamp of the role");
+            .field("lastReviewedDate", "Timestamp", true, "last review timestamp of the role")
+            .field("selfRenewEnabled", "Bool", true, "Flag indicates whether to allow expired members to renew their membership", false)
+            .field("selfRenewMins", "Int32", true, "Number of minutes members can renew their membership if self review option is enabled")
+            .field("maxMembers", "Int32", true, "Maximum number of members allowed in the group");
 
         sb.structType("Role", "RoleMeta")
             .comment("The representation for a Role with set of members. The members (Array<MemberName>) field is deprecated and not used in role objects since it incorrectly lists all the members in the role without taking into account if the member is expired or possibly disabled. Thus, using this attribute will result in incorrect authorization checks by the client and, thus, it's no longer being populated. All applications must use the roleMembers field and take into account all the attributes of the member.")
@@ -509,7 +513,10 @@ public class ZMSSchema {
             .mapField("tags", "CompoundName", "TagValueList", true, "key-value pair tags, tag might contain multiple values")
             .field("auditEnabled", "Bool", true, "Flag indicates whether or not group updates should require GRC approval. If true, the auditRef parameter must be supplied(not empty) for any API defining it", false)
             .field("deleteProtection", "Bool", true, "If true, ask for delete confirmation in audit and review enabled groups.", false)
-            .field("lastReviewedDate", "Timestamp", true, "last review timestamp of the group");
+            .field("lastReviewedDate", "Timestamp", true, "last review timestamp of the group")
+            .field("selfRenewEnabled", "Bool", true, "Flag indicates whether to allow expired members to renew their membership", false)
+            .field("selfRenewMins", "Int32", true, "Number of minutes members can renew their membership if self review option is enabled")
+            .field("maxMembers", "Int32", true, "Maximum number of members allowed in the group");
 
         sb.structType("Group", "GroupMeta")
             .comment("The representation for a Group with set of members.")

--- a/core/zms/src/main/rdl/Domain.tdl
+++ b/core/zms/src/main/rdl/Domain.tdl
@@ -30,6 +30,7 @@ type DomainMeta Struct {
     Int32 memberPurgeExpiryDays (optional); //purge role/group members with expiry date configured days in the past
     String productId (optional); //associated product id (system attribute - uniqueness check - if enabled)
     Int32 featureFlags (optional); //features enabled per domain (system attribute)
+    Map<SimpleName,MemberName> contacts (optional); //list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value
 }
 
 //A domain is an independent partition of users, roles, and resources.

--- a/core/zms/src/main/rdl/Group.tdl
+++ b/core/zms/src/main/rdl/Group.tdl
@@ -56,6 +56,9 @@ type GroupMeta Struct {
     Bool auditEnabled (optional, default=false); //Flag indicates whether or not group updates should require GRC approval. If true, the auditRef parameter must be supplied(not empty) for any API defining it
     Bool deleteProtection (optional, default=false); //If true, ask for delete confirmation in audit and review enabled groups.
     Timestamp lastReviewedDate (optional); //last review timestamp of the group
+    Bool selfRenewEnabled (optional, default=false); //Flag indicates whether to allow expired members to renew their membership
+    Int32 selfRenewMins (optional); //Number of minutes members can renew their membership if self review option is enabled
+    Int32 maxMembers (optional); //Maximum number of members allowed in the group
 }
 
 //The representation for a Group with set of members.

--- a/core/zms/src/main/rdl/Role.tdl
+++ b/core/zms/src/main/rdl/Role.tdl
@@ -55,6 +55,9 @@ type RoleMeta Struct {
     Bool auditEnabled (optional, default=false); //Flag indicates whether or not role updates should be approved by GRC. If true, the auditRef parameter must be supplied(not empty) for any API defining it.
     Bool deleteProtection (optional, default=false); //If true, ask for delete confirmation in audit and review enabled roles.
     Timestamp lastReviewedDate (optional); //last review timestamp of the role
+    Bool selfRenewEnabled (optional, default=false); //Flag indicates whether to allow expired members to renew their membership
+    Int32 selfRenewMins (optional); //Number of minutes members can renew their membership if self review option is enabled
+    Int32 maxMembers (optional); //Maximum number of members allowed in the group
 }
 
 //The representation for a Role with set of members.

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/DomainTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/DomainTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.*;
 import static org.testng.Assert.assertFalse;
@@ -84,7 +85,7 @@ public class DomainTest {
                 .setAzureSubscription("azure").setGcpProject("gcp").setBusinessService("business-service")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setMemberPurgeExpiryDays(10).setGcpProjectNumber("1240").setProductId("abcd-1234")
-                .setFeatureFlags(3);
+                .setFeatureFlags(3).setContacts(Map.of("pe-owner", "user.test"));
 
         Validator.Result result = validator.validate(dm, "DomainMeta");
         assertTrue(result.valid);
@@ -114,6 +115,7 @@ public class DomainTest {
         assertEquals(dm.getMemberPurgeExpiryDays(), 10);
         assertEquals(dm.getProductId(), "abcd-1234");
         assertEquals(dm.getFeatureFlags(), 3);
+        assertEquals(dm.getContacts(), Map.of("pe-owner", "user.test"));
 
         DomainMeta dm2 = new DomainMeta().init();
         dm2.setDescription("domain desc").setOrg("org:test").setEnabled(true).setAuditEnabled(false)
@@ -124,10 +126,17 @@ public class DomainTest {
                 .setAzureSubscription("azure").setGcpProject("gcp").setBusinessService("business-service")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setMemberPurgeExpiryDays(10).setGcpProjectNumber("1240").setProductId("abcd-1234")
-                .setFeatureFlags(3);
+                .setFeatureFlags(3).setContacts(Map.of("pe-owner", "user.test"));
 
         assertEquals(dm, dm2);
         assertEquals(dm, dm);
+
+        dm2.setContacts(Map.of("product-owner", "user.test"));
+        assertNotEquals(dm, dm2);
+        dm2.setContacts(null);
+        assertNotEquals(dm, dm2);
+        dm2.setContacts(Map.of("pe-owner", "user.test"));
+        assertEquals(dm, dm2);
 
         dm2.setUserAuthorityFilter("NotOnShore");
         assertNotEquals(dm, dm2);
@@ -302,7 +311,8 @@ public class DomainTest {
                 .setServiceExpiryDays(40).setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1242").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1242").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         result = validator.validate(tld, "TopLevelDomain");
         assertTrue(result.valid);
@@ -335,6 +345,7 @@ public class DomainTest {
         assertEquals(tld.getMemberPurgeExpiryDays(), 10);
         assertEquals(tld.getProductId(), "abcd-1234");
         assertEquals(tld.getFeatureFlags(), 3);
+        assertEquals(tld.getContacts(), Map.of("pe-owner", "user.test"));
 
         TopLevelDomain tld2 = new TopLevelDomain().setDescription("domain desc").setOrg("org:test").setEnabled(true)
                 .setAuditEnabled(false).setAccount("aws").setYpmId(10).setName("testdomain").setAdminUsers(admins)
@@ -343,10 +354,18 @@ public class DomainTest {
                 .setServiceExpiryDays(40).setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1242").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1242").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         assertEquals(tld, tld2);
         assertEquals(tld, tld);
+
+        tld2.setContacts(Map.of("product-owner", "user.test"));
+        assertNotEquals(tld, tld2);
+        tld2.setContacts(null);
+        assertNotEquals(tld, tld2);
+        tld2.setContacts(Map.of("pe-owner", "user.test"));
+        assertEquals(tld, tld2);
 
         tld2.setUserAuthorityFilter("NotOnShore");
         assertNotEquals(tld, tld2);
@@ -509,7 +528,8 @@ public class DomainTest {
                 .setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1244").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1244").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         Validator.Result result = validator.validate(sd, "SubDomain");
         assertTrue(result.valid, result.error);
@@ -543,6 +563,7 @@ public class DomainTest {
         assertEquals(sd.getMemberPurgeExpiryDays(), 10);
         assertEquals(sd.getProductId(), "abcd-1234");
         assertEquals(sd.getFeatureFlags(), 3);
+        assertEquals(sd.getContacts(), Map.of("pe-owner", "user.test"));
 
         SubDomain sd2 = new SubDomain().setDescription("domain desc").setOrg("org:test").setEnabled(true)
                 .setAuditEnabled(false).setAccount("aws").setYpmId(10).setName("testdomain").setAdminUsers(admins)
@@ -553,11 +574,19 @@ public class DomainTest {
                 .setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1244").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1244").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         assertEquals(sd, sd2);
         assertEquals(sd, sd);
         assertNotEquals(schema, sd);
+
+        sd2.setContacts(Map.of("product-owner", "user.test"));
+        assertNotEquals(sd, sd2);
+        sd2.setContacts(null);
+        assertNotEquals(sd, sd2);
+        sd2.setContacts(Map.of("pe-owner", "user.test"));
+        assertEquals(sd, sd2);
 
         sd2.setUserAuthorityFilter("NotOnShore");
         assertNotEquals(sd, sd2);
@@ -719,7 +748,7 @@ public class DomainTest {
                 .setGroupExpiryDays(50).setAzureSubscription("azure").setBusinessService("business-service")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setMemberPurgeExpiryDays(10).setGcpProject("gcp").setGcpProjectNumber("1246")
-                .setProductId("abcd-1234").setFeatureFlags(3);
+                .setProductId("abcd-1234").setFeatureFlags(3).setContacts(Map.of("pe-owner", "user.test"));
 
         Validator.Result result = validator.validate(ud, "UserDomain");
         assertTrue(result.valid);
@@ -751,6 +780,7 @@ public class DomainTest {
         assertEquals(ud.getMemberPurgeExpiryDays(), 10);
         assertEquals(ud.getProductId(), "abcd-1234");
         assertEquals(ud.getFeatureFlags(), 3);
+        assertEquals(ud.getContacts(), Map.of("pe-owner", "user.test"));
 
         UserDomain ud2 = new UserDomain().setDescription("domain desc").setOrg("org:test").setEnabled(true)
                 .setAuditEnabled(false).setAccount("aws").setYpmId(10).setName("testuser")
@@ -761,10 +791,17 @@ public class DomainTest {
                 .setGroupExpiryDays(50).setAzureSubscription("azure").setBusinessService("business-service")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setMemberPurgeExpiryDays(10).setGcpProject("gcp").setGcpProjectNumber("1246")
-                .setProductId("abcd-1234").setFeatureFlags(3);
+                .setProductId("abcd-1234").setFeatureFlags(3).setContacts(Map.of("pe-owner", "user.test"));
 
         assertEquals(ud, ud2);
         assertEquals(ud, ud);
+
+        ud2.setContacts(Map.of("product-owner", "user.test"));
+        assertNotEquals(ud, ud2);
+        ud2.setContacts(null);
+        assertNotEquals(ud, ud2);
+        ud2.setContacts(Map.of("pe-owner", "user.test"));
+        assertEquals(ud, ud2);
 
         ud2.setUserAuthorityFilter("NotOnShore");
         assertNotEquals(ud, ud2);
@@ -945,7 +982,8 @@ public class DomainTest {
                 .setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1237").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1237").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         Validator.Result result = validator.validate(d, "Domain");
         assertTrue(result.valid);
@@ -978,6 +1016,7 @@ public class DomainTest {
         assertEquals(d.getMemberPurgeExpiryDays(), 10);
         assertEquals(d.getProductId(), "abcd-1234");
         assertEquals(d.getFeatureFlags(), 3);
+        assertEquals(d.getContacts(), Map.of("pe-owner", "user.test"));
 
         Domain d2 = new Domain();
         d2.setName("test.domain").setModified(Timestamp.fromMillis(123456789123L)).setId(UUID.fromMillis(100))
@@ -988,10 +1027,18 @@ public class DomainTest {
                 .setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1237").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1237").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         assertEquals(d, d2);
         assertEquals(d, d);
+
+        d2.setContacts(Map.of("product-owner", "user.test"));
+        assertNotEquals(d, d2);
+        d2.setContacts(null);
+        assertNotEquals(d, d2);
+        d2.setContacts(Map.of("pe-owner", "user.test"));
+        assertEquals(d, d2);
 
         d2.setUserAuthorityFilter("NotOnShore");
         assertNotEquals(d, d2);

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/GroupTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/GroupTest.java
@@ -17,9 +17,7 @@
 package com.yahoo.athenz.zms;
 
 import com.yahoo.rdl.Schema;
-import com.yahoo.rdl.Struct;
 import com.yahoo.rdl.Timestamp;
-import com.yahoo.rdl.UUID;
 import com.yahoo.rdl.Validator;
 import com.yahoo.rdl.Validator.Result;
 
@@ -39,10 +37,9 @@ public class GroupTest {
         GroupAuditLog ral = new GroupAuditLog().setMember("user.test").setAdmin("user.admin")
                 .setCreated(Timestamp.fromMillis(123456789123L)).setAction("add").setAuditRef("zmstest");
 
-        List<GroupAuditLog> rall = Arrays.asList(ral);
+        List<GroupAuditLog> rall = Collections.singletonList(ral);
 
         // Group test
-        List<String> members = Arrays.asList("user.boynton");
         List<GroupMember> groupMembers = new ArrayList<>();
         groupMembers.add(new GroupMember().setMemberName("member1"));
 
@@ -61,26 +58,10 @@ public class GroupTest {
                 .setMemberExpiryDays(10)
                 .setServiceExpiryDays(20)
                 .setDeleteProtection(false)
-                .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))));
-
-        Result result = validator.validate(r, "Group");
-        assertTrue(result.valid);
-
-        assertEquals(r.getName(), "sys.auth:group.admin");
-        assertEquals(r.getModified(), Timestamp.fromMillis(123456789123L));
-        assertEquals(r.getAuditLog(), rall);
-        assertEquals(r.getGroupMembers(), groupMembers);
-        assertTrue(r.getAuditEnabled());
-        assertFalse(r.getSelfServe());
-        assertFalse(r.getReviewEnabled());
-        assertEquals(r.getLastReviewedDate(), Timestamp.fromMillis(123456789123L));
-        assertEquals(r.getNotifyRoles(), "role1,domain:role.role2");
-        assertEquals(r.getUserAuthorityExpiration(), "attr1");
-        assertEquals(r.getUserAuthorityFilter(), "attr2,attr3");
-        assertEquals(r.getMemberExpiryDays().intValue(), 10);
-        assertEquals(r.getServiceExpiryDays().intValue(), 20);
-        assertFalse(r.getDeleteProtection());
-        assertEquals(r.getTags().get("tagKey").getList().get(0), "tagValue");
+                .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
+                .setSelfRenewEnabled(true)
+                .setSelfRenewMins(180)
+                .setMaxMembers(5);
 
         Group r2 = new Group()
                 .setName("sys.auth:group.admin")
@@ -97,101 +78,147 @@ public class GroupTest {
                 .setMemberExpiryDays(10)
                 .setServiceExpiryDays(20)
                 .setDeleteProtection(false)
-                .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))));
+                .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
+                .setSelfRenewEnabled(true)
+                .setSelfRenewMins(180)
+                .setMaxMembers(5);
 
-        assertTrue(r2.equals(r));
-        assertTrue(r.equals(r));
+        assertEquals(r, r2);
+        assertEquals(r, r);
+
+        assertEquals(r.getName(), "sys.auth:group.admin");
+        assertEquals(r.getModified(), Timestamp.fromMillis(123456789123L));
+        assertEquals(r.getAuditLog(), rall);
+        assertEquals(r.getGroupMembers(), groupMembers);
+        assertTrue(r.getAuditEnabled());
+        assertFalse(r.getSelfServe());
+        assertFalse(r.getReviewEnabled());
+        assertEquals(r.getLastReviewedDate(), Timestamp.fromMillis(123456789123L));
+        assertEquals(r.getNotifyRoles(), "role1,domain:role.role2");
+        assertEquals(r.getUserAuthorityExpiration(), "attr1");
+        assertEquals(r.getUserAuthorityFilter(), "attr2,attr3");
+        assertEquals(r.getMemberExpiryDays().intValue(), 10);
+        assertEquals(r.getServiceExpiryDays().intValue(), 20);
+        assertFalse(r.getDeleteProtection());
+        assertEquals(r.getTags().get("tagKey").getList().get(0), "tagValue");
+        assertEquals(r.getSelfRenewMins(), 180);
+        assertEquals(r.getSelfRenewEnabled(), Boolean.TRUE);
+        assertEquals(r.getMaxMembers(), 5);
 
         r2.setLastReviewedDate(Timestamp.fromMillis(123456789124L));
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setLastReviewedDate(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setLastReviewedDate(Timestamp.fromMillis(123456789123L));
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
+
+        r2.setMaxMembers(15);
+        assertNotEquals(r, r2);
+        r2.setMaxMembers(null);
+        assertNotEquals(r, r2);
+        r2.setMaxMembers(5);
+        assertEquals(r, r2);
 
         r2.setNotifyRoles("group1");
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setNotifyRoles(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setNotifyRoles("role1,domain:role.role2");
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setReviewEnabled(true);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setReviewEnabled(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setReviewEnabled(false);
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
+
+        r2.setSelfRenewEnabled(false);
+        assertNotEquals(r, r2);
+        r2.setSelfRenewEnabled(null);
+        assertNotEquals(r, r2);
+        r2.setSelfRenewEnabled(true);
+        assertEquals(r, r2);
+
+        r2.setSelfRenewMins(15);
+        assertNotEquals(r, r2);
+        r2.setSelfRenewMins(null);
+        assertNotEquals(r, r2);
+        r2.setSelfRenewMins(180);
+        assertEquals(r, r2);
 
         r2.setAuditEnabled(false);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setAuditEnabled(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setAuditEnabled(true);
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setSelfServe(true);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setSelfServe(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setSelfServe(false);
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setDeleteProtection(true);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setDeleteProtection(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setDeleteProtection(false);
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setUserAuthorityExpiration("attr11");
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setUserAuthorityExpiration(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setUserAuthorityExpiration("attr1");
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setUserAuthorityFilter("attr2");
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setUserAuthorityFilter(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setUserAuthorityFilter("attr2,attr3");
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setMemberExpiryDays(15);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setMemberExpiryDays(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setMemberExpiryDays(10);
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setServiceExpiryDays(15);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setServiceExpiryDays(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setServiceExpiryDays(20);
-        assertTrue(r2.equals(r));
+        assertEquals(r, r2);
 
         r2.setAuditLog(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setGroupMembers(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setModified(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setName(null);
-        assertFalse(r2.equals(r));
-        assertFalse(r.equals(new String()));
+        assertNotEquals(r, r2);
+        assertNotEquals("group", r);
 
         r2.setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue1"))));
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
         r2.setTags(null);
-        assertFalse(r2.equals(r));
+        assertNotEquals(r, r2);
 
-        List<Group> rl = Arrays.asList(r);
+        Result result = validator.validate(r, "Group");
+        assertTrue(result.valid);
+
+        List<Group> rl = List.of(r);
 
         // Groups test
         Groups rs1 = new Groups().setList(rl);
-        assertTrue(rs1.equals(rs1));
+        assertEquals(rs1, rs1);
 
         result = validator.validate(rs1, "Groups");
         assertTrue(result.valid);
@@ -199,13 +226,13 @@ public class GroupTest {
         assertEquals(rs1.getList(), rl);
 
         Groups rs2 = new Groups().setList(rl);
-        assertTrue(rs2.equals(rs1));
+        assertEquals(rs1, rs2);
 
         rs2.setList(null);
-        assertFalse(rs2.equals(rs1));
+        assertNotEquals(rs1, rs2);
 
-        assertFalse(rs1.equals(null));
-        assertFalse(rs1.equals(new String()));
+        assertNotEquals(rs1, null);
+        assertNotEquals("group", rs1);
     }
 
     @Test
@@ -230,7 +257,9 @@ public class GroupTest {
                 .setPrincipalType(1)
                 .setPendingState("ADD");
 
-        assertTrue(rm.equals(rm));
+        assertEquals(rm, rm);
+        assertNotEquals("data", rm);
+        assertNotEquals(null, rm);
 
         Result result = validator.validate(rm, "GroupMember");
         assertTrue(result.valid);
@@ -265,107 +294,107 @@ public class GroupTest {
                 .setSystemDisabled(1)
                 .setPrincipalType(1)
                 .setPendingState("ADD");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setRequestPrincipal("user.test2");
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setRequestPrincipal(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setRequestPrincipal("user.admin");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setDomainName("domain2");
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setDomainName(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setDomainName("domain1");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setGroupName("group2");
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setGroupName(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setGroupName("group1");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setMemberName("user.test2");
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setMemberName(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setMemberName("user.test1");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setExpiration(Timestamp.fromMillis(123456789124L));
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setExpiration(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setExpiration(Timestamp.fromMillis(123456789123L));
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setRequestTime(Timestamp.fromMillis(123456789125L));
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setRequestTime(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setRequestTime(Timestamp.fromMillis(123456789124L));
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setLastNotifiedTime(Timestamp.fromMillis(123456789128L));
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setLastNotifiedTime(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setLastNotifiedTime(Timestamp.fromMillis(123456789125L));
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setAuditRef("audit2-ref");
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setAuditRef(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setAuditRef("audit-ref");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setActive(true);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setActive(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setActive(false);
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setApproved(false);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setApproved(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setApproved(true);
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setReviewLastNotifiedTime(Timestamp.fromMillis(123456789124L));
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setReviewLastNotifiedTime(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setReviewLastNotifiedTime(Timestamp.fromMillis(123456789127L));
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setSystemDisabled(2);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setSystemDisabled(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setSystemDisabled(1);
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setPendingState("DELETE");
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setPendingState(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setPendingState("ADD");
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
         rm2.setPrincipalType(2);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setPrincipalType(null);
-        assertFalse(rm2.equals(rm));
+        assertNotEquals(rm, rm2);
         rm2.setPrincipalType(1);
-        assertTrue(rm2.equals(rm));
+        assertEquals(rm, rm2);
 
-        assertFalse(rm2.equals(null));
+        assertNotEquals(rm2, null);
 
         GroupMember rm3 = new GroupMember();
         rm3.init();
@@ -394,23 +423,24 @@ public class GroupTest {
         assertEquals("mbr1", mbr1.getMemberName());
         assertEquals(list1, mbr1.getMemberGroups());
 
-        assertTrue(mbr1.equals(mbr1));
-        assertFalse(mbr1.equals(null));
+        assertEquals(mbr1, mbr1);
+        assertNotEquals(null, mbr1);
+        assertNotEquals("data", mbr1);
 
         DomainGroupMember mbr2 = new DomainGroupMember();
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         mbr2.setMemberName("mbr2");
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         mbr2.setMemberName("mbr1");
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         mbr2.setMemberGroups(list2);
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         list2.add(new GroupMember().setGroupName("group1"));
-        assertTrue(mbr2.equals(mbr1));
+        assertEquals(mbr1, mbr2);
 
         GroupMember mbr3 = new GroupMember();
         mbr3.init();
@@ -436,23 +466,24 @@ public class GroupTest {
         assertEquals("dom1", mbr1.getDomainName());
         assertEquals(list1, mbr1.getMembers());
 
-        assertTrue(mbr1.equals(mbr1));
-        assertFalse(mbr1.equals(null));
+        assertEquals(mbr1, mbr1);
+        assertNotEquals(null, mbr1);
+        assertNotEquals("data", mbr1);
 
         DomainGroupMembers mbr2 = new DomainGroupMembers();
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         mbr2.setDomainName("dom2");
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         mbr2.setDomainName("dom1");
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         mbr2.setMembers(list2);
-        assertFalse(mbr2.equals(mbr1));
+        assertNotEquals(mbr1, mbr2);
 
         list2.add(new DomainGroupMember().setMemberName("mbr1"));
-        assertTrue(mbr2.equals(mbr1));
+        assertEquals(mbr1, mbr2);
     }
 
     @Test
@@ -468,16 +499,16 @@ public class GroupTest {
         assertFalse(rsm.getAuditEnabled());
 
         GroupSystemMeta rsm2 = new GroupSystemMeta();
-        assertFalse(rsm2.equals(rsm));
+        assertNotEquals(rsm, rsm2);
         rsm2.setAuditEnabled(false);
-        assertTrue(rsm2.equals(rsm));
-        assertTrue(rsm.equals(rsm));
+        assertEquals(rsm, rsm2);
+        assertEquals(rsm, rsm);
 
         rsm2.setAuditEnabled(null);
-        assertFalse(rsm2.equals(rsm));
+        assertNotEquals(rsm, rsm2);
 
-        assertFalse(rsm2.equals(null));
-        assertFalse(rsm.equals(new String()));
+        assertNotEquals(rsm2, null);
+        assertNotEquals("group-meta", rsm);
     }
 
     @Test
@@ -494,7 +525,10 @@ public class GroupTest {
                 .setServiceExpiryDays(20)
                 .setDeleteProtection(false)
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
-                .setLastReviewedDate(Timestamp.fromMillis(100));
+                .setLastReviewedDate(Timestamp.fromMillis(100))
+                .setSelfRenewEnabled(true)
+                .setSelfRenewMins(180)
+                .setMaxMembers(5);
 
         assertFalse(gm1.getSelfServe());
         assertEquals(gm1.getNotifyRoles(), "role1,domain:role.role2");
@@ -507,6 +541,9 @@ public class GroupTest {
         assertEquals(gm1.getServiceExpiryDays().intValue(), 20);
         assertEquals(gm1.getTags().get("tagKey").getList().get(0), "tagValue");
         assertEquals(gm1.getLastReviewedDate(), Timestamp.fromMillis(100));
+        assertEquals(gm1.getSelfRenewMins(), 180);
+        assertEquals(gm1.getSelfRenewEnabled(), Boolean.TRUE);
+        assertEquals(gm1.getMaxMembers(), 5);
 
         GroupMeta gm2 = new GroupMeta()
                 .setSelfServe(false)
@@ -519,12 +556,22 @@ public class GroupTest {
                 .setServiceExpiryDays(20)
                 .setDeleteProtection(false)
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
-                .setLastReviewedDate(Timestamp.fromMillis(100));
+                .setLastReviewedDate(Timestamp.fromMillis(100))
+                .setSelfRenewEnabled(true)
+                .setSelfRenewMins(180)
+                .setMaxMembers(5);
 
         assertEquals(gm1, gm2);
         assertEquals(gm1, gm1);
         assertNotEquals(null, gm1);
         assertNotEquals("group-meta", gm1);
+
+        gm2.setMaxMembers(15);
+        assertNotEquals(gm1, gm2);
+        gm2.setMaxMembers(null);
+        assertNotEquals(gm1, gm2);
+        gm2.setMaxMembers(5);
+        assertEquals(gm1, gm2);
 
         gm2.setNotifyRoles("role1");
         assertNotEquals(gm2, gm1);
@@ -539,6 +586,20 @@ public class GroupTest {
         assertNotEquals(gm2, gm1);
         gm2.setReviewEnabled(false);
         assertEquals(gm2, gm1);
+
+        gm2.setSelfRenewEnabled(false);
+        assertNotEquals(gm1, gm2);
+        gm2.setSelfRenewEnabled(null);
+        assertNotEquals(gm1, gm2);
+        gm2.setSelfRenewEnabled(true);
+        assertEquals(gm1, gm2);
+
+        gm2.setSelfRenewMins(15);
+        assertNotEquals(gm1, gm2);
+        gm2.setSelfRenewMins(null);
+        assertNotEquals(gm1, gm2);
+        gm2.setSelfRenewMins(180);
+        assertEquals(gm1, gm2);
 
         gm2.setAuditEnabled(true);
         assertNotEquals(gm2, gm1);
@@ -649,69 +710,69 @@ public class GroupTest {
                 .setActive(true).setAuditRef("audit-ref").setApproved(false)
                 .setRequestPrincipal("user.admin").setSystemDisabled(1).setPendingState("ADD");
 
-        assertTrue(ms2.equals(ms));
-        assertTrue(ms.equals(ms));
+        assertEquals(ms, ms2);
+        assertEquals(ms, ms);
 
         ms2.setRequestPrincipal("user.test2");
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setRequestPrincipal(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setRequestPrincipal("user.admin");
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setExpiration(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setExpiration(Timestamp.fromMillis(100));
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setGroupName(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setGroupName("group1");
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setIsMember(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setIsMember(false);
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setMemberName(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setMemberName("test.member");
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setAuditRef(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setAuditRef("audit-ref");
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setActive(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setActive(true);
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setApproved(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setApproved(true);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setApproved(false);
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setSystemDisabled(2);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setSystemDisabled(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setSystemDisabled(1);
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
         ms2.setPendingState("DELETE");
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setPendingState(null);
-        assertFalse(ms2.equals(ms));
+        assertNotEquals(ms, ms2);
         ms2.setPendingState("ADD");
-        assertTrue(ms2.equals(ms));
+        assertEquals(ms, ms2);
 
-        assertFalse(ms2.equals(null));
-        assertFalse(ms.equals(new String()));
+        assertNotEquals(ms2, null);
+        assertNotEquals("data", ms);
     }
 
     @Test
@@ -735,20 +796,20 @@ public class GroupTest {
         GroupAuditLog ral2 = new GroupAuditLog().setMember("user.test").setAdmin("user.admin")
                 .setCreated(Timestamp.fromMillis(123456789123L)).setAction("add").setAuditRef("zmstest");
 
-        assertTrue(ral2.equals(ral));
-        assertTrue(ral.equals(ral));
+        assertEquals(ral, ral2);
+        assertEquals(ral, ral);
 
         ral2.setAuditRef(null);
-        assertFalse(ral2.equals(ral));
+        assertNotEquals(ral, ral2);
         ral2.setAction(null);
-        assertFalse(ral2.equals(ral));
+        assertNotEquals(ral, ral2);
         ral2.setCreated(null);
-        assertFalse(ral2.equals(ral));
+        assertNotEquals(ral, ral2);
         ral2.setAdmin(null);
-        assertFalse(ral2.equals(ral));
+        assertNotEquals(ral, ral2);
         ral2.setMember(null);
-        assertFalse(ral2.equals(ral));
-        assertFalse(ral2.equals(new String()));
+        assertNotEquals(ral, ral2);
+        assertNotEquals("data", ral2);
     }
 
     @Test
@@ -772,17 +833,17 @@ public class GroupTest {
 
         DomainGroupMembership groupMembership2 = new DomainGroupMembership().setDomainGroupMembersList(list2);
 
-        assertTrue(groupMembership2.equals(groupMembership1));
-        assertTrue(groupMembership1.equals(groupMembership1));
-        assertFalse(groupMembership1.equals(null));
-        assertFalse(groupMembership1.equals(new String()));
+        assertEquals(groupMembership1, groupMembership2);
+        assertEquals(groupMembership1, groupMembership1);
+        assertNotEquals(groupMembership1, null);
+        assertNotEquals("data", groupMembership1);
 
         List<DomainGroupMembers> list3 = Collections.emptyList();
 
         groupMembership2.setDomainGroupMembersList(list3);
-        assertFalse(groupMembership2.equals(groupMembership1));
+        assertNotEquals(groupMembership1, groupMembership2);
         groupMembership2.setDomainGroupMembersList(null);
-        assertFalse(groupMembership2.equals(groupMembership1));
+        assertNotEquals(groupMembership1, groupMembership2);
         groupMembership2.setDomainGroupMembersList(list2);
     }
 }

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
@@ -140,273 +140,6 @@ public class ZMSCoreTest {
     }
 
     @Test
-    public void testRolesMethod() {
-        Schema schema = ZMSSchema.instance();
-        Validator validator = new Validator(schema);
-
-        RoleAuditLog ral = new RoleAuditLog().setMember("user.test").setAdmin("user.admin")
-                .setCreated(Timestamp.fromMillis(123456789123L)).setAction("add").setAuditRef("zmstest");
-
-        List<RoleAuditLog> rall = Arrays.asList(ral);
-
-        // Role test
-        List<String> members = Arrays.asList("user.boynton");
-        List<RoleMember> roleMembers = new ArrayList<>();
-        roleMembers.add(new RoleMember().setMemberName("member1"));
-
-        Role r = new Role()
-                .setName("sys.auth:role.admin")
-                .setMembers(members)
-                .setRoleMembers(roleMembers)
-                .setAuditEnabled(true)
-                .setModified(Timestamp.fromMillis(123456789123L))
-                .setTrust("domain.admin")
-                .setAuditLog(rall)
-                .setSelfServe(false)
-                .setMemberExpiryDays(30)
-                .setServiceExpiryDays(40)
-                .setGroupExpiryDays(50)
-                .setGroupReviewDays(55)
-                .setTokenExpiryMins(300)
-                .setCertExpiryMins(120)
-                .setMemberReviewDays(70)
-                .setServiceReviewDays(80)
-                .setSignAlgorithm("ec")
-                .setReviewEnabled(false)
-                .setDeleteProtection(false)
-                .setNotifyRoles("role1,domain:role.role2")
-                .setLastReviewedDate(Timestamp.fromMillis(123456789123L))
-                .setUserAuthorityExpiration("attr1")
-                .setUserAuthorityFilter("attr2,attr3")
-                .setDescription("test role")
-                .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))));
-
-        Result result = validator.validate(r, "Role");
-        assertTrue(result.valid);
-
-        assertEquals(r.getName(), "sys.auth:role.admin");
-        assertEquals(r.getModified(), Timestamp.fromMillis(123456789123L));
-        assertEquals(r.getMembers(), members);
-        assertEquals(r.getTrust(), "domain.admin");
-        assertEquals(r.getAuditLog(), rall);
-        assertEquals(r.getRoleMembers(), roleMembers);
-        assertTrue(r.getAuditEnabled());
-        assertFalse(r.getSelfServe());
-        assertEquals(r.getMemberExpiryDays(), Integer.valueOf(30));
-        assertEquals(r.getServiceExpiryDays(), Integer.valueOf(40));
-        assertEquals(r.getGroupExpiryDays(), Integer.valueOf(50));
-        assertEquals(r.getGroupReviewDays(), Integer.valueOf(55));
-        assertEquals(r.getTokenExpiryMins(), Integer.valueOf(300));
-        assertEquals(r.getCertExpiryMins(), Integer.valueOf(120));
-        assertEquals(r.getMemberReviewDays(), Integer.valueOf(70));
-        assertEquals(r.getServiceReviewDays(), Integer.valueOf(80));
-        assertEquals(r.getSignAlgorithm(), "ec");
-        assertFalse(r.getReviewEnabled());
-        assertFalse(r.getDeleteProtection());
-        assertEquals(r.getLastReviewedDate(), Timestamp.fromMillis(123456789123L));
-        assertEquals(r.getNotifyRoles(), "role1,domain:role.role2");
-        assertEquals(r.getUserAuthorityExpiration(), "attr1");
-        assertEquals(r.getUserAuthorityFilter(), "attr2,attr3");
-        assertEquals(r.getTags().get("tagKey").getList().get(0), "tagValue");
-        assertEquals(r.getDescription(), "test role");
-
-        Role r2 = new Role()
-                .setName("sys.auth:role.admin")
-                .setMembers(members)
-                .setRoleMembers(roleMembers)
-                .setAuditEnabled(true)
-                .setModified(Timestamp.fromMillis(123456789123L))
-                .setTrust("domain.admin")
-                .setAuditLog(rall)
-                .setSelfServe(false)
-                .setMemberExpiryDays(30)
-                .setServiceExpiryDays(40)
-                .setGroupExpiryDays(50)
-                .setGroupReviewDays(55)
-                .setTokenExpiryMins(300)
-                .setCertExpiryMins(120)
-                .setMemberReviewDays(70)
-                .setServiceReviewDays(80)
-                .setSignAlgorithm("ec")
-                .setReviewEnabled(false)
-                .setDeleteProtection(false)
-                .setNotifyRoles("role1,domain:role.role2")
-                .setLastReviewedDate(Timestamp.fromMillis(123456789123L))
-                .setUserAuthorityExpiration("attr1")
-                .setUserAuthorityFilter("attr2,attr3")
-                .setDescription("test role")
-                .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))));
-
-        assertTrue(r2.equals(r));
-        assertTrue(r.equals(r));
-
-        r2.setLastReviewedDate(Timestamp.fromMillis(123456789124L));
-        assertFalse(r2.equals(r));
-        r2.setLastReviewedDate(null);
-        assertFalse(r2.equals(r));
-        r2.setLastReviewedDate(Timestamp.fromMillis(123456789123L));
-        assertTrue(r2.equals(r));
-
-        r2.setNotifyRoles("role1");
-        assertFalse(r2.equals(r));
-        r2.setNotifyRoles(null);
-        assertFalse(r2.equals(r));
-        r2.setNotifyRoles("role1,domain:role.role2");
-        assertTrue(r2.equals(r));
-
-        r2.setReviewEnabled(true);
-        assertFalse(r2.equals(r));
-        r2.setReviewEnabled(null);
-        assertFalse(r2.equals(r));
-        r2.setReviewEnabled(false);
-        assertTrue(r2.equals(r));
-
-        r2.setDeleteProtection(true);
-        assertFalse(r2.equals(r));
-        r2.setDeleteProtection(null);
-        assertFalse(r2.equals(r));
-        r2.setDeleteProtection(false);
-        assertTrue(r2.equals(r));
-
-        r2.setDescription("test role1");
-        assertFalse(r2.equals(r));
-        r2.setDescription(null);
-        assertFalse(r2.equals(r));
-        r2.setDescription("test role");
-        assertTrue(r2.equals(r));
-
-        r2.setSignAlgorithm("rsa");
-        assertFalse(r2.equals(r));
-        r2.setSignAlgorithm(null);
-        assertFalse(r2.equals(r));
-        r2.setSignAlgorithm("ec");
-        assertTrue(r2.equals(r));
-
-        r2.setMemberExpiryDays(45);
-        assertFalse(r2.equals(r));
-        r2.setMemberExpiryDays(null);
-        assertFalse(r2.equals(r));
-        r2.setMemberExpiryDays(30);
-        assertTrue(r2.equals(r));
-
-        r2.setServiceExpiryDays(45);
-        assertFalse(r2.equals(r));
-        r2.setServiceExpiryDays(null);
-        assertFalse(r2.equals(r));
-        r2.setServiceExpiryDays(40);
-        assertTrue(r2.equals(r));
-
-        r2.setGroupExpiryDays(55);
-        assertFalse(r2.equals(r));
-        r2.setGroupExpiryDays(null);
-        assertFalse(r2.equals(r));
-        r2.setGroupExpiryDays(50);
-        assertTrue(r2.equals(r));
-
-        r2.setGroupReviewDays(60);
-        assertFalse(r2.equals(r));
-        r2.setGroupReviewDays(null);
-        assertFalse(r2.equals(r));
-        r2.setGroupReviewDays(55);
-        assertTrue(r2.equals(r));
-
-        r2.setTokenExpiryMins(450);
-        assertFalse(r2.equals(r));
-        r2.setTokenExpiryMins(null);
-        assertFalse(r2.equals(r));
-        r2.setTokenExpiryMins(300);
-        assertTrue(r2.equals(r));
-
-        r2.setCertExpiryMins(150);
-        assertFalse(r2.equals(r));
-        r2.setCertExpiryMins(null);
-        assertFalse(r2.equals(r));
-        r2.setCertExpiryMins(120);
-        assertTrue(r2.equals(r));
-
-        r2.setAuditEnabled(false);
-        assertFalse(r2.equals(r));
-        r2.setAuditEnabled(null);
-        assertFalse(r2.equals(r));
-        r2.setAuditEnabled(true);
-        assertTrue(r2.equals(r));
-
-        r2.setSelfServe(true);
-        assertFalse(r2.equals(r));
-        r2.setSelfServe(null);
-        assertFalse(r2.equals(r));
-        r2.setSelfServe(false);
-        assertTrue(r2.equals(r));
-
-        r2.setMemberReviewDays(75);
-        assertFalse(r2.equals(r));
-        r2.setMemberReviewDays(null);
-        assertFalse(r2.equals(r));
-        r2.setMemberReviewDays(70);
-        assertTrue(r2.equals(r));
-
-        r2.setServiceReviewDays(85);
-        assertFalse(r2.equals(r));
-        r2.setServiceReviewDays(null);
-        assertFalse(r2.equals(r));
-        r2.setServiceReviewDays(80);
-        assertTrue(r2.equals(r));
-
-        r2.setUserAuthorityExpiration("attr11");
-        assertFalse(r2.equals(r));
-        r2.setUserAuthorityExpiration(null);
-        assertFalse(r2.equals(r));
-        r2.setUserAuthorityExpiration("attr1");
-        assertTrue(r2.equals(r));
-
-        r2.setUserAuthorityFilter("attr2");
-        assertFalse(r2.equals(r));
-        r2.setUserAuthorityFilter(null);
-        assertFalse(r2.equals(r));
-        r2.setUserAuthorityFilter("attr2,attr3");
-        assertTrue(r2.equals(r));
-
-        r2.setAuditLog(null);
-        assertFalse(r2.equals(r));
-        r2.setTrust(null);
-        assertFalse(r2.equals(r));
-        r2.setRoleMembers(null);
-        assertFalse(r2.equals(r));
-        r2.setMembers(null);
-        assertFalse(r2.equals(r));
-        r2.setModified(null);
-        assertFalse(r2.equals(r));
-        r2.setName(null);
-        assertFalse(r2.equals(r));
-        assertFalse(r.equals(new String()));
-
-        r2.setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue1"))));
-        assertFalse(r2.equals(r));
-        r2.setTags(null);
-        assertFalse(r2.equals(r));
-
-        List<Role> rl = Arrays.asList(r);
-
-        // Roles test
-        Roles rs1 = new Roles().setList(rl);
-        assertTrue(rs1.equals(rs1));
-
-        result = validator.validate(rs1, "Roles");
-        assertTrue(result.valid);
-
-        assertEquals(rs1.getList(), rl);
-
-        Roles rs2 = new Roles().setList(rl);
-        assertTrue(rs2.equals(rs1));
-
-        rs2.setList(null);
-        assertFalse(rs2.equals(rs1));
-
-        assertFalse(rs1.equals(null));
-        assertFalse(rs1.equals(new String()));
-    }
-
-    @Test
     public void testRoleListMethod() {
         Schema schema = ZMSSchema.instance();
         Validator validator = new Validator(schema);
@@ -845,7 +578,7 @@ public class ZMSCoreTest {
                 .setUserAuthorityFilter("OnShore").setGroups(gl).setAzureSubscription("azure").setGcpProject("gcp")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProjectNumber("1235")
-                .setProductId("abcd-1234").setFeatureFlags(3);
+                .setProductId("abcd-1234").setFeatureFlags(3).setContacts(Map.of("pe-owner", "user.test"));
 
         result = validator.validate(dd, "DomainData");
         assertTrue(result.valid, result.error);
@@ -882,6 +615,7 @@ public class ZMSCoreTest {
         assertEquals(dd.getMemberPurgeExpiryDays(), 10);
         assertEquals(dd.getProductId(), "abcd-1234");
         assertEquals(dd.getFeatureFlags(), 3);
+        assertEquals(dd.getContacts(), Map.of("pe-owner", "user.test"));
 
         DomainData dd2 = new DomainData().setName("test.domain").setAccount("aws").setYpmId(1).setRoles(rl)
                 .setPolicies(sp).setServices(sil).setEntities(elist).setModified(Timestamp.fromMillis(123456789123L))
@@ -891,7 +625,8 @@ public class ZMSCoreTest {
                 .setUserAuthorityFilter("OnShore").setGroupExpiryDays(50).setGroups(gl).setAzureSubscription("azure")
                 .setTags(Collections.singletonMap("tagKey", new TagValueList().setList(Collections.singletonList("tagValue"))))
                 .setBusinessService("business-service").setMemberPurgeExpiryDays(10).setGcpProject("gcp")
-                .setGcpProjectNumber("1235").setProductId("abcd-1234").setFeatureFlags(3);
+                .setGcpProjectNumber("1235").setProductId("abcd-1234").setFeatureFlags(3)
+                .setContacts(Map.of("pe-owner", "user.test"));
 
         assertEquals(dd2, dd);
         assertNotEquals(dd, null);
@@ -904,6 +639,13 @@ public class ZMSCoreTest {
         dd2.setGroups(null);
         assertNotEquals(dd, dd2);
         dd2.setGroups(gl);
+        assertEquals(dd, dd2);
+
+        dd2.setContacts(Map.of("product-owner", "user.test"));
+        assertNotEquals(dd, dd2);
+        dd2.setContacts(null);
+        assertNotEquals(dd, dd2);
+        dd2.setContacts(Map.of("pe-owner", "user.test"));
         assertEquals(dd, dd2);
 
         dd2.setName("test.domain2");
@@ -1858,7 +1600,7 @@ public class ZMSCoreTest {
 
         assertTrue(meta.equals(meta1));
         assertFalse(meta.equals(null));
-        assertFalse(meta.equals(new Integer(3)));
+        assertFalse(meta.equals(3));
 
         meta1.setAutoUpdate(false);
         assertFalse(meta1.equals(meta));

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Authority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Authority.java
@@ -200,4 +200,15 @@ public interface Authority {
     default List<Principal> getPrincipals(EnumSet<Principal.State> principalStates) {
         return Collections.emptyList();
     }
+
+    /**
+     * Retrieves the principal's manager's username. This is used for domain contacts
+     * when a domain contact user is no longer valid, the server will automatically
+     * assign the contact type to the user's manager.
+     * @param username user's name or id
+     * @return user's manager's name or id
+     */
+    default String getUserManager(final String username) {
+        return null;
+    }
 }

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/AuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/AuthorityTest.java
@@ -64,6 +64,11 @@ public class AuthorityTest {
             public String getUserEmail(String username) {
                 return username + "@example.com";
             }
+
+            @Override
+            public String getUserManager(String username) {
+                return username + "-manager";
+            }
         };
 
         assertNull(authority.getAuthenticateChallenge());
@@ -83,6 +88,7 @@ public class AuthorityTest {
         assertNull(authority.getDateAttribute("john", "review"));
         assertNotNull(authority.getDateAttribute("john", "expiry"));
         assertEquals(authority.getUserEmail("john"), "john@example.com");
+        assertEquals(authority.getUserManager("john"), "john-manager");
         assertEquals(authority.getID(), "Auth-ID");
     }
 


### PR DESCRIPTION
# Description

New attributes required for feature development:

role/group: 

Bool **selfRenewEnabled** (optional, default=false); //Flag indicates whether to allow expired members to renew their membership


Int32 **selfRenewMins** (optional); //Number of minutes members can renew their membership if self review option is enabled


Int32 **maxMembers** (optional); //Maximum number of members allowed in the role/group

domain:

Map<SimpleName,MemberName> **contacts** (optional); //list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

