### PR TITLE
upgrade nextjs major version

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -45,7 +45,7 @@
                 "moment": "2.29.4",
                 "moment-timezone": "0.5.37",
                 "multer": "1.4.5-lts.1",
-                "next": "12.3.0",
+                "next": "13.5.4",
                 "next-redux-wrapper": "8.0.0",
                 "passport": "0.6.0",
                 "passport-strategy": "1.0.0",
@@ -1707,44 +1707,14 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.0.tgz",
-            "integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
-        },
-        "node_modules/@next/swc-android-arm-eabi": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
-            "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-android-arm64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
-            "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
+            "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
-            "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
+            "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
             "cpu": [
                 "arm64"
             ],
@@ -1757,9 +1727,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
-            "integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
+            "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
             "cpu": [
                 "x64"
             ],
@@ -1771,40 +1741,10 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@next/swc-freebsd-x64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
-            "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm-gnueabihf": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
-            "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
-            "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
+            "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
             "cpu": [
                 "arm64"
             ],
@@ -1817,9 +1757,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
-            "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
+            "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
             "cpu": [
                 "arm64"
             ],
@@ -1832,9 +1772,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
-            "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
+            "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
             "cpu": [
                 "x64"
             ],
@@ -1847,9 +1787,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
-            "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
+            "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
             "cpu": [
                 "x64"
             ],
@@ -1862,9 +1802,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
-            "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
+            "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
             "cpu": [
                 "arm64"
             ],
@@ -1877,9 +1817,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
-            "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
+            "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
             "cpu": [
                 "ia32"
             ],
@@ -1892,9 +1832,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
-            "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
+            "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
             "cpu": [
                 "x64"
             ],
@@ -2116,9 +2056,9 @@
             "dev": true
         },
         "node_modules/@swc/helpers": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
-            "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+            "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -6823,6 +6763,11 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/client-only": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+        },
         "node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -9721,6 +9666,11 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "node_modules/global": {
             "version": "4.4.0",
@@ -14332,50 +14282,43 @@
             }
         },
         "node_modules/next": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/next/-/next-12.3.0.tgz",
-            "integrity": "sha512-GpzI6me9V1+XYtfK0Ae9WD0mKqHyzQlGq1xH1rzNIYMASo4Tkl4rTe9jSqtBpXFhOS33KohXs9ZY38Akkhdciw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
+            "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
             "dependencies": {
-                "@next/env": "12.3.0",
-                "@swc/helpers": "0.4.11",
-                "caniuse-lite": "^1.0.30001332",
-                "postcss": "8.4.14",
-                "styled-jsx": "5.0.6",
-                "use-sync-external-store": "1.2.0"
+                "@next/env": "13.5.4",
+                "@swc/helpers": "0.5.2",
+                "busboy": "1.6.0",
+                "caniuse-lite": "^1.0.30001406",
+                "postcss": "8.4.31",
+                "styled-jsx": "5.1.1",
+                "watchpack": "2.4.0"
             },
             "bin": {
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": ">=12.22.0"
+                "node": ">=16.14.0"
             },
             "optionalDependencies": {
-                "@next/swc-android-arm-eabi": "12.3.0",
-                "@next/swc-android-arm64": "12.3.0",
-                "@next/swc-darwin-arm64": "12.3.0",
-                "@next/swc-darwin-x64": "12.3.0",
-                "@next/swc-freebsd-x64": "12.3.0",
-                "@next/swc-linux-arm-gnueabihf": "12.3.0",
-                "@next/swc-linux-arm64-gnu": "12.3.0",
-                "@next/swc-linux-arm64-musl": "12.3.0",
-                "@next/swc-linux-x64-gnu": "12.3.0",
-                "@next/swc-linux-x64-musl": "12.3.0",
-                "@next/swc-win32-arm64-msvc": "12.3.0",
-                "@next/swc-win32-ia32-msvc": "12.3.0",
-                "@next/swc-win32-x64-msvc": "12.3.0"
+                "@next/swc-darwin-arm64": "13.5.4",
+                "@next/swc-darwin-x64": "13.5.4",
+                "@next/swc-linux-arm64-gnu": "13.5.4",
+                "@next/swc-linux-arm64-musl": "13.5.4",
+                "@next/swc-linux-x64-gnu": "13.5.4",
+                "@next/swc-linux-x64-musl": "13.5.4",
+                "@next/swc-win32-arm64-msvc": "13.5.4",
+                "@next/swc-win32-ia32-msvc": "13.5.4",
+                "@next/swc-win32-x64-msvc": "13.5.4"
             },
             "peerDependencies": {
-                "fibers": ">= 3.1.0",
-                "node-sass": "^6.0.0 || ^7.0.0",
-                "react": "^17.0.2 || ^18.0.0-0",
-                "react-dom": "^17.0.2 || ^18.0.0-0",
+                "@opentelemetry/api": "^1.1.0",
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0",
                 "sass": "^1.3.0"
             },
             "peerDependenciesMeta": {
-                "fibers": {
-                    "optional": true
-                },
-                "node-sass": {
+                "@opentelemetry/api": {
                     "optional": true
                 },
                 "sass": {
@@ -15236,9 +15179,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -15247,10 +15190,14 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.4",
+                "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
@@ -15259,9 +15206,15 @@
             }
         },
         "node_modules/postcss/node_modules/nanoid": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -17256,9 +17209,12 @@
             }
         },
         "node_modules/styled-jsx": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.6.tgz",
