### PR TITLE
improve interoperability between self-signer in dev environments with openssl generated certs

### DIFF
--- a/servers/zts/conf/dev_x509_ext.cnf
+++ b/servers/zts/conf/dev_x509_ext.cnf
@@ -1,0 +1,8 @@
+basicConstraints = CA:FALSE
+authorityKeyIdentifier=keyid,issuer
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = __athenz_hostname__

--- a/servers/zts/conf/dev_x509ca_cert.cnf
+++ b/servers/zts/conf/dev_x509ca_cert.cnf
@@ -1,0 +1,17 @@
+[req]
+default_bits = 1024
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_req
+
+[ dn ]
+C = US
+ST = CA
+O = Athenz
+OU = Testing Domain
+CN = Athenz CA
+
+[ v3_req ]
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, digitalSignature, keyEncipherment, keyCertSign

--- a/servers/zts/conf/self_x509_cert.cnf
+++ b/servers/zts/conf/self_x509_cert.cnf
@@ -1,0 +1,15 @@
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_req
+
+[ dn ]
+C = US
+O = Athenz
+CN = Self Signed Athenz CA
+
+[ v3_req ]
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, digitalSignature, keyEncipherment, keyCertSign

--- a/servers/zts/scripts/setup_dev_zts.sh
+++ b/servers/zts/scripts/setup_dev_zts.sh
@@ -25,13 +25,23 @@ cd $ROOT/var/zts_server/keys
 openssl genrsa -out zts_private.pem 2048
 openssl rsa -in zts_private.pem -pubout > zts_public.pem
 
+# Generate a self-signed CA certificate for the server
+
+echo "Generating a self signed CA certificate for ZTS Server..."
+
+cd ../certs
+cp $ROOT/conf/zts_server/dev_x509ca_cert.cnf ./dev_x509ca_cert.cnf
+openssl req -x509 -nodes -newkey rsa:2048 -keyout zts_key.pem -out zts_ca_cert.pem -days 3650 -config ./dev_x509ca_cert.cnf
+
 # Generate a self-signed x509 certificate
 
 echo "Generating a self signed certificate for ZTS Server..."
-cd ../certs
+
 ZTS_HOSTNAME=$(hostname -f)
 sed s/__athenz_hostname__/$ZTS_HOSTNAME/g $ROOT/conf/zts_server/dev_x509_cert.cnf > ./dev_x509_cert.cnf
-openssl req -x509 -nodes -newkey rsa:2048 -keyout zts_key.pem -out zts_cert.pem -days 365 -config ./dev_x509_cert.cnf
+sed s/__athenz_hostname__/$ZTS_HOSTNAME/g $ROOT/conf/zts_server/dev_x509_ext.cnf > ./dev_x509_ext.cnf
+openssl req -key zts_key.pem -new -out zts.csr -config dev_x509_cert.cnf
+openssl x509 -req -CA zts_ca_cert.pem -CAkey zts_key.pem -in zts.csr -out zts_cert.pem -days 365 -CAcreateserial -extfile dev_x509_ext.cnf
 
 # Generate a keystore in PKCS#12 format
 
@@ -39,18 +49,27 @@ echo "Generating PKCS12 keystore for ZTS Server..."
 rm -rf zts_keystore.pkcs12
 openssl pkcs12 -export -out zts_keystore.pkcs12 -in zts_cert.pem -inkey zts_key.pem -noiter -password pass:athenz
 
-# Generate a truststore in JKS format
+# Generate a truststore in JKS format for connecting to ZMS Server
 
 echo "Generating JKS truststore for ZTS Server..."
 rm -rf zts_truststore.jks
 cp $ZMS_CERT $ROOT/var/zts_server/certs/zms_cert.pem
 keytool -importcert -noprompt -alias zms -keystore zts_truststore.jks -file zms_cert.pem -storepass athenz
 
+# Generate a truststore in JKS format for ZTS clients using mTLS
+
+echo "Generating JKS truststore for ZTS Server..."
+rm -rf zts_client_truststore.jks
+cp $ROOT/conf/zts_server/self_x509_cert.cnf ./self_x509_cert.cnf
+openssl req -x509 -nodes -key $ROOT/var/zts_server/keys/zts_private.pem -out self_ca_cert.pem -days 3650 -config ./self_x509_cert.cnf
+keytool -importcert -noprompt -alias self -keystore zts_client_truststore.jks -file self_ca_cert.pem -storepass athenz
+
 # Register ZTS Server in ZMS Server
 
 echo "Registering ZTS Service in Athenz..."
 cd $ROOT
 HOST_PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+$ROOT/bin/$HOST_PLATFORM/zms-cli -c $ROOT/var/zts_server/certs/zms_cert.pem -z https://$ZMS_HOSTNAME:4443/zms/v1 -d sys.auth delete-service zts
 $ROOT/bin/$HOST_PLATFORM/zms-cli -c $ROOT/var/zts_server/certs/zms_cert.pem -z https://$ZMS_HOSTNAME:4443/zms/v1 -d sys.auth add-service zts 0 $ROOT/var/zts_server/keys/zts_public.pem
 
 # Generate athenz configuration file

