### PR TITLE
extend instance id for github actions identity to include <org>:<repo>:<job-id>

### DIFF
--- a/docs/provider_github_actions.md
+++ b/docs/provider_github_actions.md
@@ -118,19 +118,20 @@ deployment. No changes are required for the current deployment model.
 The provider will carry out the following checks during the instance registration process:
 
 - Obtain the public keys from GitHub to validate the OIDC token. It will cache the keys to avoid unnecessary calls. It
-will also limit the frequency of how often it will connect to GitHub to fetch the public keys. For example, if it
-receives a token with a key id that is not in its cache, it will attempt to update the local cache by contacting GitHub.
-However, if the key id is not found and another request is received with the same key id, it will not attempt to fetch a
-fresh set of keys from GitHub until the configured timeout has passed.
+  will also limit the frequency of how often it will connect to GitHub to fetch the public keys. For example, if it
+  receives a token with a key id that is not in its cache, it will attempt to update the local cache by contacting GitHub.
+  However, if the key id is not found and another request is received with the same key id, it will not attempt to fetch a
+  fresh set of keys from GitHub until the configured timeout has passed.
 - Validate the signature of the OIDC token and parse the claims. As part of this validation, the library verifies that the
-token is not expired.
+  token is not expired.
 - Validate the following claims from the token:
   - Audience (aud) - must be our configured server e.g. https://zts.athenz.io:4443/zts/v1
-  - Enterprise (enterprise) - matches the configured enterprise value. If the enterprise value is not configured this check
-is skipped
+  - Enterprise (enterprise) - matches the configured enterprise value. If the enterprise value is not
+    configured this check is skipped
   - Issue Time (iat) - the timestamp must be within the configured number of minutes (default 5 mins).
   - Issuer (iss) - matches the configured GitHub issuer
-  - Run ID (run_id) - identifies the instance id for the certificate request
+  - Run ID (run_id) - identifies the instance id for the certificate request by including with the
+    organization and repository names in the following format: <org-name>:<repo-name>:<run_id>
 - Extract the following two attributes for the authorization check:
   - Subject (sub) - subject for the event
   - Event Name (event_name) - name of the event

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProviderTest.java
@@ -147,8 +147,8 @@ public class InstanceGithubActionsProviderTest {
         provider.setAuthorizer(authorizer);
 
         Map<String, String> instanceAttributes = new HashMap<>();
-        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "0001");
-        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.github-actions/001");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "athenz:sia:0001");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.github-actions/athenz:sia:001");
         instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "api.sports.github-actions.athenz.io");
 
         InstanceConfirmation confirmation = new InstanceConfirmation();
@@ -156,7 +156,7 @@ public class InstanceGithubActionsProviderTest {
         confirmation.setService("api");
         confirmation.setProvider("sys.auth.github-actions");
         confirmation.setAttestationData(generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false));
+                System.currentTimeMillis() / 1000, false, false, false, false, false));
         confirmation.setAttributes(instanceAttributes);
 
         provider.signingKeyResolver.addPublicKey("0", Crypto.loadPublicKey(ecPublicKey));
@@ -184,8 +184,8 @@ public class InstanceGithubActionsProviderTest {
         provider.setAuthorizer(authorizer);
 
         Map<String, String> instanceAttributes = new HashMap<>();
-        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "0001");
-        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.github-actions/001");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "athenz:sia:0001");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.github-actions/athenz:sia:001");
         instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "host1.athenz.io");
 
         InstanceConfirmation confirmation = new InstanceConfirmation();
@@ -193,7 +193,7 @@ public class InstanceGithubActionsProviderTest {
         confirmation.setService("api");
         confirmation.setProvider("sys.auth.github-actions");
         confirmation.setAttestationData(generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false));
+                System.currentTimeMillis() / 1000, false, false, false, false, false));
         confirmation.setAttributes(instanceAttributes);
 
         // without the public key we should get a token validation failure
@@ -368,9 +368,9 @@ public class InstanceGithubActionsProviderTest {
         // our issuer will not match
 
         String idToken = generateIdToken("https://token-actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false);
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("token issuer is not GitHub Actions"));
     }
@@ -389,9 +389,9 @@ public class InstanceGithubActionsProviderTest {
         // our audience will not match
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false);
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("token audience is not ZTS Server audience"));
     }
@@ -411,9 +411,9 @@ public class InstanceGithubActionsProviderTest {
         // our enterprise will not match
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false);
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("token enterprise is not the configured enterprise"));
     }
@@ -432,18 +432,18 @@ public class InstanceGithubActionsProviderTest {
         // our issue time is not recent enough
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000 - 400, false, false, false);
+                System.currentTimeMillis() / 1000 - 400, false, false, false, false, false);
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("job start time is not recent enough"));
 
         // create another token without the issue time
 
         idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, true);
+                System.currentTimeMillis() / 1000, false, false, true, false, false);
         errMsg.setLength(0);
-        result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("job start time is not recent enough"));
     }
@@ -463,11 +463,25 @@ public class InstanceGithubActionsProviderTest {
         // our issue time is not recent enough
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false);
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "1001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:1001", errMsg);
         assertFalse(result);
-        assertTrue(errMsg.toString().contains("invalid instance id in token"));
+        assertTrue(errMsg.toString().contains("invalid instance id: athenz:sia:0001/athenz:sia:1001"));
+
+        idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, true, false);
+        errMsg.setLength(0);
+        result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:1001", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token does not contain required run_id or repository claims"));
+
+        idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, false, true);
+        errMsg.setLength(0);
+        result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:1001", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token does not contain required run_id or repository claims"));
     }
 
     @Test
@@ -485,10 +499,10 @@ public class InstanceGithubActionsProviderTest {
         // create an id token without the event_name claim
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, true, false);
+                System.currentTimeMillis() / 1000, false, true, false, false, false);
 
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("token does not contain required event_name claim"));
     }
@@ -508,10 +522,10 @@ public class InstanceGithubActionsProviderTest {
         // create an id token without the subject claim
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, true, false, false);
+                System.currentTimeMillis() / 1000, true, false, false, false, false);
 
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("token does not contain required subject claim"));
     }
@@ -538,24 +552,29 @@ public class InstanceGithubActionsProviderTest {
         // create an id token
 
         String idToken = generateIdToken("https://token.actions.githubusercontent.com",
-                System.currentTimeMillis() / 1000, false, false, false);
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
 
         StringBuilder errMsg = new StringBuilder(256);
-        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "0001", errMsg);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
         assertFalse(result);
         assertTrue(errMsg.toString().contains("authorization check failed for action"));
     }
 
     private String generateIdToken(final String issuer, long currentTimeSecs, boolean skipSubject,
-            boolean skipEventName, boolean skipIssuedAt) {
+            boolean skipEventName, boolean skipIssuedAt, boolean skipRunId, boolean skipRepository) {
 
         PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
         JwtBuilder jwtBuilder = Jwts.builder()
                 .setExpiration(Date.from(Instant.ofEpochSecond(currentTimeSecs + 3600)))
                 .setIssuer(issuer)
                 .setAudience("https://athenz.io")
-                .claim("run_id", "0001")
                 .claim("enterprise", "athenz");
+        if (!skipRunId) {
+            jwtBuilder.claim("run_id", "0001");
+        }
+        if (!skipRepository) {
+            jwtBuilder.claim("repository", "athenz/sia");
+        }
         if (!skipSubject) {
             jwtBuilder.setSubject("repo:athenz/sia:ref:refs/heads/main");
         }


### PR DESCRIPTION
# Description

The instance id now provides useful information about the org and repo where the job is running in.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