-            "integrity": "sha512-xOeROtkK5MGMDimBQ3J6iPId8q0t/BDoG5XN6oKkZClVz9ISF/hihN8OCn2LggMU6N32aXnrXBdn3auSqNS9fA==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+            "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+            "dependencies": {
+                "client-only": "0.0.1"
+            },
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -18214,6 +18170,18 @@
             "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
             "dependencies": {
                 "loose-envify": "^1.0.0"
+            }
+        },
+        "node_modules/watchpack": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/wcwidth": {
@@ -20379,86 +20347,62 @@
             }
         },
         "@next/env": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.0.tgz",
-            "integrity": "sha512-PTJpjAFVbzBQ9xXpzMTroShvD5YDIIy46jQ7d4LrWpY+/5a8H90Tm8hE3Hvkc5RBRspVo7kvEOnqQms0A+2Q6w=="
-        },
-        "@next/swc-android-arm-eabi": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.0.tgz",
-            "integrity": "sha512-/PuirPnAKsYBw93w/7Q9hqy+KGOU9mjYprZ/faxMUJh/dc6v3rYLxkZKNG9nFPIW4QKNTCnhP40xF9hLnxO+xg==",
-            "optional": true
-        },
-        "@next/swc-android-arm64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.0.tgz",
-            "integrity": "sha512-OaI+FhAM6P9B6Ybwbn0Zl8YwWido0lLwhDBi9WiYCh4RQmIXAyVIoIJPHo4fP05+mXaJ/k1trvDvuURvHOq2qw==",
-            "optional": true
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
+            "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
         },
         "@next/swc-darwin-arm64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.0.tgz",
-            "integrity": "sha512-9s4d3Mhii+WFce8o8Jok7WC3Bawkr9wEUU++SJRptjU1L5tsfYJMrSYCACHLhZujziNDLyExe4Hwwsccps1sfg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
+            "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.0.tgz",
-            "integrity": "sha512-2scC4MqUTwGwok+wpVxP+zWp7WcCAVOtutki2E1n99rBOTnUOX6qXkgxSy083yBN6GqwuC/dzHeN7hIKjavfRA==",
-            "optional": true
-        },
-        "@next/swc-freebsd-x64": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.0.tgz",
-            "integrity": "sha512-xAlruUREij/bFa+qsE1tmsP28t7vz02N4ZDHt2lh3uJUniE0Ne9idyIDLc1Ed0IF2RjfgOp4ZVunuS3OM0sngw==",
-            "optional": true
-        },
-        "@next/swc-linux-arm-gnueabihf": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.0.tgz",
-            "integrity": "sha512-jin2S4VT/cugc2dSZEUIabhYDJNgrUh7fufbdsaAezgcQzqfdfJqfxl4E9GuafzB4cbRPTaqA0V5uqbp0IyGkQ==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
+            "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.0.tgz",
-            "integrity": "sha512-RqJHDKe0WImeUrdR0kayTkRWgp4vD/MS7g0r6Xuf8+ellOFH7JAAJffDW3ayuVZeMYOa7RvgNFcOoWnrTUl9Nw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
+            "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.0.tgz",
-            "integrity": "sha512-nvNWoUieMjvDjpYJ/4SQe9lQs2xMj6ZRs8N+bmTrVu9leY2Fg3WD6W9p/1uU9hGO8u+OdF13wc4iRShu/WYIHg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
+            "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.0.tgz",
-            "integrity": "sha512-4ajhIuVU9PeQCMMhdDgZTLrHmjbOUFuIyg6J19hZqwEwDTSqQyrSLkbJs2Nd7IRiM6Ul/XyrtEFCpk4k+xD2+w==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
+            "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.0.tgz",
-            "integrity": "sha512-U092RBYbaGxoMAwpauePJEu2PuZSEoUCGJBvsptQr2/2XIMwAJDYM4c/M5NfYEsBr+yjvsYNsOpYfeQ88D82Yg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
+            "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.0.tgz",
-            "integrity": "sha512-pzSzaxjDEJe67bUok9Nxf9rykbJfHXW0owICFsPBsqHyc+cr8vpF7g9e2APTCddtVhvjkga9ILoZJ9NxWS7Yiw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
+            "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.0.tgz",
-            "integrity": "sha512-MQGUpMbYhQmTZ06a9e0hPQJnxFMwETo2WtyAotY3GEzbNCQVbCGhsvqEKcl+ZEHgShlHXUWvSffq1ZscY6gK7A==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
+            "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz",
-            "integrity": "sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
+            "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
             "optional": true
         },
         "@pkgjs/parseargs": {
@@ -20624,9 +20568,9 @@
             "dev": true
         },
         "@swc/helpers": {
-            "version": "0.4.11",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.11.tgz",
-            "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+            "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
             "requires": {
                 "tslib": "^2.4.0"
             }
@@ -24422,6 +24366,11 @@
             "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==",
             "dev": true
         },
+        "client-only": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+        },
         "cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -26741,6 +26690,11 @@
             "requires": {
                 "is-glob": "^4.0.1"
             }
+        },
+        "glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
         },
         "global": {
             "version": "4.4.0",
@@ -30185,29 +30139,26 @@
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
         },
         "next": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/next/-/next-12.3.0.tgz",
