### PR TITLE
fix to don't omit user domain when completion search result is empty

### DIFF
--- a/ui/src/__tests__/components/group/AddGroup.test.js
+++ b/ui/src/__tests__/components/group/AddGroup.test.js
@@ -337,9 +337,9 @@ describe('AddGroup', () => {
         });
 
         await waitFor(() => {
-            expect(screen.getByText('test1.')).toBeInTheDocument();
+            expect(screen.getByText('user.test1.')).toBeInTheDocument();
         });
-        fireEvent.click(screen.getByText('test1.'));
+        fireEvent.click(screen.getByText('user.test1.'));
 
         const button = getByText('Add');
         fireEvent.click(button);

--- a/ui/src/components/utils/MemberUtils.js
+++ b/ui/src/components/utils/MemberUtils.js
@@ -41,10 +41,8 @@ export default class MemberUtils {
     }
 
     static userSearch(part, userList) {
-        if (part.startsWith(USER_DOMAIN)) {
-            part = part.substring(USER_DOMAIN.length + 1);
-        }
-        return MemberUtils.getUsers(part, userList).then((r) => {
+        const userDomainOmitPart = part.startsWith(USER_DOMAIN) ? part.substring(USER_DOMAIN.length + 1) : part;
+        return MemberUtils.getUsers(userDomainOmitPart, userList).then((r) => {
             let usersArr = [];
             r.forEach((u) =>
                 usersArr.push({


### PR DESCRIPTION
# Description
We are utilizing Athenz with identical strings set for both user domain and home domain. Consequently, since the member completion search in AthenzUI returns results without the user domain, it becomes impossible to add RoleMembers or GroupMembers that begin with the user domain.

For instance, if both userdomain and homedomain are `personal`:

1. I attempt to add `personal.hiragi-gkuth.subdomain.test-service`
2. The AddMember.js modal for completion suggests `hiragi-gkuth.subdomain.test-service` as the result.
3. I'm unable to add `hiragi-gkuth.subdomain.test-servic` because it is not exists.

Therefore, I have made a fix ensuring that the AddMember completion returns exactly the input text when the search result is empty.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
  - This PR has breaking changes, but it doesn't looks so critical.
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

