### PR TITLE
sia: set service cert and key in role option

### DIFF
--- a/libs/go/sia/aws/options/data/sia_with_roles
+++ b/libs/go/sia/aws/options/data/sia_with_roles
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "service": "api",
+    "accounts": [
+        {
+            "domain": "athenz",
+            "user": "nobody",
+            "account": "123456789012",
+            "roles": {
+                "sports:role.readers": {
+                },
+                "sports:role.writers": {
+                }
+            }
+        }
+    ]
+}

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -437,6 +437,62 @@ func TestOptionsWithGenerateRoleKeyConfig(t *testing.T) {
 	assert.Equal(t, 2, count)
 }
 
+func TestOptionsWithRolesConfig(t *testing.T) {
+	cfg, cfgAccount, _ := getConfig("data/sia_generate_role_key", "-service", "http://localhost:80", false, "us-west-2")
+	opts, e := setOptions(cfg, cfgAccount, nil, "/tmp", "1.0.0")
+	require.Nilf(t, e, "error should not be thrown, error: %v", e)
+	assert.True(t, opts.GenerateRoleKey)
+	assert.Equal(t, 2, len(opts.Roles))
+	count := 0
+	for _, role := range opts.Roles {
+		switch role.Name {
+		case "sports:role.readers":
+			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "/tmp/keys/sports:role.readers.key.pem", role.RoleKeyFilename)
+			assert.Equal(t, "/tmp/certs/sports:role.readers.cert.pem", role.RoleCertFilename)
+			assert.Equal(t, "/tmp/keys/athenz.api.key.pem", role.SvcKeyFilename)
+			assert.Equal(t, "/tmp/certs/athenz.api.cert.pem", role.SvcCertFilename)
+			count += 1
+		case "sports:role.writers":
+			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "/tmp/keys/sports:role.writers.key.pem", role.RoleKeyFilename)
+			assert.Equal(t, "/tmp/certs/sports:role.writers.cert.pem", role.RoleCertFilename)
+			assert.Equal(t, "/tmp/keys/athenz.api.key.pem", role.SvcKeyFilename)
+			assert.Equal(t, "/tmp/certs/athenz.api.cert.pem", role.SvcCertFilename)
+			count += 1
+		}
+	}
+	assert.Equal(t, 2, count)
+}
+
+func TestOptionsWithRoles(t *testing.T) {
+	cfg, cfgAccount, _ := getConfig("data/sia_with_roles", "-service", "http://localhost:80", false, "us-west-2")
+	opts, e := setOptions(cfg, cfgAccount, nil, "/tmp", "1.0.0")
+	require.Nilf(t, e, "error should not be thrown, error: %v", e)
+	assert.False(t, opts.GenerateRoleKey)
+	assert.Equal(t, 2, len(opts.Roles))
+	count := 0
+	for _, role := range opts.Roles {
+		switch role.Name {
+		case "sports:role.readers":
+			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "", role.RoleKeyFilename)
+			assert.Equal(t, "/tmp/certs/sports:role.readers.cert.pem", role.RoleCertFilename)
+			assert.Equal(t, "/tmp/keys/athenz.api.key.pem", role.SvcKeyFilename)
+			assert.Equal(t, "/tmp/certs/athenz.api.cert.pem", role.SvcCertFilename)
+			count += 1
+		case "sports:role.writers":
+			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "", role.RoleKeyFilename)
+			assert.Equal(t, "/tmp/certs/sports:role.writers.cert.pem", role.RoleCertFilename)
+			assert.Equal(t, "/tmp/keys/athenz.api.key.pem", role.SvcKeyFilename)
+			assert.Equal(t, "/tmp/certs/athenz.api.cert.pem", role.SvcCertFilename)
+			count += 1
+		}
+	}
+	assert.Equal(t, 2, count)
+}
+
 func TestOptionsWithRotateKeyConfig(t *testing.T) {
 	cfg, cfgAccount, _ := getConfig("data/sia_rotate_key", "-service", "http://localhost:80", false, "us-west-2")
 	opts, e := setOptions(cfg, cfgAccount, nil, "/tmp", "1.0.0")

--- a/libs/go/sia/options/data/sia_with_roles
+++ b/libs/go/sia/options/data/sia_with_roles
@@ -1,0 +1,19 @@
+{
+    "version": "1.0.0",
+    "service": "api",
+    "domain": "athenz",
+    "user": "nobody",
+    "accounts": [
+        {
+            "domain": "athenz",
+            "user": "nobody",
+            "account": "123456789012"
+        }
+    ],
+    "roles": {
+        "sports:role.readers": {
+        },
+        "sports:role.writers": {
+        }
+    }
+}

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -779,8 +779,8 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 			role := Role{
 				Name:             name,
 				Service:          roleService.Name,
-				SvcKeyFilename:   roleService.KeyFilename,
-				SvcCertFilename:  roleService.CertFilename,
+				SvcKeyFilename:   util.GetSvcKeyFileName(keyDir, roleService.KeyFilename, account.Domain, roleService.Name),
+				SvcCertFilename:  util.GetSvcCertFileName(certDir, roleService.CertFilename, account.Domain, roleService.Name),
 				RoleCertFilename: util.GetRoleCertFileName(certDir, r.Filename, name),
 				RoleKeyFilename:  util.GetRoleKeyFileName(keyDir, r.Filename, name, generateRoleKey),
 				ExpiryTime:       r.ExpiryTime,

--- a/libs/go/sia/options/options_test.go
+++ b/libs/go/sia/options/options_test.go
@@ -430,9 +430,39 @@ func TestOptionsWithGenerateRoleKeyConfig(t *testing.T) {
 		switch role.Name {
 		case "sports:role.readers":
 			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "/tmp/keys/sports:role.readers.key.pem", role.RoleKeyFilename)
 			count += 1
 		case "sports:role.writers":
 			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "/tmp/keys/sports:role.writers.key.pem", role.RoleKeyFilename)
+			count += 1
+		}
+	}
+	assert.Equal(t, 2, count)
+}
+
+func TestOptionsWithRoles(t *testing.T) {
+	cfg, cfgAccount, _ := getConfig("data/sia_with_roles", "-service", "http://localhost:80", false, "us-west-2")
+	opts, e := setOptions(cfg, cfgAccount, nil, "/tmp", "1.0.0")
+	require.Nilf(t, e, "error should not be thrown, error: %v", e)
+	assert.False(t, opts.GenerateRoleKey)
+	assert.Equal(t, 2, len(opts.Roles))
+	count := 0
+	for _, role := range opts.Roles {
+		switch role.Name {
+		case "sports:role.readers":
+			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "", role.RoleKeyFilename)
+			assert.Equal(t, "/tmp/certs/sports:role.readers.cert.pem", role.RoleCertFilename)
+			assert.Equal(t, "/tmp/keys/athenz.api.key.pem", role.SvcKeyFilename)
+			assert.Equal(t, "/tmp/certs/athenz.api.cert.pem", role.SvcCertFilename)
+			count += 1
+		case "sports:role.writers":
+			assert.Equal(t, 0440, role.FileMode)
+			assert.Equal(t, "", role.RoleKeyFilename)
+			assert.Equal(t, "/tmp/certs/sports:role.writers.cert.pem", role.RoleCertFilename)
+			assert.Equal(t, "/tmp/keys/athenz.api.key.pem", role.SvcKeyFilename)
+			assert.Equal(t, "/tmp/certs/athenz.api.cert.pem", role.SvcCertFilename)
 			count += 1
 		}
 	}


### PR DESCRIPTION
# Description
When the generateRoleKey is set to false then the expectation is RoleKeyFileName will be empty and we should use SvcKeyFileName to get the key to be used with role certificate, but svcKeyFileName is set only when user provides a key file name for svc in their [config](https://github.com/AthenZ/athenz/blob/d64a9c8dcdad45791d8a51332cd1c6f3be378efe/libs/go/sia/aws/options/options.go#L43)

The update is to set the svcKeyFileName and svcCertFileName using the util function to ensure the value is always populated

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