-            "integrity": "sha512-GpzI6me9V1+XYtfK0Ae9WD0mKqHyzQlGq1xH1rzNIYMASo4Tkl4rTe9jSqtBpXFhOS33KohXs9ZY38Akkhdciw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
+            "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
             "requires": {
-                "@next/env": "12.3.0",
-                "@next/swc-android-arm-eabi": "12.3.0",
-                "@next/swc-android-arm64": "12.3.0",
-                "@next/swc-darwin-arm64": "12.3.0",
-                "@next/swc-darwin-x64": "12.3.0",
-                "@next/swc-freebsd-x64": "12.3.0",
-                "@next/swc-linux-arm-gnueabihf": "12.3.0",
-                "@next/swc-linux-arm64-gnu": "12.3.0",
-                "@next/swc-linux-arm64-musl": "12.3.0",
-                "@next/swc-linux-x64-gnu": "12.3.0",
-                "@next/swc-linux-x64-musl": "12.3.0",
-                "@next/swc-win32-arm64-msvc": "12.3.0",
-                "@next/swc-win32-ia32-msvc": "12.3.0",
-                "@next/swc-win32-x64-msvc": "12.3.0",
-                "@swc/helpers": "0.4.11",
-                "caniuse-lite": "^1.0.30001332",
-                "postcss": "8.4.14",
-                "styled-jsx": "5.0.6",
-                "use-sync-external-store": "1.2.0"
+                "@next/env": "13.5.4",
+                "@next/swc-darwin-arm64": "13.5.4",
+                "@next/swc-darwin-x64": "13.5.4",
+                "@next/swc-linux-arm64-gnu": "13.5.4",
+                "@next/swc-linux-arm64-musl": "13.5.4",
+                "@next/swc-linux-x64-gnu": "13.5.4",
+                "@next/swc-linux-x64-musl": "13.5.4",
+                "@next/swc-win32-arm64-msvc": "13.5.4",
+                "@next/swc-win32-ia32-msvc": "13.5.4",
+                "@next/swc-win32-x64-msvc": "13.5.4",
+                "@swc/helpers": "0.5.2",
+                "busboy": "1.6.0",
+                "caniuse-lite": "^1.0.30001406",
+                "postcss": "8.4.31",
+                "styled-jsx": "5.1.1",
+                "watchpack": "2.4.0"
             }
         },
         "next-redux-wrapper": {
@@ -30844,19 +30795,19 @@
             }
         },
         "postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "requires": {
-                "nanoid": "^3.3.4",
+                "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
             "dependencies": {
                 "nanoid": {
-                    "version": "3.3.4",
-                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-                    "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+                    "version": "3.3.7",
+                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+                    "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
                 }
             }
         },
@@ -32360,10 +32311,12 @@
             }
         },
         "styled-jsx": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.6.tgz",
-            "integrity": "sha512-xOeROtkK5MGMDimBQ3J6iPId8q0t/BDoG5XN6oKkZClVz9ISF/hihN8OCn2LggMU6N32aXnrXBdn3auSqNS9fA==",
-            "requires": {}
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+            "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+            "requires": {
+                "client-only": "0.0.1"
+            }
         },
         "stylis": {
             "version": "4.0.13",
@@ -33099,6 +33052,15 @@
             "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
             "requires": {
                 "loose-envify": "^1.0.0"
+            }
+        },
+        "watchpack": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
             }
         },
         "wcwidth": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -80,7 +80,7 @@
         "moment": "2.29.4",
         "moment-timezone": "0.5.37",
         "multer": "1.4.5-lts.1",
-        "next": "12.3.0",
+        "next": "13.5.4",
         "next-redux-wrapper": "8.0.0",
         "passport": "0.6.0",
         "passport-strategy": "1.0.0",

--- a/ui/src/__tests__/components/domain/__snapshots__/UserDomain.test.js.snap
+++ b/ui/src/__tests__/components/domain/__snapshots__/UserDomain.test.js.snap
@@ -203,6 +203,7 @@ exports[`UserDomains should render 1`] = `
       <div>
         <a
           class="emotion-9 emotion-10"
+          href="/domain/create"
         >
           Create
         </a>
@@ -213,6 +214,7 @@ exports[`UserDomains should render 1`] = `
         </span>
         <a
           class="emotion-9 emotion-10"
+          href="/domain/manage"
         >
           Manage
         </a>
@@ -251,6 +253,7 @@ exports[`UserDomains should render 1`] = `
         </div>
         <a
           class="emotion-9 emotion-10"
+          href="/domain/athens/role"
         >
           athens
         </a>
@@ -285,6 +288,7 @@ exports[`UserDomains should render 1`] = `
         </div>
         <a
           class="emotion-9 emotion-10"
+          href="/domain/athens.ci/role"
         >
           athens.ci
         </a>
@@ -419,6 +423,7 @@ exports[`UserDomains should render with no domains 1`] = `
       <div>
         <a
           class="emotion-9 emotion-10"
+          href="/domain/create"
         >
           Create
         </a>
@@ -429,6 +434,7 @@ exports[`UserDomains should render with no domains 1`] = `
         </span>
         <a
           class="emotion-9 emotion-10"
+          href="/domain/manage"
         >
           Manage
         </a>

