### PR TITLE
fix functional test sd job

### DIFF
--- a/ui/src/__tests__/spec/wdio.conf.js
+++ b/ui/src/__tests__/spec/wdio.conf.js
@@ -37,8 +37,8 @@ if (process.env.INSTANCE) {
     athenzService = 'devui';
 }
 
-let sdAthenzKeyFilePath = WORK_DIR + '/func.key.pem';
-let sdAthenzCertFiledPath = WORK_DIR + '/func.cert.pem';
+let sdAthenzKeyFilePath = '/tokens/key';
+let sdAthenzCertFiledPath = '/tokens/cert';
 let localAthenzKeyFilePath =
     '~/.athenz/keys/' + athenzDomain + '.' + athenzService + '.key.pem';
 let localAthenzCertFilePath =


### PR DESCRIPTION
Problem: Screwdriver calls `zts-accesstoken` with the incorrect cert/key thus having incorrect identity and permissions during it's functional test instance.

Solution: Use the screwdriver job cert/key.