### PR TITLE
do not allow deletion of domain is it's associated with aws/gcp/azure

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -552,3 +552,10 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # have the same concerns as with updated objects, so we're allowing a much
 # larger offset.
 #athenz.zms.review_date_offset_days_new_objects=365
+
+# The setting specifies comma separated list of domain meta attributes that
+# must be empty when a domain is deleted. Supported values for now are the
+# meta attributes for the public cloud providers - aws/gcp/azure settings
+# (e.g. account,gcpproject,azuresubscription). The server will validate that
+# the domain does not have any of these attributes set when the domain is deleted.
+#athenz.zms.domain_delete_meta_attributes=

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -100,7 +100,6 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_MAX_POLICY_VERSIONS     = "athenz.zms.max_policy_versions";
     public static final String ZMS_PROP_DOMAIN_CONTACT_TYPES    = "athenz.zms.domain_contact_types";
     public static final String ZMS_PROP_DOMAIN_ENVIRONMENTS     = "athenz.zms.domain_environments";
-
     public static final String ZMS_DEFAULT_DOMAIN_ENVIRONMENTS  = "production,integration,staging,sandbox,qa,development";
 
     public static final String ZMS_PROP_VALIDATE_USER_MEMBERS    = "athenz.zms.validate_user_members";
@@ -110,6 +109,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_VALIDATE_SERVICE_MEMBERS_SKIP_DOMAINS = "athenz.zms.validate_service_members_skip_domains";
     public static final String ZMS_PROP_MASTER_COPY_FOR_SIGNED_DOMAINS        = "athenz.zms.master_copy_for_signed_domains";
     public static final String ZMS_PROP_ALLOW_UNDERSCORE_IN_SERVICE_NAMES     = "athenz.zms.allow_underscore_in_service_names";
+    public static final String ZMS_PROP_DOMAIN_DELETE_META_ATTRIBUTES         = "athenz.zms.domain_delete_meta_attributes";
 
     // properties used to over-ride default Audit logger
  

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -235,6 +235,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     protected Info serverInfo = null;
     protected Set<String> domainContactTypes = new HashSet<>();
     protected Set<String> domainEnvironments = new HashSet<>();
+    protected List<String> domainDeleteMetaAttributes = new ArrayList<>();
 
     // enum to represent our access response since in some cases we want to
     // handle domain not founds differently instead of just returning failure
@@ -986,6 +987,14 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // get server region
 
         serverRegion = System.getProperty(ZMSConsts.ZMS_PROP_SERVER_REGION);
+
+        // fetch the list of system meta attributes that must be empty when a domain
+        // is to be deleted
+
+        final String metaAttributes = System.getProperty(ZMSConsts.ZMS_PROP_DOMAIN_DELETE_META_ATTRIBUTES);
+        if (!StringUtil.isEmpty(metaAttributes)) {
+            domainDeleteMetaAttributes.addAll(Arrays.asList(metaAttributes.split(",")));
+        }
     }
 
     void loadObjectStore() {
@@ -1672,10 +1681,37 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         verifyNoServiceDependenciesOnDomain(domainName, caller);
         verifyServiceProvidersAuthorizeDelete(ctx, domainName, caller);
+        verifyEmptyDomainMetaAttributes(domain.getDomain(), caller);
 
         // no service is dependent on the domain, we can go ahead and delete the domain
 
         dbService.executeDeleteDomain(ctx, domainName, auditRef, caller);
+    }
+
+    void verifyEmptyDomainMetaAttributes(Domain domain, final String caller) {
+
+        for (String metaAttribute : domainDeleteMetaAttributes) {
+            switch (metaAttribute) {
+                case ZMSConsts.SYSTEM_META_ACCOUNT:
+                    if (!StringUtil.isEmpty(domain.getAccount())) {
+                        throw ZMSUtils.requestError("Domain has non-empty account attribute: "
+                                + domain.getAccount(), caller);
+                    }
+                    break;
+                case ZMSConsts.SYSTEM_META_GCP_PROJECT:
+                    if (!StringUtil.isEmpty(domain.getGcpProject())) {
+                        throw ZMSUtils.requestError("Domain has non-empty gcp-project attribute: "
+                                + domain.getGcpProject(), caller);
+                    }
+                    break;
+                case ZMSConsts.SYSTEM_META_AZURE_SUBSCRIPTION:
+                    if (!StringUtil.isEmpty(domain.getAzureSubscription())) {
+                        throw ZMSUtils.requestError("Domain has non-empty azure-subscription attribute: "
+                                + domain.getAzureSubscription(), caller);
+                    }
+                    break;
+            }
+        }
     }
 
     private void verifyNoServiceDependenciesOnDomain(String domainName, String caller) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSDeleteDomainTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSDeleteDomainTest.java
