### PR TITLE
provide sia config option to exit process if run_after script fails

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -629,7 +629,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
 		}
 		if count != 0 {
-			util.ExecuteScript(opts.RunAfterParts)
+			util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		}
 	case "token":
 		if tokenOpts != nil {
@@ -637,7 +637,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			if err != nil && !skipErrors {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}
-			util.ExecuteScript(opts.RunAfterTokensParts)
+			util.ExecuteScript(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 		} else {
 			log.Print("unable to fetch access tokens, invalid or missing configuration")
 		}
@@ -646,14 +646,14 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 		if err != nil {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
-		util.ExecuteScript(opts.RunAfterParts)
+		util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		log.Printf("identity registered for services: %s\n", svcs)
 	case "rotate", "refresh":
 		err = RefreshInstance(ztsUrl, opts)
 		if err != nil {
 			log.Fatalf("Refresh identity failed, err: %v\n", err)
 		}
-		util.ExecuteScript(opts.RunAfterParts)
+		util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		log.Printf("Identity successfully refreshed for services: %s\n", svcs)
 	case "init":
 		err := RegisterInstance(ztsUrl, opts, false)
@@ -665,13 +665,13 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 		if failures != 0 && !skipErrors {
 			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
 		}
-		util.ExecuteScript(opts.RunAfterParts)
+		util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		if tokenOpts != nil {
 			err := fetchAccessToken(tokenOpts)
 			if err != nil && !skipErrors {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}
-			util.ExecuteScript(opts.RunAfterTokensParts)
+			util.ExecuteScript(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 		}
 	default:
 		// we're going to iterate through our configured services.
@@ -741,13 +741,13 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 					if err != nil {
 						errors <- fmt.Errorf("Unable to fetch access tokens after identity refresh, err: %v\n", err)
 					} else {
-						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts)
+						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 					}
 				} else {
 					log.Print("token config does not exist - do not refresh tokens")
 				}
 				GetRoleCertificates(ztsUrl, opts)
-				util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
+				util.ExecuteScriptWithoutBlock(opts.RunAfterParts, opts.RunAfterFailExit)
 
 				if opts.SDSUdsPath != "" {
 					certUpdates <- true
@@ -798,7 +798,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 					if err != nil {
 						errors <- fmt.Errorf("refresh access-token task got error: %v\n", err)
 					} else {
-						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts)
+						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 					}
 				case <-stop:
 					errors <- nil

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -625,7 +625,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
 		}
 		if count != 0 {
-			util.ExecuteScript(opts.RunAfterParts)
+			util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		}
 	case "token":
 		if tokenOpts != nil {
@@ -633,7 +633,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			if err != nil && !skipErrors {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}
-			util.ExecuteScript(opts.RunAfterTokensParts)
+			util.ExecuteScript(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 		} else {
 			log.Print("unable to fetch access tokens, invalid or missing configuration")
 		}
@@ -642,14 +642,14 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 		if err != nil {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
-		util.ExecuteScript(opts.RunAfterParts)
+		util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		log.Printf("identity registered for services: %s\n", svcs)
 	case "rotate", "refresh":
 		err = RefreshInstance(data, ztsUrl, opts)
 		if err != nil {
 			log.Fatalf("Refresh identity failed, err: %v\n", err)
 		}
-		util.ExecuteScript(opts.RunAfterParts)
+		util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		log.Printf("Identity successfully refreshed for services: %s\n", svcs)
 	case "init":
 		err := RegisterInstance(data, ztsUrl, opts, false)
@@ -661,13 +661,13 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 		if failures != 0 && !skipErrors {
 			log.Fatalf("unable to fetch %d out of %d requested role certificates\n", failures, count)
 		}
-		util.ExecuteScript(opts.RunAfterParts)
+		util.ExecuteScript(opts.RunAfterParts, opts.RunAfterFailExit)
 		if tokenOpts != nil {
 			err := fetchAccessToken(tokenOpts)
 			if err != nil && !skipErrors {
 				log.Fatalf("Unable to fetch access tokens, err: %v\n", err)
 			}
-			util.ExecuteScript(opts.RunAfterTokensParts)
+			util.ExecuteScript(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 		}
 	default:
 		// we're going to iterate through our configured services.
@@ -742,13 +742,13 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 					if err != nil {
 						errors <- fmt.Errorf("Unable to fetch access token after identity refresh, err: %v\n", err)
 					} else {
-						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts)
+						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 					}
 				} else {
 					log.Print("token config does not exist - do not refresh token")
 				}
 				GetRoleCertificates(ztsUrl, opts)
-				util.ExecuteScriptWithoutBlock(opts.RunAfterParts)
+				util.ExecuteScriptWithoutBlock(opts.RunAfterParts, opts.RunAfterFailExit)
 
 				if opts.SDSUdsPath != "" {
 					certUpdates <- true
@@ -799,7 +799,7 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 					if err != nil {
 						errors <- fmt.Errorf("refresh access-token task got error: %v\n", err)
 					} else {
-						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts)
+						util.ExecuteScriptWithoutBlock(opts.RunAfterTokensParts, opts.RunAfterFailExit)
 					}
 				case <-stop:
 					errors <- nil

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -113,6 +113,7 @@ type Config struct {
 	RunAfterTokens    string                   `json:"run_after_tokens,omitempty"`    //execute the command mentioned after tokens are created
 	SpiffeTrustDomain string                   `json:"spiffe_trust_domain,omitempty"` //spiffe trust domain - if configured used full spiffe uri with namespace
 	StoreTokenOption  *int                     `json:"store_token_option,omitempty"`  //store access token option
+	RunAfterFailExit  bool                     `json:"run_after_fail_exit,omitempty"` //exit process if run_after script fails
 }
 
 type AccessProfileConfig struct {
@@ -218,6 +219,7 @@ type Options struct {
 	SpiffeNamespace     string            //spiffe uri namespace
 	OmitDomain          bool              //attestation role only includes service name
 	StoreTokenOption    *int              //store access token option
+	RunAfterFailExit    bool              //exit process if run_after script fails
 }
 
 const (
@@ -452,6 +454,9 @@ func InitEnvConfig(config *Config) (*Config, *ConfigAccount, error) {
 	if !config.AccessManagement {
 		config.AccessManagement = util.ParseEnvBooleanFlag("ATHENZ_SIA_ACCESS_MANAGEMENT")
 	}
+	if !config.RunAfterFailExit {
+		config.RunAfterFailExit = util.ParseEnvBooleanFlag("ATHENZ_SIA_RUN_AFTER_FAIL_EXIT")
+	}
 
 	roleArn := os.Getenv("ATHENZ_SIA_IAM_ROLE_ARN")
 	if roleArn == "" {
@@ -549,6 +554,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 	runAfterTokens := ""
 	spiffeTrustDomain := ""
 	addlSanDNSEntries := make([]string, 0)
+	runAfterFailExit := false
 
 	var storeTokenOption *int
 	if config != nil {
@@ -564,6 +570,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		fileDirectUpdate = config.FileDirectUpdate
 		accessManagement = config.AccessManagement
 		storeTokenOption = config.StoreTokenOption
+		runAfterFailExit = config.RunAfterFailExit
 
 		if config.RefreshInterval > 0 {
 			refreshInterval = config.RefreshInterval
@@ -781,6 +788,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		OmitDomain:          account.OmitDomain,
 		StoreTokenOption:    storeTokenOption,
 		AddlSanDNSEntries:   addlSanDNSEntries,
+		RunAfterFailExit:    runAfterFailExit,
 	}, nil
 }
 

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -121,6 +121,7 @@ type Config struct {
 	RunAfterTokens    string                   `json:"run_after_tokens,omitempty"`           //execute the command mentioned after tokens are created
 	SpiffeTrustDomain string                   `json:"spiffe_trust_domain,omitempty"`        //spiffe trust domain - if configured generate full spiffe uri with namespace
 	StoreTokenOption  *int                     `json:"store_token_option,omitempty"`         //store access token option
+	RunAfterFailExit  bool                     `json:"run_after_fail_exit,omitempty"`        //exit process if run_after script fails
 }
 
 type AccessProfileConfig struct {
@@ -228,6 +229,7 @@ type Options struct {
 	SpiffeNamespace     string            //spiffe uri namespace
 	OmitDomain          bool              //attestation role only includes service name
 	StoreTokenOption    *int              //store access token option
+	RunAfterFailExit    bool              //exit process if run_after script fails
 }
 
 const (
@@ -500,6 +502,9 @@ func InitEnvConfig(config *Config, provider provider.Provider) (*Config, *Config
 	if !config.AccessManagement {
 		config.AccessManagement = util.ParseEnvBooleanFlag("ATHENZ_SIA_ACCESS_MANAGEMENT")
 	}
+	if !config.RunAfterFailExit {
+		config.RunAfterFailExit = util.ParseEnvBooleanFlag("ATHENZ_SIA_RUN_AFTER_FAIL_EXIT")
+	}
 
 	config.Threshold = util.ParseEnvFloatFlag("ATHENZ_SIA_ACCOUNT_THRESHOLD", DefaultThreshold)
 	config.SshThreshold = util.ParseEnvFloatFlag("ATHENZ_SIA_ACCOUNT_SSH_THRESHOLD", DefaultThreshold)
@@ -610,6 +615,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 	runAfterTokens := ""
 	spiffeTrustDomain := ""
 	addlSanDNSEntries := make([]string, 0)
+	runAfterFailExit := false
 
 	var storeTokenOption *int
 	if config != nil {
@@ -625,6 +631,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		fileDirectUpdate = config.FileDirectUpdate
 		accessManagement = config.AccessManagement
 		storeTokenOption = config.StoreTokenOption
+		runAfterFailExit = config.RunAfterFailExit
 
 		if config.RefreshInterval > 0 {
 			refreshInterval = config.RefreshInterval
@@ -850,6 +857,7 @@ func setOptions(config *Config, account *ConfigAccount, profileConfig *AccessPro
 		OmitDomain:          account.OmitDomain,
 		StoreTokenOption:    storeTokenOption,
 		AddlSanDNSEntries:   addlSanDNSEntries,
+		RunAfterFailExit:    runAfterFailExit,
 	}, nil
 }
 

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -1282,7 +1282,7 @@ func ParseScriptArguments(script string) []string {
 
 // ExecuteScript executes a script along with the provided
 // arguments while blocking the agent
-func ExecuteScript(script []string) error {
+func ExecuteScript(script []string, runAfterFailExit bool) error {
 	// execute run after script (if provided)
 	if len(script) == 0 {
 		return nil
@@ -1291,15 +1291,18 @@ func ExecuteScript(script []string) error {
 	err := exec.Command(script[0], script[1:]...).Run()
 	if err != nil {
 		log.Printf("unable to execute: %q, err: %v", script, err)
+		if runAfterFailExit {
+			os.Exit(1)
+		}
 	}
 	return err
 }
 
 // ExecuteScriptWithoutBlock executes a script along with the provided
 // arguments in a go subroutine without blocking the agent
-func ExecuteScriptWithoutBlock(script []string) {
+func ExecuteScriptWithoutBlock(script []string, runAfterFailExit bool) {
 	go func() {
-		ExecuteScript(script)
+		ExecuteScript(script, runAfterFailExit)
 	}()
 }
 

--- a/libs/go/sia/util/util_test.go
+++ b/libs/go/sia/util/util_test.go
@@ -1685,13 +1685,13 @@ func TestParseSiaCmd(test *testing.T) {
 func TestExecuteScript(test *testing.T) {
 
 	// non-existent script
-	err := ExecuteScript([]string{"unknown-script"})
+	err := ExecuteScript([]string{"unknown-script"}, false)
 	assert.NotNil(test, err)
 
 	// remove our test file if it exists
 	os.Remove("/tmp/test-after-script")
 	// valid script
-	err = ExecuteScript([]string{"data/test_after_script.sh"})
+	err = ExecuteScript([]string{"data/test_after_script.sh"}, true)
 	assert.Nil(test, err)
 	// verify our test file was created
 	_, err = os.Stat("/tmp/test-after-script")


### PR DESCRIPTION
# Description

provide sia config option to exit process if run_after script fails

{
  "run_after": "/opt/bin/script-to-run.sh",
  "run_after_fail_exit": true
}

if script-to-runs.sh return failure, the process will exit with return code 1

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

