### PR TITLE
Adding provider interface for fetching public keys of a service

### DIFF
--- a/libs/go/sia/agent/agent_test.go
+++ b/libs/go/sia/agent/agent_test.go
@@ -21,13 +21,14 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"k8s.io/utils/strings/slices"
 	"log"
 	"net"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"k8s.io/utils/strings/slices"
 
 	"github.com/AthenZ/athenz/libs/go/sia/access/config"
 	"github.com/AthenZ/athenz/libs/go/sia/agent/devel/ztsmock"
@@ -101,8 +102,8 @@ func (tp TestProvider) GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP {
 	return nil
 }
 
-func (tp TestProvider) GetSuffix() string {
-	return ""
+func (tp TestProvider) GetSuffixes() []string {
+	return []string{}
 }
 
 func (tp TestProvider) CloudAttestationData(string, string, string) (string, error) {

--- a/libs/go/sia/aws/agent/agent_test.go
+++ b/libs/go/sia/aws/agent/agent_test.go
@@ -22,13 +22,14 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
-	"github.com/AthenZ/athenz/libs/go/sia/ssh/hostkey"
 	"log"
 	"net"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/AthenZ/athenz/libs/go/sia/ssh/hostkey"
 
 	"github.com/AthenZ/athenz/libs/go/sia/access/config"
 	"github.com/AthenZ/athenz/libs/go/sia/aws/agent/devel/ztsmock"
@@ -102,8 +103,8 @@ func (tp TestProvider) GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP {
 	return nil
 }
 
-func (tp TestProvider) GetSuffix() string {
-	return ""
+func (tp TestProvider) GetSuffixes() []string {
+	return []string{}
 }
 
 func (tp TestProvider) CloudAttestationData(string, string, string) (string, error) {

--- a/libs/go/sia/host/provider/provider.go
+++ b/libs/go/sia/host/provider/provider.go
@@ -61,8 +61,8 @@ type Provider interface {
 	// GetSanIp returns an array of IPs that can be included in San IPs from the list of IPs found on the box
 	GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP
 
-	// GetSuffix returns the suffix for the current provider
-	GetSuffix() string
+	// GetSuffixes returns a list of suffixes for the current provider
+	GetSuffixes() []string
 
 	// CloudAttestationData gets the attestation data to prove the identity from metadata of the respective cloud
 	CloudAttestationData(string, string, string) (string, error)

--- a/libs/go/sia/options/mockawsprovider.go
+++ b/libs/go/sia/options/mockawsprovider.go
@@ -6,11 +6,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+
 	"github.com/AthenZ/athenz/libs/go/sia/aws/attestation"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
-	"net"
-	"net/url"
 )
 
 type MockAWSProvider struct {
@@ -60,8 +61,8 @@ func (tp MockAWSProvider) GetSanIp(map[string]bool, []net.IP, ip.Opts) []net.IP 
 	return nil
 }
 
-func (tp MockAWSProvider) GetSuffix() string {
-	return ""
+func (tp MockAWSProvider) GetSuffixes() []string {
+	return []string{}
 }
 
 func (tp MockAWSProvider) CloudAttestationData(string, string, string) (string, error) {

--- a/libs/go/sia/options/mockgcpprovider.go
+++ b/libs/go/sia/options/mockgcpprovider.go
@@ -6,11 +6,12 @@ import (
 	"crypto/x509/pkix"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+
 	"github.com/AthenZ/athenz/libs/go/sia/gcp/attestation"
 	"github.com/AthenZ/athenz/libs/go/sia/host/ip"
 	"github.com/AthenZ/athenz/libs/go/sia/host/signature"
-	"net"
-	"net/url"
 )
 
 type MockGCPProvider struct {
@@ -60,8 +61,8 @@ func (tp MockGCPProvider) GetSanIp(docIp map[string]bool, ips []net.IP, opts ip.
 	return nil
 }
 
-func (tp MockGCPProvider) GetSuffix() string {
-	return ""
+func (tp MockGCPProvider) GetSuffixes() []string {
+	return []string{}
 }
 
 func (tp MockGCPProvider) CloudAttestationData(base, svc, ztsServerName string) (string, error) {

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/InstanceProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/InstanceProvider.java
@@ -19,6 +19,7 @@ import com.yahoo.athenz.auth.Authorizer;
 import com.yahoo.athenz.auth.KeyStore;
 import com.yahoo.athenz.common.server.db.RolesProvider;
 import com.yahoo.athenz.common.server.dns.HostnameResolver;
+import com.yahoo.athenz.common.server.key.PubKeysProvider;
 import com.yahoo.athenz.zts.InstanceRegisterToken;
 import io.jsonwebtoken.SignatureAlgorithm;
 
@@ -125,6 +126,14 @@ public interface InstanceProvider {
      * @param rolesProvider the roles provider object
      */
     default void setRolesProvider(RolesProvider rolesProvider) {
+    }
+
+    /**
+     * sets PubKeysProvider allowing provider to look up public keys of the provider service
+     * @param pubKeyProvider the service pub keys provider
+     */
+
+    default void setPubKeysProvider(PubKeysProvider pubKeyProvider) {
     }
 
     /**

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/InstanceProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/InstanceProviderTest.java
@@ -49,6 +49,7 @@ public class InstanceProviderTest {
         provider.setHostnameResolver(null);
         provider.setRolesProvider(null);
         provider.setExternalCredentialsProvider(null);
+        provider.setPubKeysProvider(null);
 
         assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.UNKNOWN);
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/key/PubKeysProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/key/PubKeysProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.key;
+
+import com.yahoo.athenz.zms.PublicKeyEntry;
+import java.util.List;
+
+/**
+ * PubKeysProvider is an interface to fetch public keys of the service requested
+ */
+public interface PubKeysProvider {
+    /**
+     * getPubKeysByService fetches the list of public keys for the given serviceName
+     * @param domainName domain name
+     * @param serviceName service name
+     * @return List of public key entries
+     */
+    default List<PublicKeyEntry> getPubKeysByService(String domainName, String serviceName) {
+        throw new IllegalStateException("Not Implemented");
+    }
+}

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/key/PubKeysProviderTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/key/PubKeysProviderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.key;
+
+import com.yahoo.athenz.zms.PublicKeyEntry;
+import org.testng.annotations.Test;
+import java.util.List;
+import static org.testng.Assert.*;
+
+public class PubKeysProviderTest {
+    @Test
+    public void testGetPubKeysByService() {
+        PubKeysProvider pubKeysProvider = new PubKeysProvider() {
+            @Override
+            public List<PublicKeyEntry> getPubKeysByService(String domainName, String serviceName) {
+                return List.of(new PublicKeyEntry().setKey("sample key").setId("0"));
+            }
+        };
+
+        assertEquals(pubKeysProvider.getPubKeysByService("sports", "api").size(), 1);
+
+        PubKeysProvider defaultPubKeysProvider = new PubKeysProvider() {};
+
+        try {
+            defaultPubKeysProvider.getPubKeysByService("sports", "api");
+            fail();
+        } catch (IllegalStateException e) {
+        }
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/InstanceProviderManager.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/InstanceProviderManager.java
@@ -176,6 +176,7 @@ public class InstanceProviderManager {
         provider.setRolesProvider(dataStore);
         provider.setExternalCredentialsProvider(new InstanceExternalCredentialsProvider(providerName, ztsHandler));
         provider.setAuthorizer(authorizer);
+        provider.setPubKeysProvider(dataStore);
         if (ZTS_PROVIDER.equals(providerName)) {
             provider.setPrivateKey(serverPrivateKey.getKey(), serverPrivateKey.getId(), serverPrivateKey.getAlgorithm());
         }


### PR DESCRIPTION
# Description
Adding a provider interface for fetching public keys of a service
Extending Go provider interface with GetSuffixes method

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

