### PR TITLE
replace aws role session name from harcoded to principal name

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -724,3 +724,17 @@ athenz.zts.k8s_provider_distribution_validator_factory_class=com.yahoo.athenz.in
 # be enabled in the server. Current, we have only one provider
 # implemented for GCP and the default value includes this provider.
 #athenz.zts.external_creds_providers=gcp
+
+# The property specifies a hard-coded string to include as the aws
+# role session name when the server is requesting aws temporary
+# credentials. Without this property, the server is using the
+# principal name as the session name. The server validates that
+# the session name is valid and not to long since AWS defines
+# the session role name with the following restrictions:
+#   Length Constraints: Minimum length of 2. Maximum length of 64.
+#   Pattern: [\w+=,.@-]*
+# Athenz principals can also include _'s which are not allowed
+# but the system admin can enable it, so we'll replace those
+# with ='s if we come across. And we'll truncate the principal
+# name to 60 and add insert ... in the middle to indicate truncation
+#athenz.zts.aws_role_session_name=

--- a/servers/zts/pom.xml
+++ b/servers/zts/pom.xml
@@ -29,7 +29,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <code.coverage.min>0.9953</code.coverage.min>
+    <code.coverage.min>0.9954</code.coverage.min>
   </properties>
 
   <dependencyManagement>

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -57,6 +57,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_AWS_CREDS_INVALID_CACHE_TIMEOUT     = "athenz.zts.aws_creds_invalid_cache_timeout";
     public static final String ZTS_PROP_AWS_ENABLED                         = "athenz.zts.aws_enabled";
     public static final String ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT            = "athenz.zts.aws_creds_update_timeout";
+    public static final String ZTS_PROP_AWS_ROLE_SESSION_NAME               = "athenz.zts.aws_role_session_name";
 
     public static final String ZTS_PROP_CERT_REFRESH_IP_FNAME  = "athenz.zts.cert_refresh_ip_fname";
     public static final String ZTS_PROP_CERT_ALLOWED_O_VALUES  = "athenz.zts.cert_allowed_o_values";


### PR DESCRIPTION
# Description

replace aws role session name from harcoded to principal name since it provides better audibility of requests
in AWS. Instead of just seeing athenz-zts-service, the logs now show the identity that requested the credentials

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

