### PR TITLE
use correct algorithm when generating csr

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -1469,7 +1470,7 @@ public class ZTSClient implements Closeable {
         String csr;
         try {
             csr = Crypto.generateX509CSR(privateKey, dn, sanArray);
-        } catch (OperatorCreationException | IOException ex) {
+        } catch (OperatorCreationException | IOException | NoSuchAlgorithmException ex) {
             throw new ZTSClientException(ResourceException.BAD_REQUEST, ex.getMessage());
         }
 
@@ -1556,7 +1557,7 @@ public class ZTSClient implements Closeable {
         String csr;
         try {
             csr = Crypto.generateX509CSR(privateKey, dn, sanArray);
-        } catch (OperatorCreationException | IOException ex) {
+        } catch (OperatorCreationException | IOException | NoSuchAlgorithmException ex) {
             throw new ZTSClientException(ResourceException.BAD_REQUEST, ex.getMessage());
         }
 
@@ -2522,7 +2523,7 @@ public class ZTSClient implements Closeable {
         try {
             info.setCsr(Crypto.generateX509CSR(lambdaIdentity.getPrivateKey(),
                     dnBuilder.toString(), sanArray));
-        } catch (OperatorCreationException | IOException ex) {
+        } catch (OperatorCreationException | IOException | NoSuchAlgorithmException ex) {
             throw new ZTSClientException(ResourceException.BAD_REQUEST, ex.getMessage());
         }
         

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Crypto.java
@@ -1125,8 +1125,8 @@ public class Crypto {
         return convertToPEMFormat(publicKey);
     }
 
-    public static String generateX509CSR(PrivateKey privateKey, String x500Principal,
-                                         GeneralName[] sanArray) throws OperatorCreationException, IOException {
+    public static String generateX509CSR(PrivateKey privateKey, String x500Principal, GeneralName[] sanArray)
+            throws OperatorCreationException, IOException, NoSuchAlgorithmException {
         final PublicKey publicKey = extractPublicKey(privateKey);
         if (publicKey == null) {
             throw new CryptoException("Unable to extract public key from private key");
@@ -1134,8 +1134,8 @@ public class Crypto {
         return generateX509CSR(privateKey, publicKey, x500Principal, sanArray);
     }
 
-    public static String generateX509CSR(PrivateKey privateKey, PublicKey publicKey,
-                                         String x500Principal, GeneralName[] sanArray) throws OperatorCreationException, IOException {
+    public static String generateX509CSR(PrivateKey privateKey, PublicKey publicKey, String x500Principal,
+            GeneralName[] sanArray) throws OperatorCreationException, IOException, NoSuchAlgorithmException {
 
         // Create Distinguished Name
 
@@ -1143,7 +1143,8 @@ public class Crypto {
 
         // Create ContentSigner
 
-        JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(Crypto.RSA_SHA256);
+        JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder(
+                getSignatureAlgorithm(privateKey.getAlgorithm(), SHA256));
         ContentSigner signer = csBuilder.build(privateKey);
 
         // Create the CSR

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -642,9 +642,30 @@ public class CryptoTest {
     }
 
     @Test(dataProvider = "x500Principal")
-    public void testX509CSRrequest(String x500Principal, boolean badRequest) {
+    public void testGenerateX509CSRKeyTypeRSA(String x500Principal, boolean badRequest) {
         PublicKey publicKey = Crypto.loadPublicKey(rsaPublicKey);
         PrivateKey privateKey = Crypto.loadPrivateKey(rsaPrivateKey);
+        String certRequest = null;
+        GeneralName otherName1 = new GeneralName(GeneralName.otherName, new DERIA5String("role1"));
+        GeneralName otherName2 = new GeneralName(GeneralName.otherName, new DERIA5String("role2"));
+        GeneralName[] sanArray = new GeneralName[]{otherName1, otherName2};
+        try {
+            certRequest = Crypto.generateX509CSR(privateKey, publicKey, x500Principal, sanArray);
+        } catch (Exception e) {
+            if (!badRequest) {
+                fail("Should not have failed to create csr");
+            }
+        }
+        if (!badRequest) {
+            //Now validate the csr
+            Crypto.getPKCS10CertRequest(certRequest);
+        }
+    }
+
+    @Test(dataProvider = "x500Principal")
+    public void testGenerateX509CSRKeyTypeECDSA(String x500Principal, boolean badRequest) {
+        PublicKey publicKey = Crypto.loadPublicKey(ecPublicKey);
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
         String certRequest = null;
         GeneralName otherName1 = new GeneralName(GeneralName.otherName, new DERIA5String("role1"));
         GeneralName otherName2 = new GeneralName(GeneralName.otherName, new DERIA5String("role2"));

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerFactory.java
@@ -25,6 +25,7 @@ import com.yahoo.athenz.common.server.cert.CertSignerFactory;
 import com.yahoo.athenz.zts.ZTSConsts;
 
 import java.io.File;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
@@ -62,7 +63,7 @@ public class SelfCertSignerFactory implements CertSignerFactory {
         String csr;
         try {
             csr = Crypto.generateX509CSR(caPrivateKey, csrDn, null);
-        } catch (IllegalArgumentException | OperatorCreationException | IOException ex) {
+        } catch (IllegalArgumentException | OperatorCreationException | IOException | NoSuchAlgorithmException ex) {
             LOGGER.error("Unable to generate X509 CSR for dn: {}, error: {}", csrDn, ex.getMessage());
             return null;
         }


### PR DESCRIPTION
# Description

when generating a CSR, the library was hard-coding it to RSA instead of looking at the private key to determine the signing algorithm.

addresses #2512 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

