### PR TITLE
update entityName in audit logs for role/group meta calls

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -6342,7 +6342,7 @@ public class DBService implements RolesProvider {
                 auditLogRoleSystemMeta(auditDetails, updatedRole, roleName);
 
                 auditLogRequest(ctx, domainName, auditRef, caller, ZMSConsts.HTTP_PUT,
-                        domainName, auditDetails.toString());
+                        roleName, auditDetails.toString());
 
                 // add domain change event
                 addDomainChangeMessage(ctx, domainName, roleName, DomainChangeMessage.ObjectType.ROLE);
@@ -6418,7 +6418,7 @@ public class DBService implements RolesProvider {
                 auditLogGroupSystemMeta(auditDetails, updatedGroup, groupName);
 
                 auditLogRequest(ctx, domainName, auditRef, ctx.getApiName(), ZMSConsts.HTTP_PUT,
-                        domainName, auditDetails.toString());
+                        groupName, auditDetails.toString());
 
                 // add domain change event
 
@@ -6617,7 +6617,7 @@ public class DBService implements RolesProvider {
                 // audit log the request
 
                 auditLogRequest(ctx, domainName, auditRef, caller, ZMSConsts.HTTP_PUT,
-                        domainName, auditDetails.toString());
+                        roleName, auditDetails.toString());
 
                 // if the role member expiry date or review date has changed then we're going
                 // process all the members in the role and update the expiration and review
@@ -6751,7 +6751,7 @@ public class DBService implements RolesProvider {
                 // audit log the request
 
                 auditLogRequest(ctx, domainName, auditRef, ctx.getApiName(), ZMSConsts.HTTP_PUT,
-                        domainName, auditDetails.toString());
+                        groupName, auditDetails.toString());
 
                 // if the group user authority expiration attribute has changed, we're going
                 // process all the members in the group and update the expiration date accordingly


### PR DESCRIPTION
# Description
On making a putRoleMeta/putRoleSystemMeta/putGroupMeta/putGroupSystemMeta calls, the entityName in audit logs is currently set to the domainName. This PR updates the audit logs to have the entityName as role/group which got modified. 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

