### PR TITLE
extend schema for contact type to string

### DIFF
--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -283,7 +283,7 @@ type DomainMeta struct {
 	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
 	// a single value
 	//
-	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+	Contacts map[SimpleName]string `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 }
 
 // NewDomainMeta - creates an initialized DomainMeta instance, returns a pointer to it
@@ -539,7 +539,7 @@ type Domain struct {
 	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
 	// a single value
 	//
-	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+	Contacts map[SimpleName]string `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// the common name to be referred to, the symbolic id. It is immutable
@@ -3713,7 +3713,7 @@ type TopLevelDomain struct {
 	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
 	// a single value
 	//
-	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+	Contacts map[SimpleName]string `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the domain
@@ -3993,7 +3993,7 @@ type SubDomain struct {
 	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
 	// a single value
 	//
-	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+	Contacts map[SimpleName]string `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the domain
@@ -4287,7 +4287,7 @@ type UserDomain struct {
 	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
 	// a single value
 	//
-	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+	Contacts map[SimpleName]string `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// user id which will be the domain name
@@ -6797,7 +6797,7 @@ type DomainData struct {
 	// list of domain contacts (PE-Owner, Product-Owner, etc), each type can have
 	// a single value
 	//
-	Contacts map[SimpleName]MemberName `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
+	Contacts map[SimpleName]string `json:"contacts,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// name of the domain

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -161,7 +161,7 @@ func init() {
 	tDomainMeta.Field("memberPurgeExpiryDays", "Int32", true, nil, "purge role/group members with expiry date configured days in the past")
 	tDomainMeta.Field("productId", "String", true, nil, "associated product id (system attribute - uniqueness check - if enabled)")
 	tDomainMeta.Field("featureFlags", "Int32", true, nil, "features enabled per domain (system attribute)")
-	tDomainMeta.MapField("contacts", "SimpleName", "MemberName", true, "list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value")
+	tDomainMeta.MapField("contacts", "SimpleName", "String", true, "list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value")
 	sb.AddType(tDomainMeta.Build())
 
 	tDomain := rdl.NewStructTypeBuilder("DomainMeta", "Domain")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -138,7 +138,7 @@ public class ZMSSchema {
             .field("memberPurgeExpiryDays", "Int32", true, "purge role/group members with expiry date configured days in the past")
             .field("productId", "String", true, "associated product id (system attribute - uniqueness check - if enabled)")
             .field("featureFlags", "Int32", true, "features enabled per domain (system attribute)")
-            .mapField("contacts", "SimpleName", "MemberName", true, "list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value");
+            .mapField("contacts", "SimpleName", "String", true, "list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value");
 
         sb.structType("Domain", "DomainMeta")
             .comment("A domain is an independent partition of users, roles, and resources. Its name represents the definition of a namespace; the only way a new namespace can be created, from the top, is by creating Domains. Administration of a domain is governed by the parent domain (using reverse-DNS namespaces). The top level domains are governed by the special \"sys.auth\" domain.")

--- a/core/zms/src/main/rdl/Domain.tdl
+++ b/core/zms/src/main/rdl/Domain.tdl
@@ -30,7 +30,7 @@ type DomainMeta Struct {
     Int32 memberPurgeExpiryDays (optional); //purge role/group members with expiry date configured days in the past
     String productId (optional); //associated product id (system attribute - uniqueness check - if enabled)
     Int32 featureFlags (optional); //features enabled per domain (system attribute)
-    Map<SimpleName,MemberName> contacts (optional); //list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value
+    Map<SimpleName,String> contacts (optional); //list of domain contacts (PE-Owner, Product-Owner, etc), each type can have a single value
 }
 
 //A domain is an independent partition of users, roles, and resources.

--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -793,13 +793,9 @@ func (cli Zms) SetDomainContact(dn, contactType, contactUser string) (*string, e
 	}
 	domainContacts := domain.Contacts
 	if domainContacts == nil {
-		domainContacts = make(map[zms.SimpleName]zms.MemberName)
+		domainContacts = make(map[zms.SimpleName]string)
 	}
-	if contactUser == "" {
-		delete(domainContacts, zms.SimpleName(contactType))
-	} else {
-		domainContacts[zms.SimpleName(contactType)] = zms.MemberName(contactUser)
-	}
+	domainContacts[zms.SimpleName(contactType)] = contactUser
 	meta := zms.DomainMeta{
 		Contacts: domainContacts,
 	}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -4230,12 +4230,15 @@ public class DBService implements RolesProvider {
         }
 
         // if our original list is empty then we're going to insert
-        // all of our new contacts if any are present
+        // all of our new contacts if any are present. we'll make
+        // sure they all have non-empty values
 
         if (originalContacts == null || originalContacts.isEmpty()) {
             for (Map.Entry<String, String> entry : updatedContacts.entrySet()) {
-                if (!con.insertDomainContact(domainName, entry.getKey(), entry.getValue())) {
-                    return false;
+                if (!StringUtil.isEmpty(entry.getValue())) {
+                    if (!con.insertDomainContact(domainName, entry.getKey(), entry.getValue())) {
+                        return false;
+                    }
                 }
             }
             return true;
@@ -4253,21 +4256,29 @@ public class DBService implements RolesProvider {
             return true;
         }
 
-        // process our updated contacts - we're either going to update
-        // or insert our contacts
+        // process our updated contacts - we're either going to update, insert,
+        // or delete our contacts
 
         for (Map.Entry<String, String> entry : updatedContacts.entrySet()) {
             String type = entry.getKey();
             String name = entry.getValue();
             if (originalContacts.containsKey(type)) {
                 if (!originalContacts.get(type).equals(name)) {
-                    if (!con.updateDomainContact(domainName, type, name)) {
-                        return false;
+                    if (StringUtil.isEmpty(name)) {
+                        if (!con.deleteDomainContact(domainName, type)) {
+                            return false;
+                        }
+                    } else {
+                        if (!con.updateDomainContact(domainName, type, name)) {
+                            return false;
+                        }
                     }
                 }
             } else {
-                if (!con.insertDomainContact(domainName, type, name)) {
-                    return false;
+                if (!StringUtil.isEmpty(entry.getValue())) {
+                    if (!con.insertDomainContact(domainName, type, name)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -742,7 +742,7 @@ public class DBService implements RolesProvider {
         // open our audit record and log our trust field if one is available
 
         auditLogRoleMeta(auditDetails, role, roleName, false);
-        auditDetails.append("\", \"trust\": \"").append(role.getTrust()).append('\"');
+        auditDetails.append(", \"trust\": \"").append(role.getTrust()).append('\"');
 
         // now we need process our role members depending on if this is
         // a new insert operation or an update
@@ -6016,8 +6016,22 @@ public class DBService implements RolesProvider {
                 .append("\", \"userAuthorityFilter\": \"").append(domain.getUserAuthorityFilter())
                 .append("\", \"businessService\": \"").append(domain.getBusinessService())
                 .append("\", \"productId\": \"").append(domain.getProductId())
-                .append("\", \"featureFlags\": \"").append(domain.getFeatureFlags())
-                .append("\"}");
+                .append("\", \"featureFlags\": \"").append(domain.getFeatureFlags()).append("\"");
+        auditLogTags(auditDetails, domain.getTags());
+        auditLogDomainContacts(auditDetails, domain.getContacts());
+        auditDetails.append("}");
+    }
+
+    void auditLogDomainContacts(StringBuilder auditDetails, Map<String, String> contacts) {
+        if (contacts != null) {
+            auditDetails.append(", \"contacts\": {");
+            boolean firstEntry = true;
+            for (Map.Entry<String, String> entry: contacts.entrySet()) {
+                firstEntry = auditLogSeparator(auditDetails, firstEntry);
+                auditDetails.append("\"").append(entry.getKey()).append("\": \"").append(entry.getValue()).append("\"");
+            }
+            auditDetails.append("}");
+        }
     }
 
     void auditLogRoleSystemMeta(StringBuilder auditDetails, Role role, String roleName) {
@@ -6059,10 +6073,10 @@ public class DBService implements RolesProvider {
                 .append("\", \"lastReviewedDate\": \"").append(role.getLastReviewedDate())
                 .append("\", \"maxMembers\": \"").append(role.getMembers())
                 .append("\", \"selfRenew\": \"").append(role.getSelfRenew())
-                .append("\", \"selfRenewMins\": \"").append(role.getSelfRenewMins());
+                .append("\", \"selfRenewMins\": \"").append(role.getSelfRenewMins()).append("\"");
         auditLogTags(auditDetails, role.getTags());
         if (close) {
-            auditDetails.append("\"}");
+            auditDetails.append("}");
         }
     }
 
@@ -6079,16 +6093,16 @@ public class DBService implements RolesProvider {
                 .append("\", \"lastReviewedDate\": \"").append(group.getLastReviewedDate())
                 .append("\", \"maxMembers\": \"").append(group.getMaxMembers())
                 .append("\", \"selfRenew\": \"").append(group.getSelfRenew())
-                .append("\", \"selfRenewMins\": \"").append(group.getSelfRenewMins());
+                .append("\", \"selfRenewMins\": \"").append(group.getSelfRenewMins()).append("\"");
         auditLogTags(auditDetails, group.getTags());
         if (close) {
-            auditDetails.append("\"}");
+            auditDetails.append("}");
         }
     }
 
     void auditLogTags(StringBuilder auditDetails, Map<String, TagValueList> tags) {
         if (tags != null) {
-            auditDetails.append("\", \"tags\": {");
+            auditDetails.append(", \"tags\": {");
             boolean firstEntry = true;
             for (String key : tags.keySet()) {
                 firstEntry = auditLogTag(auditDetails, tags.get(key), key, firstEntry);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -2193,11 +2193,22 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // is a valid principal according to the user authority
 
         for (Map.Entry<String, String> entry : contacts.entrySet()) {
+
             if (!domainContactTypes.contains(entry.getKey())) {
                 throw ZMSUtils.requestError("invalid domain contact type: " + entry.getKey(), caller);
             }
+
+            // empty value indicates that we want to delete the contact
+
+            if (StringUtil.isEmpty(entry.getValue())) {
+                continue;
+            }
+
+            // if we have a user authority defined, verify that the given contact
+            // is a valid principal according to the user authority
+
             if (userAuthority != null && !userAuthority.isValidUser(entry.getValue())) {
-                throw ZMSUtils.requestError("invalid domain contact: " + entry.getKey() + "/" + entry.getValue(), caller);
+                throw ZMSUtils.requestError("invalid domain contact: " + entry.getKey(), caller);
             }
         }
     }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -2954,7 +2954,8 @@ public class DBServiceTest {
 
         StringBuilder auditDetails = new StringBuilder(ZMSConsts.STRING_BLDR_SIZE_DEFAULT);
         auditDetails.append("{\"add-templates\": ");
-        zms.dbService.addSolutionTemplate(mockDomRsrcCtx, conn, domainName, "templateWithRoleMeta", adminUser, domainTemplate.getParams(), auditRef, auditDetails);
+        zms.dbService.addSolutionTemplate(mockDomRsrcCtx, conn, domainName, "templateWithRoleMeta",
+                adminUser, domainTemplate.getParams(), auditRef, auditDetails);
         auditDetails.append("}");
 
         assertTrue(isValidJSON(auditDetails.toString()));

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -12892,7 +12892,7 @@ public class DBServiceTest {
     }
 
     @Test
-    public void testProcessDomainContacts() {
+    public void testProcessDomainContactsFailureCases() {
 
         final String domainName = "process-domain-contacts";
         ObjectStoreConnection conn = Mockito.mock(ObjectStoreConnection.class);
@@ -12957,6 +12957,17 @@ public class DBServiceTest {
 
         updatedContacts = new HashMap<>();
         updatedContacts.put("security-contact", "user.joe");
+
+        originalContacts = new HashMap<>();
+        originalContacts.put("security-contact", "user.joe");
+        originalContacts.put("sre-contact", "user.joe");
+        assertFalse(zms.dbService.processDomainContacts(conn, domainName, updatedContacts, originalContacts));
+
+        // test case 5 - delete a contact during update with empty string
+
+        updatedContacts = new HashMap<>();
+        updatedContacts.put("security-contact", "user.joe");
+        updatedContacts.put("sre-contact", "");
 
         originalContacts = new HashMap<>();
         originalContacts.put("security-contact", "user.joe");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DomainContactsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DomainContactsTest.java
@@ -33,7 +33,7 @@ public class DomainContactsTest {
 
     @BeforeClass
     public void startMemoryMySQL() {
-        System.setProperty(ZMSConsts.ZMS_PROP_DOMAIN_CONTACT_TYPES, "pe-owner,security-contact,audit-contact");
+        System.setProperty(ZMSConsts.ZMS_PROP_DOMAIN_CONTACT_TYPES, "pe-owner,security-contact,audit-contact,product-owner");
         zmsTestInitializer.startMemoryMySQL();
     }
 
@@ -62,6 +62,7 @@ public class DomainContactsTest {
         Map<String, String> domainContacts = new HashMap<>();
         domainContacts.put("pe-owner", "user.user1");
         domainContacts.put("security-contact", "user.user2");
+        domainContacts.put("audit-contact", "");
         dom1.setContacts(domainContacts);
         zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
 
@@ -90,11 +91,15 @@ public class DomainContactsTest {
         assertEquals(domainContactsRes.get("security-contact"), "user.user2");
 
         // this time we're going to add a new contact, update one and then
-        // delete one
+        // delete one (we're going to delete the security-contact by passing
+        // an empty string). the code should also skip new product-owner since
+        // it has an empty value
 
         domainContacts = new HashMap<>();
         domainContacts.put("pe-owner", "user.user2");
         domainContacts.put("audit-contact", "user.user3");
+        domainContacts.put("security-contact", "");
+        domainContacts.put("product-owner", "");
         domainMeta = new DomainMeta().setContacts(domainContacts);
         zmsImpl.putDomainMeta(ctx, domainName, auditRef, domainMeta);
 
@@ -221,7 +226,7 @@ public class DomainContactsTest {
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);
-            assertTrue(ex.getMessage().contains("invalid domain contact: security-contact/user.user3"));
+            assertTrue(ex.getMessage().contains("invalid domain contact: security-contact"));
         }
 
         // now let's add all three valid users and contacts

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -27260,7 +27260,7 @@ public class ZMSImplTest {
                     + "\"serviceExpiryDays\": \"null\", \"reviewEnabled\": \"false\", \"notifyRoles\": \"null\", "
                     + "\"userAuthorityFilter\": \"null\", \"userAuthorityExpiration\": \"null\", "
                     + "\"deleteProtection\": \"false\", \"lastReviewedDate\": \"null\", \"maxMembers\": \"null\", "
-                    + "\"selfRenew\": \"null\", \"selfRenewMins\": \"null, "
+                    + "\"selfRenew\": \"null\", \"selfRenewMins\": \"null\", "
                     + "\"deleted-members\": [{\"member\": \"user.jane\", \"approved\": true, \"system-disabled\": 0}], "
                     + "\"added-members\": []}");
             assertTrue(index2 > index, msg);


### PR DESCRIPTION
# Description
For domain contacts #2430 extend the schema for user value to be a std string to provide more flexibility. also extended the delete capability to support passing empty strings
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

