### PR TITLE
generate notifications 3 days before expiry

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -384,7 +384,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "WHERE DAYOFWEEK(req_time)=DAYOFWEEK(?) AND (last_notified_time IS NULL || last_notified_time < (CURRENT_TIME - INTERVAL ? DAY));";
     private static final String SQL_UPDATE_ROLE_MEMBERS_EXPIRY_NOTIFICATION_TIMESTAMP =
               "UPDATE role_member SET last_notified_time=?, server=? "
-            + "WHERE expiration > CURRENT_TIME AND DATEDIFF(expiration, CURRENT_TIME) IN (0,1,7,14,21,28);";
+            + "WHERE expiration > CURRENT_TIME AND DATEDIFF(expiration, CURRENT_TIME) IN (0,1,3,7,14,21,28);";
     private static final String SQL_LIST_NOTIFY_TEMPORARY_ROLE_MEMBERS = "SELECT domain.name AS domain_name, role.name AS role_name, "
             + "principal.name AS principal_name, role_member.expiration, role_member.review_reminder FROM role_member "
             + "JOIN role ON role.role_id=role_member.role_id "
@@ -393,7 +393,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "WHERE role_member.last_notified_time=? AND role_member.server=?;";
     private static final String SQL_UPDATE_ROLE_MEMBERS_REVIEW_NOTIFICATION_TIMESTAMP =
               "UPDATE role_member SET review_last_notified_time=?, review_server=? "
-            + "WHERE review_reminder > CURRENT_TIME AND expiration IS NULL AND DATEDIFF(review_reminder, CURRENT_TIME) IN (0,1,7,14,21,28);";
+            + "WHERE review_reminder > CURRENT_TIME AND expiration IS NULL AND DATEDIFF(review_reminder, CURRENT_TIME) IN (0,1,3,7,14,21,28);";
     private static final String SQL_LIST_NOTIFY_REVIEW_ROLE_MEMBERS = "SELECT domain.name AS domain_name, role.name AS role_name, "
             + "principal.name AS principal_name, role_member.expiration, role_member.review_reminder FROM role_member "
             + "JOIN role ON role.role_id=role_member.role_id "
@@ -541,7 +541,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "WHERE grp.self_serve=true AND pgm.last_notified_time=? AND pgm.server=?;";
     private static final String SQL_UPDATE_GROUP_MEMBERS_EXPIRY_NOTIFICATION_TIMESTAMP =
               "UPDATE principal_group_member SET last_notified_time=?, server=? "
-            + "WHERE expiration > CURRENT_TIME AND DATEDIFF(expiration, CURRENT_TIME) IN (0,1,7,14,21,28);";
+            + "WHERE expiration > CURRENT_TIME AND DATEDIFF(expiration, CURRENT_TIME) IN (0,1,3,7,14,21,28);";
     private static final String SQL_LIST_NOTIFY_TEMPORARY_GROUP_MEMBERS = "SELECT domain.name AS domain_name, principal_group.name AS group_name, "
             + "principal.name AS principal_name, principal_group_member.expiration FROM principal_group_member "
             + "JOIN principal_group ON principal_group.group_id=principal_group_member.group_id "

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSNotificationsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSNotificationsTest.java
@@ -83,9 +83,12 @@ public class ZMSNotificationsTest {
                             notificationToEmailConverterCommon, false);
             List<Notification> notifications = roleMemberExpiryNotificationTask.getNotifications();
 
-            // Email notifications should be sent every 7 days while metrics should be recorded every day
-            Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList("user.expireddays0",
+            // Email notifications should be sent 0,1,3,7,14,21,28 days
+            // while metrics should be recorded every day
+            Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList(
+                    "user.expireddays0",
                     "user.expireddays1",
+                    "user.expireddays3",
                     "user.expireddays7",
                     "user.expireddays14",
                     "user.expireddays21",
@@ -148,14 +151,16 @@ public class ZMSNotificationsTest {
                             zmsImpl.notificationToEmailConverterCommon, false);
             List<Notification> notifications = groupMemberExpiryNotificationTask.getNotifications();
 
-            // Email notifications should be sent every 7 days
-            Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList("user.expireddays0",
+            // Email notifications are generated based 0,1,3,7,14,21,28 days schedule
+            Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList(
+                    "user.expireddays0",
                     "user.expireddays1",
+                    "user.expireddays3",
                     "user.expireddays7",
                     "user.expireddays14",
                     "user.expireddays21",
                     "user.expireddays28"));
-            assertEquals(notifications.size(), 7, "notificationRecipients: " + notificationsToRecipientString(notifications));
+            assertEquals(notifications.size(), 8, "notificationRecipients: " + notificationsToRecipientString(notifications));
             for (Notification notification : notifications) {
                 String recipient = notification.getRecipients().stream().findFirst().get();
                 if (recipient.equals("user.testadminuser")) {
@@ -204,10 +209,11 @@ public class ZMSNotificationsTest {
                             zmsImpl.notificationToEmailConverterCommon, false);
             List<Notification> notifications = groupMemberExpiryNotificationTask.getNotifications();
 
-            // Email notifications should be sent every 7 days
+            // Email notifications are generated based 0,1,3,7,14,21,28 days schedule
             Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList(
                     "user.expireddays0",
                     "user.expireddays1",
+                    "user.expireddays3",
                     "user.expireddays7",
                     "user.expireddays14",
                     "user.expireddays21",
@@ -258,14 +264,16 @@ public class ZMSNotificationsTest {
                             zmsImpl.notificationToEmailConverterCommon, false);
             List<Notification> notifications = groupMemberExpiryNotificationTask.getNotifications();
 
-            // Email notifications should be sent every 7 days
-            Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList("user.expireddays0",
+            // Email notifications are generated based 0,1,3,7,14,21,28 days schedule
+            Set<String> emailNotificationMembers = new HashSet<>(Arrays.asList(
+                    "user.expireddays0",
                     "user.expireddays1",
+                    "user.expireddays3",
                     "user.expireddays7",
                     "user.expireddays14",
                     "user.expireddays21",
                     "user.expireddays28"));
-            assertEquals(notifications.size(), 6, "notificationRecipients: " + notificationsToRecipientString(notifications));
+            assertEquals(notifications.size(), 7, "notificationRecipients: " + notificationsToRecipientString(notifications));
             for (Notification notification : notifications) {
                 assertEquals(notification.getRecipients().size(), 1, "notificationRecipients: "
                         + notificationsToRecipientString(notifications));


### PR DESCRIPTION
# Description

zms generates expiry notifications multiple times - most notably 1 and 7 days before expiry. However, sometimes, teams miss the 7-day notification and the if 1 day comes during weekend, it's missed. So we're going to add 3 day notification to the list as well.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

