### PR TITLE
sia-aws: set service cert and key in role option

### DIFF
--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -711,8 +711,8 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		role := Role{
 			Name:             name,
 			Service:          roleService.Name,
-			SvcKeyFilename:   roleService.KeyFilename,
-			SvcCertFilename:  roleService.CertFilename,
+			SvcKeyFilename:   util.GetSvcKeyFileName(keyDir, roleService.KeyFilename, account.Domain, roleService.Name),
+			SvcCertFilename:  util.GetSvcCertFileName(certDir, roleService.CertFilename, account.Domain, roleService.Name),
 			RoleCertFilename: util.GetRoleCertFileName(certDir, r.Filename, name),
 			RoleKeyFilename:  util.GetRoleKeyFileName(keyDir, r.Filename, name, generateRoleKey),
 			ExpiryTime:       r.ExpiryTime,

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -426,9 +426,11 @@ func TestOptionsWithGenerateRoleKeyConfig(t *testing.T) {
 		switch role.Name {
 		case "sports:role.readers":
 			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "/tmp/keys/sports:role.readers.key.pem", role.RoleKeyFilename)
 			count += 1
 		case "sports:role.writers":
 			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "/tmp/keys/sports:role.writers.key.pem", role.RoleKeyFilename)
 			count += 1
 		}
 	}


### PR DESCRIPTION
# Description
When the generateRoleKey is set to false then the expectation is RoleKeyFileName will be empty and we should use SvcKeyFileName to get the key to be used with role certificate, but svcKeyFileName is set only when user provides a key file name for svc in their [config](https://github.com/AthenZ/athenz/blob/d64a9c8dcdad45791d8a51332cd1c6f3be378efe/libs/go/sia/aws/options/options.go#L43) 

The update is to set the svcKeyFileName and svcCertFileName using the util function to ensure the value is always populated

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

