### PR TITLE
increase width for email notification body to full page

### DIFF
--- a/libs/java/server_common/src/main/resources/emails/base.css
+++ b/libs/java/server_common/src/main/resources/emails/base.css
@@ -17,8 +17,8 @@ body {
     min-height: 402px;
 }
 .athenz-wrapper .mbrapproval {
-    width: 500px;
-    height: 402px;
+    width: 100%;
+    min-height: 402px;
     margin: auto;
     background-color:white;
     border-radius: 5px;
@@ -52,7 +52,7 @@ body {
 .mbrapproval .bt {
     background-color: rgba(255, 255, 255, 0.0);
     height: auto;
-    width: 440px;
+    width: 100%;
     margin: 20px;
     font-size: 14px;
     color: rgba(47, 48, 47, 1.0);

--- a/libs/java/server_common/src/test/resources/messages/role-member-expiry-email.html
+++ b/libs/java/server_common/src/test/resources/messages/role-member-expiry-email.html
@@ -22,8 +22,8 @@
         min-height: 402px;
     }
     .athenz-wrapper .mbrapproval {
-        width: 500px;
-        height: 402px;
+        width: 100%;
+        min-height: 402px;
         margin: auto;
         background-color:white;
         border-radius: 5px;
@@ -57,7 +57,7 @@
     .mbrapproval .bt {
         background-color: rgba(255, 255, 255, 0.0);
         height: auto;
-        width: 440px;
+        width: 100%;
         margin: 20px;
         font-size: 14px;
         color: rgba(47, 48, 47, 1.0);


### PR DESCRIPTION
# Description

increase the width for the main body from hard-coded px size to full 100% width to avoid getting data cut off and not visible in the message.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