@@ -1,0 +1,1134 @@
+/*
+ *
+ *  * Copyright The Athenz Authors
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.yahoo.athenz.zms;
+
+import com.yahoo.athenz.auth.Authority;
+import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.impl.SimplePrincipal;
+import com.yahoo.athenz.common.server.util.ResourceUtils;
+import com.yahoo.athenz.zms.provider.DomainDependencyProviderResponse;
+import com.yahoo.athenz.zms.provider.ServiceProviderClient;
+import com.yahoo.athenz.zms.provider.ServiceProviderManager;
+import org.mockito.Mockito;
+import org.testng.annotations.*;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+import static com.yahoo.athenz.zms.ZMSConsts.*;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+public class ZMSDeleteDomainTest {
+
+    private final ZMSTestInitializer zmsTestInitializer = new ZMSTestInitializer();
+    private final long fetchDomainDependencyFrequency = 1L; // For the tests, fetch every second
+
+    @BeforeClass
+    public void startMemoryMySQL() {
+        zmsTestInitializer.startMemoryMySQL();
+    }
+
+    @AfterClass
+    public void stopMemoryMySQL() {
+        zmsTestInitializer.stopMemoryMySQL();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        System.setProperty(ZMS_PROP_SERVICE_PROVIDER_MANAGER_FREQUENCY_SECONDS,
+                String.valueOf(fetchDomainDependencyFrequency));
+        zmsTestInitializer.setUp();
+    }
+
+    @AfterMethod
+    public void clearConnections() throws Exception {
+        zmsTestInitializer.clearConnections();
+        System.clearProperty(ZMS_PROP_SERVICE_PROVIDER_MANAGER_FREQUENCY_SECONDS);
+        // Reset ServiceProviderManager Singleton
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        ServiceProviderManager.getInstance(zmsImpl.dbService, zmsImpl).shutdown();
+        Field instance = ServiceProviderManager.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+
+    @Test
+    public void testDeleteDomainWithGroupConsistency() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        final String domainName1 = "delete-group1";
+        final String domainName2 = "delete-group2";
+        final String domainName3 = "delete-group3";
+        final String groupName1 = "group1";
+        final String groupName2 = "group2";
+        final String groupName3 = "group3";
+        final String roleName1 = "role1";
+        final String roleName2 = "role2";
+        final String roleName3 = "role3";
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName1, "Test Domain1",
+                "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        TopLevelDomain dom2 = zmsTestInitializer.createTopLevelDomainObject(domainName2, "Test Domain2",
+                "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom2);
+
+        TopLevelDomain dom3 = zmsTestInitializer.createTopLevelDomainObject(domainName3, "Test Domain3",
+                "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom3);
+
+        Group group1 = zmsTestInitializer.createGroupObject(domainName1, groupName1, "user.joe", "user.jane");
+        zmsImpl.putGroup(ctx, domainName1, groupName1, auditRef, false, group1);
+
+        Group group2 = zmsTestInitializer.createGroupObject(domainName1, groupName2, "user.joe", "user.jane");
+        zmsImpl.putGroup(ctx, domainName1, groupName2, auditRef, false, group2);
+
+        Group group3 = zmsTestInitializer.createGroupObject(domainName3, groupName3, "user.joe", "user.jane");
+        zmsImpl.putGroup(ctx, domainName3, groupName3, auditRef, false, group3);
+
+        // add group2 as a member to roles in 2 different domains
+
+        Role role1 = zmsTestInitializer.createRoleObject(domainName1, roleName1, null, "user.john",
+                ResourceUtils.groupResourceName(domainName1, groupName2));
+        zmsImpl.putRole(ctx, domainName1, roleName1, auditRef, false, role1);
+
+        Role role2 = zmsTestInitializer.createRoleObject(domainName2, roleName2, null, "user.john",
+                ResourceUtils.groupResourceName(domainName1, groupName2));
+        zmsImpl.putRole(ctx, domainName2, roleName2, auditRef, false, role2);
+
+        Role role3 = zmsTestInitializer.createRoleObject(domainName3, roleName3, null, "user.john",
+                ResourceUtils.groupResourceName(domainName3, groupName3));
+        zmsImpl.putRole(ctx, domainName3, roleName3, auditRef, false, role3);
+
+        // we should be able to delete domain3 without any issues since
+        // group3 is included in the same domain only
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName3, auditRef);
+
+        // we should not able to delete domain1 since the group from domain1
+        // is included in both domain1 and domain2. our error message should
+        // only include reference from domain2
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, domainName1, auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertFalse(ex.getMessage().contains(ResourceUtils.roleResourceName(domainName1, roleName1)));
+            assertTrue(ex.getMessage().contains(ResourceUtils.roleResourceName(domainName2, roleName2)));
+        }
+
+        // after we delete domain2 we can delete domain1 successfully
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName2, auditRef);
+        zmsImpl.deleteTopLevelDomain(ctx, domainName1, auditRef);
+    }
+
+    @Test
+    public void testDeleteDomain() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // make sure we can't delete system domains
+
+        try {
+            zmsImpl.deleteDomain(ctx, auditRef, "sys.auth", "testDeleteDomain");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("reserved system domain"));
+        }
+
+        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
+                "TestDeleteDomain", null, null, zmsTestInitializer.getAdminUser());
+        dom.setAuditEnabled(true);
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
+
+        zmsImpl.deleteDomain(ctx, auditRef, "testdeletedomain", "testDeleteDomain");
+
+        try {
+            zmsImpl.getDomain(ctx, "TestDeleteDomain");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 404);
+        }
+    }
+
+    @Test
+    public void testDeleteDomainNonExistant() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        try {
+            zmsImpl.deleteDomain(ctx, auditRef, "TestDeleteDomainNonExist", "testDeleteDomainNonExistant");
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 404);
+        }
+    }
+
+    @Test
+    public void testDeleteDomainMissingAuditRef() {
+        // create domain and require auditing
+        String domain = "testdeletedomainmissingauditref";
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
+                domain, null, null, zmsTestInitializer.getAdminUser());
+        dom.setAuditEnabled(true);
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
+
+        // delete it without an auditRef and catch exception
+        try {
+            zmsImpl.deleteDomain(ctx, null, domain, "testDeleteDomainMissingAuditRef");
+            fail("requesterror not thrown by testDeleteDomainMissingAuditRef.");
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Audit reference required"));
+        } finally {
+            zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef);
+        }
+    }
+
+    @Test
+    public void testDeleteTopLevelDomain() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelTopDom1",
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        Domain resDom1 = zmsImpl.getDomain(ctx, "DelTopDom1");
+        assertNotNull(resDom1);
+
+        zmsImpl.deleteTopLevelDomain(ctx, "DelTopDom1", auditRef);
+
+        // we should get a forbidden exception since the domain
+        // no longer exists
+
+        try {
+            zmsImpl.getDomain(ctx, "DelTopDom1");
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testVerifyServiceProvidersAuthorizeDelete() {
+        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+
+        String domain = "test";
+        String caller = "deleteDomain";
+
+        // Mock service provider manager and service provider client
+
+        zmsImpl.serviceProviderManager = Mockito.mock(ServiceProviderManager.class);
+        zmsImpl.serviceProviderClient = Mockito.mock(ServiceProviderClient.class);
+        Map<String, ServiceProviderManager.DomainDependencyProvider> serviceProvidersWithEndpoints = new HashMap<>();
+        boolean isInstance = false;
+        String status = PROVIDER_RESPONSE_DENY;
+        int numberOfProviders = 20;
+        for (int i = 1; i <= numberOfProviders; ++i) {
+            ServiceProviderManager.DomainDependencyProvider domainDependencyProvider =
+                    new ServiceProviderManager.DomainDependencyProvider("provider" + i, "https://provider" + i, isInstance);
+            serviceProvidersWithEndpoints.put("provider" + i, domainDependencyProvider);
+            DomainDependencyProviderResponse providerResponse = new DomainDependencyProviderResponse();
+            providerResponse.setStatus(status);
+            providerResponse.setMessage("message for provider number " + i + "isInstance? " + isInstance);
+            Mockito.when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider,
+                    domain, ctx.principal().getFullName())).thenReturn(providerResponse);
+            isInstance = !isInstance;
+            status = status.equals(PROVIDER_RESPONSE_DENY) ? PROVIDER_RESPONSE_ALLOW : PROVIDER_RESPONSE_DENY;
+        }
+        Mockito.when(zmsImpl.serviceProviderManager.getServiceProvidersWithEndpoints())
+                .thenReturn(serviceProvidersWithEndpoints);
+
+        try {
+            zmsImpl.verifyServiceProvidersAuthorizeDelete(ctx, domain, caller);
+            fail();
+        } catch (ResourceException ex) {
+            status = PROVIDER_RESPONSE_DENY;
+            isInstance = false;
+            for (int i = 1; i <= numberOfProviders; ++i) {
+                if (status.equals(PROVIDER_RESPONSE_DENY)) {
+                    assertTrue(ex.getMessage().contains("message for provider number " + i + "isInstance? " + isInstance));
+                } else {
+                    assertFalse(ex.getMessage().contains("message for provider number " + i + "isInstance? " + isInstance));
+                }
+                isInstance = !isInstance;
+                status = status.equals(PROVIDER_RESPONSE_DENY) ? PROVIDER_RESPONSE_ALLOW : PROVIDER_RESPONSE_DENY;
+            }
+        }
+        Mockito.verify(zmsImpl.serviceProviderManager, Mockito.times(1)).getServiceProvidersWithEndpoints();
+    }
+
+    @Test
+    public void testDeleteTopLevelDomainServiceProviderDeclines() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        String topLevelDomainName = "deltopdomdependencyexist";
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(topLevelDomainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        Domain resDom1 = zmsImpl.getDomain(ctx, topLevelDomainName);
+        assertNotNull(resDom1);
+
+        // Create services
+
+        ServiceIdentity service = zmsTestInitializer.createServiceObject(topLevelDomainName,
+                "Service1", "http://localhost/ser", "/usr/bin/java", "root",
+                "users", "host1");
+
+        zmsImpl.putServiceIdentity(ctx, topLevelDomainName, "Service1", auditRef, false, service);
+
+        ServiceIdentity service2 = zmsTestInitializer.createServiceObject(topLevelDomainName,
+                "Service2", "http://localhost/ser2", "/usr/bin/java", "root",
+                "users", "host1");
+
+        zmsImpl.putServiceIdentity(ctx, topLevelDomainName, "Service2", auditRef, false, service2);
+
+        // Set endpoint for services
+
+        RsrcCtxWrapper sysAdminCtx = zmsTestInitializer.contextWithMockPrincipal("deleteMembership");
+
+        ServiceIdentitySystemMeta meta = new ServiceIdentitySystemMeta();
+        meta.setProviderEndpoint("https://localhost/service-provider-test-delete");
+        zmsImpl.putServiceIdentitySystemMeta(sysAdminCtx, topLevelDomainName, "Service1", "providerendpoint", auditRef, meta);
+
+        ServiceIdentitySystemMeta meta2 = new ServiceIdentitySystemMeta();
+        meta2.setProviderEndpoint("https://localhost/service-provider-test-delete2");
+        zmsImpl.putServiceIdentitySystemMeta(sysAdminCtx, topLevelDomainName, "Service2", "providerendpoint", auditRef, meta2);
+
+        // Make service2 an instance provider as well as service provider
+        makeInstanceProvider(topLevelDomainName, sysAdminCtx, "service2");
+        zmsTestInitializer.makeServiceProviders(zmsImpl, sysAdminCtx, Arrays.asList(topLevelDomainName + ".service1",
+                topLevelDomainName + ".service2"), fetchDomainDependencyFrequency);
+
+        // Make service1 provider deny deletion for regular user and allow it for admin for service1
+        // Make service2 provider deny deletion for all users
+
+        zmsImpl.serviceProviderClient = Mockito.mock(ServiceProviderClient.class);
+        DomainDependencyProviderResponse providerResponseDeniesRegularUser = new DomainDependencyProviderResponse();
+        providerResponseDeniesRegularUser.setStatus(PROVIDER_RESPONSE_DENY);
+        providerResponseDeniesRegularUser.setMessage("provider denied deleting the domain for principal " + ctx.principal().getFullName());
+        ServiceProviderManager.DomainDependencyProvider domainDependencyProvider = new ServiceProviderManager.DomainDependencyProvider(topLevelDomainName + ".service1", "https://localhost/service-provider-test-delete", false);
+        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider, topLevelDomainName, ctx.principal().getFullName())).thenReturn(providerResponseDeniesRegularUser);
+        DomainDependencyProviderResponse providerResponseAllows = new DomainDependencyProviderResponse();
+        providerResponseAllows.setStatus(PROVIDER_RESPONSE_ALLOW);
+        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider, topLevelDomainName, sysAdminCtx.principal().getFullName())).thenReturn(providerResponseAllows);
+        ServiceProviderManager.DomainDependencyProvider domainDependencyProvider2 = new ServiceProviderManager.DomainDependencyProvider(topLevelDomainName + ".service2", "https://localhost/service-provider-test-delete2", true);
+        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider2, topLevelDomainName, ctx.principal().getFullName())).thenReturn(providerResponseDeniesRegularUser);
+        DomainDependencyProviderResponse providerResponseDeniesAdmin = new DomainDependencyProviderResponse();
+        providerResponseDeniesAdmin.setStatus(PROVIDER_RESPONSE_DENY);
+        providerResponseDeniesAdmin.setMessage("provider denied deleting the domain for principal " + sysAdminCtx.principal().getFullName());
+        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider2, topLevelDomainName, sysAdminCtx.principal().getFullName()))
+                .thenReturn(providerResponseDeniesAdmin) // Service2 provider will deny deletion in the first call by a sysadmin
+                .thenReturn(providerResponseAllows);
+
+        // Wait for cache to be ServiceProviderManager cache to refresh
+
+        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
+
+        // Denies deletion for regular user by both service providers
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Service 'deltopdomdependencyexist.service2' is dependent on domain 'deltopdomdependencyexist'. Error: provider denied deleting the domain for principal user.user1, Service 'deltopdomdependencyexist.service1' is dependent on domain 'deltopdomdependencyexist'. Error: provider denied deleting the domain for principal user.user1\"}");
+        }
+
+        // Denies deletion for sys admin by service2 provider
+
+        try {
+            zmsImpl.deleteTopLevelDomain(sysAdminCtx, topLevelDomainName, auditRef);
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Service 'deltopdomdependencyexist.service2' is dependent on domain 'deltopdomdependencyexist'. Error: provider denied deleting the domain for principal user.testadminuser\"}");
+        }
+
+
+        // Now the client will start to allow deletions for sysadmin
+
+        zmsImpl.deleteTopLevelDomain(sysAdminCtx, topLevelDomainName, auditRef);
+    }
+
+    @Test
+    public void testDeleteTopLevelDomainDependencyExist() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        String topLevelDomainName = "deltopdomdependencyexist";
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(topLevelDomainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        Domain resDom1 = zmsImpl.getDomain(ctx, topLevelDomainName);
+        assertNotNull(resDom1);
+
+        registerDependency(ctx, topLevelDomainName, zmsImpl, topLevelDomainName, "service-provider1");
+
+        // We can't delete a domain that has service dependency
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove domain" +
+                    " 'deltopdomdependencyexist' dependency from the following" +
+                    " service(s):deltopdomdependencyexist.service-provider1\"}");
+        }
+
+        // Register another dependency, verify it appears in the delete error list
+
+        registerDependency(ctx, topLevelDomainName, zmsImpl, topLevelDomainName, "service-provider2");
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove domain" +
+                    " 'deltopdomdependencyexist' dependency from the following service(s):" +
+                    "deltopdomdependencyexist.service-provider1, deltopdomdependencyexist.service-provider2\"}");
+        }
+
+        // Remove one of the dependencies, verify the error message is updated
+
+        deRegisterDependency(topLevelDomainName, zmsImpl, topLevelDomainName, "service-provider1");
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove domain" +
+                    " 'deltopdomdependencyexist' dependency from the following" +
+                    " service(s):deltopdomdependencyexist.service-provider2\"}");
+        }
+
+        // Now remove the dependency but set endpoint for the service - verify the error message change
+
+        RsrcCtxWrapper sysAdminCtx = zmsTestInitializer.contextWithMockPrincipal("deleteMembership");
+        zmsImpl.deleteDomainDependency(sysAdminCtx, topLevelDomainName,
+                topLevelDomainName + ".service-provider2", auditRef);
+
+        // Verify dependency was removed
+
+        DomainList dependentDomainList = zmsImpl.getDependentDomainList(sysAdminCtx,
+                topLevelDomainName + ".service-provider1");
+        assertEquals(dependentDomainList.getNames().size(), 0);
+        ServiceIdentitySystemMeta meta = new ServiceIdentitySystemMeta();
+        meta.setProviderEndpoint("https://localhost/testendpoint");
+        zmsImpl.putServiceIdentitySystemMeta(ctx, topLevelDomainName, "service-provider2",
+                "providerendpoint", auditRef, meta);
+
+        // Wait for cache to be ServiceProviderManager cache to refresh
+
+        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
+            fail();
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Service '" +
+                    topLevelDomainName + ".service-provider2' is dependent on domain '" + topLevelDomainName +
+                    "'. Error: Exception thrown during call to provider: Failed to get response from" +
+                    " server: https://localhost/testendpoint\"}");
+        }
+
+        // Now make the provider approve the deletion
+
+        ServiceProviderManager.DomainDependencyProvider domainDependencyProvider =
+                new ServiceProviderManager.DomainDependencyProvider(topLevelDomainName + ".service-provider2",
+                        "https://localhost/testendpoint", false);
+        DomainDependencyProviderResponse providerResponse = new DomainDependencyProviderResponse();
+        providerResponse.setStatus("allow");
+        ServiceProviderClient serviceProviderClientMock = Mockito.mock(ServiceProviderClient.class);
+        when(serviceProviderClientMock.getDependencyStatus(domainDependencyProvider, topLevelDomainName,
+                ctx.principal().getFullName())).thenReturn(providerResponse);
+        zmsImpl.serviceProviderClient = serviceProviderClientMock;
+        zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
+    }
+
+    @Test
+    public void testDeleteTopLevelDomainChildExist() {
+
+        ZMSImplTest.TestAuditLogger alogger = new ZMSImplTest.TestAuditLogger();
+        ZMSImpl zmsImpl = zmsTestInitializer.getZmsImpl(alogger);
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelTopChildDom1",
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", "DelTopChildDom1",
+                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postSubDomain(ctx, "DelTopChildDom1", auditRef, dom2);
+
+        // we can't delete Dom1 since Dom2 still exists
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, "DelTopChildDom1", auditRef);
+            fail("requesterror not thrown.");
+        } catch (ResourceException ex) {
+            assertEquals(400, ex.getCode());
+        }
+
+        zmsImpl.deleteSubDomain(ctx, "DelTopChildDom1", "DelSubDom2", auditRef);
+        zmsImpl.deleteTopLevelDomain(ctx, "DelTopChildDom1", auditRef);
+    }
+
+    @Test
+    public void testDeleteTopLevelDomainNonExistant() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, "NonExistantDomain", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 404);
+        }
+    }
+
+    @Test
+    public void testDeleteTopLevelDomainNonExistantNoAuditRef() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, "NonExistantDomain", null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 404);
+        }
+    }
+
+    @Test
+    public void testDeleteTopLevelDomainMissingAuditRef() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // create domain and require auditing
+        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
+                "TopDomainAuditRequired", null, null, zmsTestInitializer.getAdminUser());
+        dom.setAuditEnabled(true);
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
+
+        // delete it without an auditRef and catch exception
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, "TopDomainAuditRequired", null);
+            fail("requesterror not thrown by deleteTopLevelDomain.");
+        } catch (ResourceException ex) {
+            System.out.println("*** " + ex.getMessage());
+            assertEquals(400, ex.getCode());
+            assertTrue(ex.getMessage().contains("Audit reference required"));
+        } finally {
+            zmsImpl.deleteTopLevelDomain(ctx, "TopDomainAuditRequired", auditRef);
+        }
+    }
+
+    @Test
+    public void testDeleteSubDomain() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelSubDom1",
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", "DelSubDom1",
+                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postSubDomain(ctx, "DelSubDom1", auditRef, dom2);
+
+        Domain resDom1 = zmsImpl.getDomain(ctx, "DelSubDom1.DelSubDom2");
+        assertNotNull(resDom1);
+
+        zmsImpl.deleteSubDomain(ctx, "DelSubDom1", "DelSubDom2", auditRef);
+
+        // we should get a forbidden exception since the domain
+        // no longer exists
+
+        try {
+            zmsImpl.getDomain(ctx, "DelSubDom1.DelSubDom2");
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
+
+        zmsImpl.deleteTopLevelDomain(ctx, "DelSubDom1", auditRef);
+    }
+
+    @Test
+    public void testDeleteSubDomainNotAuthorized() {
+
+        final String domainName = "delsubdom1authz";
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", domainName,
+                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postSubDomain(ctx, "DelSubDom1Authz", auditRef, dom2);
+
+        Domain resDom1 = zmsImpl.getDomain(ctx, domainName + ".DelSubDom2");
+        assertNotNull(resDom1);
+
+        Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
+        Principal principal2 = principalAuthority.authenticate("v=U1;d=user;n=user2;s=signature",
+                "10.11.12.13", "GET", null);
+        ResourceContext ctx2 = zmsTestInitializer.createResourceContext(principal2);
+
+        // using a different principal, this operation should get rejected
+
+        try {
+            zmsImpl.deleteSubDomain(ctx2, domainName, "DelSubDom2", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Principal is not authorized to delete domain: delsubdom1authz.delsubdom2"));
+        }
+
+        // with our standard principal we should be able to delete the subdomain
+
+        zmsImpl.deleteSubDomain(ctx, domainName, "DelSubDom2", auditRef);
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+    }
+
+    @Test
+    public void testDeleteSubDomainChildExist() {
+
+        ZMSImplTest.TestAuditLogger alogger = new ZMSImplTest.TestAuditLogger();
+        ZMSImpl zmsImpl = zmsTestInitializer.getZmsImpl(alogger);
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelSubChildDom1",
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", "DelSubChildDom1",
+                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
+        zmsImpl.postSubDomain(ctx, "DelSubChildDom1", auditRef, dom2);
+
+        SubDomain dom3 = zmsTestInitializer.createSubDomainObject("DelSubDom3", "DelSubChildDom1.DelSubDom2",
+                "Test Domain3", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postSubDomain(ctx, "DelSubChildDom1.DelSubDom2", auditRef, dom3);
+
+        // we can't delete Dom2 since Dom3 still exists
+
+        try {
+            zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1", "DelSubDom2", auditRef);
+        } catch (ResourceException ex) {
+            assertEquals(400, ex.getCode());
+        }
+
+        zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1.DelSubDom2", "DelSubDom3", auditRef);
+        zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1", "DelSubDom2", auditRef);
+        zmsImpl.deleteTopLevelDomain(ctx, "DelSubChildDom1", auditRef);
+    }
+
+    @Test
+    public void testDeleteSubDomainNonExistant() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
+                "ExistantTopDomain", null, null, zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
+        try {
+            zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain", "NonExistantSubDomain", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 404);
+        }
+        zmsImpl.deleteTopLevelDomain(ctx, "ExistantTopDomain", auditRef);
+    }
+
+    @Test
+    public void testDeleteSubDomainSubAndTopNonExistant() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        try {
+            zmsImpl.deleteSubDomain(ctx, "NonExistantTopDomain", "NonExistantSubDomain", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 404);
+        }
+    }
+
+    @Test
+    public void testDeleteSubDomainMissingAuditRef() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
+                "ExistantTopDomain2", null, null, zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
+        dom.setAuditEnabled(true);
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
+
+        SubDomain subDom = zmsTestInitializer.createSubDomainObject(
+                "ExistantSubDom2", "ExistantTopDomain2",
+                null, null, zmsTestInitializer.getAdminUser());
+        subDom.setAuditEnabled(true);
+        zmsImpl.postSubDomain(ctx, "ExistantTopDomain2", auditRef, subDom);
+
+        try {
+            zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain2", "ExistantSubDom2", null);
+            fail("requesterror not thrown by deleteSubDomain.");
+        } catch (ResourceException ex) {
+            assertEquals(400, ex.getCode());
+            assertTrue(ex.getMessage().contains("Audit reference required"));
+        } finally {
+            zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain2", "ExistantSubDom2", auditRef);
+            zmsImpl.deleteTopLevelDomain(ctx, "ExistantTopDomain2", auditRef);
+        }
+    }
+
+    @Test
+    public void testDeleteDomainTemplateNull() {
+        Authority userAuthority = new com.yahoo.athenz.common.server.debug.DebugUserAuthority();
+        String userId = "user1";
+        Principal principal = SimplePrincipal.create("user", userId, userId + ":password", 0, userAuthority);
+        assertNotNull(principal);
+        ((SimplePrincipal) principal).setUnsignedCreds(userId);
+        ResourceContext rsrcCtx1 = zmsTestInitializer.createResourceContext(principal);
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        try {
+            zmsImpl.deleteDomainTemplate(rsrcCtx1, "dom1", null, "zms");
+            fail();
+        } catch (ResourceException ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testDeleteDomainTemplate() {
+        Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
+        Principal principal1 = principalAuthority.authenticate("v=U1;d=user;n=user1;s=signature",
+                "10.11.12.13", "GET", null);
+        ResourceContext rsrcCtx1 = zmsTestInitializer.createResourceContext(principal1);
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        try{
+            zmsImpl.deleteDomainTemplate(rsrcCtx1, null, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testDeleteDomainRoleMemberInvalidDomain() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        try {
+            zmsImpl.deleteDomainRoleMember(ctx, "invalid-domain", "user.joe", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(404, ex.getCode());
+        }
+    }
+
+    @Test
+    public void testDeleteDomainRoleMember() {
+
+        String domainName = "deletedomainrolemember2";
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        Role role1 = zmsTestInitializer.createRoleObject(domainName, "role1", null,
+                "user.jack", "user.janie");
+        zmsImpl.putRole(ctx, domainName, "role1", auditRef, false, role1);
+
+        Role role2 = zmsTestInitializer.createRoleObject(domainName, "role2", null,
+                "user.janie", "user.jane");
+        zmsImpl.putRole(ctx, domainName, "role2", auditRef, false, role2);
+
+        Role role3 = zmsTestInitializer.createRoleObject(domainName, "role3", null,
+                "user.jack", "user.jane");
+        zmsImpl.putRole(ctx, domainName, "role3", auditRef, false, role3);
+
+        Role role4 = zmsTestInitializer.createRoleObject(domainName, "role4", null,
+                "user.jack", null);
+        zmsImpl.putRole(ctx, domainName, "role4", auditRef, false, role4);
+
+        Role role5 = zmsTestInitializer.createRoleObject(domainName, "role5", null,
+                "user.jack-service", "user.jane");
+        zmsImpl.putRole(ctx, domainName, "role5", auditRef, false, role5);
+
+        DomainRoleMembers domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
+        assertEquals(domainName, domainRoleMembers.getDomainName());
+
+        List<DomainRoleMember> members = domainRoleMembers.getMembers();
+        assertNotNull(members);
+        assertEquals(5, members.size());
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
+        ZMSTestUtils.verifyDomainRoleMember(members, zmsTestInitializer.getAdminUser(), "admin");
+
+        // with unknown user we get back 404
+
+        try {
+            zmsImpl.deleteDomainRoleMember(ctx, domainName, "user.unknown", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
+        }
+
+        members = domainRoleMembers.getMembers();
+        assertNotNull(members);
+        assertEquals(5, members.size());
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
+        ZMSTestUtils.verifyDomainRoleMember(members, zmsTestInitializer.getAdminUser(), "admin");
+
+        // now remove a known user
+
+        zmsImpl.deleteDomainRoleMember(ctx, domainName, "user.jack", auditRef);
+
+        domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
+        assertEquals(domainName, domainRoleMembers.getDomainName());
+
+        members = domainRoleMembers.getMembers();
+        assertNotNull(members);
+        assertEquals(4, members.size());
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
+        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
+        ZMSTestUtils.verifyDomainRoleMember(members, zmsTestInitializer.getAdminUser(), "admin");
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+    }
+
+    @Test
+    public void testDeleteUserDomainNull() {
+        Authority userAuthority = new com.yahoo.athenz.common.server.debug.DebugUserAuthority();
+        String userId = "user1";
+        Principal principal = SimplePrincipal.create("user", userId, userId + ":password", 0, userAuthority);
+        assertNotNull(principal);
+        ((SimplePrincipal) principal).setUnsignedCreds(userId);
+        ResourceContext rsrcCtx1 = zmsTestInitializer.createResourceContext(principal);
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        try {
+            zmsImpl.deleteUserDomain(rsrcCtx1, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testDeleteUserDomain() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        UserDomain dom1 = zmsTestInitializer.createUserDomainObject("john-doe",
+                "Test Domain Delete User Domain", "testDeleteOrg");
+        zmsImpl.postUserDomain(ctx, "john-doe", auditRef, dom1);
+
+        zmsImpl.deleteUserDomain(ctx, "john-doe", auditRef);
+
+        try {
+            zmsImpl.getDomain(ctx, "john-doe");
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testDeleteServiceIdentityDependencyExist() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("ServiceDelDom1",
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        TopLevelDomain dom2 = zmsTestInitializer.createTopLevelDomainObject("ServiceDelDom2",
+                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom2);
+
+        ServiceIdentity service1 = zmsTestInitializer.createServiceObject("ServiceDelDom1",
+                "Service1", "http://localhost", "/usr/bin/java", "root",
+                "users", "host1");
+
+        zmsImpl.putServiceIdentity(ctx, "ServiceDelDom1", "Service1", auditRef, false, service1);
+
+        ServiceIdentity serviceRes1 = zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1",
+                "Service1");
+        assertNotNull(serviceRes1);
+
+        // add a domain dependency on the service and verify it prevents service deletion
+
+        RsrcCtxWrapper providerCtx = registerDependency(ctx, "ServiceDelDom1".toLowerCase(), zmsImpl,
+                "ServiceDelDom1".toLowerCase(), "Service1".toLowerCase());
+        try {
+            zmsImpl.deleteServiceIdentity(providerCtx, "ServiceDelDom1", "Service1", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove service" +
+                    " 'servicedeldom1.service1' dependency from the following domain(s):servicedeldom1\"}");
+        }
+
+        // Register another dependency, verify it appears in the delete error list
+
+        providerCtx = registerDependency(ctx, "ServiceDelDom2".toLowerCase(), zmsImpl,
+                "ServiceDelDom1".toLowerCase(), "Service1".toLowerCase());
+        try {
+            zmsImpl.deleteServiceIdentity(providerCtx, "ServiceDelDom1", "Service1", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message:" +
+                    " \"Remove service 'servicedeldom1.service1' dependency from the following" +
+                    " domain(s):servicedeldom1, servicedeldom2\"}");
+        }
+
+        // Remove one of the dependencies, verify the error message is updated
+
+        deRegisterDependency("ServiceDelDom1".toLowerCase(), zmsImpl, "ServiceDelDom1".toLowerCase(),
+                "Service1".toLowerCase());
+        try {
+            zmsImpl.deleteServiceIdentity(providerCtx, "ServiceDelDom1", "Service1", auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message:" +
+                    " \"Remove service 'servicedeldom1.service1' dependency from the following" +
+                    " domain(s):servicedeldom2\"}");
+        }
+        deRegisterDependency("ServiceDelDom2".toLowerCase(), zmsImpl, "ServiceDelDom1".toLowerCase(),
+                "Service1".toLowerCase());
+        zmsImpl.deleteServiceIdentity(ctx, "ServiceDelDom1", "Service1", auditRef);
+        zmsImpl.deleteTopLevelDomain(ctx, "ServiceDelDom1", auditRef);
+        zmsImpl.deleteTopLevelDomain(ctx, "ServiceDelDom2", auditRef);
+    }
+
+    private void makeInstanceProvider(String topLevelDomainName, RsrcCtxWrapper sysAdminCtx,
+            String serviceInstanceProvider) {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        String instanceProvidersRoleName = "instance-providers";
+        Role role = new Role();
+        role.setName(instanceProvidersRoleName);
+        RoleMember roleMember = new RoleMember();
+        roleMember.setMemberName(topLevelDomainName + "." + serviceInstanceProvider);
+        List<RoleMember> roleMembers = Arrays.asList(roleMember);
+        role.setRoleMembers(roleMembers);
+        zmsImpl.putRole(sysAdminCtx, "sys.auth", instanceProvidersRoleName, auditRef, false, role);
+
+        String instanceProviderPolicyName = "instanceProviderPolicy";
+        Policy policy = new Policy();
+        policy.setName(instanceProviderPolicyName);
+        Assertion assertion = new Assertion();
+        assertion.setAction("launch");
+        assertion.setResource("sys.auth:instance");
+        assertion.setEffect(AssertionEffect.ALLOW);
+        assertion.setRole("sys.auth:role." + instanceProvidersRoleName);
+        List<Assertion> assertions = List.of(assertion);
+        policy.setAssertions(assertions);
+        zmsImpl.putPolicy(sysAdminCtx, "sys.auth", instanceProviderPolicyName, auditRef, false, policy);
+    }
+
+    private RsrcCtxWrapper registerDependency(RsrcCtxWrapper mockDomRsrcCtx, String domainName,
+            ZMSImpl zmsImpl, String serviceProviderDomain, String serviceProviderName) {
+
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // Check if service provider exists. If not create it
+
+        try {
+            zmsImpl.getServiceIdentity(mockDomRsrcCtx, serviceProviderDomain, serviceProviderName);
+        } catch (ResourceException ex) {
+            ServiceIdentity serviceProvider = zmsTestInitializer.createServiceObject(serviceProviderDomain,
+                    serviceProviderName, "http://localhost", "/usr/bin/java", "root",
+                    "users", "host1");
+
+            zmsImpl.putServiceIdentity(mockDomRsrcCtx, serviceProviderDomain, serviceProviderName,
+                    auditRef, false, serviceProvider);
+        }
+
+        String fullServiceProviderName = serviceProviderDomain + "." + serviceProviderName;
+
+        // Create service provider role if it it doesn't exist
+
+        String sysAdminDomainName = "sys.auth";
+        String serviceProvidersRoleName = "service_providers";
+        try {
+            zmsImpl.getRole(mockDomRsrcCtx, sysAdminDomainName, serviceProvidersRoleName, false, false, false);
+        } catch (ResourceException ex) {
+            Role role = new Role();
+            role.setName(serviceProvidersRoleName);
+            role.setRoleMembers(new ArrayList<>());
+            zmsImpl.putRole(mockDomRsrcCtx, sysAdminDomainName, serviceProvidersRoleName, auditRef, false, role);
+        }
+
+        // Add service to authorized service providers list
+
+        Membership membership = new Membership();
+        membership.setMemberName(fullServiceProviderName);
+
+        RsrcCtxWrapper sysAdminContext = zmsTestInitializer.contextWithMockPrincipal("putMembership");
+        zmsImpl.putMembership(sysAdminContext, sysAdminDomainName, serviceProvidersRoleName,
+                fullServiceProviderName, auditRef, false, membership);
+
+        // Wait for cache to be ServiceProviderManager cache to refresh
+
+        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
+
+        // Now make the service provider put a dependency on the  domain
+
+        RsrcCtxWrapper serviceProviderCtx = zmsTestInitializer.contextWithMockPrincipal(
+                "putDomainDependency", serviceProviderDomain, serviceProviderName);
+        DependentService dependentService = new DependentService().setService(fullServiceProviderName);
+        zmsImpl.putDomainDependency(serviceProviderCtx, domainName, auditRef, dependentService);
+        return serviceProviderCtx;
+    }
+
+    private void deRegisterDependency(final String domainName, ZMSImpl zmsImpl, final String serviceProviderDomain,
+            final String serviceProviderName) {
+
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        String fullServiceProviderName = serviceProviderDomain + "." + serviceProviderName;
+        RsrcCtxWrapper serviceProviderCtx = zmsTestInitializer.contextWithMockPrincipal("putDomainDependency",
+                serviceProviderDomain, serviceProviderName);
+        zmsImpl.deleteDomainDependency(serviceProviderCtx, domainName, fullServiceProviderName, auditRef);
+    }
+
+    @Test
+    public void testDeleteWithMetaAttributes() {
+
+        System.setProperty(ZMS_PROP_DOMAIN_DELETE_META_ATTRIBUTES, "account,gcpproject,azuresubscription");
+
+        final String domainName = "del-with-meta-attrs";
+        ZMSImplTest.TestAuditLogger alogger = new ZMSImplTest.TestAuditLogger();
+        ZMSImpl zmsImpl = zmsTestInitializer.getZmsImpl(alogger);
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "account", "gcpproject", "azuresubscription", "public-cloud");
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
+
+        DomainMeta meta = new DomainMeta();
+
+        meta.setAccount("acct-1234");
+        meta.setGcpProject("gcp-project");
+        meta.setGcpProjectNumber("1234");
+        meta.setAzureSubscription("azure-subscription");
+        zmsImpl.putDomainSystemMeta(ctx, domainName, ZMSConsts.SYSTEM_META_ACCOUNT, auditRef, meta);
+        zmsImpl.putDomainSystemMeta(ctx, domainName, ZMSConsts.SYSTEM_META_GCP_PROJECT, auditRef, meta);
+        zmsImpl.putDomainSystemMeta(ctx, domainName, ZMSConsts.SYSTEM_META_AZURE_SUBSCRIPTION, auditRef, meta);
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+            fail("request-error not thrown.");
+        } catch (ResourceException ex) {
+            assertEquals(400, ex.getCode());
+            assertTrue(ex.getMessage().contains("Domain has non-empty account attribute"));
+        }
+
+        // remove the aws account and try again
+
+        meta.setAccount(null);
+        zmsImpl.putDomainSystemMeta(ctx, domainName, ZMSConsts.SYSTEM_META_ACCOUNT, auditRef, meta);
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+            fail("request-error not thrown.");
+        } catch (ResourceException ex) {
+            assertEquals(400, ex.getCode());
+            assertTrue(ex.getMessage().contains("Domain has non-empty gcp-project attribute"));
+        }
+
+        // remove the gcp project and try again
+
+        meta.setGcpProject(null);
+        meta.setGcpProjectNumber(null);
+        zmsImpl.putDomainSystemMeta(ctx, domainName, ZMSConsts.SYSTEM_META_GCP_PROJECT, auditRef, meta);
+
+        try {
+            zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+            fail("request-error not thrown.");
+        } catch (ResourceException ex) {
+            assertEquals(400, ex.getCode());
+            assertTrue(ex.getMessage().contains("Domain has non-empty azure-subscription attribute"));
+        }
+
+        meta.setAzureSubscription(null);
+        zmsImpl.putDomainSystemMeta(ctx, domainName, ZMSConsts.SYSTEM_META_AZURE_SUBSCRIPTION, auditRef, meta);
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
+
+        System.clearProperty(ZMS_PROP_DOMAIN_DELETE_META_ATTRIBUTES);
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -49,8 +49,6 @@ import com.yahoo.athenz.zms.ZMSImpl.AccessStatus;
 import com.yahoo.athenz.zms.ZMSImpl.AthenzObject;
 import com.yahoo.athenz.zms.config.MemberDueDays;
 import com.yahoo.athenz.zms.notification.PutRoleMembershipNotificationTask;
-import com.yahoo.athenz.zms.provider.DomainDependencyProviderResponse;
-import com.yahoo.athenz.zms.provider.ServiceProviderClient;
 import com.yahoo.athenz.zms.provider.ServiceProviderManager;
 import com.yahoo.athenz.zms.status.MockStatusCheckerNoException;
 import com.yahoo.athenz.zms.status.MockStatusCheckerThrowException;
@@ -1118,26 +1116,6 @@ public class ZMSImplTest {
     }
 
     @Test
-    public void testDeleteUserDomain() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        UserDomain dom1 = zmsTestInitializer.createUserDomainObject("john-doe", "Test Domain Delete User Domain", "testDeleteOrg");
-        zmsImpl.postUserDomain(ctx, "john-doe", auditRef, dom1);
-
-        zmsImpl.deleteUserDomain(ctx, "john-doe", auditRef);
-
-        try {
-            zmsImpl.getDomain(ctx, "john-doe");
-            fail();
-        } catch (Exception ex) {
-            assertTrue(true);
-        }
-    }
-
-    @Test
     public void testCreateSubDomainNoParent() {
 
         ZMSImpl zmsImpl = zmsTestInitializer.getZms();
@@ -1379,659 +1357,6 @@ public class ZMSImplTest {
     }
 
     @Test
-    public void testDeleteDomain() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        // make sure we can't delete system domains
-
-        try {
-            zmsImpl.deleteDomain(ctx, auditRef, "sys.auth", "testDeleteDomain");
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 400);
-            assertTrue(ex.getMessage().contains("reserved system domain"));
-        }
-
-        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
-                "TestDeleteDomain", null, null, zmsTestInitializer.getAdminUser());
-        dom.setAuditEnabled(true);
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
-
-        zmsImpl.deleteDomain(ctx, auditRef, "testdeletedomain", "testDeleteDomain");
-
-        try {
-            zmsImpl.getDomain(ctx, "TestDeleteDomain");
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 404);
-        }
-    }
-
-    @Test
-    public void testDeleteDomainNonExistant() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        try {
-            zmsImpl.deleteDomain(ctx, auditRef, "TestDeleteDomainNonExist", "testDeleteDomainNonExistant");
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 404);
-        }
-    }
-
-    @Test
-    public void testDeleteDomainMissingAuditRef() {
-        // create domain and require auditing
-        String domain = "testdeletedomainmissingauditref";
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
-                domain, null, null, zmsTestInitializer.getAdminUser());
-        dom.setAuditEnabled(true);
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
-
-        // delete it without an auditRef and catch exception
-        try {
-            zmsImpl.deleteDomain(ctx, null, domain, "testDeleteDomainMissingAuditRef");
-            fail("requesterror not thrown by testDeleteDomainMissingAuditRef.");
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 400);
-            assertTrue(ex.getMessage().contains("Audit reference required"));
-        } finally {
-            zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef);
-        }
-    }
-
-    @Test
-    public void testDeleteTopLevelDomain() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelTopDom1",
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        Domain resDom1 = zmsImpl.getDomain(ctx, "DelTopDom1");
-        assertNotNull(resDom1);
-
-        zmsImpl.deleteTopLevelDomain(ctx, "DelTopDom1", auditRef);
-
-        // we should get a forbidden exception since the domain
-        // no longer exists
-
-        try {
-            zmsImpl.getDomain(ctx, "DelTopDom1");
-            fail();
-        } catch (Exception ex) {
-            assertTrue(true);
-        }
-    }
-
-    @Test
-    public void testVerifyServiceProvidersAuthorizeDelete() {
-        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-
-        String domain = "test";
-        String caller = "deleteDomain";
-
-        // Mock service provider manager and service provider client
-
-        zmsImpl.serviceProviderManager = Mockito.mock(ServiceProviderManager.class);
-        zmsImpl.serviceProviderClient = Mockito.mock(ServiceProviderClient.class);
-        Map<String, ServiceProviderManager.DomainDependencyProvider> serviceProvidersWithEndpoints = new HashMap<>();
-        boolean isInstance = false;
-        String status = PROVIDER_RESPONSE_DENY;
-        int numberOfProviders = 20;
-        for (int i = 1; i <= numberOfProviders; ++i) {
-            ServiceProviderManager.DomainDependencyProvider domainDependencyProvider = new ServiceProviderManager.DomainDependencyProvider("provider" + i, "https://provider" + i, isInstance);
-            serviceProvidersWithEndpoints.put("provider" + i, domainDependencyProvider);
-            DomainDependencyProviderResponse providerResponse = new DomainDependencyProviderResponse();
-            providerResponse.setStatus(status);
-            providerResponse.setMessage("message for provider number " + i + "isInstance? " + isInstance);
-            Mockito.when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider, domain, ctx.principal().getFullName())).thenReturn(providerResponse);
-            isInstance = !isInstance;
-            status = status.equals(PROVIDER_RESPONSE_DENY) ? PROVIDER_RESPONSE_ALLOW : PROVIDER_RESPONSE_DENY;
-        }
-        Mockito.when(zmsImpl.serviceProviderManager.getServiceProvidersWithEndpoints()).thenReturn(serviceProvidersWithEndpoints);
-
-        try {
-            zmsImpl.verifyServiceProvidersAuthorizeDelete(ctx, domain, caller);
-            fail();
-        } catch (ResourceException ex) {
-            status = PROVIDER_RESPONSE_DENY;
-            isInstance = false;
-            for (int i = 1; i <= numberOfProviders; ++i) {
-                if (status.equals(PROVIDER_RESPONSE_DENY)) {
-                    assertTrue(ex.getMessage().contains("message for provider number " + i + "isInstance? " + isInstance));
-                } else {
-                    assertFalse(ex.getMessage().contains("message for provider number " + i + "isInstance? " + isInstance));
-                }
-                isInstance = !isInstance;
-                status = status.equals(PROVIDER_RESPONSE_DENY) ? PROVIDER_RESPONSE_ALLOW : PROVIDER_RESPONSE_DENY;
-            }
-        }
-        Mockito.verify(zmsImpl.serviceProviderManager, Mockito.times(1)).getServiceProvidersWithEndpoints();
-    }
-
-    @Test
-    public void testDeleteTopLevelDomainServiceProviderDeclines() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        String topLevelDomainName = "deltopdomdependencyexist";
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(topLevelDomainName,
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        Domain resDom1 = zmsImpl.getDomain(ctx, topLevelDomainName);
-        assertNotNull(resDom1);
-
-        // Create services
-
-        ServiceIdentity service = zmsTestInitializer.createServiceObject(topLevelDomainName,
-                "Service1", "http://localhost/ser", "/usr/bin/java", "root",
-                "users", "host1");
-
-        zmsImpl.putServiceIdentity(ctx, topLevelDomainName, "Service1", auditRef, false, service);
-
-        ServiceIdentity service2 = zmsTestInitializer.createServiceObject(topLevelDomainName,
-                "Service2", "http://localhost/ser2", "/usr/bin/java", "root",
-                "users", "host1");
-
-        zmsImpl.putServiceIdentity(ctx, topLevelDomainName, "Service2", auditRef, false, service2);
-
-        // Set endpoint for services
-
-        RsrcCtxWrapper sysAdminCtx = zmsTestInitializer.contextWithMockPrincipal("deleteMembership");
-
-        ServiceIdentitySystemMeta meta = new ServiceIdentitySystemMeta();
-        meta.setProviderEndpoint("https://localhost/service-provider-test-delete");
-        zmsImpl.putServiceIdentitySystemMeta(sysAdminCtx, topLevelDomainName, "Service1", "providerendpoint", auditRef, meta);
-
-        ServiceIdentitySystemMeta meta2 = new ServiceIdentitySystemMeta();
-        meta2.setProviderEndpoint("https://localhost/service-provider-test-delete2");
-        zmsImpl.putServiceIdentitySystemMeta(sysAdminCtx, topLevelDomainName, "Service2", "providerendpoint", auditRef, meta2);
-
-        // Make service2 an instance provider as well as service provider
-        makeInstanceProvider(topLevelDomainName, sysAdminCtx, "service2");
-        makeServiceProviders(zmsImpl, sysAdminCtx, Arrays.asList(topLevelDomainName + ".service1", topLevelDomainName + ".service2"));
-
-        // Make service1 provider deny deletion for regular user and allow it for admin for service1
-        // Make service2 provider deny deletion for all users
-
-        zmsImpl.serviceProviderClient = Mockito.mock(ServiceProviderClient.class);
-        DomainDependencyProviderResponse providerResponseDeniesRegularUser = new DomainDependencyProviderResponse();
-        providerResponseDeniesRegularUser.setStatus(PROVIDER_RESPONSE_DENY);
-        providerResponseDeniesRegularUser.setMessage("provider denied deleting the domain for principal " + ctx.principal().getFullName());
-        ServiceProviderManager.DomainDependencyProvider domainDependencyProvider = new ServiceProviderManager.DomainDependencyProvider(topLevelDomainName + ".service1", "https://localhost/service-provider-test-delete", false);
-        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider, topLevelDomainName, ctx.principal().getFullName())).thenReturn(providerResponseDeniesRegularUser);
-        DomainDependencyProviderResponse providerResponseAllows = new DomainDependencyProviderResponse();
-        providerResponseAllows.setStatus(PROVIDER_RESPONSE_ALLOW);
-        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider, topLevelDomainName, sysAdminCtx.principal().getFullName())).thenReturn(providerResponseAllows);
-        ServiceProviderManager.DomainDependencyProvider domainDependencyProvider2 = new ServiceProviderManager.DomainDependencyProvider(topLevelDomainName + ".service2", "https://localhost/service-provider-test-delete2", true);
-        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider2, topLevelDomainName, ctx.principal().getFullName())).thenReturn(providerResponseDeniesRegularUser);
-        DomainDependencyProviderResponse providerResponseDeniesAdmin = new DomainDependencyProviderResponse();
-        providerResponseDeniesAdmin.setStatus(PROVIDER_RESPONSE_DENY);
-        providerResponseDeniesAdmin.setMessage("provider denied deleting the domain for principal " + sysAdminCtx.principal().getFullName());
-        when(zmsImpl.serviceProviderClient.getDependencyStatus(domainDependencyProvider2, topLevelDomainName, sysAdminCtx.principal().getFullName()))
-                .thenReturn(providerResponseDeniesAdmin) // Service2 provider will deny deletion in the first call by a sysadmin
-                .thenReturn(providerResponseAllows);
-
-        // Wait for cache to be ServiceProviderManager cache to refresh
-
-        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
-
-        // Denies deletion for regular user by both service providers
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
-            fail();
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Service 'deltopdomdependencyexist.service2' is dependent on domain 'deltopdomdependencyexist'. Error: provider denied deleting the domain for principal user.user1, Service 'deltopdomdependencyexist.service1' is dependent on domain 'deltopdomdependencyexist'. Error: provider denied deleting the domain for principal user.user1\"}");
-        }
-
-        // Denies deletion for sys admin by service2 provider
-
-        try {
-            zmsImpl.deleteTopLevelDomain(sysAdminCtx, topLevelDomainName, auditRef);
-            fail();
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Service 'deltopdomdependencyexist.service2' is dependent on domain 'deltopdomdependencyexist'. Error: provider denied deleting the domain for principal user.testadminuser\"}");
-        }
-
-
-        // Now the client will start to allow deletions for sysadmin
-
-        zmsImpl.deleteTopLevelDomain(sysAdminCtx, topLevelDomainName, auditRef);
-    }
-
-    private void makeInstanceProvider(String topLevelDomainName, RsrcCtxWrapper sysAdminCtx, String serviceInstanceProvider) {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        String instanceProvidersRoleName = "instance-providers";
-        Role role = new Role();
-        role.setName(instanceProvidersRoleName);
-        RoleMember roleMember = new RoleMember();
-        roleMember.setMemberName(topLevelDomainName + "." + serviceInstanceProvider);
-        List<RoleMember> roleMembers = Arrays.asList(roleMember);
-        role.setRoleMembers(roleMembers);
-        zmsImpl.putRole(sysAdminCtx, "sys.auth", instanceProvidersRoleName, auditRef, false, role);
-
-        String instanceProviderPolicyName = "instanceProviderPolicy";
-        Policy policy = new Policy();
-        policy.setName(instanceProviderPolicyName);
-        Assertion assertion = new Assertion();
-        assertion.setAction("launch");
-        assertion.setResource("sys.auth:instance");
-        assertion.setEffect(AssertionEffect.ALLOW);
-        assertion.setRole("sys.auth:role." + instanceProvidersRoleName);
-        List<Assertion> assertions = List.of(assertion);
-        policy.setAssertions(assertions);
-        zmsImpl.putPolicy(sysAdminCtx, "sys.auth", instanceProviderPolicyName, auditRef, false, policy);
-    }
-
-    @Test
-    public void testDeleteTopLevelDomainDependencyExist() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        String topLevelDomainName = "deltopdomdependencyexist";
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(topLevelDomainName,
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        Domain resDom1 = zmsImpl.getDomain(ctx, topLevelDomainName);
-        assertNotNull(resDom1);
-
-        registerDependency(ctx, topLevelDomainName, zmsImpl, topLevelDomainName, "service-provider1");
-
-        // We can't delete a domain that has service dependency
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
-            fail();
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove domain 'deltopdomdependencyexist' dependency from the following service(s):deltopdomdependencyexist.service-provider1\"}");
-        }
-
-        // Register another dependency, verify it appears in the delete error list
-
-        registerDependency(ctx, topLevelDomainName, zmsImpl, topLevelDomainName, "service-provider2");
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
-            fail();
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove domain 'deltopdomdependencyexist' dependency from the following service(s):deltopdomdependencyexist.service-provider1, deltopdomdependencyexist.service-provider2\"}");
-        }
-
-        // Remove one of the dependencies, verify the error message is updated
-
-        deRegisterDependency(topLevelDomainName, zmsImpl, topLevelDomainName, "service-provider1");
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
-            fail();
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove domain 'deltopdomdependencyexist' dependency from the following service(s):deltopdomdependencyexist.service-provider2\"}");
-        }
-
-        // Now remove the dependency but set endpoint for the service - verify the error message change
-        RsrcCtxWrapper sysAdminCtx = zmsTestInitializer.contextWithMockPrincipal("deleteMembership");
-        zmsImpl.deleteDomainDependency(sysAdminCtx, topLevelDomainName, topLevelDomainName + ".service-provider2", auditRef);
-        // Verify dependency was removed
-        DomainList dependentDomainList = zmsImpl.getDependentDomainList(sysAdminCtx, topLevelDomainName + ".service-provider1");
-        assertEquals(dependentDomainList.getNames().size(), 0);
-        ServiceIdentitySystemMeta meta = new ServiceIdentitySystemMeta();
-        meta.setProviderEndpoint("https://localhost/testendpoint");
-        zmsImpl.putServiceIdentitySystemMeta(ctx, topLevelDomainName, "service-provider2", "providerendpoint", auditRef, meta);
-
-        // Wait for cache to be ServiceProviderManager cache to refresh
-
-        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
-            fail();
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Service '" + topLevelDomainName + ".service-provider2' is dependent on domain '" + topLevelDomainName + "'. Error: Exception thrown during call to provider: Failed to get response from server: https://localhost/testendpoint\"}");
-        }
-
-        // Now make the provider approve the deletion
-
-        ServiceProviderManager.DomainDependencyProvider domainDependencyProvider = new ServiceProviderManager.DomainDependencyProvider(topLevelDomainName + ".service-provider2", "https://localhost/testendpoint", false);
-        DomainDependencyProviderResponse providerResponse = new DomainDependencyProviderResponse();
-        providerResponse.setStatus("allow");
-        ServiceProviderClient serviceProviderClientMock = Mockito.mock(ServiceProviderClient.class);
-        when(serviceProviderClientMock.getDependencyStatus(domainDependencyProvider, topLevelDomainName, ctx.principal().getFullName())).thenReturn(providerResponse);
-        zmsImpl.serviceProviderClient = serviceProviderClientMock;
-        zmsImpl.deleteTopLevelDomain(ctx, topLevelDomainName, auditRef);
-    }
-
-    private RsrcCtxWrapper registerDependency(RsrcCtxWrapper mockDomRsrcCtx, String domainName, ZMSImpl zmsImpl, String serviceProviderDomain, String serviceProviderName) {
-
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        // Check if service provider exists. If not create it
-
-        try {
-            zmsImpl.getServiceIdentity(mockDomRsrcCtx, serviceProviderDomain, serviceProviderName);
-        } catch (ResourceException ex) {
-            ServiceIdentity serviceProvider = zmsTestInitializer.createServiceObject(serviceProviderDomain,
-                    serviceProviderName, "http://localhost", "/usr/bin/java", "root",
-                    "users", "host1");
-
-            zmsImpl.putServiceIdentity(mockDomRsrcCtx, serviceProviderDomain, serviceProviderName, auditRef, false, serviceProvider);
-        }
-
-        String fullServiceProviderName = serviceProviderDomain + "." + serviceProviderName;
-
-        // Create service provider role if it it doesn't exist
-
-        String sysAdminDomainName = "sys.auth";
-        String serviceProvidersRoleName = "service_providers";
-        try {
-            zmsImpl.getRole(mockDomRsrcCtx, sysAdminDomainName, serviceProvidersRoleName, false, false, false);
-        } catch (ResourceException ex) {
-            Role role = new Role();
-            role.setName(serviceProvidersRoleName);
-            role.setRoleMembers(new ArrayList<>());
-            zmsImpl.putRole(mockDomRsrcCtx, sysAdminDomainName, serviceProvidersRoleName, auditRef, false, role);
-        }
-
-        // Add service to authorized service providers list
-
-        Membership membership = new Membership();
-        membership.setMemberName(fullServiceProviderName);
-
-        RsrcCtxWrapper sysAdminContext = zmsTestInitializer.contextWithMockPrincipal("putMembership");
-        zmsImpl.putMembership(sysAdminContext, sysAdminDomainName, serviceProvidersRoleName, fullServiceProviderName, auditRef, false, membership);
-
-        // Wait for cache to be ServiceProviderManager cache to refresh
-
-        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
-
-        // Now make the service provider put a dependency on the  domain
-
-        RsrcCtxWrapper serviceProviderCtx = zmsTestInitializer.contextWithMockPrincipal("putDomainDependency", serviceProviderDomain, serviceProviderName);
-        DependentService dependentService = new DependentService().setService(fullServiceProviderName);
-        zmsImpl.putDomainDependency(serviceProviderCtx, domainName, auditRef, dependentService);
-        return serviceProviderCtx;
-    }
-
-    private void deRegisterDependency(String domainName, ZMSImpl zmsImpl, String serviceProviderDomain, String serviceProviderName) {
-
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        String fullServiceProviderName = serviceProviderDomain + "." + serviceProviderName;
-        RsrcCtxWrapper serviceProviderCtx = zmsTestInitializer.contextWithMockPrincipal("putDomainDependency", serviceProviderDomain, serviceProviderName);
-        zmsImpl.deleteDomainDependency(serviceProviderCtx, domainName, fullServiceProviderName, auditRef);
-    }
-
-    @Test
-    public void testDeleteTopLevelDomainChildExist() {
-
-        TestAuditLogger alogger = new TestAuditLogger();
-        ZMSImpl zmsImpl = zmsTestInitializer.getZmsImpl(alogger);
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelTopChildDom1",
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", "DelTopChildDom1",
-                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postSubDomain(ctx, "DelTopChildDom1", auditRef, dom2);
-
-        // we can't delete Dom1 since Dom2 still exists
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, "DelTopChildDom1", auditRef);
-            fail("requesterror not thrown.");
-        } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
-        }
-
-        zmsImpl.deleteSubDomain(ctx, "DelTopChildDom1", "DelSubDom2", auditRef);
-        zmsImpl.deleteTopLevelDomain(ctx, "DelTopChildDom1", auditRef);
-    }
-
-    @Test
-    public void testDeleteTopLevelDomainNonExistant() {
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, "NonExistantDomain", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 404);
-        }
-    }
-
-    @Test
-    public void testDeleteTopLevelDomainNonExistantNoAuditRef() {
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, "NonExistantDomain", null);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 404);
-        }
-    }
-
-    @Test
-    public void testDeleteTopLevelDomainMissingAuditRef() {
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        // create domain and require auditing
-        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
-                "TopDomainAuditRequired", null, null, zmsTestInitializer.getAdminUser());
-        dom.setAuditEnabled(true);
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
-
-        // delete it without an auditRef and catch exception
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, "TopDomainAuditRequired", null);
-            fail("requesterror not thrown by deleteTopLevelDomain.");
-        } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
-            assertTrue(ex.getMessage().contains("Audit reference required"));
-        } finally {
-            zmsImpl.deleteTopLevelDomain(ctx, "TopDomainAuditRequired", auditRef);
-        }
-    }
-
-    @Test
-    public void testDeleteSubDomain() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelSubDom1",
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", "DelSubDom1",
-                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postSubDomain(ctx, "DelSubDom1", auditRef, dom2);
-
-        Domain resDom1 = zmsImpl.getDomain(ctx, "DelSubDom1.DelSubDom2");
-        assertNotNull(resDom1);
-
-        zmsImpl.deleteSubDomain(ctx, "DelSubDom1", "DelSubDom2", auditRef);
-
-        // we should get a forbidden exception since the domain
-        // no longer exists
-
-        try {
-            zmsImpl.getDomain(ctx, "DelSubDom1.DelSubDom2");
-            fail();
-        } catch (Exception ex) {
-            assertTrue(true);
-        }
-
-        zmsImpl.deleteTopLevelDomain(ctx, "DelSubDom1", auditRef);
-    }
-
-    @Test
-    public void testDeleteSubDomainNotAuthorized() {
-
-        final String domainName = "delsubdom1authz";
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", domainName,
-                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postSubDomain(ctx, "DelSubDom1Authz", auditRef, dom2);
-
-        Domain resDom1 = zmsImpl.getDomain(ctx, domainName + ".DelSubDom2");
-        assertNotNull(resDom1);
-
-        Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
-        Principal principal2 = principalAuthority.authenticate("v=U1;d=user;n=user2;s=signature",
-                "10.11.12.13", "GET", null);
-        ResourceContext ctx2 = zmsTestInitializer.createResourceContext(principal2);
-
-        // using a different principal, this operation should get rejected
-
-        try {
-            zmsImpl.deleteSubDomain(ctx2, domainName, "DelSubDom2", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 403);
-            assertTrue(ex.getMessage().contains("Principal is not authorized to delete domain: delsubdom1authz.delsubdom2"));
-        }
-
-        // with our standard principal we should be able to delete the subdomain
-
-        zmsImpl.deleteSubDomain(ctx, domainName, "DelSubDom2", auditRef);
-        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
-    }
-
-    @Test
-    public void testDeleteSubDomainChildExist() {
-
-        TestAuditLogger alogger = new TestAuditLogger();
-        ZMSImpl zmsImpl = zmsTestInitializer.getZmsImpl(alogger);
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("DelSubChildDom1",
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        SubDomain dom2 = zmsTestInitializer.createSubDomainObject("DelSubDom2", "DelSubChildDom1",
-                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
-        zmsImpl.postSubDomain(ctx, "DelSubChildDom1", auditRef, dom2);
-
-        SubDomain dom3 = zmsTestInitializer.createSubDomainObject("DelSubDom3", "DelSubChildDom1.DelSubDom2",
-                "Test Domain3", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postSubDomain(ctx, "DelSubChildDom1.DelSubDom2", auditRef, dom3);
-
-        // we can't delete Dom2 since Dom3 still exists
-
-        try {
-            zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1", "DelSubDom2", auditRef);
-        } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
-        }
-
-        zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1.DelSubDom2", "DelSubDom3", auditRef);
-        zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1", "DelSubDom2", auditRef);
-        zmsImpl.deleteTopLevelDomain(ctx, "DelSubChildDom1", auditRef);
-    }
-
-    @Test
-    public void testDeleteSubDomainNonExistant() {
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
-                "ExistantTopDomain", null, null, zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
-        try {
-            zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain", "NonExistantSubDomain", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 404);
-        }
-        zmsImpl.deleteTopLevelDomain(ctx, "ExistantTopDomain", auditRef);
-    }
-
-    @Test
-    public void testDeleteSubDomainSubAndTopNonExistant() {
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        try {
-            zmsImpl.deleteSubDomain(ctx, "NonExistantTopDomain", "NonExistantSubDomain", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 404);
-        }
-    }
-
-    @Test
-    public void testDeleteSubDomainMissingAuditRef() {
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom = zmsTestInitializer.createTopLevelDomainObject(
-                "ExistantTopDomain2", null, null, zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
-        dom.setAuditEnabled(true);
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom);
-
-        SubDomain subDom = zmsTestInitializer.createSubDomainObject(
-                "ExistantSubDom2", "ExistantTopDomain2",
-                null, null, zmsTestInitializer.getAdminUser());
-        subDom.setAuditEnabled(true);
-        zmsImpl.postSubDomain(ctx, "ExistantTopDomain2", auditRef, subDom);
-
-        try {
-            zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain2", "ExistantSubDom2", null);
-            fail("requesterror not thrown by deleteSubDomain.");
-        } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
-            assertTrue(ex.getMessage().contains("Audit reference required"));
-        } finally {
-            zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain2", "ExistantSubDom2", auditRef);
-            zmsImpl.deleteTopLevelDomain(ctx, "ExistantTopDomain2", auditRef);
-        }
-    }
-
-    @Test
     public void testPutDomainMetaThrowException() {
 
         TestAuditLogger alogger = new TestAuditLogger();
@@ -2092,7 +1417,7 @@ public class ZMSImplTest {
         zmsImpl.putDomainSystemMeta(ctx, domainName, "certdnsdomain", auditRef, meta);
 
         zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
-                domainName, "productid", "org", "certdnsdomain");
+                domainName, "domain", "productid", "org", "certdnsdomain");
         zmsImpl.putDomainSystemMeta(ctx, domainName, "org", auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, domainName, "productid", auditRef, meta);
 
@@ -2217,7 +1542,7 @@ public class ZMSImplTest {
         resDom3 = zmsImpl.getDomain(ctx, domainName);
         assertEquals(resDom3.getFeatureFlags().intValue(), 7);
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
     }
 
@@ -2273,7 +1598,8 @@ public class ZMSImplTest {
         assertFalse(resDom.getAuditEnabled());
         Integer productId = resDom.getYpmId();
 
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), domainName, "productid");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "productid");
         DomainMeta meta = zmsTestInitializer.createDomainMetaObject("Test2 Domain", "NewOrg",
                 true, true, "12345", null);
         try {
@@ -2353,7 +1679,7 @@ public class ZMSImplTest {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         zmsImpl.deleteTopLevelDomain(ctx, "MetaDomProductid", auditRef);
         zmsImpl.deleteTopLevelDomain(ctx, "MetaDomProductid2", auditRef);
         System.clearProperty(ZMSConsts.ZMS_PROP_PRODUCT_ID_SUPPORT);
@@ -7303,66 +6629,6 @@ public class ZMSImplTest {
     }
 
     @Test
-    public void testDeleteServiceIdentityDependencyExist() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject("ServiceDelDom1",
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        TopLevelDomain dom2 = zmsTestInitializer.createTopLevelDomainObject("ServiceDelDom2",
-                "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom2);
-
-        ServiceIdentity service1 = zmsTestInitializer.createServiceObject("ServiceDelDom1",
-                "Service1", "http://localhost", "/usr/bin/java", "root",
-                "users", "host1");
-
-        zmsImpl.putServiceIdentity(ctx, "ServiceDelDom1", "Service1", auditRef, false, service1);
-
-        ServiceIdentity serviceRes1 = zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1",
-                "Service1");
-        assertNotNull(serviceRes1);
-
-        // add a domain dependency on the service and verify it prevents service deletion
-
-        RsrcCtxWrapper providerCtx = registerDependency(ctx, "ServiceDelDom1".toLowerCase(), zmsImpl, "ServiceDelDom1".toLowerCase(), "Service1".toLowerCase());
-        try {
-            zmsImpl.deleteServiceIdentity(providerCtx, "ServiceDelDom1", "Service1", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove service 'servicedeldom1.service1' dependency from the following domain(s):servicedeldom1\"}");
-        }
-
-        // Register another dependency, verify it appears in the delete error list
-
-        providerCtx = registerDependency(ctx, "ServiceDelDom2".toLowerCase(), zmsImpl, "ServiceDelDom1".toLowerCase(), "Service1".toLowerCase());
-        try {
-            zmsImpl.deleteServiceIdentity(providerCtx, "ServiceDelDom1", "Service1", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove service 'servicedeldom1.service1' dependency from the following domain(s):servicedeldom1, servicedeldom2\"}");
-        }
-
-        // Remove one of the dependencies, verify the error message is updated
-
-        deRegisterDependency("ServiceDelDom1".toLowerCase(), zmsImpl, "ServiceDelDom1".toLowerCase(), "Service1".toLowerCase());
-        try {
-            zmsImpl.deleteServiceIdentity(providerCtx, "ServiceDelDom1", "Service1", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getMessage(), "ResourceException (403): {code: 403, message: \"Remove service 'servicedeldom1.service1' dependency from the following domain(s):servicedeldom2\"}");
-        }
-        deRegisterDependency("ServiceDelDom2".toLowerCase(), zmsImpl, "ServiceDelDom1".toLowerCase(), "Service1".toLowerCase());
-        zmsImpl.deleteServiceIdentity(ctx, "ServiceDelDom1", "Service1", auditRef);
-        zmsImpl.deleteTopLevelDomain(ctx, "ServiceDelDom1", auditRef);
-        zmsImpl.deleteTopLevelDomain(ctx, "ServiceDelDom2", auditRef);
-    }
-
-    @Test
     public void testDeleteServiceIdentityMissingAuditRef() {
 
         ZMSImpl zmsImpl = zmsTestInitializer.getZms();
@@ -8022,30 +7288,6 @@ public class ZMSImplTest {
         zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef);
     }
 
-    public void makeServiceProviders(ZMSImpl zmsImpl, RsrcCtxWrapper ctx, List<String> providerNames) {
-
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        // Create Service Provider
-
-        final String sysAdminDomainName = "sys.auth";
-        final String serviceProvidersRoleName = "service_providers";
-        List<RoleMember> roleMembers = providerNames.stream().map(provider -> {
-            RoleMember authorizedServiceRoleMember = new RoleMember();
-            authorizedServiceRoleMember.setMemberName(provider.toLowerCase());
-            return authorizedServiceRoleMember;
-        }).collect(Collectors.toList());
-        Role role = new Role();
-        role.setName(serviceProvidersRoleName);
-        role.setRoleMembers(roleMembers);
-
-        zmsImpl.putRole(ctx, sysAdminDomainName, serviceProvidersRoleName, auditRef, false, role);
-
-        // Wait for cache to be ServiceProviderManager cache to refresh
-
-        ZMSTestUtils.sleep((1000 * fetchDomainDependencyFrequency) + 50);
-    }
-
     @Test
     public void testGetTenantResourceGroupRolesDomainDependency() {
 
@@ -8079,7 +7321,8 @@ public class ZMSImplTest {
 
         zmsImpl.putServiceIdentity(ctx, domain, serviceName, auditRef, false, serviceProviderIdentity);
 
-        makeServiceProviders(zmsImpl, ctx, Collections.singletonList(domain + "." + serviceName));
+        zmsTestInitializer.makeServiceProviders(zmsImpl, ctx, Collections.singletonList(domain + "." + serviceName),
+                fetchDomainDependencyFrequency);
         TenantResourceGroupRoles tenantRoles = new TenantResourceGroupRoles().setDomain(domain)
                 .setService(serviceName).setTenant(tenantDomain)
                 .setRoles(roleActions).setResourceGroup(resourceGroup);
@@ -11195,7 +10438,8 @@ public class ZMSImplTest {
         zmsTestInitializer.setupTenantDomainProviderService(zmsImpl, "AddTenancyDom1", "coretech", "storage",
                 "http://localhost:8090/provider");
 
-        makeServiceProviders(zmsImpl, ctx, Collections.singletonList("coretech.storage"));
+        zmsTestInitializer.makeServiceProviders(zmsImpl, ctx, Collections.singletonList("coretech.storage"),
+                fetchDomainDependencyFrequency);
 
         Tenancy tenant = zmsTestInitializer.createTenantObject("AddTenancyDom1", "coretech.storage");
         zmsImpl.putTenancy(ctx, "AddTenancyDom1", "coretech.storage", auditRef, tenant);
@@ -11462,7 +10706,8 @@ public class ZMSImplTest {
         final String auditRef = zmsTestInitializer.getAuditRef();
 
         zmsTestInitializer.setupTenantDomainProviderService(zmsImpl, tenantDomain, providerDomain, providerService, null);
-        makeServiceProviders(zmsImpl, ctx, Collections.singletonList("coretech.storage"));
+        zmsTestInitializer.makeServiceProviders(zmsImpl, ctx, Collections.singletonList("coretech.storage"),
+                fetchDomainDependencyFrequency);
 
         // tenant is set up so let's set up up policy to authorize access to tenants
         // without this role/policy we won't be authorized to add tenant roles
@@ -16028,7 +15273,8 @@ public class ZMSImplTest {
         zmsTestInitializer.setupTenantDomainProviderService(zms, tenantDomain, providerDomain, providerService,
                 "http://localhost:8090/tableprovider");
 
-        makeServiceProviders(zms, ctx, Collections.singletonList("coretech.storage"));
+        zmsTestInitializer.makeServiceProviders(zms, ctx, Collections.singletonList("coretech.storage"),
+                fetchDomainDependencyFrequency);
 
         // tenant is setup so let's setup up policy to authorize access to tenants
         // without this role/policy we won't be authorized to add tenant roles
@@ -19397,55 +18643,6 @@ public class ZMSImplTest {
     }
 
     @Test
-    public void testDeleteUserDomainNull() {
-        Authority userAuthority = new com.yahoo.athenz.common.server.debug.DebugUserAuthority();
-        String userId = "user1";
-        Principal principal = SimplePrincipal.create("user", userId, userId + ":password", 0, userAuthority);
-        assertNotNull(principal);
-        ((SimplePrincipal) principal).setUnsignedCreds(userId);
-        ResourceContext rsrcCtx1 = zmsTestInitializer.createResourceContext(principal);
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        try {
-            zmsImpl.deleteUserDomain(rsrcCtx1, null, null);
-            fail();
-        } catch (ResourceException ex) {
-            assertTrue(true);
-        }
-    }
-
-    @Test
-    public void testDeleteDomainTemplateNull() {
-        Authority userAuthority = new com.yahoo.athenz.common.server.debug.DebugUserAuthority();
-        String userId = "user1";
-        Principal principal = SimplePrincipal.create("user", userId, userId + ":password", 0, userAuthority);
-        assertNotNull(principal);
-        ((SimplePrincipal) principal).setUnsignedCreds(userId);
-        ResourceContext rsrcCtx1 = zmsTestInitializer.createResourceContext(principal);
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        try {
-            zmsImpl.deleteDomainTemplate(rsrcCtx1, "dom1", null, "zms");
-            fail();
-        } catch (ResourceException ex) {
-            assertTrue(true);
-        }
-    }
-
-    @Test
-    public void testDeleteDomainTemplate() {
-        Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
-        Principal principal1 = principalAuthority.authenticate("v=U1;d=user;n=user1;s=signature",
-                "10.11.12.13", "GET", null);
-        ResourceContext rsrcCtx1 = zmsTestInitializer.createResourceContext(principal1);
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        try{
-            zmsImpl.deleteDomainTemplate(rsrcCtx1, null, null, null);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 400);
-        }
-    }
-
-    @Test
     public void testPutTenantResourceGroupRolesNull() {
         Authority principalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();
         Principal principal1 = principalAuthority.authenticate("v=U1;d=user;n=user1;s=signature",
@@ -20263,8 +19460,6 @@ public class ZMSImplTest {
         zmsImpl.deleteTopLevelDomain(ctx, "grid", auditRef);
     }
 
-
-
     @Test
     public void testGetDomainRoleMembersInvalidDomain() {
 
@@ -20277,101 +19472,6 @@ public class ZMSImplTest {
         } catch (ResourceException ex) {
             assertEquals(404, ex.getCode());
         }
-    }
-
-    @Test
-    public void testDeleteDomainRoleMemberInvalidDomain() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        try {
-            zmsImpl.deleteDomainRoleMember(ctx, "invalid-domain", "user.joe", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
-        }
-    }
-
-    @Test
-    public void testDeleteDomainRoleMember() {
-
-        String domainName = "deletedomainrolemember2";
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
-                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        Role role1 = zmsTestInitializer.createRoleObject(domainName, "role1", null,
-                "user.jack", "user.janie");
-        zmsImpl.putRole(ctx, domainName, "role1", auditRef, false, role1);
-
-        Role role2 = zmsTestInitializer.createRoleObject(domainName, "role2", null,
-                "user.janie", "user.jane");
-        zmsImpl.putRole(ctx, domainName, "role2", auditRef, false, role2);
-
-        Role role3 = zmsTestInitializer.createRoleObject(domainName, "role3", null,
-                "user.jack", "user.jane");
-        zmsImpl.putRole(ctx, domainName, "role3", auditRef, false, role3);
-
-        Role role4 = zmsTestInitializer.createRoleObject(domainName, "role4", null,
-                "user.jack", null);
-        zmsImpl.putRole(ctx, domainName, "role4", auditRef, false, role4);
-
-        Role role5 = zmsTestInitializer.createRoleObject(domainName, "role5", null,
-                "user.jack-service", "user.jane");
-        zmsImpl.putRole(ctx, domainName, "role5", auditRef, false, role5);
-
-        DomainRoleMembers domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
-
-        List<DomainRoleMember> members = domainRoleMembers.getMembers();
-        assertNotNull(members);
-        assertEquals(5, members.size());
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
-        ZMSTestUtils.verifyDomainRoleMember(members, zmsTestInitializer.getAdminUser(), "admin");
-
-        // with unknown user we get back 404
-
-        try {
-            zmsImpl.deleteDomainRoleMember(ctx, domainName, "user.unknown", auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
-        }
-
-        members = domainRoleMembers.getMembers();
-        assertNotNull(members);
-        assertEquals(5, members.size());
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
-        ZMSTestUtils.verifyDomainRoleMember(members, zmsTestInitializer.getAdminUser(), "admin");
-
-        // now remove a known user
-
-        zmsImpl.deleteDomainRoleMember(ctx, domainName, "user.jack", auditRef);
-
-        domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
-
-        members = domainRoleMembers.getMembers();
-        assertNotNull(members);
-        assertEquals(4, members.size());
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
-        ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
-        ZMSTestUtils.verifyDomainRoleMember(members, zmsTestInitializer.getAdminUser(), "admin");
-
-        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
     }
 
     @Test
@@ -21267,10 +20367,11 @@ public class ZMSImplTest {
         meta = zmsTestInitializer.createDomainMetaObject("Tenant Domain2", null, true, false, "12346", null);
         zmsImpl.putDomainSystemMeta(ctx, "signeddom2", "account", auditRef, meta);
 
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), "signeddom2", "productid");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                "signeddom2", "domain", "productid");
         meta = zmsTestInitializer.createDomainMetaObject("Tenant Domain2", null, true, false, "12346", null);
         zmsImpl.putDomainSystemMeta(ctx, "signeddom2", "productid", auditRef, meta);
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
 
         DomainList domList = zmsImpl.getDomainList(ctx, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null);
@@ -21607,9 +20708,13 @@ public class ZMSImplTest {
         service.setName(ResourceUtils.serviceResourceName("providerdomain", "api"));
         zms.putServiceIdentity(ctx, "providerdomain", "api", auditRef, false, service);
 
-        makeServiceProviders(zms, ctx, Collections.singletonList("providerdomain.api"));
+        zmsTestInitializer.makeServiceProviders(zms, ctx, Collections.singletonList("providerdomain.api"),
+                fetchDomainDependencyFrequency);
+
         // Switch to service provider context
-        RsrcCtxWrapper serviceProviderCtx = zmsTestInitializer.contextWithMockPrincipal("putTenant", "providerdomain", "api");
+
+        RsrcCtxWrapper serviceProviderCtx = zmsTestInitializer.contextWithMockPrincipal("putTenant",
+                "providerdomain", "api");
 
         Tenancy tenant = new Tenancy().setDomain("sports").setService("providerdomain.api");
         zms.putTenant(serviceProviderCtx, "providerdomain", "api", "sports", auditRef, tenant);
@@ -21980,40 +21085,6 @@ public class ZMSImplTest {
         return meta;
     }
 
-    private void setupPrincipalRoleSystemMetaDelete(ZMSImpl zmsImpl, final String principal,
-                                                    final String domainName, final String attributeName) {
-
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        Role role = zmsTestInitializer.createRoleObject("sys.auth", "metaroleadmin", null, principal, null);
-        zmsImpl.putRole(ctx, "sys.auth", "metaroleadmin", auditRef, false, role);
-
-        Policy policy = new Policy();
-        policy.setName("metaroleadmin");
-
-        Assertion assertion = new Assertion();
-        assertion.setAction("delete");
-        assertion.setEffect(AssertionEffect.ALLOW);
-        assertion.setResource("sys.auth:meta.role." + attributeName + "." + domainName);
-        assertion.setRole("sys.auth:role.metaroleadmin");
-
-        List<Assertion> assertList = new ArrayList<>();
-        assertList.add(assertion);
-
-        policy.setAssertions(assertList);
-
-        zmsImpl.putPolicy(ctx, "sys.auth", "metaroleadmin", auditRef, false, policy);
-    }
-
-    private void cleanupPrincipalRoleSystemMetaDelete(ZMSImpl zmsImpl) {
-
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-        zmsImpl.deletePolicy(ctx, "sys.auth", "metaroleadmin", auditRef);
-        zmsImpl.deleteRole(ctx, "sys.auth", "metaroleadmin", auditRef);
-    }
-
     @Test
     public void testPutRoleSystemMeta() {
 
@@ -22103,9 +21174,10 @@ public class ZMSImplTest {
         ZMSImpl zmsImpl = zmsTestInitializer.getZmsImpl(alogger);
         RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
         assertFalse(zmsImpl.isAllowedSystemMetaDelete(ctx.principal(), "mockdom1", "auditenabled", "role"));
-        setupPrincipalRoleSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), "mockdom1", "auditenabled");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                "mockdom1", "role", "auditenabled");
         assertTrue(zmsImpl.isAllowedSystemMetaDelete(ctx.principal(), "mockdom1", "auditenabled", "role"));
-        cleanupPrincipalRoleSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "role");
 
         System.clearProperty(ZMSConsts.ZMS_PROP_PRODUCT_ID_SUPPORT);
     }
@@ -23476,7 +22548,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, "testdomain1", auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, "testdomain1", "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), "testdomain1", "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                "testdomain1", "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, "testdomain1", "org", auditRef, meta);
 
         Role auditedRole = zmsTestInitializer.createRoleObject("testdomain1", "testrole1", null, "user.john", "user.jane");
@@ -23546,7 +22619,7 @@ public class ZMSImplTest {
             }
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, "testdomain1", auditRef);
@@ -23569,7 +22642,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, "testdomain1", auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, "testdomain1", "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), "testdomain1", "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                "testdomain1", "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, "testdomain1", "org", auditRef, meta);
 
         Role auditedRole = zmsTestInitializer.createRoleObject("testdomain1", "testrole1", null, "user.john", "user.jane");
@@ -23661,7 +22735,7 @@ public class ZMSImplTest {
             }
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, "testdomain1", auditRef);
@@ -25052,7 +24126,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, domainName, auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, domainName, "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), domainName, "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, domainName, "org", auditRef, meta);
 
         Role auditedRole = zmsTestInitializer.createRoleObject(domainName, "testrole1", null, "user.john", "user.jane");
@@ -25130,7 +24205,7 @@ public class ZMSImplTest {
             assertEquals(ex.getCode(), 404);
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
@@ -25154,7 +24229,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, domainName, auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, domainName, "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), domainName, "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, domainName, "org", auditRef, meta);
 
         Role auditedRole = zmsTestInitializer.createRoleObject(domainName, "testrole1", null, "user.john", "user.jane");
@@ -25224,7 +24300,7 @@ public class ZMSImplTest {
         assertNotNull(domainRoleMembership);
         assertTrue(domainRoleMembership.getDomainRoleMembersList().isEmpty());
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
@@ -27962,7 +27038,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, domainName, auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, domainName, "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), domainName, "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, domainName, "org", auditRef, meta);
 
         Group auditedGroup = zmsTestInitializer.createGroupObject(domainName, groupName, "user.john", "user.jane");
@@ -28040,7 +27117,7 @@ public class ZMSImplTest {
             assertEquals(ex.getCode(), 404);
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
@@ -28151,7 +27228,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, domainName, auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, domainName, "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), domainName, "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, domainName, "org", auditRef, meta);
 
         Group auditedGroup = zmsTestInitializer.createGroupObject(domainName, groupName, "user.john", "user.jane");
@@ -28225,7 +27303,7 @@ public class ZMSImplTest {
             }
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
@@ -28250,7 +27328,8 @@ public class ZMSImplTest {
                 true, true, "12345", 1001);
         zmsImpl.putDomainMeta(ctx, domainName, auditRef, meta);
         zmsImpl.putDomainSystemMeta(ctx, domainName, "auditenabled", auditRef, meta);
-        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(), domainName, "org");
+        zmsTestInitializer.setupPrincipalSystemMetaDelete(zmsImpl, ctx.principal().getFullName(),
+                domainName, "domain", "org");
         zmsImpl.putDomainSystemMeta(ctx, domainName, "org", auditRef, meta);
 
         Group auditedGroup = zmsTestInitializer.createGroupObject(domainName, groupName, "user.john", "user.jane");
@@ -28343,7 +27422,7 @@ public class ZMSImplTest {
             }
         }
 
-        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl);
+        zmsTestInitializer.cleanupPrincipalSystemMetaDelete(zmsImpl, "domain");
         cleanupPrincipalAuditedRoleApprovalByOrg(zmsImpl, "testOrg");
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
@@ -29722,78 +28801,6 @@ public class ZMSImplTest {
         zmsImpl.dbService.zmsConfig.setUserAuthority(savedAuthority);
         zmsImpl.userAuthority = savedAuthority;
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef);
-    }
-
-    @Test
-    public void testDeleteDomainWithGroupConsistency() {
-
-        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
-        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
-        final String auditRef = zmsTestInitializer.getAuditRef();
-
-        final String domainName1 = "delete-group1";
-        final String domainName2 = "delete-group2";
-        final String domainName3 = "delete-group3";
-        final String groupName1 = "group1";
-        final String groupName2 = "group2";
-        final String groupName3 = "group3";
-        final String roleName1 = "role1";
-        final String roleName2 = "role2";
-        final String roleName3 = "role3";
-
-        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName1, "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom1);
-
-        TopLevelDomain dom2 = zmsTestInitializer.createTopLevelDomainObject(domainName2, "Test Domain2", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom2);
-
-        TopLevelDomain dom3 = zmsTestInitializer.createTopLevelDomainObject(domainName3, "Test Domain3", "testOrg", zmsTestInitializer.getAdminUser());
-        zmsImpl.postTopLevelDomain(ctx, auditRef, dom3);
-
-        Group group1 = zmsTestInitializer.createGroupObject(domainName1, groupName1, "user.joe", "user.jane");
-        zmsImpl.putGroup(ctx, domainName1, groupName1, auditRef, false, group1);
-
-        Group group2 = zmsTestInitializer.createGroupObject(domainName1, groupName2, "user.joe", "user.jane");
-        zmsImpl.putGroup(ctx, domainName1, groupName2, auditRef, false, group2);
-
-        Group group3 = zmsTestInitializer.createGroupObject(domainName3, groupName3, "user.joe", "user.jane");
-        zmsImpl.putGroup(ctx, domainName3, groupName3, auditRef, false, group3);
-
-        // add group2 as a member to roles in 2 different domains
-
-        Role role1 = zmsTestInitializer.createRoleObject(domainName1, roleName1, null, "user.john",
-                ResourceUtils.groupResourceName(domainName1, groupName2));
-        zmsImpl.putRole(ctx, domainName1, roleName1, auditRef, false, role1);
-
-        Role role2 = zmsTestInitializer.createRoleObject(domainName2, roleName2, null, "user.john",
-                ResourceUtils.groupResourceName(domainName1, groupName2));
-        zmsImpl.putRole(ctx, domainName2, roleName2, auditRef, false, role2);
-
-        Role role3 = zmsTestInitializer.createRoleObject(domainName3, roleName3, null, "user.john",
-                ResourceUtils.groupResourceName(domainName3, groupName3));
-        zmsImpl.putRole(ctx, domainName3, roleName3, auditRef, false, role3);
-
-        // we should be able to delete domain3 without any issues since
-        // group3 is included in the same domain only
-
-        zmsImpl.deleteTopLevelDomain(ctx, domainName3, auditRef);
-
-        // we should not able to delete domain1 since the group from domain1
-        // is included in both domain1 and domain2. our error message should
-        // only include reference from domain2
-
-        try {
-            zmsImpl.deleteTopLevelDomain(ctx, domainName1, auditRef);
-            fail();
-        } catch (ResourceException ex) {
-            assertFalse(ex.getMessage().contains(ResourceUtils.roleResourceName(domainName1, roleName1)));
-            assertTrue(ex.getMessage().contains(ResourceUtils.roleResourceName(domainName2, roleName2)));
-        }
-
-        // after we delete domain2 we can delete domain1 successfully
-
-        zmsImpl.deleteTopLevelDomain(ctx, domainName2, auditRef);
-        zmsImpl.deleteTopLevelDomain(ctx, domainName1, auditRef);
     }
 
     @Test


### PR DESCRIPTION
# Description

addresses feature request #2548 

also some re-ordering of the tests. to decrease the size of the ZMSImplTest class, the domain delete test cases have been moved to the new ZMSDeleteDomainTest class

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