--- a/servers/zts/scripts/zts
+++ b/servers/zts/scripts/zts
@@ -39,7 +39,7 @@ JAVA_OPTS="${JAVA_OPTS} -Dathenz.prop_file=${ROOT}/conf/zts_server/athenz.proper
 JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.prop_file=${ROOT}/conf/zts_server/zts.properties"
 JAVA_OPTS="${JAVA_OPTS} -Dlogback.configurationFile=${ROOT}/conf/zts_server/logback.xml"
 JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_key_store=${ROOT}/var/zts_server/certs/zts_keystore.pkcs12"
-JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_trust_store=${ROOT}/var/zts_server/certs/zts_truststore.jks"
+JAVA_OPTS="${JAVA_OPTS} -Dathenz.ssl_trust_store=${ROOT}/var/zts_server/certs/zts_client_truststore.jks"
 JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.ssl_key_store=${ROOT}/var/zts_server/certs/zts_keystore.pkcs12"
 JAVA_OPTS="${JAVA_OPTS} -Dathenz.zts.ssl_trust_store=${ROOT}/var/zts_server/certs/zts_truststore.jks"
 JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${ROOT}/var/zts_server/certs/zts_truststore.jks"

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/KeyStoreCertSigner.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/KeyStoreCertSigner.java
@@ -25,9 +25,9 @@ import java.security.cert.X509Certificate;
 
 public class KeyStoreCertSigner implements CertSigner, AutoCloseable {
 
-    private X509Certificate caCertificate;
-    private PrivateKey caPrivateKey;
-    private int maxCertExpiryTimeMins;
+    private final X509Certificate caCertificate;
+    private final PrivateKey caPrivateKey;
+    private final int maxCertExpiryTimeMins;
 
     public KeyStoreCertSigner(X509Certificate caCertificate, PrivateKey caPrivateKey, int maxCertExpiryTimeMins) {
         this.caCertificate = caCertificate;
@@ -41,11 +41,12 @@ public class KeyStoreCertSigner implements CertSigner, AutoCloseable {
     }
 
     @Override
-    public String generateX509Certificate(String provider, String certIssuer, String csr, String keyUsage, int certExpiryMins, Priority priority) {
+    public String generateX509Certificate(String provider, String certIssuer, String csr, String keyUsage,
+            int certExpiryMins, Priority priority) {
+
         int certExpiryTime = (certExpiryMins == 0) ? this.maxCertExpiryTimeMins : certExpiryMins;
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
-        // keyUsage is ignored
         X509Certificate cert = Crypto.generateX509Certificate(certReq, caPrivateKey, caCertificate, certExpiryTime, false);
 
         return Crypto.convertToPEMFormat(cert);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerFactory.java
@@ -33,7 +33,6 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.IOException;
-import javax.security.auth.x500.X500Principal;
 
 public class SelfCertSignerFactory implements CertSignerFactory {
 
@@ -47,7 +46,7 @@ public class SelfCertSignerFactory implements CertSignerFactory {
         final String pKeyFileName = System.getProperty(ZTSConsts.ZTS_PROP_SELF_SIGNER_PRIVATE_KEY_FNAME);
         final String pKeyPassword = System.getProperty(ZTSConsts.ZTS_PROP_SELF_SIGNER_PRIVATE_KEY_PASSWORD);
         final String csrDn = System.getProperty(ZTSConsts.ZTS_PROP_SELF_SIGNER_CERT_DN,
-                "cn=Self Signed Athenz CA,o=Athenz,c=US");
+                "CN=Self Signed Athenz CA, O=Athenz, C=US");
         final int maxCertExpiryTimeMins = Integer.parseInt(System.getProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME, "43200"));
 
         if (StringUtil.isEmpty(pKeyFileName)) {
@@ -69,12 +68,11 @@ public class SelfCertSignerFactory implements CertSignerFactory {
         }
         
         // generate our self-signed certificate
-        
-        X500Principal subject = new X500Principal(csrDn);
-        X500Name issuer = X500Name.getInstance(subject.getEncoded());
+
+        X500Name issuer = Crypto.utf8DEREncodedIssuer(csrDn);
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
         X509Certificate caCertificate = Crypto.generateX509Certificate(certReq,
-                caPrivateKey, issuer, 30 * 24 * 60, true);
+                caPrivateKey, issuer, 365 * 24 * 60, true);
 
         return new KeyStoreCertSigner(caCertificate, caPrivateKey, maxCertExpiryTimeMins);
     }


### PR DESCRIPTION

# Description

In a dev environment that is setup with our scripts, we using openssl to generate our self-signed server certs with the CA while the server is using the self signer library which uses BouncyCastle to sign the certificates.

During this process, openssl when it generates the server ca certs used in the trust store it uses DER PrintableString for the C component and UTF8String for all other components. BouncyCastle library, on the other hand, uses PrintableString for all the components.

Now, with curl, this is not a problem and curl determines that the server is accepting client connections from a given issuer. With Go, the tls module actually compares the DER encoding (RawIssuer field) and determines that the client certificate used in the TLSConfig object is not accepted by the server thus it ignores it.

Now, both BC library and openssl are using the same DER encoding and the self-signed certs work fine in a dev environment.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

