### PR TITLE
use spiffe namespace of default

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509ServiceCertRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509ServiceCertRequest.java
@@ -28,8 +28,9 @@ public class X509ServiceCertRequest extends X509CertRequest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(X509ServiceCertRequest.class);
 
-    public static final String SPIFFE_SERVICE_AGENT = "sa";
-    public static final String SPIFFE_NAMESPACE_AGENT = "ns";
+    public static final String SPIFFE_SERVICE_AGENT     = "sa";
+    public static final String SPIFFE_NAMESPACE_AGENT   = "ns";
+    public static final String SPIFFE_DEFAULT_NAMESPACE = "default";
 
     public X509ServiceCertRequest(String csr) throws CryptoException {
         super(csr);
@@ -101,9 +102,10 @@ public class X509ServiceCertRequest extends X509CertRequest {
             return true;
         }
 
+        final String ns = StringUtil.isEmpty(namespace) ? SPIFFE_DEFAULT_NAMESPACE : namespace;
         final String reqUri1 = "spiffe://" + domainName + "/" + SPIFFE_SERVICE_AGENT + "/" + serviceName;
         final String reqUri2 = "spiffe://" + SPIFFE_TRUST_DOMAIN + "/" + SPIFFE_NAMESPACE_AGENT + "/" +
-                namespace + "/" + SPIFFE_SERVICE_AGENT + "/" + domainName + "." + serviceName;
+                ns + "/" + SPIFFE_SERVICE_AGENT + "/" + domainName + "." + serviceName;
         boolean uriVerified = reqUri1.equalsIgnoreCase(spiffeUri) || reqUri2.equalsIgnoreCase(spiffeUri);
 
         if (!uriVerified) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/X509ServiceCertRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/X509ServiceCertRequestTest.java
@@ -339,7 +339,7 @@ public class X509ServiceCertRequestTest {
     }
 
     @Test
-    public void testValidateSpiffeURI() throws IOException {
+    public void testValidateSpiffeURIWithoutURI() throws IOException {
 
         Path path = Paths.get("src/test/resources/valid.csr");
         String csr = new String(Files.readAllBytes(path));
@@ -358,7 +358,11 @@ public class X509ServiceCertRequestTest {
         X509ServiceCertRequest certReq = new X509ServiceCertRequest(csr);
         assertTrue(certReq.validateSpiffeURI("athenz", "production", "default"));
         assertFalse(certReq.validateSpiffeURI("athenz", "production", "test"));
-        assertFalse(certReq.validateSpiffeURI("athenz", "production", null));
+
+        // with null or empty we default to value of default
+
+        assertTrue(certReq.validateSpiffeURI("athenz", "production", null));
+        assertTrue(certReq.validateSpiffeURI("athenz", "production", ""));
     }
 
     @Test


### PR DESCRIPTION
# Description
 when not running within K8S, the spiffe uri is generated using namespace of default. On the server side instead of requiring the client to submit the namespace as part of the instance object, we'll default to value "default" if the field is empty or null.
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

