### PR TITLE
simplify expiry notification lookups

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationManager.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationManager.java
@@ -128,10 +128,10 @@ public class NotificationManager {
                     notifications.stream()
                             .filter(Objects::nonNull)
                             .forEach(notification -> notificationServices.forEach(service -> service.notify(notification)));
-                    LOGGER.info("PeriodicNotificationsSender: Sent {} notifications of type {}.",
+                    LOGGER.info("PeriodicNotificationsSender: Sent {} notifications of type {}",
                             notifications.size(), notificationTask.getDescription());
                 } catch (Throwable t) {
-                    LOGGER.error(String.format("PeriodicNotificationsSender: unable to send %s: ", notificationTask.getDescription()), t);
+                    LOGGER.error("PeriodicNotificationsSender: unable to send {}", notificationTask.getDescription(), t);
                 }
             }
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -7798,10 +7798,10 @@ public class DBService implements RolesProvider {
         return null;
     }
 
-    public Map<String, DomainRoleMember> getRoleExpiryMembers(int delayDays, boolean metricsOnly) {
+    public Map<String, DomainRoleMember> getRoleExpiryMembers(int delayDays) {
         try (ObjectStoreConnection con = store.getConnection(true, true)) {
             long updateTs = System.currentTimeMillis();
-            if (con.updateRoleMemberExpirationNotificationTimestamp(zmsConfig.getServerHostName(), updateTs, delayDays, metricsOnly)) {
+            if (con.updateRoleMemberExpirationNotificationTimestamp(zmsConfig.getServerHostName(), updateTs, delayDays)) {
                 return con.getNotifyTemporaryRoleMembers(zmsConfig.getServerHostName(), updateTs);
             }
         }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
@@ -55,16 +55,13 @@ public class RoleMemberExpiryNotificationTask implements NotificationTask {
 
     @Override
     public List<Notification> getNotifications() {
-        Map<String, DomainRoleMember> expiryMembers = dbService.getRoleExpiryMembers(1, false);
+        Map<String, DomainRoleMember> expiryMembers = dbService.getRoleExpiryMembers(1);
         if (expiryMembers == null || expiryMembers.isEmpty()) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("No expiry members available to send email notifications");
-            }
-            return getMetricNotificationDetails();
+            LOGGER.info("No expiry members available to send email notifications");
+            return Collections.emptyList();
         }
 
-        List<Notification> metricNotificationDetails = getMetricNotificationDetails();
-        List<Notification> metricAndEmailNotificationDetails = roleMemberNotificationCommon.getNotificationDetails(
+        return roleMemberNotificationCommon.getNotificationDetails(
                 expiryMembers,
                 roleExpiryPrincipalNotificationToEmailConverter,
                 roleExpiryDomainNotificationToEmailConverter,
@@ -72,28 +69,6 @@ public class RoleMemberExpiryNotificationTask implements NotificationTask {
                 roleExpiryPrincipalNotificationToMetricConverter,
                 roleExpiryDomainNotificationToMetricConverter,
                 new ReviewDisableRoleMemberNotificationFilter());
-        metricNotificationDetails.addAll(metricAndEmailNotificationDetails);
-        return metricNotificationDetails;
-    }
-
-    private List<Notification> getMetricNotificationDetails() {
-        Map<String, DomainRoleMember> expiryMembers = dbService.getRoleExpiryMembers(1, true);
-        if (expiryMembers == null || expiryMembers.isEmpty()) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("No expiry members available to send metric notifications");
-            }
-
-            return new ArrayList<>();
-        }
-
-        return roleMemberNotificationCommon.getNotificationDetails(
-                expiryMembers,
-                null,
-                null,
-                new ExpiryRoleMemberDetailStringer(),
-                roleExpiryPrincipalNotificationToMetricConverter,
-                roleExpiryDomainNotificationToMetricConverter,
-                memberRole -> DisableNotificationEnum.getEnumSet(0));
     }
 
     static class ExpiryRoleMemberDetailStringer implements RoleMemberNotificationCommon.RoleMemberDetailStringer {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/ObjectStoreConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/ObjectStoreConnection.java
@@ -200,7 +200,7 @@ public interface ObjectStoreConnection extends Closeable {
     boolean updatePendingRoleMembersNotificationTimestamp(String server, long timestamp, int delayDays);
 
     Map<String, DomainRoleMember> getNotifyTemporaryRoleMembers(String server, long timestamp);
-    boolean updateRoleMemberExpirationNotificationTimestamp(String server, long timestamp, int delayDays, boolean metricsOnly);
+    boolean updateRoleMemberExpirationNotificationTimestamp(String server, long timestamp, int delayDays);
 
     Map<String, DomainRoleMember> getNotifyReviewRoleMembers(String server, long timestamp);
     boolean updateRoleMemberReviewNotificationTimestamp(String server, long timestamp, int delayDays);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -7508,7 +7508,7 @@ public class DBServiceTest {
         zms.dbService.executePutRole(mockDomRsrcCtx, domainName2, "role3", role3, "test", "putrole", false);
 
         Map<String, DomainRoleMember> domainRoleMembers = isRoleExpire ?
-                zms.dbService.getRoleExpiryMembers(0, false) : zms.dbService.getRoleReviewMembers(0);
+                zms.dbService.getRoleExpiryMembers(0) : zms.dbService.getRoleReviewMembers(0);
         assertNotNull(domainRoleMembers);
         assertEquals(domainRoleMembers.size(), 3);
 
@@ -7605,9 +7605,9 @@ public class DBServiceTest {
 
         ObjectStoreConnection mockConn = Mockito.mock(ObjectStoreConnection.class);
         Mockito.when(mockObjStore.getConnection(anyBoolean(), anyBoolean())).thenReturn(mockConn);
-        Mockito.when(mockConn.updateRoleMemberExpirationNotificationTimestamp(anyString(), anyLong(), anyInt(), anyBoolean())).thenReturn(false);
+        Mockito.when(mockConn.updateRoleMemberExpirationNotificationTimestamp(anyString(), anyLong(), anyInt())).thenReturn(false);
 
-        assertNull(zms.dbService.getRoleExpiryMembers(1, false));
+        assertNull(zms.dbService.getRoleExpiryMembers(1));
         zms.dbService.store = saveStore;
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
@@ -47,7 +47,7 @@ public class RoleMemberExpiryNotificationTaskTest {
 
         // we're going to throw an exception when called
 
-        Mockito.when(dbsvc.getRoleExpiryMembers(1, false)).thenThrow(new IllegalArgumentException());
+        Mockito.when(dbsvc.getRoleExpiryMembers(1)).thenThrow(new IllegalArgumentException());
         NotificationManager notificationManager = getNotificationManager(dbsvc, testfact);
 
         RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(
@@ -108,7 +108,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         // run during init call and then the real data for the second
         // call
 
-        Mockito.when(dbsvc.getRoleExpiryMembers(1, false))
+        Mockito.when(dbsvc.getRoleExpiryMembers(1))
                 .thenReturn(null)
                 .thenReturn(expiryMembers);
 
@@ -193,7 +193,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         // run during init call and then the real data for the second
         // call
 
-        Mockito.when(dbsvc.getRoleExpiryMembers(1, false))
+        Mockito.when(dbsvc.getRoleExpiryMembers(1))
                 .thenReturn(null)
                 .thenReturn(expiryMembers);
 
@@ -276,7 +276,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         // run during init call and then the real data for the second
         // call
 
-        Mockito.when(dbsvc.getRoleExpiryMembers(1, false))
+        Mockito.when(dbsvc.getRoleExpiryMembers(1))
                 .thenReturn(null)
                 .thenReturn(expiryMembers);
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationManagerTest.java
@@ -273,7 +273,7 @@ public class ZMSNotificationManagerTest {
         // run during init call and then the real data for the second
         // call
 
-        Mockito.when(dbsvc.getRoleExpiryMembers(1, false)).thenReturn(null);
+        Mockito.when(dbsvc.getRoleExpiryMembers(1)).thenReturn(null);
         DomainRoleMembersFetcher domainRoleMembersFetcher = new DomainRoleMembersFetcher(dbsvc, USER_DOMAIN_PREFIX);
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
@@ -10518,7 +10518,7 @@ public class JDBCConnectionTest {
                 .thenReturn(3); // 3 members updated
         long timestamp = System.currentTimeMillis();
         boolean result = isRoleExpire ?
-                jdbcConn.updateRoleMemberExpirationNotificationTimestamp("localhost", timestamp, 1, false) :
+                jdbcConn.updateRoleMemberExpirationNotificationTimestamp("localhost", timestamp, 1) :
                 jdbcConn.updateRoleMemberReviewNotificationTimestamp("localhost", timestamp, 1);
         java.sql.Timestamp ts = new java.sql.Timestamp(timestamp);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(1, ts);
@@ -10543,7 +10543,7 @@ public class JDBCConnectionTest {
                 .thenThrow(new SQLException("sql error"));
         try {
             if (isRoleExpire) {
-                jdbcConn.updateRoleMemberExpirationNotificationTimestamp("localhost", System.currentTimeMillis(), 1, false);
+                jdbcConn.updateRoleMemberExpirationNotificationTimestamp("localhost", System.currentTimeMillis(), 1);
             } else {
                 jdbcConn.updateRoleMemberReviewNotificationTimestamp("localhost", System.currentTimeMillis(), 1);
             }
@@ -15327,7 +15327,7 @@ public class JDBCConnectionTest {
         Mockito.when(mockResultSet.getTimestamp(1))
                 .thenReturn(new java.sql.Timestamp(System.currentTimeMillis() - 24 * 60 * 60 * 1000 + 10000));
 
-        assertFalse(jdbcConn.updateRoleMemberExpirationNotificationTimestamp("server", 0, 1, false));
+        assertFalse(jdbcConn.updateRoleMemberExpirationNotificationTimestamp("server", 0, 1));
         jdbcConn.close();
     }
 


### PR DESCRIPTION
# Description

we're addressing 2 issues with this simplification:
a) bug fix: with consolidated email where we only generate notifications once a day, it conflicts with metric notifications which also uses the same attribute and if we generate a metric notification, we might skip the email notification. So now we just use the same list of expired members to generate both email and metric notifications

b) remove the logic where the member has both expiration and review reminder options enabled, start notifications with the review reminder date. most of the users unknowingly set both to the same value and end up with no notifications. Now, that we're generating consolidated notifications, the issue with getting too many emails a day is no longer an issue so no need for extra logic.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

