### PR TITLE
support internal authz check with roles specified

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -1963,8 +1963,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // our action are always converted to lowercase
 
         String resource = SYS_AUTH + ":domain";
-        AccessStatus accessStatus = evaluateAccess(domain, principal.getFullName(), "create",
-                resource, null, null, principal);
+        AccessStatus accessStatus = hasAccess(domain, "create", resource, principal, null);
 
         return accessStatus == AccessStatus.ALLOWED;
     }
@@ -3768,8 +3767,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         if (!StringUtil.isEmpty(domainName)) {
             AthenzDomain requestDomain = getAthenzDomain(domainName, true);
             if (requestDomain != null) {
-                AccessStatus accessStatus = evaluateAccess(requestDomain, principal.getFullName(), "access",
-                        domainName + ":meta.role.lookup", null, null, principal);
+                AccessStatus accessStatus = hasAccess(requestDomain, "access",
+                        domainName + ":meta.role.lookup", principal, null);
                 if (accessStatus == AccessStatus.ALLOWED) {
                     return true;
                 }
@@ -3785,9 +3784,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // is allowed or not for the given operation and resource
         // our action are always converted to lowercase
 
-        AccessStatus accessStatus = evaluateAccess(domain, principal.getFullName(), "access",
-                "sys.auth:meta.role.lookup", null, null, principal);
 
+        AccessStatus accessStatus = hasAccess(domain, "access", "sys.auth:meta.role.lookup", principal, null);
         if (accessStatus == AccessStatus.ALLOWED) {
             return true;
         }
@@ -3816,8 +3814,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             return false;
         }
 
-        accessStatus = evaluateAccess(domain, principal.getFullName(), "update",
-                checkResource, null, null, principal);
+        accessStatus = hasAccess(domain, "update", checkResource, principal, null);
         return accessStatus == AccessStatus.ALLOWED;
     }
 
@@ -9118,8 +9115,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // our action are always converted to lowercase
 
         String resource = SYS_AUTH + ":meta." + objectType + "." + attribute + "." + reqDomain;
-        AccessStatus accessStatus = evaluateAccess(domain, principal.getFullName(), "delete",
-                resource, null, null, principal);
+        AccessStatus accessStatus = hasAccess(domain, "delete", resource, principal, null);
 
         return accessStatus == AccessStatus.ALLOWED;
     }
@@ -9486,8 +9482,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // our action are always converted to lowercase
 
         String resource = ZMSConsts.SYS_AUTH_AUDIT_BY_DOMAIN + ":audit." + reqDomain.getDomain().getName();
-        AccessStatus accessStatus = evaluateAccess(authDomain, principal.getFullName(),
-                "update", resource, null, null, principal);
+        AccessStatus accessStatus = hasAccess(authDomain, "update", resource, principal, null);
         if (accessStatus == AccessStatus.ALLOWED) {
             return true;
         }
@@ -9497,8 +9492,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         authDomain = getAthenzDomain(ZMSConsts.SYS_AUTH_AUDIT_BY_ORG, true);
         resource = ZMSConsts.SYS_AUTH_AUDIT_BY_ORG + ":audit." + reqDomain.getDomain().getOrg();
-        accessStatus = evaluateAccess(authDomain, principal.getFullName(),
-                "update", resource, null, null, principal);
+        accessStatus = hasAccess(authDomain, "update", resource, principal, null);
 
         return accessStatus == AccessStatus.ALLOWED;
     }
@@ -9543,7 +9537,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         return isAllowedActionOnResource(principal, domain, roleName, "update", "update_meta");
     }
 
-    private boolean isAllowedActionOnResource(Principal principal, final AthenzDomain domain, final String resourceName, String... actions) {
+    private boolean isAllowedActionOnResource(Principal principal, final AthenzDomain domain,
+            final String resourceName, String... actions) {
 
         // evaluate our domain's roles and policies to see if one of the actions specified
         // is allowed for the given resource (role or group):
@@ -9552,7 +9547,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // update_meta - only allows access to manage metadata
 
         for (String action : actions) {
-            if (evaluateAccess(domain, principal.getFullName(), action, resourceName, null, null, principal) == AccessStatus.ALLOWED) {
+            if (hasAccess(domain, action, resourceName, principal, null) == AccessStatus.ALLOWED) {
                 return true;
             }
         }
@@ -11402,8 +11397,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // is allowed or not for the given operation and resource
         // our action are always converted to lowercase
 
-        AccessStatus accessStatus = evaluateAccess(domain, principal.getFullName(), "access",
-                "sys.auth:meta.review.lookup", null, null, principal);
+        AccessStatus accessStatus = hasAccess(domain, "access", "sys.auth:meta.review.lookup", principal, null);
         return accessStatus == AccessStatus.ALLOWED;
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -769,19 +769,14 @@ public class ZMSImplTest {
         // let's get the current time
 
         Date now = new Date();
+        DateFormat df = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss zzz");
+        String modifiedSince = df.format(now);
 
-        ZMSUtils.threadSleep(1000);
+        ZMSUtils.threadSleep(2000);
 
         TopLevelDomain dom2 = zmsTestInitializer.createTopLevelDomainObject("ListDom2",
                 "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
         zmsImpl.postTopLevelDomain(ctx, auditRef, dom2);
-
-        DateFormat df = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss zzz");
-        String modifiedSince = df.format(now);
-
-        // this is only a partial list since our file struct store
-        // which the unit tests use does not support last modified
-        // option so this will be tested in zms_system_test package
 
         DomainList domList = zmsImpl.getDomainList(ctx, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null, modifiedSince);
@@ -13968,7 +13963,7 @@ public class ZMSImplTest {
         RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
         final String auditRef = zmsTestInitializer.getAuditRef();
 
-        long timestamp = System.currentTimeMillis() - 1001;
+        long timestamp = System.currentTimeMillis() - 2001;
 
         TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("ListDomMod1",
                 "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSObjectReviewTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSObjectReviewTest.java
@@ -93,6 +93,21 @@ public class ZMSObjectReviewTest {
 
         assertTrue(zmsImpl.isAllowedObjectReviewLookup(principal, "user.jane"));
 
+        // try the access check with role based principal
+
+        List<String> roles = List.of("review-role");
+        Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
+        principal = SimplePrincipal.create("sys.auth", "unsigned-creds", roles, principalAuthority);
+
+        assertTrue(zmsImpl.isAllowedObjectReviewLookup(principal, "user.jane"));
+
+        // without the required role, we should get failure
+
+        roles = List.of("role1", "role2");
+        principal = SimplePrincipal.create("sys.auth", "unsigned-creds", roles, principalAuthority);
+
+        assertFalse(zmsImpl.isAllowedObjectReviewLookup(principal, "user.jane"));
+
         zmsImpl.deletePolicy(ctx, "sys.auth", "review-policy", auditRef);
         zmsImpl.deleteRole(ctx, "sys.auth", "review-role", auditRef);
     }


### PR DESCRIPTION
# Description
this is required in case the property is running with an authority that is based on access tokens and the roles object is set as expected in the principal object.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

