### PR TITLE
fix direct link service tabs bug

### DIFF
--- a/ui/src/redux/thunks/services.js
+++ b/ui/src/redux/thunks/services.js
@@ -58,6 +58,7 @@ import {
     SERVICE_TYPE_DYNAMIC,
     SERVICE_TYPE_STATIC,
 } from '../../components/constants/constants';
+import { getFeatureFlag } from './domains';
 
 export const addService =
     (domainName, service, _csrf) => async (dispatch, getState) => {
@@ -272,6 +273,7 @@ export const getServiceHeaderAndInstances =
         await dispatch(getServices(domainName));
         await dispatch(getServiceInstances(domainName, serviceName, category));
         await dispatch(getServiceHeaderDetails(domainName, serviceName));
+        await dispatch(getFeatureFlag());
     };
 
 export const getServiceInstances =


### PR DESCRIPTION
Problem: hitting the direct link of a services page shows only the tags tab because we are filtering out certain tabs based on the `featureFlag` property that's incorrectly loaded in the redux store when visiting via direct link.

Solution: Ensure `featureFlag` is correctly loaded in reduxStore.