### PR TITLE
support for systemd notify option for sia agents

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -701,6 +701,13 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			}
 		}
 
+		if cmd == "systemd-notify" {
+			err = util.NotifySystemdReady()
+			if err != nil {
+				log.Printf("failed to notify systemd: %v", err)
+			}
+		}
+
 		log.Printf("Identity established for services: %s\n", svcs)
 
 		stop := make(chan bool, 1)

--- a/libs/go/sia/aws/agent/agent.go
+++ b/libs/go/sia/aws/agent/agent.go
@@ -697,6 +697,13 @@ func RunAgent(siaCmd, ztsUrl string, opts *options.Options) {
 			}
 		}
 
+		if cmd == "systemd-notify" {
+			err = util.NotifySystemdReady()
+			if err != nil {
+				log.Printf("failed to notify systemd: %v", err)
+			}
+		}
+		
 		log.Printf("Identity established for services: %s\n", svcs)
 
 		stop := make(chan bool, 1)

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -1318,3 +1318,22 @@ func ParseSiaCmd(siaCmd string) (string, bool) {
 		return parts[0], parts[1] == "skip-errors"
 	}
 }
+
+// NotifySystemDReady sends a notification to systemd that the service is ready
+func NotifySystemdReady() error {
+	notifySocket := os.Getenv("NOTIFY_SOCKET")
+	if notifySocket == "" {
+		return fmt.Errorf("notify socket is not set")
+	}
+	socketAddr := &net.UnixAddr{
+		Name: notifySocket,
+		Net:  "unixgram",
+	}
+	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte("READY=1"))
+	return err
+}


### PR DESCRIPTION
# Description

By default the type for systemd services is simple so as soon as siad is launched, the service is marked as running. However, it might take a while for the agent to get identity certs and if another service relies on siad service, it might think it's running so it can try to run but fail since there is no identity cert yet available. If the Type is set to notify in the service definition, the command line can be set to -cmd systems-notify so the sia service will not be set as active running until the agent is able to fetch a certificate.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