--- a/ui/src/__tests__/components/header/__snapshots__/RoleNameHeader.test.js.snap
+++ b/ui/src/__tests__/components/header/__snapshots__/RoleNameHeader.test.js.snap
@@ -106,6 +106,7 @@ exports[`Header should render delegated role 1`] = `
   </span>
   <a
     class="emotion-3 emotion-4"
+    href="/domain/home.mujibur/role"
   >
     home.mujibur
   </a>
@@ -114,6 +115,7 @@ exports[`Header should render delegated role 1`] = `
    (Delegated to 
   <a
     class="emotion-3 emotion-4"
+    href="/domain/home.hga/role"
   >
     home.hga
   </a>

--- a/ui/src/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/ui/src/__tests__/pages/__snapshots__/index.test.js.snap
@@ -821,6 +821,7 @@ exports[`Home should render 1`] = `
             <div>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -831,6 +832,7 @@ exports[`Home should render 1`] = `
               </span>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -869,6 +871,7 @@ exports[`Home should render 1`] = `
               </div>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/dom1/role"
               >
                 dom1
               </a>
@@ -903,6 +906,7 @@ exports[`Home should render 1`] = `
               </div>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/dom2/role"
               >
                 dom2
               </a>
@@ -1948,6 +1952,7 @@ exports[`Home should render 2`] = `
             <div>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1958,6 +1963,7 @@ exports[`Home should render 2`] = `
               </span>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1996,6 +2002,7 @@ exports[`Home should render 2`] = `
               </div>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/dom1/role"
               >
                 dom1
               </a>
@@ -2030,6 +2037,7 @@ exports[`Home should render 2`] = `
               </div>
               <a
                 class="emotion-47 emotion-48"
+                href="/domain/dom2/role"
               >
                 dom2
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/domain-settings.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/domain-settings.test.js.snap
@@ -1723,6 +1723,7 @@ exports[`DomainSettingsPage should render 1`] = `
             <div>
               <a
                 class="emotion-176 emotion-177"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1733,6 +1734,7 @@ exports[`DomainSettingsPage should render 1`] = `
               </span>
               <a
                 class="emotion-176 emotion-177"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1771,6 +1773,7 @@ exports[`DomainSettingsPage should render 1`] = `
               </div>
               <a
                 class="emotion-176 emotion-177"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1805,6 +1808,7 @@ exports[`DomainSettingsPage should render 1`] = `
               </div>
               <a
                 class="emotion-176 emotion-177"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/group.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/group.test.js.snap
@@ -1369,6 +1369,7 @@ exports[`GroupPage should render 1`] = `
             <div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1379,6 +1380,7 @@ exports[`GroupPage should render 1`] = `
               </span>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1417,6 +1419,7 @@ exports[`GroupPage should render 1`] = `
               </div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1451,6 +1454,7 @@ exports[`GroupPage should render 1`] = `
               </div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/microsegmentation.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/microsegmentation.test.js.snap
@@ -1400,6 +1400,7 @@ exports[`MicrosegmentationPage should render 1`] = `
             <div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1410,6 +1411,7 @@ exports[`MicrosegmentationPage should render 1`] = `
               </span>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1448,6 +1450,7 @@ exports[`MicrosegmentationPage should render 1`] = `
               </div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1482,6 +1485,7 @@ exports[`MicrosegmentationPage should render 1`] = `
               </div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/policy.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/policy.test.js.snap
@@ -1453,6 +1453,7 @@ exports[`PolicyPage should render 1`] = `
             <div>
               <a
                 class="emotion-129 emotion-130"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1463,6 +1464,7 @@ exports[`PolicyPage should render 1`] = `
               </span>
               <a
                 class="emotion-129 emotion-130"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1501,6 +1503,7 @@ exports[`PolicyPage should render 1`] = `
               </div>
               <a
                 class="emotion-129 emotion-130"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1535,6 +1538,7 @@ exports[`PolicyPage should render 1`] = `
               </div>
               <a
                 class="emotion-129 emotion-130"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/role.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/role.test.js.snap
@@ -1737,6 +1737,7 @@ exports[`RolePage should render 1`] = `
             <div>
               <a
                 class="emotion-142 emotion-143"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1747,6 +1748,7 @@ exports[`RolePage should render 1`] = `
               </span>
               <a
                 class="emotion-142 emotion-143"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1785,6 +1787,7 @@ exports[`RolePage should render 1`] = `
               </div>
               <a
                 class="emotion-142 emotion-143"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1819,6 +1822,7 @@ exports[`RolePage should render 1`] = `
               </div>
               <a
                 class="emotion-142 emotion-143"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/service.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/service.test.js.snap
@@ -1729,6 +1729,7 @@ exports[`ServicePage should render 1`] = `
             <div>
               <a
                 class="emotion-169 emotion-170"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1739,6 +1740,7 @@ exports[`ServicePage should render 1`] = `
               </span>
               <a
                 class="emotion-169 emotion-170"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1777,6 +1779,7 @@ exports[`ServicePage should render 1`] = `
               </div>
               <a
                 class="emotion-169 emotion-170"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1811,6 +1814,7 @@ exports[`ServicePage should render 1`] = `
               </div>
               <a
                 class="emotion-169 emotion-170"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/tags.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/tags.test.js.snap
@@ -1371,6 +1371,7 @@ exports[`Tag Page should render 1`] = `
             <div>
               <a
                 class="emotion-111 emotion-112"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1381,6 +1382,7 @@ exports[`Tag Page should render 1`] = `
               </span>
               <a
                 class="emotion-111 emotion-112"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1419,6 +1421,7 @@ exports[`Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-111 emotion-112"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1453,6 +1456,7 @@ exports[`Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-111 emotion-112"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/template.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/template.test.js.snap
@@ -1465,6 +1465,7 @@ exports[`Template Page should render 1`] = `
             <div>
               <a
                 class="emotion-140 emotion-141"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1475,6 +1476,7 @@ exports[`Template Page should render 1`] = `
               </span>
               <a
                 class="emotion-140 emotion-141"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1513,6 +1515,7 @@ exports[`Template Page should render 1`] = `
               </div>
               <a
                 class="emotion-140 emotion-141"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1547,6 +1550,7 @@ exports[`Template Page should render 1`] = `
               </div>
               <a
                 class="emotion-140 emotion-141"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/visibility.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/visibility.test.js.snap
@@ -1405,6 +1405,7 @@ exports[`VisibilityPage should render 1`] = `
             <div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1415,6 +1416,7 @@ exports[`VisibilityPage should render 1`] = `
               </span>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1453,6 +1455,7 @@ exports[`VisibilityPage should render 1`] = `
               </div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1487,6 +1490,7 @@ exports[`VisibilityPage should render 1`] = `
               </div>
               <a
                 class="emotion-110 emotion-111"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/members.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/members.test.js.snap
@@ -1054,6 +1054,7 @@ exports[`GroupMemberPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/group"
               >
                 dom
               </a>
@@ -1257,6 +1258,7 @@ exports[`GroupMemberPage should render 1`] = `
             <div>
               <a
                 class="emotion-86 emotion-87"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1267,6 +1269,7 @@ exports[`GroupMemberPage should render 1`] = `
               </span>
               <a
                 class="emotion-86 emotion-87"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1305,6 +1308,7 @@ exports[`GroupMemberPage should render 1`] = `
               </div>
               <a
                 class="emotion-86 emotion-87"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1339,6 +1343,7 @@ exports[`GroupMemberPage should render 1`] = `
               </div>
               <a
                 class="emotion-86 emotion-87"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/review.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/review.test.js.snap
@@ -1099,6 +1099,7 @@ exports[`GroupReviewPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/group"
               >
                 dom
               </a>
@@ -1338,6 +1339,7 @@ exports[`GroupReviewPage should render 1`] = `
             <div>
               <a
                 class="emotion-96 emotion-97"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1348,6 +1350,7 @@ exports[`GroupReviewPage should render 1`] = `
               </span>
               <a
                 class="emotion-96 emotion-97"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1386,6 +1389,7 @@ exports[`GroupReviewPage should render 1`] = `
               </div>
               <a
                 class="emotion-96 emotion-97"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1420,6 +1424,7 @@ exports[`GroupReviewPage should render 1`] = `
               </div>
               <a
                 class="emotion-96 emotion-97"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/roles.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/roles.test.js.snap
@@ -1046,6 +1046,7 @@ exports[`GroupRolesPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/group"
               >
                 dom
               </a>
@@ -1224,6 +1225,7 @@ exports[`GroupRolesPage should render 1`] = `
             <div>
               <a
                 class="emotion-76 emotion-77"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1234,6 +1236,7 @@ exports[`GroupRolesPage should render 1`] = `
               </span>
               <a
                 class="emotion-76 emotion-77"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1272,6 +1275,7 @@ exports[`GroupRolesPage should render 1`] = `
               </div>
               <a
                 class="emotion-76 emotion-77"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1306,6 +1310,7 @@ exports[`GroupRolesPage should render 1`] = `
               </div>
               <a
                 class="emotion-76 emotion-77"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/settings.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/settings.test.js.snap
@@ -1448,6 +1448,7 @@ exports[`GroupSettingPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/group"
               >
                 dom
               </a>
@@ -2073,6 +2074,7 @@ exports[`GroupSettingPage should render 1`] = `
             <div>
               <a
                 class="emotion-192 emotion-193"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -2083,6 +2085,7 @@ exports[`GroupSettingPage should render 1`] = `
               </span>
               <a
                 class="emotion-192 emotion-193"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -2121,6 +2124,7 @@ exports[`GroupSettingPage should render 1`] = `
               </div>
               <a
                 class="emotion-192 emotion-193"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -2155,6 +2159,7 @@ exports[`GroupSettingPage should render 1`] = `
               </div>
               <a
                 class="emotion-192 emotion-193"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/tags.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/group/[group]/__snapshots__/tags.test.js.snap
@@ -1102,6 +1102,7 @@ exports[`Groups Tag Page should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/group"
               >
                 dom
               </a>
@@ -1401,6 +1402,7 @@ exports[`Groups Tag Page should render 1`] = `
             <div>
               <a
                 class="emotion-105 emotion-106"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1411,6 +1413,7 @@ exports[`Groups Tag Page should render 1`] = `
               </span>
               <a
                 class="emotion-105 emotion-106"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1449,6 +1452,7 @@ exports[`Groups Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-105 emotion-106"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1483,6 +1487,7 @@ exports[`Groups Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-105 emotion-106"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/policy/[policy]/__snapshots__/tags.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/policy/[policy]/__snapshots__/tags.test.js.snap
@@ -1116,6 +1116,7 @@ exports[`Policies Tag Page should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/service"
               >
                 dom
               </a>
@@ -1494,6 +1495,7 @@ exports[`Policies Tag Page should render 1`] = `
             <div>
               <a
                 class="emotion-124 emotion-125"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1504,6 +1506,7 @@ exports[`Policies Tag Page should render 1`] = `
               </span>
               <a
                 class="emotion-124 emotion-125"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1542,6 +1545,7 @@ exports[`Policies Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-124 emotion-125"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1576,6 +1580,7 @@ exports[`Policies Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-124 emotion-125"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/members.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/members.test.js.snap
@@ -1054,6 +1054,7 @@ exports[`MemberPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/role"
               >
                 dom
               </a>
@@ -1263,6 +1264,7 @@ exports[`MemberPage should render 1`] = `
             <div>
               <a
                 class="emotion-88 emotion-89"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1273,6 +1275,7 @@ exports[`MemberPage should render 1`] = `
               </span>
               <a
                 class="emotion-88 emotion-89"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1311,6 +1314,7 @@ exports[`MemberPage should render 1`] = `
               </div>
               <a
                 class="emotion-88 emotion-89"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1345,6 +1349,7 @@ exports[`MemberPage should render 1`] = `
               </div>
               <a
                 class="emotion-88 emotion-89"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/policy.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/policy.test.js.snap
@@ -970,6 +970,7 @@ exports[`RolePolicyPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/role"
               >
                 dom
               </a>
@@ -1123,6 +1124,7 @@ exports[`RolePolicyPage should render 1`] = `
             <div>
               <a
                 class="emotion-73 emotion-74"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1133,6 +1135,7 @@ exports[`RolePolicyPage should render 1`] = `
               </span>
               <a
                 class="emotion-73 emotion-74"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1171,6 +1174,7 @@ exports[`RolePolicyPage should render 1`] = `
               </div>
               <a
                 class="emotion-73 emotion-74"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1205,6 +1209,7 @@ exports[`RolePolicyPage should render 1`] = `
               </div>
               <a
                 class="emotion-73 emotion-74"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/review.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/review.test.js.snap
@@ -1104,6 +1104,7 @@ exports[`ReviewPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/role"
               >
                 dom
               </a>
@@ -1362,6 +1363,7 @@ exports[`ReviewPage should render 1`] = `
             <div>
               <a
                 class="emotion-102 emotion-103"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1372,6 +1374,7 @@ exports[`ReviewPage should render 1`] = `
               </span>
               <a
                 class="emotion-102 emotion-103"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1410,6 +1413,7 @@ exports[`ReviewPage should render 1`] = `
               </div>
               <a
                 class="emotion-102 emotion-103"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1444,6 +1448,7 @@ exports[`ReviewPage should render 1`] = `
               </div>
               <a
                 class="emotion-102 emotion-103"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/settings.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/settings.test.js.snap
@@ -1448,6 +1448,7 @@ exports[`SettingPage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/role"
               >
                 dom
               </a>
@@ -2372,6 +2373,7 @@ exports[`SettingPage should render 1`] = `
             <div>
               <a
                 class="emotion-283 emotion-284"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -2382,6 +2384,7 @@ exports[`SettingPage should render 1`] = `
               </span>
               <a
                 class="emotion-283 emotion-284"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -2420,6 +2423,7 @@ exports[`SettingPage should render 1`] = `
               </div>
               <a
                 class="emotion-283 emotion-284"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -2454,6 +2458,7 @@ exports[`SettingPage should render 1`] = `
               </div>
               <a
                 class="emotion-283 emotion-284"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/tags.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/role/[role]/__snapshots__/tags.test.js.snap
@@ -1102,6 +1102,7 @@ exports[`Roles Tag Page should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/role"
               >
                 dom
               </a>
@@ -1369,6 +1370,7 @@ exports[`Roles Tag Page should render 1`] = `
             <div>
               <a
                 class="emotion-99 emotion-100"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1379,6 +1381,7 @@ exports[`Roles Tag Page should render 1`] = `
               </span>
               <a
                 class="emotion-99 emotion-100"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1417,6 +1420,7 @@ exports[`Roles Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-99 emotion-100"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1451,6 +1455,7 @@ exports[`Roles Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-99 emotion-100"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/microsegmentation.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/microsegmentation.test.js.snap
@@ -1113,6 +1113,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/service"
               >
                 dom
               </a>
@@ -1840,6 +1841,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
             <div>
               <a
                 class="emotion-194 emotion-195"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1850,6 +1852,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
               </span>
               <a
                 class="emotion-194 emotion-195"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1888,6 +1891,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
               </div>
               <a
                 class="emotion-194 emotion-195"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1922,6 +1926,7 @@ exports[`Service Microsegmentation Page should render 1`] = `
               </div>
               <a
                 class="emotion-194 emotion-195"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/tags.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/__snapshots__/tags.test.js.snap
@@ -962,6 +962,7 @@ exports[`Service Tag Page should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/service"
               >
                 dom
               </a>
@@ -1061,6 +1062,7 @@ exports[`Service Tag Page should render 1`] = `
             <div>
               <a
                 class="emotion-60 emotion-61"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1071,6 +1073,7 @@ exports[`Service Tag Page should render 1`] = `
               </span>
               <a
                 class="emotion-60 emotion-61"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1109,6 +1112,7 @@ exports[`Service Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-60 emotion-61"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1143,6 +1147,7 @@ exports[`Service Tag Page should render 1`] = `
               </div>
               <a
                 class="emotion-60 emotion-61"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/dynamic.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/dynamic.test.js.snap
@@ -1148,6 +1148,7 @@ exports[`DynamicInstancePage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/service"
               >
                 dom
               </a>
@@ -1556,6 +1557,7 @@ exports[`DynamicInstancePage should render 1`] = `
             <div>
               <a
                 class="emotion-122 emotion-123"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1566,6 +1568,7 @@ exports[`DynamicInstancePage should render 1`] = `
               </span>
               <a
                 class="emotion-122 emotion-123"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1604,6 +1607,7 @@ exports[`DynamicInstancePage should render 1`] = `
               </div>
               <a
                 class="emotion-122 emotion-123"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1638,6 +1642,7 @@ exports[`DynamicInstancePage should render 1`] = `
               </div>
               <a
                 class="emotion-122 emotion-123"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/static.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/static.test.js.snap
@@ -1172,6 +1172,7 @@ exports[`StaticInstancePage should render 1`] = `
             >
               <a
                 class="emotion-32 emotion-33"
+                href="/domain/dom/service"
               >
                 dom
               </a>
@@ -1453,6 +1454,7 @@ exports[`StaticInstancePage should render 1`] = `
             <div>
               <a
                 class="emotion-97 emotion-98"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1463,6 +1465,7 @@ exports[`StaticInstancePage should render 1`] = `
               </span>
               <a
                 class="emotion-97 emotion-98"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1501,6 +1504,7 @@ exports[`StaticInstancePage should render 1`] = `
               </div>
               <a
                 class="emotion-97 emotion-98"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1535,6 +1539,7 @@ exports[`StaticInstancePage should render 1`] = `
               </div>
               <a
                 class="emotion-97 emotion-98"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/__snapshots__/create.test.js.snap
+++ b/ui/src/__tests__/pages/domain/__snapshots__/create.test.js.snap
@@ -1245,6 +1245,7 @@ exports[`CreateDomainPage should render 1`] = `
             <div>
               <a
                 class="emotion-95 emotion-96"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1255,6 +1256,7 @@ exports[`CreateDomainPage should render 1`] = `
               </span>
               <a
                 class="emotion-95 emotion-96"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1293,6 +1295,7 @@ exports[`CreateDomainPage should render 1`] = `
               </div>
               <a
                 class="emotion-95 emotion-96"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1327,6 +1330,7 @@ exports[`CreateDomainPage should render 1`] = `
               </div>
               <a
                 class="emotion-95 emotion-96"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/domain/__snapshots__/manage.test.js.snap
+++ b/ui/src/__tests__/pages/domain/__snapshots__/manage.test.js.snap
@@ -1310,6 +1310,7 @@ exports[`PageManageDomains should render 1`] = `
             <div>
               <a
                 class="emotion-180 emotion-181"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -1320,6 +1321,7 @@ exports[`PageManageDomains should render 1`] = `
               </span>
               <a
                 class="emotion-180 emotion-181"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -1358,6 +1360,7 @@ exports[`PageManageDomains should render 1`] = `
               </div>
               <a
                 class="emotion-180 emotion-181"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -1392,6 +1395,7 @@ exports[`PageManageDomains should render 1`] = `
               </div>
               <a
                 class="emotion-180 emotion-181"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/__tests__/pages/search/[type]/[searchterm]/__snapshots__/search.test.js.snap
+++ b/ui/src/__tests__/pages/search/[type]/[searchterm]/__snapshots__/search.test.js.snap
@@ -850,6 +850,7 @@ exports[`Search should render 1`] = `
             </div>
             <a
               class="emotion-41 emotion-42"
+              href="/domain/athens.ci/role"
             >
               athens.ci
             </a>
@@ -893,6 +894,7 @@ exports[`Search should render 1`] = `
             <div>
               <a
                 class="emotion-52 emotion-53"
+                href="/domain/create"
               >
                 Create
               </a>
@@ -903,6 +905,7 @@ exports[`Search should render 1`] = `
               </span>
               <a
                 class="emotion-52 emotion-53"
+                href="/domain/manage"
               >
                 Manage
               </a>
@@ -941,6 +944,7 @@ exports[`Search should render 1`] = `
               </div>
               <a
                 class="emotion-52 emotion-53"
+                href="/domain/athens/role"
               >
                 athens
               </a>
@@ -975,6 +979,7 @@ exports[`Search should render 1`] = `
               </div>
               <a
                 class="emotion-52 emotion-53"
+                href="/domain/athens.ci/role"
               >
                 athens.ci
               </a>

--- a/ui/src/components/domain/UserDomains.js
+++ b/ui/src/components/domain/UserDomains.js
@@ -145,7 +145,7 @@ class UserDomains extends React.Component {
                                 verticalAlign={'baseline'}
                             />
                         </UserAdminLogoDiv>
-                        <Link href={PageUtils.rolePage(domainName)}>
+                        <Link href={PageUtils.rolePage(domainName)} passHref legacyBehavior>
                             <StyledAnchor active={currentDomain === domainName}>
                                 {domainName}
                             </StyledAnchor>
@@ -177,11 +177,11 @@ class UserDomains extends React.Component {
                                 My Domains
                             </ManageDomainsTitleDiv>
                             <div>
-                                <Link href={PageUtils.createDomainPage()}>
+                                <Link href={PageUtils.createDomainPage()} passHref legacyBehavior>
                                     <StyledAnchor>Create</StyledAnchor>
                                 </Link>
                                 <DividerSpan> | </DividerSpan>
-                                <Link href={PageUtils.manageDomainPage()}>
+                                <Link href={PageUtils.manageDomainPage()} passHref legacyBehavior>
                                     <StyledAnchor>Manage</StyledAnchor>
                                 </Link>
                             </div>

--- a/ui/src/components/header/Header.js
+++ b/ui/src/components/header/Header.js
@@ -50,9 +50,7 @@ const Header = (props) => {
             <NavBar background={'#002339'}>
                 <NavBarItem>
                     <Link href={PageUtils.homePage()}>
-                        <a>
-                            <LogoStyled />
-                        </a>
+                        <LogoStyled />
                     </Link>
                 </NavBarItem>
                 <NavBarItemDiv>

--- a/ui/src/components/header/NameHeader.js
+++ b/ui/src/components/header/NameHeader.js
@@ -96,12 +96,12 @@ class NameHeader extends React.Component {
                 <TitleDiv data-testid='collection-name-header'>
                     {roleTypeIcon}
                     {roleAuditIcon}
-                    <Link href={PageUtils.rolePage(domain)}>
+                    <Link href={PageUtils.rolePage(domain)} passHref legacyBehavior>
                         <StyledAnchor>{domain}</StyledAnchor>
                     </Link>
                     :role.{collection}
                     {' (Delegated to '}
-                    <Link href={PageUtils.rolePage(deDomain)}>
+                    <Link href={PageUtils.rolePage(deDomain)} passHref legacyBehavior>
                         <StyledAnchor>{deDomain}</StyledAnchor>
                     </Link>
                     {')'}
@@ -111,25 +111,25 @@ class NameHeader extends React.Component {
         let link;
         if (this.props.category === 'group') {
             link = (
-                <Link href={PageUtils.groupPage(domain)}>
+                <Link href={PageUtils.groupPage(domain)} passHref legacyBehavior>
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );
         } else if (this.props.category === 'role') {
             link = (
-                <Link href={PageUtils.rolePage(domain)}>
+                <Link href={PageUtils.rolePage(domain)} passHref legacyBehavior>
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );
         } else if (this.props.category === 'policy') {
             link = (
-                <Link href={PageUtils.servicePage(domain)}>
+                <Link href={PageUtils.servicePage(domain)} passHref legacyBehavior>
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );
         } else if (this.props.category === 'service') {
             link = (
-                <Link href={PageUtils.servicePage(domain)}>
+                <Link href={PageUtils.servicePage(domain)} passHref legacyBehavior>
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );

--- a/ui/src/components/header/ServiceNameHeader.js
+++ b/ui/src/components/header/ServiceNameHeader.js
@@ -51,7 +51,7 @@ export default function ServiceNameHeader(props) {
     const { domain, service, serviceHeaderDetails } = props;
 
     let link = (
-        <Link href={PageUtils.servicePage(domain)}>
+        <Link href={PageUtils.servicePage(domain)} passHref legacyBehavior>
             <StyledAnchor>{domain}</StyledAnchor>
         </Link>
     );

--- a/ui/src/components/visibility/ServiceDependencyResGroupRoles.js
+++ b/ui/src/components/visibility/ServiceDependencyResGroupRoles.js
@@ -52,10 +52,8 @@ export default class ServiceDependencyResGroupRoles extends React.Component {
                         roleEntry.resourceGroupRole
                     }
                 >
-                    <Link href={roleEntry.roleLink}>
-                        <a style={{ textDecoration: 'none' }}>
-                            {roleEntry.resourceGroupRole}
-                        </a>
+                    <Link href={roleEntry.roleLink} style={{ textDecoration: 'none' }}>
+                        {roleEntry.resourceGroupRole}
                     </Link>
                     {'  '}
                 </Tag>
@@ -90,10 +88,8 @@ export default class ServiceDependencyResGroupRoles extends React.Component {
                                 roleEntry.resourceGroupRole
                             }
                         >
-                            <Link href={roleEntry.roleLink}>
-                                <a style={{ textDecoration: 'none' }}>
-                                    {roleEntry.resourceGroupRole}
-                                </a>
+                            <Link href={roleEntry.roleLink} style={{ textDecoration: 'none' }}>
+                                {roleEntry.resourceGroupRole}
                             </Link>
                             {'  '}
                         </Tag>

--- a/ui/src/pages/_error.js
+++ b/ui/src/pages/_error.js
@@ -113,7 +113,7 @@ class Error extends React.Component {
                                         </span>
                                         <HomeDiv>
                                             <Link href={PageUtils.homePage()}>
-                                                <a>Athenz Home</a>
+                                                Athenz Home
                                             </Link>
                                         </HomeDiv>
                                     </DetailsDiv>

--- a/ui/src/pages/login.js
+++ b/ui/src/pages/login.js
@@ -196,9 +196,7 @@ class PageLogin extends React.Component {
                         <NavBar background={'#002339'}>
                             <NavBarItem>
                                 <Link href={PageUtils.homePage()}>
-                                    <a>
-                                        <LogoStyled />
-                                    </a>
+                                    <LogoStyled />
                                 </Link>
                             </NavBarItem>
                         </NavBar>

--- a/ui/src/pages/search/[type]/[searchterm].js
+++ b/ui/src/pages/search/[type]/[searchterm].js
@@ -206,7 +206,7 @@ class PageSearchDetails extends React.Component {
             items.push(
                 <ResultsDiv key={domain}>
                     <DomainLogoDiv>{icon}</DomainLogoDiv>
-                    <Link href={PageUtils.rolePage(domain)}>
+                    <Link href={PageUtils.rolePage(domain)} passHref legacyBehavior>
                         <StyledAnchor>{domain}</StyledAnchor>
                     </Link>
                 </ResultsDiv>


### PR DESCRIPTION
This PR upgrades nextjs from 12->13. Breaking changes detailed below are both `<Link>` related. 

https://nextjs.org/docs/pages/api-reference/components/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag

https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor