### PR TITLE
maintain a static map of trusted roles for resource list lookup api

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -526,3 +526,10 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # fact that we want roles/groups to be reviewed every 90 days and the server
 # generates reminder notifications starting 28 days before the expiry date.
 #athenz.zms.review_days_percentage=68
+
+# When handling requests for resource lists, the server needs access to
+# all trust roles map. Getting the data from the DB is expensive, so we're
+# caching the result set for the specified number of milliseconds so any
+# deletions to the rows can be reflected in the result set. If there are
+# additions then the server always fetches the latest data.
+#athenz.zms.mysql_server_trust_roles_update_timeout=600000

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -163,6 +163,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_QUOTA_SERVICE_TAG   = "athenz.zms.quota_service_tag";
 
     public static final String ZMS_PROP_MYSQL_SERVER_TIMEZONE = "athenz.zms.mysql_server_timezone";
+    public static final String ZMS_PROP_MYSQL_SERVER_TRUST_ROLES_UPDATE_TIMEOUT = "athenz.zms.mysql_server_trust_roles_update_timeout";
 
     public static final String ZMS_PRINCIPAL_AUTHORITY_CLASS  = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -8961,11 +8961,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         validateRequest(ctx.request(), caller, true);
 
-        // for now we're going to verify our database connectivity
-        // in case of failure we're going to return not found
+        // we're going to verify our database connectivity
+        // by listing our system domains. In case of failure
+        // we're going to return not found
 
-        DomainList dlist = listDomains(null, null, null, null, 0, false);
-        if (dlist.getNames() == null || dlist.getNames().isEmpty()) {
+        if (dbService.listDomains(SYS_AUTH, 0, false).isEmpty()) {
             throw ZMSUtils.notFoundError("Error - no domains available", caller);
         }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
@@ -7435,11 +7435,16 @@ public class JDBCConnectionTest {
     public void testGetTrustedRoles() throws Exception {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        jdbcConn.resetTrustRolesMap();
 
         Mockito.when(mockResultSet.next())
             .thenReturn(true)
             .thenReturn(true)
             .thenReturn(true)
+            .thenReturn(false)
+            .thenReturn(false) // end of first call
+            .thenReturn(true)  // for timestamp lookup
+            .thenReturn(true)  // single entry returned
             .thenReturn(false);
         Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_NAME))
             .thenReturn("trole1")
@@ -7457,6 +7462,9 @@ public class JDBCConnectionTest {
             .thenReturn("101")
             .thenReturn("101")
             .thenReturn("103");
+        long now = System.currentTimeMillis();
+        Mockito.when(mockResultSet.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED))
+            .thenReturn(new java.sql.Timestamp(now + 30000));
 
         Map<String, List<String>> trustedRoles = jdbcConn.getTrustedRoles("getTrustedRoles");
         assertEquals(2, trustedRoles.size());
@@ -7472,6 +7480,29 @@ public class JDBCConnectionTest {
 
         assertEquals("103:trole3", roles.get(0));
 
+        trustedRoles = jdbcConn.getTrustedRoles("getTrustedRoles");
+        assertEquals(1, trustedRoles.size());
+
+        roles = trustedRoles.get("103:role3");
+        assertEquals(1, roles.size());
+
+        assertEquals("103:trole3", roles.get(0));
+
+        // when we call the update trust map with timestamp in the past, it should return
+        // right away without making any mysql calls
+
+        jdbcConn.updateTrustRolesMap(now - 30000, false, "trustMapTest");
+
+        // second time calling the api should now give us an empty map
+        // since our values will no longer match
+
+        jdbcConn.updateTrustRolesMap(now + 60000, false, "trustMapTest");
+        assertTrue(jdbcConn.getTrustedRoles("getTrustedRoles").isEmpty());
+
+        // specifying timeout update with a second difference should not
+        // trigger an update
+
+        jdbcConn.updateTrustRolesMap(now + 60001, true, "trustMapTest");
         jdbcConn.close();
     }
 
@@ -7656,6 +7687,7 @@ public class JDBCConnectionTest {
     public void testListResourceAccessNotRegisteredRolePrincipals() throws SQLException {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        jdbcConn.resetTrustRolesMap();
 
         // no role principals
 
@@ -7678,6 +7710,7 @@ public class JDBCConnectionTest {
     public void testListResourceAccessRegisteredRolePrincipals() throws SQLException {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        jdbcConn.resetTrustRolesMap();
 
         // no role principals
 
@@ -7705,6 +7738,7 @@ public class JDBCConnectionTest {
     public void testListResourceAccessEmptyRoleAssertions() throws SQLException {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        jdbcConn.resetTrustRolesMap();
 
         Mockito.when(mockResultSet.next())
             .thenReturn(true)
@@ -7743,6 +7777,7 @@ public class JDBCConnectionTest {
     public void testListResourceAccess() throws SQLException {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        jdbcConn.resetTrustRolesMap();
 
         Mockito.when(mockResultSet.next())
             .thenReturn(true)
@@ -7808,6 +7843,7 @@ public class JDBCConnectionTest {
     public void testListResourceAccessAws() throws SQLException {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        jdbcConn.resetTrustRolesMap();
 
         Mockito.when(mockResultSet.next())
             .thenReturn(true)
@@ -7819,6 +7855,7 @@ public class JDBCConnectionTest {
             .thenReturn(true)
             .thenReturn(true)
             .thenReturn(false) // up to here is role assertions
+            .thenReturn(true) // this is for last modified timestamp
             .thenReturn(true)
             .thenReturn(true)
             .thenReturn(true)
@@ -7827,6 +7864,8 @@ public class JDBCConnectionTest {
             .thenReturn(true)
             .thenReturn(true)
             .thenReturn(false); // up to here is aws domains
+        Mockito.when(mockResultSet.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED))
+            .thenReturn(new java.sql.Timestamp(1454358916));
         Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_NAME))
             .thenReturn("dom1")
             .thenReturn("dom2")
@@ -7893,6 +7932,7 @@ public class JDBCConnectionTest {
 
         jdbcConn.close();
     }
+
     @Test
     public void testGetResourceAccessObject() throws SQLException {
 
@@ -15794,6 +15834,15 @@ public class JDBCConnectionTest {
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.INTERNAL_SERVER_ERROR);
         }
+        jdbcConn.close();
+    }
+
+    @Test
+    public void testLastTrustRoleUpdatesTimestampException() throws Exception {
+
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Mockito.when(mockPrepStmt.executeQuery()).thenThrow(new SQLException("failed operation", "state", 1001));
+        assertEquals(jdbcConn.lastTrustRoleUpdatesTimestamp(), 0);
         jdbcConn.close();
     }
 }


### PR DESCRIPTION
# Description
when we get large number of simultaneous listResourceAccess calls, all try to get the current list of trust roles setup in the server. This could get quite large so all the threads are busy getting large number of rows from DB. However, in most cases, those never change so there is no need to fetch the list for every request. So now we're maintaining a static map of the roles to address the case with large simultaneous calls:
a) by default we drop the map every 10 minutes so any deletions to the rows can be reflected in 10 minutes. This could be changed by the specifying the different value for the athenz.zms.mysql_server_trust_roles_update_timeout property value in milliseconds (default 600,000).
b) we check the last modification timestamp of the policy that has an assertion with assume_role action. this way new assertions are in effect immediately
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

