### PR TITLE
store operation type as part of the auth history record

### DIFF
--- a/syncers/auth_history_syncer/pom.xml
+++ b/syncers/auth_history_syncer/pom.xml
@@ -32,7 +32,7 @@
     <description>Authentication History Syncer (Cloudwatch logs to DynamoDB)</description>
 
     <properties>
-        <code.coverage.min>0.7738</code.coverage.min>
+        <code.coverage.min>0.8593</code.coverage.min>
         <aws.dynamodb.local.version>2.2.1</aws.dynamodb.local.version>
         <sqlite4java.version>1.0.392</sqlite4java.version>
         <junit.version>4.13.2</junit.version>

--- a/syncers/auth_history_syncer/src/main/java/com/yahoo/athenz/syncer/auth/history/AuthHistoryDynamoDBRecord.java
+++ b/syncers/auth_history_syncer/src/main/java/com/yahoo/athenz/syncer/auth/history/AuthHistoryDynamoDBRecord.java
@@ -36,19 +36,21 @@ public class AuthHistoryDynamoDBRecord {
     private String principalName;
     private String endpoint;
     private String timestamp;
+    private String operation;
     private long ttl;
 
     public AuthHistoryDynamoDBRecord() {
-
     }
 
-    public AuthHistoryDynamoDBRecord(String primaryKey, String uriDomain, String principalDomain, String principalName, String endpoint, String timestamp, long ttl) {
+    public AuthHistoryDynamoDBRecord(String primaryKey, String uriDomain, String principalDomain,
+            String principalName, String endpoint, String timestamp, String operation, long ttl) {
         this.primaryKey = primaryKey;
         this.uriDomain = uriDomain;
         this.principalDomain = principalDomain;
         this.principalName = principalName;
         this.endpoint = endpoint;
         this.timestamp = timestamp;
+        this.operation = operation;
         this.ttl = ttl;
     }
 
@@ -83,6 +85,10 @@ public class AuthHistoryDynamoDBRecord {
         return timestamp;
     }
 
+    public String getOperation() {
+        return operation;
+    }
+
     // Set methods must exist for @DynamoDbBean successful marshalling
     public void setPrimaryKey(String primaryKey) {
         this.primaryKey = primaryKey;
@@ -102,6 +108,9 @@ public class AuthHistoryDynamoDBRecord {
     public void setTimestamp(String timestamp) {
         this.timestamp = timestamp;
     }
+    public void setOperation(String operation) {
+        this.operation = operation;
+    }
     public void setTtl(long ttl) {
         this.ttl = ttl;
     }
@@ -116,11 +125,7 @@ public class AuthHistoryDynamoDBRecord {
         }
 
         AuthHistoryDynamoDBRecord record = (AuthHistoryDynamoDBRecord) o;
-        if (getPrimaryKey() == null ? record.getPrimaryKey() != null : !getPrimaryKey().equals(record.getPrimaryKey())) {
-            return false;
-        }
-
-        return true;
+        return getPrimaryKey() == null ? record.getPrimaryKey() == null : getPrimaryKey().equals(record.getPrimaryKey());
     }
 
     @Override
@@ -137,6 +142,7 @@ public class AuthHistoryDynamoDBRecord {
                 ", principalName='" + principalName + '\'' +
                 ", endpoint='" + endpoint + '\'' +
                 ", timestamp='" + timestamp + '\'' +
+                ", operation='" + operation + '\'' +
                 ", ttl=" + ttl +
                 '}';
     }

--- a/syncers/auth_history_syncer/src/main/java/com/yahoo/athenz/syncer/auth/history/AuthHistorySyncer.java
+++ b/syncers/auth_history_syncer/src/main/java/com/yahoo/athenz/syncer/auth/history/AuthHistorySyncer.java
@@ -94,7 +94,7 @@ public class AuthHistorySyncer {
         return pkeyFactory.create();
     }
         
-    private AuthHistoryFetcher getAuthHistoryFetcher(PrivateKeyStore privateKeyStore, String region) throws Exception {
+    AuthHistoryFetcher getAuthHistoryFetcher(PrivateKeyStore privateKeyStore, String region) throws Exception {
         String authHistoryFetcherFactoryClass = System.getProperty(PROP_AUTH_HISTORY_FETCH_FACTORY_CLASS);
         if (authHistoryFetcherFactoryClass == null) {
             System.out.println("Error: " + PROP_AUTH_HISTORY_FETCH_FACTORY_CLASS + " system property is mandatory");
@@ -110,7 +110,7 @@ public class AuthHistorySyncer {
         }
     }
 
-    private AuthHistorySender getAuthHistorySender(PrivateKeyStore privateKeyStore, String region) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    AuthHistorySender getAuthHistorySender(PrivateKeyStore privateKeyStore, String region) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
         String authHistorySenderFactoryClass = System.getProperty(PROP_AUTH_HISTORY_SEND_FACTORY_CLASS, PROP_AUTH_HISTORY_SEND_FACTORY_CLASS_DEFAULT);
         AuthHistorySenderFactory authHistorySenderFactory;
         try {

--- a/syncers/auth_history_syncer/src/main/java/com/yahoo/athenz/syncer/auth/history/AuthHistorySyncerConsts.java
+++ b/syncers/auth_history_syncer/src/main/java/com/yahoo/athenz/syncer/auth/history/AuthHistorySyncerConsts.java
@@ -34,4 +34,7 @@ public class AuthHistorySyncerConsts {
     public static final String PROP_DYNAMODB_EXTERNAL_ID         = "auth_history_syncer.dynamodb_external_id";
     public static final String PROP_DYNAMODB_MIN_EXPIRY_TIME     = "auth_history_syncer.dynamodb_min_expiry_time";
     public static final String PROP_DYNAMODB_MAX_EXPIRY_TIME     = "auth_history_syncer.dynamodb_max_expiry_time";
+
+    public static final String PROP_CLOUDWATCH_ZMS_LOG_GROUP     = "auth_history_syncer.cloudwatch_zms_log_group";
+    public static final String PROP_CLOUDWATCH_ZTS_LOG_GROUP     = "auth_history_syncer.cloudwatch_zts_log_group";
 }

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/AuthHistoryDynamoDBRecordTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/AuthHistoryDynamoDBRecordTest.java
@@ -1,0 +1,81 @@
+/*
+ *
+ *  * Copyright The Athenz Authors
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.syncer.auth.history;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class AuthHistoryDynamoDBRecordTest {
+
+    @Test
+    public void testAuthHistoryDynamoDBRecord() {
+        AuthHistoryDynamoDBRecord authHistoryDynamoDBRecord = new AuthHistoryDynamoDBRecord();
+        authHistoryDynamoDBRecord.setPrimaryKey("primaryKeyTest");
+        authHistoryDynamoDBRecord.setUriDomain("uriDomainTest");
+        authHistoryDynamoDBRecord.setPrincipalDomain("principalDomainTest");
+        authHistoryDynamoDBRecord.setPrincipalName("principalNameTest");
+        authHistoryDynamoDBRecord.setEndpoint("endpointTest");
+        authHistoryDynamoDBRecord.setTimestamp("timestampTest");
+        authHistoryDynamoDBRecord.setOperation("access-check");
+        authHistoryDynamoDBRecord.setTtl(1000L);
+
+        assertEquals(authHistoryDynamoDBRecord.getPrimaryKey(), "primaryKeyTest");
+        assertEquals(authHistoryDynamoDBRecord.getUriDomain(), "uriDomainTest");
+        assertEquals(authHistoryDynamoDBRecord.getPrincipalDomain(), "principalDomainTest");
+        assertEquals(authHistoryDynamoDBRecord.getPrincipalName(), "principalNameTest");
+        assertEquals(authHistoryDynamoDBRecord.getEndpoint(), "endpointTest");
+        assertEquals(authHistoryDynamoDBRecord.getTimestamp(), "timestampTest");
+        assertEquals(authHistoryDynamoDBRecord.getOperation(), "access-check");
+        assertEquals(authHistoryDynamoDBRecord.getTtl(), 1000L);
+
+        AuthHistoryDynamoDBRecord authHistoryDynamoDBRecord2 = new AuthHistoryDynamoDBRecord("primaryKeyTest",
+                "uriDomainTest", "principalDomainTest", "principalNameTest", "endpointTest",
+                "timestampTest", "access-check", 1000L);
+        assertEquals(authHistoryDynamoDBRecord, authHistoryDynamoDBRecord2);
+
+        assertEquals(authHistoryDynamoDBRecord, authHistoryDynamoDBRecord);
+        assertFalse(authHistoryDynamoDBRecord.equals(null));
+        assertFalse(authHistoryDynamoDBRecord.equals("test"));
+
+        assertEquals(authHistoryDynamoDBRecord.hashCode(), authHistoryDynamoDBRecord2.hashCode());
+        assertEquals(authHistoryDynamoDBRecord.toString(),
+                "AuthHistoryDynamoDBRecord{primaryKey='primaryKeyTest', uriDomain='uriDomainTest', principalDomain='principalDomainTest', principalName='principalNameTest', endpoint='endpointTest', timestamp='timestampTest', operation='access-check', ttl=1000}");
+
+        // records equal with no primary key
+        AuthHistoryDynamoDBRecord authHistoryDynamoDBRecord3 = new AuthHistoryDynamoDBRecord();
+        AuthHistoryDynamoDBRecord authHistoryDynamoDBRecord4 = new AuthHistoryDynamoDBRecord();
+        assertTrue(authHistoryDynamoDBRecord3.equals(authHistoryDynamoDBRecord4));
+
+        // same values - match
+        authHistoryDynamoDBRecord3.setPrimaryKey("primaryKeyTest");
+        authHistoryDynamoDBRecord4.setPrimaryKey("primaryKeyTest");
+        assertTrue(authHistoryDynamoDBRecord3.equals(authHistoryDynamoDBRecord4));
+
+        // different values - no match
+        authHistoryDynamoDBRecord3.setPrimaryKey("primaryKeyTest");
+        authHistoryDynamoDBRecord4.setPrimaryKey("primaryKeyTest2");
+        assertFalse(authHistoryDynamoDBRecord3.equals(authHistoryDynamoDBRecord4));
+
+        // one null value - no match
+        authHistoryDynamoDBRecord3.setPrimaryKey(null);
+        authHistoryDynamoDBRecord4.setPrimaryKey("primaryKeyTest2");
+        assertFalse(authHistoryDynamoDBRecord3.equals(authHistoryDynamoDBRecord4));
+    }
+}

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/AuthHistorySyncerTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/AuthHistorySyncerTest.java
@@ -91,4 +91,39 @@ public class AuthHistorySyncerTest {
         assertNotNull(privateKeyStore);
         System.clearProperty("auth_history_syncer.private_key_store_factory_class");
     }
+
+    @Test
+    public void testAuthHistorySyncerFailures() {
+        AuthHistorySyncer authHistorySyncer = new AuthHistorySyncer();
+        assertNotNull(authHistorySyncer);
+        AuthHistorySyncer.usage();
+
+        System.setProperty("auth_history_syncer.fetch_factory_class", "unknown-class");
+        try {
+            authHistorySyncer.getAuthHistoryFetcher(null, null);
+            fail();
+        } catch (Exception ex) {
+            assertTrue(ex instanceof ClassNotFoundException);
+        }
+
+        System.setProperty("auth_history_syncer.private_key_store_factory_class", "unknown-class");
+        try {
+            authHistorySyncer.getPrivateKeyStore();
+            fail();
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("Invalid private key store"));
+        }
+
+        System.setProperty("auth_history_syncer.send_factory_class", "unknown-class");
+        try {
+            authHistorySyncer.getAuthHistorySender(null, null);
+            fail();
+        } catch (Exception ex) {
+            assertTrue(ex instanceof ClassNotFoundException);
+        }
+
+        System.clearProperty("auth_history_syncer.fetch_factory_class");
+        System.clearProperty("auth_history_syncer.send_factory_class");
+        System.clearProperty("auth_history_syncer.private_key_store_factory_class");
+    }
 }

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/LogsParserUtilsTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/LogsParserUtilsTest.java
@@ -23,12 +23,17 @@ import org.junit.Test;
 import java.net.MalformedURLException;
 
 import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.fail;
 
 public class LogsParserUtilsTest {
 
     @Test
     public void testGetRecordFromLogEvent() throws MalformedURLException {
+
+        LogsParserUtils utils = new LogsParserUtils();
+        assertNotNull(utils);
+
         // Test /domain/{domainName}/token
         String message = "98.136.200.210 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zms/v1/domain/home.testuser/token HTTP/1.1\" 200 16 \"-\" \"Jersey/2.18 (HttpUrlConnection 1.8.0_302)\" - 2 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         AuthHistoryDynamoDBRecord recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/impl/MockAuthHistoryFetcher.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/impl/MockAuthHistoryFetcher.java
@@ -33,7 +33,9 @@ public class MockAuthHistoryFetcher implements AuthHistoryFetcher {
             return new HashSet<>();
         }
         Set<AuthHistoryDynamoDBRecord> records = new HashSet<>();
-        AuthHistoryDynamoDBRecord authHistoryDynamoDBRecord = new AuthHistoryDynamoDBRecord("primaryKeyTest", "uriDomainTest", "principalDomainTest", "principalNameTest", "endpointTest", "timestampTest", 0L);
+        AuthHistoryDynamoDBRecord authHistoryDynamoDBRecord = new AuthHistoryDynamoDBRecord("primaryKeyTest",
+                "uriDomainTest", "principalDomainTest", "principalNameTest", "endpointTest",
+                "timestampTest", "access-check", 0L);
         records.add(authHistoryDynamoDBRecord);
         return records;
     }


### PR DESCRIPTION
# Description

as part of the auth history record, we're also now storing the operation type which could be one of these values:

access-check
access-token
role-token
role-cert

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

