### PR TITLE
mark trust role vars as volatile

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -700,8 +700,8 @@ public class JDBCConnection implements ObjectStoreConnection {
     Map<String, Integer> objectMap;
     boolean transactionCompleted;
     DomainOptions domainOptions;
-    private static Map<String, List<String>> SERVER_TRUST_ROLES_MAP;
-    private static long SERVER_TRUST_ROLES_TIMESTAMP;
+    private volatile static Map<String, List<String>> SERVER_TRUST_ROLES_MAP;
+    private volatile static long SERVER_TRUST_ROLES_TIMESTAMP;
     private static final long SERVER_TRUST_ROLES_UPDATE_TIMEOUT = Long.parseLong(
             System.getProperty(ZMSConsts.ZMS_PROP_MYSQL_SERVER_TRUST_ROLES_UPDATE_TIMEOUT, "600000"));
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCObjectStore.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCObjectStore.java
@@ -33,6 +33,7 @@ public class JDBCObjectStore implements ObjectStore {
     private int serviceTagsLimit;
     private int policyTagsLimit;
     private DomainOptions domainOptions;
+    private final Object synchronizer = new Object();
 
     public JDBCObjectStore(PoolableDataSource rwSrc, PoolableDataSource roSrc) {
         this.rwSrc = rwSrc;
@@ -52,6 +53,7 @@ public class JDBCObjectStore implements ObjectStore {
         try {
             PoolableDataSource src = readWrite ? rwSrc : roSrc;
             JDBCConnection jdbcConn = new JDBCConnection(src.getConnection(), autoCommit);
+            jdbcConn.setObjectSynchronizer(synchronizer);
             jdbcConn.setOperationTimeout(opTimeout);
             jdbcConn.setTagLimit(domainTagsLimit, roleTagsLimit, groupTagsLimit, policyTagsLimit, serviceTagsLimit);
             jdbcConn.setDomainOptions(domainOptions);


### PR DESCRIPTION
# Description

this should eliminate the case when sometimes the timestamp check causes unnecessary loads from db.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

