### PR TITLE
sia init/rolecert command line option - report error code for failures

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -641,7 +641,10 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 	switch siaCmd {
 	case "rolecert":
 		count, failures := GetRoleCertificates(ztsUrl, opts)
-		if failures != count {
+		if failures != 0 {
+			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
+		}
+		if count != 0 {
 			util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		}
 	case "token":
@@ -674,7 +677,10 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
 		log.Printf("identity registered for services: %s\n", svcs)
-		GetRoleCertificates(ztsUrl, opts)
+		count, failures := GetRoleCertificates(ztsUrl, opts)
+		if failures != 0 {
+			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
+		}
 		util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		if tokenOpts != nil {
 			err := accessTokenRequest(tokenOpts)

--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -649,7 +649,7 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 		}
 	case "token":
 		if tokenOpts != nil {
-			err := accessTokenRequest(tokenOpts)
+			err := fetchAccessToken(tokenOpts)
 			if err != nil {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}
@@ -683,7 +683,7 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 		}
 		util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		if tokenOpts != nil {
-			err := accessTokenRequest(tokenOpts)
+			err := fetchAccessToken(tokenOpts)
 			if err != nil {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -627,7 +627,10 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 	switch siaCmd {
 	case "rolecert":
 		count, failures := GetRoleCertificates(ztsUrl, opts)
-		if failures != count {
+		if failures != 0 {
+			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
+		}
+		if count != 0 {
 			util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		}
 	case "token":
@@ -660,7 +663,10 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
 		log.Printf("identity registered for services: %s\n", svcs)
-		GetRoleCertificates(ztsUrl, opts)
+		count, failures := GetRoleCertificates(ztsUrl, opts)
+		if failures != 0 {
+			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
+		}
 		util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		if tokenOpts != nil {
 			err := accessTokenRequest(tokenOpts)

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -635,7 +635,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 		}
 	case "token":
 		if tokenOpts != nil {
-			err := accessTokenRequest(tokenOpts)
+			err := fetchAccessToken(tokenOpts)
 			if err != nil {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}
@@ -669,7 +669,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 		}
 		util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		if tokenOpts != nil {
-			err := accessTokenRequest(tokenOpts)
+			err := fetchAccessToken(tokenOpts)
 			if err != nil {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}


### PR DESCRIPTION
# Description

if the user calls ./siad -cmd rolecert and the agent fails to refresh any of the certs, we now return an error code instead of returning success
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

