### PR TITLE
Perform a retry when error code 3101 is returned from the MySQL DB

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -6975,8 +6975,8 @@ public class JDBCConnection implements ObjectStoreConnection {
 
         // check to see if this is a conflict error in which case
         // we're going to let the server to retry the caller
-        // The two SQL states that are 'retry-able' are 08S01
-        // for a communications error, and 40001 for deadlock.
+        // The SQL states that are 'retry-able' are 08S01
+        // for a communications error, and 40001 for deadlock, 3101 for transaction rollback.
         // also check for the error code where the mysql server is
         // in read-mode which could happen if we had a failover
         // and the connections are still going to the old master

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -44,6 +44,7 @@ public class JDBCConnection implements ObjectStoreConnection {
 
     private static final int MYSQL_ER_OPTION_PREVENTS_STATEMENT = 1290;
     private static final int MYSQL_ER_OPTION_DUPLICATE_ENTRY = 1062;
+    private static final int MYSQL_ER_TRANSACTION_ROLLBACK_DURING_COMMIT = 3101;
 
     private static final String MYSQL_EXC_STATE_DEADLOCK   = "40001";
     private static final String MYSQL_EXC_STATE_COMM_ERROR = "08S01";
@@ -6986,6 +6987,9 @@ public class JDBCConnection implements ObjectStoreConnection {
         if (MYSQL_EXC_STATE_COMM_ERROR.equals(sqlState) || MYSQL_EXC_STATE_DEADLOCK.equals(sqlState)) {
             code = ResourceException.CONFLICT;
             msg = "Concurrent update conflict, please retry your operation later.";
+        } else if (ex.getErrorCode() == MYSQL_ER_TRANSACTION_ROLLBACK_DURING_COMMIT) {
+            code = ResourceException.CONFLICT;
+            msg = "Plugin instructed the server to rollback the current transaction.";
         } else if (ex.getErrorCode() == MYSQL_ER_OPTION_PREVENTS_STATEMENT) {
             code = ResourceException.GONE;
             msg = "MySQL Database running in read-only mode";

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
@@ -7680,6 +7680,10 @@ public class JDBCConnectionTest {
         rEx = (ResourceException) jdbcConn.sqlError(ex, "sqlError");
         assertEquals(ResourceException.CONFLICT, rEx.getCode());
 
+        ex = new SQLException("sql-reason", "sql-state", 3101);
+        rEx = (ResourceException) jdbcConn.sqlError(ex, "sqlError");
+        assertEquals(ResourceException.CONFLICT, rEx.getCode());
+
         ex = new SQLException("sql-reason", "sql-state", 1290);
         rEx = (ResourceException) jdbcConn.sqlError(ex, "sqlError");
         assertEquals(ResourceException.GONE, rEx.getCode());


### PR DESCRIPTION
# Description
We use MySQL as the storage for ZMS domain information. However, when using Group Replication with MySQL v8, there are cases where [ErrorCode 3101](https://dev.mysql.com/doc/mysql-errors/8.3/en/server-error-reference.html#error_er_transaction_rollback_during_commit) is returned in the response. The current implementation does not retry the DB update operation when a 3101 error is returned from the DB.

Therefore, we have made changes to perform a retry when a 3101 error is returned.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

