### PR TITLE
include instance-id as a principal in ssh host certificates on aws ec2

### DIFF
--- a/libs/go/sia/agent/agent_test.go
+++ b/libs/go/sia/agent/agent_test.go
@@ -218,7 +218,7 @@ func TestRegisterInstance(test *testing.T) {
 		SanDnsHostname:   true,
 	}
 
-	err := RegisterInstance("http://127.0.0.1:5084/zts/v1", "", opts, false)
+	err := RegisterInstance("http://127.0.0.1:5084/zts/v1", opts, false)
 	assert.Nil(test, err, "unable to register instance")
 
 	if err != nil {
@@ -304,7 +304,7 @@ func TestRefreshInstance(test *testing.T) {
 		return
 	}
 
-	err := RefreshInstance("http://127.0.0.1:5084/zts/v1", "", opts)
+	err := RefreshInstance("http://127.0.0.1:5084/zts/v1", opts)
 	assert.Nil(test, err, fmt.Sprintf("unable to refresh instance: %v", err))
 
 	oldCert, _ := os.ReadFile("devel/data/cert.pem")
@@ -603,7 +603,7 @@ func TestGenerateSshRequest(test *testing.T) {
 		Provider: tp,
 	}
 	// ssh option false we should get success with nils and empty csr
-	sshReq, sshCsr, err := generateSshRequest(&opts, "backend", "hostname.athenz.io", "")
+	sshReq, sshCsr, err := generateSshRequest(&opts, "backend", "hostname.athenz.io")
 	assert.Nil(test, sshReq)
 	assert.Equal(test, "", sshCsr)
 	assert.Nil(test, err)
@@ -614,7 +614,7 @@ func TestGenerateSshRequest(test *testing.T) {
 			Name: "api",
 		},
 	}
-	sshReq, sshCsr, err = generateSshRequest(&opts, "backend", "hostname.athenz.io", "")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "backend", "hostname.athenz.io")
 	assert.Nil(test, sshReq)
 	assert.Equal(test, "", sshCsr)
 	assert.Nil(test, err)
@@ -623,13 +623,13 @@ func TestGenerateSshRequest(test *testing.T) {
 	opts.Domain = "athenz"
 	opts.ZTSAWSDomains = []string{"athenz.io"}
 	opts.SshHostKeyType = hostkey.Rsa
-	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io", "")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io")
 	assert.Nil(test, sshReq)
 	assert.NotEmpty(test, sshCsr)
 	assert.Nil(test, err)
 	// ssh enabled with primary service and key type is ecdsa - empty csr but not-nil cert request
 	opts.SshHostKeyType = hostkey.Ecdsa
-	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io", "")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io")
 	assert.NotNil(test, sshReq)
 	assert.Equal(test, 3, len(sshReq.CertRequestData.Principals))
 	assert.True(test, slices.Contains(sshReq.CertRequestData.Principals, "my-vm"))
@@ -639,7 +639,7 @@ func TestGenerateSshRequest(test *testing.T) {
 	// ssh enabled with primary service and key type is ecdsa - empty csr but not-nil cert request, opts defines sshPrincipals
 	opts.SshHostKeyType = hostkey.Ecdsa
 	opts.SshPrincipals = "cname.athenz.io"
-	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io", "")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io")
 	assert.NotNil(test, sshReq)
 	assert.Equal(test, 4, len(sshReq.CertRequestData.Principals))
 	assert.True(test, slices.Contains(sshReq.CertRequestData.Principals, "hostname.athenz.io"))
@@ -670,7 +670,7 @@ func TestShouldExitRightAwayCertificate(test *testing.T) {
 		return
 	}
 
-	err := RefreshInstance("http://127.0.0.1:5084/zts/v1", "", opts)
+	err := RefreshInstance("http://127.0.0.1:5084/zts/v1", opts)
 	assert.Nil(test, err, fmt.Sprintf("unable to refresh instance: %v", err))
 
 	// our certs are valid for 30 days, so we'll set the refresh

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -175,7 +175,7 @@ func GetRoleCertificates(ztsUrl string, opts *options.Options) (int, int) {
 	return len(opts.Roles), failures
 }
 
