### PR TITLE
minor update to zts java client unit test

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -1853,7 +1853,12 @@ public class ZTSClient implements Closeable {
     int getScheduledItemsSize() {
         return PREFETCH_SCHEDULED_ITEMS.size();
     }
-    
+
+    // method useful for test purposes only
+    void clearScheduledItems() {
+        PREFETCH_SCHEDULED_ITEMS.clear();
+    }
+
     /**
      * Pre-fetches role tokens so that the client does not take the hit of
      * contacting ZTS Server for its first request (avg ~75ms). The client

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
@@ -3970,6 +3970,7 @@ public class ZTSClientTest {
                 "user", siaProvider);
         ZTSClient.setPrefetchInterval(1);
         client.setZTSRDLGeneratedClient(ztsClientMock);
+        client.clearScheduledItems();
 
         // initially, id token was never fetched.
         assertTrue(ztsClientMock.getLastIdTokenFetchedTime("openid sports.api:role.readers") < 0);


### PR DESCRIPTION
# Description

to have a better reliability of running unit tests, added a method for internal tests only to clear the internal prefetch list so the list is empty and nothing is left over from other tests.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

