### PR TITLE
maintain a static map of trusted roles

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -163,6 +163,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_QUOTA_SERVICE_TAG   = "athenz.zms.quota_service_tag";
 
     public static final String ZMS_PROP_MYSQL_SERVER_TIMEZONE = "athenz.zms.mysql_server_timezone";
+    public static final String ZMS_PROP_MYSQL_SERVER_TRUST_ROLES_UPDATE_TIMEOUT = "athenz.zms.mysql_server_trust_roles_update_timeout";
 
     public static final String ZMS_PRINCIPAL_AUTHORITY_CLASS  = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -47,7 +47,6 @@ public class JDBCConnection implements ObjectStoreConnection {
     private static final String MYSQL_EXC_STATE_DEADLOCK   = "40001";
     private static final String MYSQL_EXC_STATE_COMM_ERROR = "08S01";
 
-
     private static final String SQL_TABLE_DOMAIN = "domain";
     private static final String SQL_TABLE_ROLE = "role";
     private static final String SQL_TABLE_ROLE_MEMBER = "role_member";
@@ -675,6 +674,9 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "JOIN domain ON domain_contacts.domain_id=domain.domain_id "
             + "WHERE domain_contacts.name=?;";
     private static final String SQL_LIST_DOMAIN_CONTACTS = "SELECT type, name FROM domain_contacts WHERE domain_id=?;";
+    private static final String SQL_GET_LAST_ASSUME_ROLE_ASSERTION = "SELECT policy.modified FROM policy "
+            + " JOIN assertion ON policy.policy_id=assertion.policy_id WHERE assertion.action='assume_role' "
+            + " ORDER BY policy.modified DESC LIMIT 1";
 
     private static final String CACHE_DOMAIN    = "d:";
     private static final String CACHE_ROLE      = "r:";
@@ -698,12 +700,24 @@ public class JDBCConnection implements ObjectStoreConnection {
     Map<String, Integer> objectMap;
     boolean transactionCompleted;
     DomainOptions domainOptions;
+    private static Map<String, List<String>> SERVER_TRUST_ROLES_MAP;
+    private static long SERVER_TRUST_ROLES_TIMESTAMP;
+    private static long SERVER_TRUST_ROLES_UPDATE_TIMEOUT = Long.parseLong(
+            System.getProperty(ZMSConsts.ZMS_PROP_MYSQL_SERVER_TRUST_ROLES_UPDATE_TIMEOUT, "120000"));
 
     public JDBCConnection(Connection con, boolean autoCommit) throws SQLException {
         this.con = con;
         con.setAutoCommit(autoCommit);
         transactionCompleted = autoCommit;
         objectMap = new HashMap<>();
+    }
+
+    /**
+     * Used only by the test classes to reset the server trust roles map
+     */
+    void resetTrustRolesMap() {
+        SERVER_TRUST_ROLES_MAP = null;
+        SERVER_TRUST_ROLES_TIMESTAMP = 0;
     }
 
     @Override
@@ -4612,12 +4626,75 @@ public class JDBCConnection implements ObjectStoreConnection {
         }
     }
 
+    long lastTrustRoleUpdatesTimestamp() {
+
+        final String caller = "lastTrustRoleUpdatesTimestamp";
+
+        long timeStamp = 0;
+        try (PreparedStatement ps = con.prepareStatement(SQL_GET_LAST_ASSUME_ROLE_ASSERTION)) {
+            try (ResultSet rs = executeQuery(ps, caller)) {
+                if (rs.next()) {
+                    timeStamp = rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime();
+                }
+            }
+        } catch (SQLException ignored) {
+        }
+
+        return timeStamp;
+    }
+
     Map<String, List<String>> getTrustedRoles(String caller) {
+
+        // if our last timestamp has passed our timeout or our map has not been
+        // initialized, then we need to update our trust map so need for any
+        // extra timestamp checks
+
+        long now = System.currentTimeMillis();
+        if (SERVER_TRUST_ROLES_MAP == null || now - SERVER_TRUST_ROLES_TIMESTAMP > SERVER_TRUST_ROLES_UPDATE_TIMEOUT) {
+            updateTrustRolesMap(now, true, caller);
+
+        } else {
+
+            // we want to make sure to capture any additions right away, so we'll get
+            // the last modification timestamp of the latest policy that has an assume_role
+            // assertion
+
+            long lastTimeStamp = lastTrustRoleUpdatesTimestamp();
+            if (lastTimeStamp > SERVER_TRUST_ROLES_TIMESTAMP) {
+                updateTrustRolesMap(lastTimeStamp, false, caller);
+            }
+        }
+
+        return SERVER_TRUST_ROLES_MAP;
+    }
+
+    synchronized void updateTrustRolesMap(long lastTimeStamp, boolean timeoutUpdate, final String caller) {
+
+        // a couple of simple checks in case we already have a valid
+        // map to see if we can skip updating the map
+
+        if (SERVER_TRUST_ROLES_MAP != null) {
+
+            // if our last timestamp is older than the one we have
+            // then we're going to skip the update
+
+            if (SERVER_TRUST_ROLES_TIMESTAMP >= lastTimeStamp) {
+                return;
+            }
+
+            // if this is a timeout update we're going to check if the map
+            // has already been updated by another thread while we were waiting
+
+            if (timeoutUpdate && lastTimeStamp - SERVER_TRUST_ROLES_TIMESTAMP < SERVER_TRUST_ROLES_UPDATE_TIMEOUT) {
+                return;
+            }
+        }
 
         Map<String, List<String>> trustedRoles = new HashMap<>();
         getTrustedSubTypeRoles(SQL_LIST_TRUSTED_STANDARD_ROLES, trustedRoles, caller);
         getTrustedSubTypeRoles(SQL_LIST_TRUSTED_WILDCARD_ROLES, trustedRoles, caller);
-        return trustedRoles;
+        SERVER_TRUST_ROLES_TIMESTAMP = lastTimeStamp;
+        SERVER_TRUST_ROLES_MAP = trustedRoles;
     }
 
     void addRoleAssertions(List<Assertion> principalAssertions, List<Assertion> roleAssertions) {


### PR DESCRIPTION
# Description

when we get large number of simultaneous listResourceAccess calls, all try to get the current list of trust roles setup in the server. This could get quite large so all the threads are busy getting large number of rows from DB. However, in most cases, those never change so there is no need to fetch the list for every request. So now we're maintaining a static map of the roles to address the case with large simultaneous calls:
a) by default we drop the map every 2 minutes so any deletions to the rows can be reflected in two minutes. This could be extended by the specifying the different value for the athenz.zms.mysql_server_trust_roles_update_timeout property value in milliseconds (default 120,000).
b) we check the last modification timestamp of the policy that has an assertion with assume_role action. this way new assertions are in effect immediately

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