-func RegisterInstance(data []*attestation.AttestationData, ztsUrl, metaEndpoint string, opts *options.Options, docExpiryCheck bool) error {
+func RegisterInstance(data []*attestation.AttestationData, ztsUrl string, opts *options.Options, docExpiryCheck bool) error {
 
 	//special handling for EC2 instances
 	//before we process our register event we need to check to
@@ -187,7 +187,7 @@ func RegisterInstance(data []*attestation.AttestationData, ztsUrl, metaEndpoint 
 	}
 
 	for i, svc := range opts.Services {
-		err := registerSvc(svc, data[i], ztsUrl, metaEndpoint, opts)
+		err := registerSvc(svc, data[i], ztsUrl, opts)
 		if err != nil {
 			return fmt.Errorf("unable to register identity for svc: %q, error: %v", svc.Name, err)
 		}
@@ -195,9 +195,9 @@ func RegisterInstance(data []*attestation.AttestationData, ztsUrl, metaEndpoint 
 	return nil
 }
 
-func RefreshInstance(data []*attestation.AttestationData, ztsUrl, metaEndpoint string, opts *options.Options) error {
+func RefreshInstance(data []*attestation.AttestationData, ztsUrl string, opts *options.Options) error {
 	for i, svc := range opts.Services {
-		err := refreshSvc(svc, data[i], ztsUrl, metaEndpoint, opts)
+		err := refreshSvc(svc, data[i], ztsUrl, opts)
 		if err != nil {
 			return fmt.Errorf("unable to refresh identity for svc: %q, error: %v", svc.Name, err)
 		}
@@ -239,7 +239,7 @@ func getServiceHostname(opts *options.Options, svc options.Service, fqdn bool) s
 	return fmt.Sprintf("%s.%s.%s.%s", hostname, svc.Name, hyphenDomain, opts.HostnameSuffix)
 }
 
-func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl, metaEndpoint string, opts *options.Options) error {
+func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl string, opts *options.Options) error {
 
 	key, err := util.GenerateKeyPair(2048)
 	if err != nil {
@@ -249,7 +249,7 @@ func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl,
 	//if ssh support is enabled then we need to generate the csr
 	//it is also generated for the primary service only
 	hostname := getServiceHostname(opts, svc, false)
-	sshCertRequest, sshCsr, err := generateSshRequest(opts, svc.Name, hostname, metaEndpoint)
+	sshCertRequest, sshCsr, err := generateSshRequest(opts, svc.Name, hostname)
 	if err != nil {
 		return err
 	}
@@ -351,7 +351,7 @@ func registerSvc(svc options.Service, data *attestation.AttestationData, ztsUrl,
 	return nil
 }
 
-func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl, metaEndpoint string, opts *options.Options) error {
+func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl string, opts *options.Options) error {
 
 	keyFile := util.GetSvcKeyFileName(opts.KeyDir, svc.KeyFilename, opts.Domain, svc.Name)
 	certFile := util.GetSvcCertFileName(opts.CertDir, svc.CertFilename, opts.Domain, svc.Name)
@@ -365,7 +365,7 @@ func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl, 
 	//if ssh support is enabled then we need to generate the csr
 	//it is also generated for the primary service only
 	hostname := getServiceHostname(opts, svc, false)
-	sshCertRequest, sshCsr, err := generateSshRequest(opts, svc.Name, hostname, metaEndpoint)
+	sshCertRequest, sshCsr, err := generateSshRequest(opts, svc.Name, hostname)
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func refreshSvc(svc options.Service, data *attestation.AttestationData, ztsUrl, 
 	return nil
 }
 
-func generateSshRequest(opts *options.Options, primaryServiceName, hostname, metaEndpoint string) (*zts.SSHCertRequest, string, error) {
+func generateSshRequest(opts *options.Options, primaryServiceName, hostname string) (*zts.SSHCertRequest, string, error) {
 	var err error
 	var sshCsr string
 	var sshCertRequest *zts.SSHCertRequest
@@ -474,7 +474,7 @@ func generateSshRequest(opts *options.Options, primaryServiceName, hostname, met
 		} else {
 			sshPrincipals := opts.SshPrincipals
 			// additional ssh host principals are added on best effort basis, hence error below is ignored.
-			additionalSshHostPrincipals, _ := opts.Provider.GetAdditionalSshHostPrincipals(metaEndpoint)
+			additionalSshHostPrincipals, _ := opts.Provider.GetAdditionalSshHostPrincipals(opts.MetaEndPoint)
 			if additionalSshHostPrincipals != "" {
 				if sshPrincipals != "" {
 					sshPrincipals = sshPrincipals + "," + additionalSshHostPrincipals
@@ -618,7 +618,12 @@ func SetupAgent(opts *options.Options, siaMainDir, siaLinkDir string) {
 	}
 }
 
-func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
+func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
+
+	//make sure the meta endpoint is configured by the caller
+	if opts.MetaEndPoint == "" {
+		log.Fatalf("meta endpoint not configured")
+	}
 
 	//the default value is to rotate once every day since our
 	//server and role certs are valid for 30 days by default
@@ -654,21 +659,21 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 			log.Print("unable to fetch access tokens, invalid or missing configuration")
 		}
 	case "post", "register":
-		err := RegisterInstance(data, ztsUrl, metaEndpoint, opts, false)
+		err := RegisterInstance(data, ztsUrl, opts, false)
 		if err != nil {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
 		util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		log.Printf("identity registered for services: %s\n", svcs)
 	case "rotate", "refresh":
-		err = RefreshInstance(data, ztsUrl, metaEndpoint, opts)
+		err = RefreshInstance(data, ztsUrl, opts)
 		if err != nil {
 			log.Fatalf("Refresh identity failed, err: %v\n", err)
 		}
 		util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
 		log.Printf("Identity successfully refreshed for services: %s\n", svcs)
 	case "init":
-		err := RegisterInstance(data, ztsUrl, metaEndpoint, opts, false)
+		err := RegisterInstance(data, ztsUrl, opts, false)
 		if err != nil {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
@@ -698,7 +703,7 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 		initialSetup := true
 		for i, svc := range opts.Services {
 			if serviceAlreadyRegistered(opts, svc) {
-				err = refreshSvc(svc, data[i], ztsUrl, metaEndpoint, opts)
+				err = refreshSvc(svc, data[i], ztsUrl, opts)
 				if err != nil {
 					log.Printf("unable to refresh identity for svc: %q, error: %v", svc.Name, err)
 				}
@@ -706,7 +711,7 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 				if shouldSkipRegister(opts) {
 					log.Fatalf("identity document has expired (30 min timeout). ZTS will not register this instance. Please relaunch or stop and start your instance to refesh its identity document")
 				}
-				err = registerSvc(svc, data[i], ztsUrl, metaEndpoint, opts)
+				err = registerSvc(svc, data[i], ztsUrl, opts)
 				if err != nil {
 					log.Fatalf("unable to register identity for svc: %q, error: %v", svc.Name, err)
 				}
@@ -737,7 +742,7 @@ func RunAgent(siaCmd, ztsUrl, metaEndpoint string, opts *options.Options) {
 						errors <- fmt.Errorf("Cannot get attestation data: %v\n", err)
 						return
 					}
-					err = RefreshInstance(data, ztsUrl, metaEndpoint, opts)
+					err = RefreshInstance(data, ztsUrl, opts)
 					if err != nil {
 						failedRefreshCount++
 						if shouldExitRightAway(failedRefreshCount, opts) {

--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -229,7 +229,7 @@ func TestRegisterInstance(test *testing.T) {
 		CommonName: "athenz.hockey",
 	}
 
-	err := RegisterInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5084/zts/v1", "http://127.0.0.1:48888", opts, false)
+	err := RegisterInstance([]*attestation.AttestationData{a}, "http://127.0.0.1:5084/zts/v1", opts, false)
 	assert.Nil(test, err, "unable to register instance")
 
 	if err != nil {
@@ -320,7 +320,7 @@ func TestRefreshInstance(test *testing.T) {
 		return
 	}
 
-	err := RefreshInstance([]*attestation.AttestationData{attestationData}, "http://127.0.0.1:5084/zts/v1", "http://127.0.0.1:48888", opts)
+	err := RefreshInstance([]*attestation.AttestationData{attestationData}, "http://127.0.0.1:5084/zts/v1", opts)
 	assert.Nil(test, err, fmt.Sprintf("unable to refresh instance: %v", err))
 
 	oldCert, _ := os.ReadFile("devel/data/cert.pem")
@@ -619,7 +619,7 @@ func TestGenerateSshRequest(test *testing.T) {
 		Provider: tp,
 	}
 	// ssh option false we should get success with nils and empty csr
-	sshReq, sshCsr, err := generateSshRequest(&opts, "backend", "hostname.athenz.io", "http://127.0.0.1:48888")
+	sshReq, sshCsr, err := generateSshRequest(&opts, "backend", "hostname.athenz.io")
 	assert.Nil(test, sshReq)
 	assert.Equal(test, "", sshCsr)
 	assert.Nil(test, err)
@@ -630,7 +630,7 @@ func TestGenerateSshRequest(test *testing.T) {
 			Name: "api",
 		},
 	}
-	sshReq, sshCsr, err = generateSshRequest(&opts, "backend", "hostname.athenz.io", "http://127.0.0.1:48888")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "backend", "hostname.athenz.io")
 	assert.Nil(test, sshReq)
 	assert.Equal(test, "", sshCsr)
 	assert.Nil(test, err)
@@ -639,13 +639,13 @@ func TestGenerateSshRequest(test *testing.T) {
 	opts.Domain = "athenz"
 	opts.ZTSAWSDomains = []string{"athenz.io"}
 	opts.SshHostKeyType = hostkey.Rsa
-	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io", "http://127.0.0.1:48888")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io")
 	assert.Nil(test, sshReq)
 	assert.NotEmpty(test, sshCsr)
 	assert.Nil(test, err)
 	// ssh enabled with primary service and key type is ecdsa - empty csr but not-nil cert request
 	opts.SshHostKeyType = hostkey.Ecdsa
-	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io", "http://127.0.0.1:48888")
+	sshReq, sshCsr, err = generateSshRequest(&opts, "api", "hostname.athenz.io")
 	assert.NotNil(test, sshReq)
 	assert.Empty(test, sshCsr)
 	assert.Nil(test, err)
@@ -671,7 +671,7 @@ func TestShouldExitRightAwayCertificate(test *testing.T) {
 		return
 	}
 
-	err := RefreshInstance([]*attestation.AttestationData{attestationData}, "http://127.0.0.1:5084/zts/v1", "http://127.0.0.1:48888", opts)
+	err := RefreshInstance([]*attestation.AttestationData{attestationData}, "http://127.0.0.1:5084/zts/v1", opts)
 	assert.Nil(test, err, fmt.Sprintf("unable to refresh instance: %v", err))
 
 	// our certs are valid for 30 days, so we'll set the refresh

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -155,6 +155,7 @@ type Service struct {
 // Options represents settings that are derived from config file and application defaults
 type Options struct {
 	Provider            provider.Provider //provider instance
+	MetaEndPoint        string            //meta data service endpoint
 	Name                string            //name of the service identity
 	User                string            //the username to chown the cert/key dirs to. If absent, then root
 	Group               string            //the group name to chown the cert/key dirs to. If absent, then athenz

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -163,6 +163,7 @@ type Service struct {
 // Options represents settings that are derived from config file and application defaults
 type Options struct {
 	Provider            provider.Provider //provider instance
+	MetaEndPoint        string            //meta data service endpoint
 	Name                string            //name of the service identity
 	User                string            //the username to chown the cert/key dirs to. If absent, then root
 	Group               string            //the group name to chown the cert/key dirs to. If absent, then athenz

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSLambdaProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSLambdaProvider.java
@@ -36,7 +36,7 @@ public class InstanceAWSLambdaProvider extends InstanceAWSProvider {
     
     @Override
     protected void setConfirmationAttributes(InstanceConfirmation confirmation, boolean instanceDocumentCreds,
-             final String privateIP) {
+             final String privateIP, final String instanceId) {
         
         // for lambda we can only issue client certificates
         // and we always do not allow ssh certs

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProvider.java
@@ -302,7 +302,7 @@ public class InstanceAWSProvider implements InstanceProvider {
             
         // set the attributes to be returned to the ZTS server
 
-        setConfirmationAttributes(confirmation, instanceDocumentCreds, privateIp.toString());
+        setConfirmationAttributes(confirmation, instanceDocumentCreds, privateIp.toString(), instanceId.toString());
 
         // verify that the temporary credentials specified in the request
         // can be used to assume the given role thus verifying the
@@ -338,7 +338,7 @@ public class InstanceAWSProvider implements InstanceProvider {
         // object has an associated aws account id
         
         final String awsAccount = InstanceUtils.getInstanceProperty(instanceAttributes, ZTS_INSTANCE_AWS_ACCOUNT);
-        if (awsAccount == null) {
+        if (StringUtil.isEmpty(awsAccount)) {
             throw error("Unable to extract AWS Account id");
         }
 
@@ -374,7 +374,7 @@ public class InstanceAWSProvider implements InstanceProvider {
 
         // set the attributes to be returned to the ZTS server
 
-        setConfirmationAttributes(confirmation, instanceDocumentCreds, privateIp.toString());
+        setConfirmationAttributes(confirmation, instanceDocumentCreds, privateIp.toString(), instanceId.toString());
         
         // verify that the temporary credentials specified in the request
         // can be used to assume the given role thus verifying the
@@ -397,7 +397,7 @@ public class InstanceAWSProvider implements InstanceProvider {
     }
 
     protected void setConfirmationAttributes(InstanceConfirmation confirmation, boolean instanceDocumentCreds,
-                                   final String privateIp) {
+            final String privateIp, final String instanceId) {
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put(InstanceProvider.ZTS_CERT_SSH, Boolean.toString(instanceDocumentCreds));
@@ -406,6 +406,9 @@ public class InstanceAWSProvider implements InstanceProvider {
         }
         if (!privateIp.isEmpty()) {
             attributes.put(InstanceProvider.ZTS_INSTANCE_PRIVATE_IP, privateIp);
+        }
+        if (!instanceId.isEmpty()) {
+            attributes.put(InstanceProvider.ZTS_ATTESTED_SSH_CERT_PRINCIPALS, instanceId);
         }
         confirmation.setAttributes(attributes);
     }

--- a/provider/aws/sia-ec2/cmd/siad/main.go
+++ b/provider/aws/sia-ec2/cmd/siad/main.go
@@ -132,5 +132,5 @@ func main() {
 	}
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, opts)
+	agent.RunAgent(*cmd, ztsUrl, *ec2MetaEndPoint, opts)
 }

--- a/provider/aws/sia-ec2/cmd/siad/main.go
+++ b/provider/aws/sia-ec2/cmd/siad/main.go
@@ -102,6 +102,7 @@ func main() {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
+	opts.MetaEndPoint = *ec2MetaEndPoint
 	opts.Ssh = false
 	opts.EC2Document = string(document)
 	opts.EC2Signature = string(signature)
@@ -132,5 +133,5 @@ func main() {
 	}
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, *ec2MetaEndPoint, opts)
+	agent.RunAgent(*cmd, ztsUrl, opts)
 }

--- a/provider/aws/sia-ec2/provider.go
+++ b/provider/aws/sia-ec2/provider.go
@@ -42,11 +42,11 @@ func (ec2 EC2Provider) GetHostname(fqdn bool) string {
 	return utils.GetHostname(fqdn)
 }
 
-func (ec2 EC2Provider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (ec2 EC2Provider) AttestationData(_ string, _ crypto.PrivateKey, _ *signature.SignatureInfo) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (ec2 EC2Provider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (ec2 EC2Provider) PrepareKey(_ string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -54,23 +54,23 @@ func (ec2 EC2Provider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (ec2 EC2Provider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (ec2 EC2Provider) GetSanDns(_ string, _ bool, _ bool, _ []string) []string {
 	return nil
 }
 
-func (ec2 EC2Provider) GetSanUri(svc string, opts ip.Opts, spiffeTrustDomain, spiffeNamespace string) []*url.URL {
+func (ec2 EC2Provider) GetSanUri(_ string, _ ip.Opts, _, _ string) []*url.URL {
 	return nil
 }
 
-func (ec2 EC2Provider) GetEmail(service string) []string {
+func (ec2 EC2Provider) GetEmail(_ string) []string {
 	return nil
 }
 
-func (ec2 EC2Provider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (ec2 EC2Provider) GetRoleDnsNames(_ *x509.Certificate, _ string) []string {
 	return nil
 }
 
-func (ec2 EC2Provider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (ec2 EC2Provider) GetSanIp(_ map[string]bool, _ []net.IP, _ ip.Opts) []net.IP {
 	return nil
 }
 
@@ -78,18 +78,24 @@ func (ec2 EC2Provider) GetSuffix() string {
 	return ""
 }
 
-func (eks EC2Provider) CloudAttestationData(base, svc, ztSserverName string) (string, error) {
+func (ec2 EC2Provider) CloudAttestationData(_, _, _ string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (eks EC2Provider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (ec2 EC2Provider) GetAccountDomainServiceFromMeta(_ string) (string, string, string, error) {
 	return "", "", "", fmt.Errorf("not implemented")
 }
 
-func (tp EC2Provider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (ec2 EC2Provider) GetAccessManagementProfileFromMeta(_ string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (tp EC2Provider) GetAdditionalSshHostPrincipals(base string) (string, error) {
-	return "", nil
+// GetAdditionalSshHostPrincipals returns the additional ssh host principals
+func (ec2 EC2Provider) GetAdditionalSshHostPrincipals(base string) (string, error) {
+	// we're going to use our instance id as the additional ssh host principal
+	_, _, _, instanceId, _, _, _, err := GetEC2DocumentDetails(base)
+	if err != nil {
+		return "", err
+	}
+	return instanceId, nil
 }

--- a/provider/aws/sia-eks/cmd/siad/main.go
+++ b/provider/aws/sia-eks/cmd/siad/main.go
@@ -106,5 +106,5 @@ func main() {
 	opts.Provider = provider
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, opts)
+	agent.RunAgent(*cmd, ztsUrl, *eksMetaEndPoint, opts)
 }

--- a/provider/aws/sia-eks/cmd/siad/main.go
+++ b/provider/aws/sia-eks/cmd/siad/main.go
@@ -86,6 +86,7 @@ func main() {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
+	opts.MetaEndPoint = *eksMetaEndPoint
 	opts.Ssh = false
 	opts.ZTSCACertFile = *ztsCACert
 	opts.ZTSServerName = *ztsServerName
@@ -106,5 +107,5 @@ func main() {
 	opts.Provider = provider
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, *eksMetaEndPoint, opts)
+	agent.RunAgent(*cmd, ztsUrl, opts)
 }

--- a/provider/aws/sia-eks/provider.go
+++ b/provider/aws/sia-eks/provider.go
@@ -42,11 +42,11 @@ func (eks EKSProvider) GetHostname(fqdn bool) string {
 	return utils.GetHostname(fqdn)
 }
 
-func (eks EKSProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (eks EKSProvider) AttestationData(_ string, _ crypto.PrivateKey, _ *signature.SignatureInfo) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (eks EKSProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (eks EKSProvider) PrepareKey(_ string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -54,23 +54,23 @@ func (eks EKSProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (eks EKSProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (eks EKSProvider) GetSanDns(_ string, _ bool, _ bool, _ []string) []string {
 	return nil
 }
 
-func (eks EKSProvider) GetSanUri(svc string, opts ip.Opts, spiffeTrustDomain, spiffeNamespace string) []*url.URL {
+func (eks EKSProvider) GetSanUri(_ string, _ ip.Opts, _, _ string) []*url.URL {
 	return nil
 }
 
-func (eks EKSProvider) GetEmail(service string) []string {
+func (eks EKSProvider) GetEmail(_ string) []string {
 	return nil
 }
 
-func (eks EKSProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (eks EKSProvider) GetRoleDnsNames(_ *x509.Certificate, _ string) []string {
 	return nil
 }
 
-func (eks EKSProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (eks EKSProvider) GetSanIp(_ map[string]bool, _ []net.IP, _ ip.Opts) []net.IP {
 	return nil
 }
 
@@ -78,18 +78,18 @@ func (eks EKSProvider) GetSuffix() string {
 	return ""
 }
 
-func (eks EKSProvider) CloudAttestationData(base, svc, ztSserverName string) (string, error) {
+func (eks EKSProvider) CloudAttestationData(_, _, _ string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (eks EKSProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (eks EKSProvider) GetAccountDomainServiceFromMeta(_ string) (string, string, string, error) {
 	return "", "", "", fmt.Errorf("not implemented")
 }
 
-func (tp EKSProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (eks EKSProvider) GetAccessManagementProfileFromMeta(_ string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (tp EKSProvider) GetAdditionalSshHostPrincipals(base string) (string, error) {
+func (eks EKSProvider) GetAdditionalSshHostPrincipals(_ string) (string, error) {
 	return "", nil
 }

--- a/provider/aws/sia-fargate/cmd/siad/main.go
+++ b/provider/aws/sia-fargate/cmd/siad/main.go
@@ -87,6 +87,7 @@ func main() {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
+	opts.MetaEndPoint = *ecsMetaEndPoint
 	opts.Ssh = false
 	opts.ZTSCACertFile = *ztsCACert
 	opts.ZTSServerName = *ztsServerName
@@ -103,5 +104,5 @@ func main() {
 	opts.Provider = provider
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, *ecsMetaEndPoint, opts)
+	agent.RunAgent(*cmd, ztsUrl, opts)
 }

--- a/provider/aws/sia-fargate/cmd/siad/main.go
+++ b/provider/aws/sia-fargate/cmd/siad/main.go
@@ -103,5 +103,5 @@ func main() {
 	opts.Provider = provider
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, opts)
+	agent.RunAgent(*cmd, ztsUrl, *ecsMetaEndPoint, opts)
 }

--- a/provider/aws/sia-fargate/provider.go
+++ b/provider/aws/sia-fargate/provider.go
@@ -37,15 +37,15 @@ func (fargate FargateProvider) GetName() string {
 }
 
 // GetHostname returns the hostname as per the provider
-func (fargate FargateProvider) GetHostname(fqdn bool) string {
+func (fargate FargateProvider) GetHostname(_ bool) string {
 	return ""
 }
 
-func (fargate FargateProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (fargate FargateProvider) AttestationData(_ string, _ crypto.PrivateKey, _ *signature.SignatureInfo) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (fargate FargateProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (fargate FargateProvider) PrepareKey(_ string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -53,23 +53,23 @@ func (fargate FargateProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (fargate FargateProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (fargate FargateProvider) GetSanDns(_ string, _ bool, _ bool, _ []string) []string {
 	return nil
 }
 
-func (fargate FargateProvider) GetSanUri(svc string, opts ip.Opts, spiffeTrustDomain, spiffeNamespace string) []*url.URL {
+func (fargate FargateProvider) GetSanUri(_ string, _ ip.Opts, _, _ string) []*url.URL {
 	return nil
 }
 
-func (fargate FargateProvider) GetEmail(service string) []string {
+func (fargate FargateProvider) GetEmail(_ string) []string {
 	return nil
 }
 
-func (fargate FargateProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (fargate FargateProvider) GetRoleDnsNames(_ *x509.Certificate, _ string) []string {
 	return nil
 }
 
-func (fargate FargateProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (fargate FargateProvider) GetSanIp(_ map[string]bool, _ []net.IP, _ ip.Opts) []net.IP {
 	return nil
 }
 
@@ -77,18 +77,18 @@ func (fargate FargateProvider) GetSuffix() string {
 	return ""
 }
 
-func (eks FargateProvider) CloudAttestationData(base, svc, ztSserverName string) (string, error) {
+func (fargate FargateProvider) CloudAttestationData(_, _, _ string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (eks FargateProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (fargate FargateProvider) GetAccountDomainServiceFromMeta(_ string) (string, string, string, error) {
 	return "", "", "", fmt.Errorf("not implemented")
 }
 
-func (tp FargateProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (fargate FargateProvider) GetAccessManagementProfileFromMeta(_ string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (tp FargateProvider) GetAdditionalSshHostPrincipals(base string) (string, error) {
+func (fargate FargateProvider) GetAdditionalSshHostPrincipals(_ string) (string, error) {
 	return "", nil
 }

--- a/provider/gcp/sia-gce/cmd/siad/main.go
+++ b/provider/gcp/sia-gce/cmd/siad/main.go
@@ -138,6 +138,7 @@ func main() {
 		opts.SDSUdsPath = *udsPath
 	}
 
+	opts.MetaEndPoint = *gceMetaEndPoint
 	opts.Ssh = true
 	opts.ZTSCACertFile = *ztsCACert
 	opts.ZTSServerName = *ztsServerName
@@ -156,5 +157,5 @@ func main() {
 	opts.SshPubKeyFile = hostkey.PubKeyFile(sshDir, opts.SshHostKeyType)
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, *gceMetaEndPoint, opts)
+	agent.RunAgent(*cmd, ztsUrl, opts)
 }

--- a/provider/gcp/sia-gce/provider.go
+++ b/provider/gcp/sia-gce/provider.go
@@ -35,16 +35,16 @@ type GCEProvider struct {
 }
 
 // GetName returns the name of the current provider
-func (gke GCEProvider) GetName() string {
-	return gke.Name
+func (gce GCEProvider) GetName() string {
+	return gce.Name
 }
 
 // GetHostname returns the hostname as per the provider
-func (gke GCEProvider) GetHostname(fqdn bool) string {
+func (gce GCEProvider) GetHostname(fqdn bool) string {
 	return utils.GetHostname(fqdn)
 }
 
-func (gke GCEProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (gce GCEProvider) AttestationData(_ string, _ crypto.PrivateKey, _ *signature.SignatureInfo) (string, error) {
 	result, err := meta.GetData("http://169.254.169.254", "/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://zts.athenz.io&format=full")
 	if err == nil {
 		return string(result), nil
@@ -52,43 +52,43 @@ func (gke GCEProvider) AttestationData(svc string, key crypto.PrivateKey, sigInf
 	return "", fmt.Errorf("error while retriveing attestation data")
 }
 
-func (gke GCEProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (gce GCEProvider) PrepareKey(_ string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (gke GCEProvider) GetCsrDn() pkix.Name {
+func (gce GCEProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (gke GCEProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (gce GCEProvider) GetSanDns(_ string, _ bool, _ bool, _ []string) []string {
 	return nil
 }
 
-func (gke GCEProvider) GetSanUri(svc string, opts ip.Opts, spiffeTrustDomain, spiffeNamespace string) []*url.URL {
+func (gce GCEProvider) GetSanUri(_ string, _ ip.Opts, _, _ string) []*url.URL {
 	return nil
 }
 
-func (gke GCEProvider) GetEmail(service string) []string {
+func (gce GCEProvider) GetEmail(_ string) []string {
 	return nil
 }
 
-func (gke GCEProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (gce GCEProvider) GetRoleDnsNames(_ *x509.Certificate, _ string) []string {
 	return nil
 }
 
-func (gke GCEProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (gce GCEProvider) GetSanIp(_ map[string]bool, _ []net.IP, _ ip.Opts) []net.IP {
 	return nil
 }
 
-func (gke GCEProvider) GetSuffix() string {
+func (gce GCEProvider) GetSuffix() string {
 	return ""
 }
 
-func (gke GCEProvider) CloudAttestationData(base, svc, ztsServerName string) (string, error) {
+func (gce GCEProvider) CloudAttestationData(base, svc, ztsServerName string) (string, error) {
 	return gcpa.New(base, svc, ztsServerName)
 }
 
-func (gke GCEProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
+func (gce GCEProvider) GetAccountDomainServiceFromMeta(base string) (string, string, string, error) {
 	account, err := meta.GetProject(base)
 	if err != nil {
 		return "", "", "", err
@@ -104,7 +104,7 @@ func (gke GCEProvider) GetAccountDomainServiceFromMeta(base string) (string, str
 	return account, domain, service, nil
 }
 
-func (tp GCEProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (gce GCEProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
 	profile, err := meta.GetProfile(base)
 	if err != nil {
 		return "", err
@@ -112,7 +112,7 @@ func (tp GCEProvider) GetAccessManagementProfileFromMeta(base string) (string, e
 	return profile, nil
 }
 
-func (tp GCEProvider) GetAdditionalSshHostPrincipals(base string) (string, error) {
+func (gce GCEProvider) GetAdditionalSshHostPrincipals(base string) (string, error) {
 	instanceName, err := meta.GetInstanceName(base)
 	if err != nil {
 		return "", err

--- a/provider/gcp/sia-gke/cmd/siad/main.go
+++ b/provider/gcp/sia-gke/cmd/siad/main.go
@@ -102,6 +102,7 @@ func main() {
 		log.Fatalf("Unable to formulate options, error: %v\n", err)
 	}
 
+	opts.MetaEndPoint = *gkeMetaEndPoint
 	opts.Ssh = false
 	opts.ZTSCACertFile = *ztsCACert
 	opts.ZTSServerName = *ztsServerName
@@ -123,5 +124,5 @@ func main() {
 	// opts.SshHostKeyType = hostkey.Ecdsa
 
 	agent.SetupAgent(opts, siaMainDir, "")
-	agent.RunAgent(*cmd, ztsUrl, *gkeMetaEndPoint, opts)
+	agent.RunAgent(*cmd, ztsUrl, opts)
 }

--- a/provider/gcp/sia-gke/provider.go
+++ b/provider/gcp/sia-gke/provider.go
@@ -44,7 +44,7 @@ func (gke GKEProvider) GetHostname(fqdn bool) string {
 	return utils.GetHostname(fqdn)
 }
 
-func (gke GKEProvider) AttestationData(svc string, key crypto.PrivateKey, sigInfo *signature.SignatureInfo) (string, error) {
+func (gke GKEProvider) AttestationData(_ string, _ crypto.PrivateKey, _ *signature.SignatureInfo) (string, error) {
 	result, err := meta.GetData("http://169.254.169.254", "/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://zts.athenz.io&format=full")
 	if err == nil {
 		return string(result), nil
@@ -52,7 +52,7 @@ func (gke GKEProvider) AttestationData(svc string, key crypto.PrivateKey, sigInf
 	return "", fmt.Errorf("error while retriveing attestation data")
 }
 
-func (gke GKEProvider) PrepareKey(file string) (crypto.PrivateKey, error) {
+func (gke GKEProvider) PrepareKey(_ string) (crypto.PrivateKey, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -60,23 +60,23 @@ func (gke GKEProvider) GetCsrDn() pkix.Name {
 	return pkix.Name{}
 }
 
-func (gke GKEProvider) GetSanDns(service string, includeHost bool, wildcard bool, cnames []string) []string {
+func (gke GKEProvider) GetSanDns(_ string, _ bool, _ bool, _ []string) []string {
 	return nil
 }
 
-func (gke GKEProvider) GetSanUri(svc string, opts ip.Opts, spiffeTrustDomain, spiffeNamespace string) []*url.URL {
+func (gke GKEProvider) GetSanUri(_ string, _ ip.Opts, _, _ string) []*url.URL {
 	return nil
 }
 
-func (gke GKEProvider) GetEmail(service string) []string {
+func (gke GKEProvider) GetEmail(_ string) []string {
 	return nil
 }
 
-func (gke GKEProvider) GetRoleDnsNames(cert *x509.Certificate, service string) []string {
+func (gke GKEProvider) GetRoleDnsNames(_ *x509.Certificate, _ string) []string {
 	return nil
 }
 
-func (gke GKEProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.Opts) []net.IP {
+func (gke GKEProvider) GetSanIp(_ map[string]bool, _ []net.IP, _ ip.Opts) []net.IP {
 	return nil
 }
 
@@ -104,7 +104,7 @@ func (gke GKEProvider) GetAccountDomainServiceFromMeta(base string) (string, str
 	return account, domain, service, nil
 }
 
-func (tp GKEProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
+func (gke GKEProvider) GetAccessManagementProfileFromMeta(base string) (string, error) {
 	profile, err := meta.GetProfile(base)
 	if err != nil {
 		return "", err
@@ -112,6 +112,6 @@ func (tp GKEProvider) GetAccessManagementProfileFromMeta(base string) (string, e
 	return profile, nil
 }
 
-func (tp GKEProvider) GetAdditionalSshHostPrincipals(base string) (string, error) {
+func (gke GKEProvider) GetAdditionalSshHostPrincipals(_ string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
# Description

when using ssh over SSM in AWS, we need to have the instance id as principal in the ssh host certificate so we can execute ssh by just specifying the instance id

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

