### PR TITLE
extended notification support

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/DomainProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/DomainProvider.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.db;
+
+import com.yahoo.athenz.zms.Domain;
+
+public interface DomainProvider {
+
+    /**
+     * Return domain object with the given name
+     * @param domainName name of the domain
+     * @param masterCopy flag to indicate if we want to retrieve the master copy
+     * @return domain object
+     */
+    Domain getDomain(String domainName, boolean masterCopy);
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/Notification.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/Notification.java
@@ -22,6 +22,21 @@ import java.util.*;
 
 public class Notification {
 
+    public enum Type {
+        ROLE_MEMBER_EXPIRY,
+        ROLE_MEMBER_REVIEW,
+        GROUP_MEMBER_EXPIRY,
+        ROLE_MEMBER_APPROVAL,
+        GROUP_MEMBER_APPROVAL,
+        PENDING_ROLE_APPROVAL,
+        PENDING_GROUP_APPROVAL,
+        CERT_FAILED_REFRESH,
+        AWS_ZTS_HEALTH
+    }
+
+    // type of the notification
+    private final Type type;
+
     // Intended recipients of notification
     private Set<String> recipients;
 
@@ -34,7 +49,12 @@ public class Notification {
     // Utility class to convert the notification into metric attributes
     private NotificationToMetricConverter notificationToMetricConverter;
 
-    public Notification () {
+    public Notification(Type type) {
+        this.type = type;
+    }
+
+    public Type getType() {
+        return type;
     }
 
     public Set<String> getRecipients() {
@@ -108,7 +128,8 @@ public class Notification {
         }
         Notification that = (Notification) o;
         Timestamp currentTime = Timestamp.fromMillis(System.currentTimeMillis());
-        return  Objects.equals(getRecipients(), that.getRecipients()) &&
+        return  getType() == that.getType() &&
+                Objects.equals(getRecipients(), that.getRecipients()) &&
                 Objects.equals(getDetails(), that.getDetails()) &&
                 Objects.equals(getNotificationAsMetrics(currentTime), that.getNotificationAsMetrics(currentTime)) &&
                 Objects.equals(getNotificationAsEmail(), that.getNotificationAsEmail());
@@ -130,7 +151,8 @@ public class Notification {
             metricConverterClassName = notificationToMetricConverter.getClass().getName();
         }
         return "Notification{" +
-                "recipients=" + recipients +
+                "type=" + type +
+                ", recipients=" + recipients +
                 ", details=" + details +
                 ", emailConverterClass=" + emailConverterClassName +
                 ", metricConverterClass=" + metricConverterClassName +

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationCommon.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationCommon.java
@@ -42,7 +42,7 @@ public class NotificationCommon {
         this.userDomainPrefix = userDomainPrefix;
     }
 
-    public Notification createNotification(Set<String> recipients,
+    public Notification createNotification(Notification.Type type, Set<String> recipients,
                                            Map<String, String> details,
                                            NotificationToEmailConverter notificationToEmailConverter,
                                            NotificationToMetricConverter notificationToMetricConverter) {
@@ -52,7 +52,7 @@ public class NotificationCommon {
             return null;
         }
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(type);
         notification.setDetails(details);
         notification.setNotificationToEmailConverter(notificationToEmailConverter);
         notification.setNotificationToMetricConverter(notificationToMetricConverter);
@@ -62,14 +62,14 @@ public class NotificationCommon {
         }
 
         if (notification.getRecipients() == null || notification.getRecipients().isEmpty()) {
-            LOGGER.error("Notification requires at least 1 recipient.");
+            LOGGER.error("Notification requires at least 1 recipient");
             return null;
         }
 
         return notification;
     }
 
-    public Notification createNotification(final String recipient,
+    public Notification createNotification(Notification.Type type, final String recipient,
                                            Map<String, String> details,
                                            NotificationToEmailConverter notificationToEmailConverter,
                                            NotificationToMetricConverter notificationToMetricConverter) {
@@ -79,7 +79,7 @@ public class NotificationCommon {
             return null;
         }
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(type);
         notification.setDetails(details);
         notification.setNotificationToEmailConverter(notificationToEmailConverter);
         notification.setNotificationToMetricConverter(notificationToMetricConverter);
@@ -90,7 +90,7 @@ public class NotificationCommon {
         addNotificationRecipient(notification, recipient, false);
 
         if (notification.getRecipients() == null || notification.getRecipients().isEmpty()) {
-            LOGGER.error("Notification requires at least 1 recipient.");
+            LOGGER.error("Notification requires at least 1 recipient");
             return null;
         }
 
@@ -106,7 +106,7 @@ public class NotificationCommon {
 
             notification.getRecipients().addAll(domainRoleMembers);
         } catch (ResourceException ex) {
-            LOGGER.error("Error getting domain role members ", ex);
+            LOGGER.error("Error getting domain role members", ex);
         }
     }
 
@@ -127,16 +127,16 @@ public class NotificationCommon {
         }
     }
 
-    public List<Notification> printNotificationDetailsToLog(List<Notification> notificationDetails, String description, Logger logger) {
+    public List<Notification> printNotificationDetailsToLog(List<Notification> notificationDetails, String description) {
         if (notificationDetails != null && !notificationDetails.isEmpty()) {
             StringBuilder detailsForLog = new StringBuilder();
-            detailsForLog.append("Notifications details for ").append(description).append(" :\n");
+            detailsForLog.append("Notifications details for ").append(description).append(":");
             for (Notification notification : notificationDetails) {
-                detailsForLog.append(notification).append("\n");
+                detailsForLog.append(notification).append(":");
             }
-            logger.info(detailsForLog.toString());
+            LOGGER.info(detailsForLog.toString());
         } else {
-            logger.info("No notifications details for " + description);
+            LOGGER.info("No notifications details for {}", description);
         }
         return notificationDetails;
     }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationManager.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationManager.java
@@ -17,6 +17,8 @@
 package com.yahoo.athenz.common.server.notification;
 
 import com.yahoo.athenz.auth.Authority;
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.common.server.db.DomainProvider;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +39,9 @@ public class NotificationManager {
     private final List<NotificationTask> notificationTasks;
     private final Authority notificationUserAuthority;
 
-    public NotificationManager(List<NotificationTask> notificationTasks, Authority notificationUserAuthority) {
+    public NotificationManager(List<NotificationTask> notificationTasks, Authority notificationUserAuthority,
+            PrivateKeyStore priviateKeyStore, DomainProvider domainProvider) {
+
         this.notificationTasks = notificationTasks;
         this.notificationUserAuthority = notificationUserAuthority;
         String notificationServiceFactoryClasses = System.getProperty(NOTIFICATION_PROP_SERVICE_FACTORY_CLASS);
@@ -48,8 +52,9 @@ public class NotificationManager {
                 try {
                     notificationServiceFactory = (NotificationServiceFactory) Class.forName(
                             notificationServiceFactoryClass.trim()).getDeclaredConstructor().newInstance();
-                    NotificationService notificationService = notificationServiceFactory.create();
+                    NotificationService notificationService = notificationServiceFactory.create(priviateKeyStore);
                     if (notificationService != null) {
+                        notificationService.setDomainProvider(domainProvider);
                         notificationServices.add(notificationService);
                     }
                 } catch (Exception ex) {

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationService.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationService.java
@@ -16,6 +16,8 @@
 
 package com.yahoo.athenz.common.server.notification;
 
+import com.yahoo.athenz.common.server.db.DomainProvider;
+
 public interface NotificationService {
 
     /**
@@ -23,5 +25,13 @@ public interface NotificationService {
      * @param notification - notification to be sent containing notification type, recipients and additional details
      * @return status of sent notification
      */
-    boolean notify (Notification notification);
+    boolean notify(Notification notification);
+
+    /**
+     * Set the domain provider for the notification service.
+     * This API is called when the notification service is created.
+     * @param domainProvider - domain object provider
+     */
+    default void setDomainProvider(DomainProvider domainProvider) {
+    }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationServiceFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationServiceFactory.java
@@ -16,11 +16,22 @@
 
 package com.yahoo.athenz.common.server.notification;
 
+import com.yahoo.athenz.auth.PrivateKeyStore;
+
 public interface NotificationServiceFactory {
+
+    /**
+     * @deprecated
+     * Create and return a new NotificationService instance
+     * @return NotificationService instance
+     */
+    NotificationService create();
 
     /**
      * Create and return a new NotificationService instance
      * @return NotificationService instance
      */
-    NotificationService create();
+    default NotificationService create(PrivateKeyStore privateKeyStore) {
+        return create();
+    }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/PrincipalUtils.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/PrincipalUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.common.server.util;
+
+import com.yahoo.athenz.auth.AuthorityConsts;
+import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.util.StringUtils;
+
+import java.util.List;
+
+public class PrincipalUtils {
+
+    public static Principal.Type principalType(final String memberName, final String userDomainPrefix,
+            final List<String> addlUserCheckDomainPrefixList, final String headlessUserDomainPrefix) {
+
+        if (isUserDomainPrincipal(memberName, userDomainPrefix, addlUserCheckDomainPrefixList)) {
+            return Principal.Type.USER;
+        } else if (isHeadlessUserDomainPrincipal(memberName, headlessUserDomainPrefix)) {
+            return Principal.Type.USER_HEADLESS;
+        } else if (memberName.contains(AuthorityConsts.GROUP_SEP)) {
+            return Principal.Type.GROUP;
+        } else {
+            return Principal.Type.SERVICE;
+        }
+    }
+
+    public static boolean isUserDomainPrincipal(final String memberName, final String userDomainPrefix,
+            final List<String> addlUserCheckDomainPrefixList) {
+
+        if (memberName.startsWith(userDomainPrefix) && StringUtils.countMatches(memberName, '.') == 1) {
+            return true;
+        }
+
+        if (addlUserCheckDomainPrefixList != null) {
+            for (String prefix : addlUserCheckDomainPrefixList) {
+                if (memberName.startsWith(prefix) && StringUtils.countMatches(memberName, '.') == 1) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isHeadlessUserDomainPrincipal(final String memberName, final String headlessUserDomainPrefix) {
+        return memberName.startsWith(headlessUserDomainPrefix) && StringUtils.countMatches(memberName, '.') == 1;
+    }
+}

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationManagerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationManagerTest.java
@@ -54,7 +54,7 @@ public class NotificationManagerTest {
 
     @Test
     public void testSendNotification() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         Set<String> recipients = new HashSet<>();
         recipients.add("user.joe");
         notification.setRecipients(recipients);
@@ -97,7 +97,7 @@ public class NotificationManagerTest {
         notificationTasks.add(notificationTask2);
 
         if (notificationServiceFactories == null) {
-            return new NotificationManager(notificationTasks, null);
+            return new NotificationManager(notificationTasks, null, null, null);
         }
         return new NotificationManager(notificationServiceFactories, notificationTasks, null);
     }
@@ -120,7 +120,7 @@ public class NotificationManagerTest {
 
         // Test with two factories
         System.setProperty(NOTIFICATION_PROP_SERVICE_FACTORY_CLASS, emailNotificationFactory + ", " + metricNotificationFactory);
-        NotificationManager notificationManager = new NotificationManager(notificationTasks, null);
+        NotificationManager notificationManager = new NotificationManager(notificationTasks, null, null, null);
         assertEquals(notificationManager.getLoadedNotificationServices().size(), 2);
         assertEquals(notificationManager.getLoadedNotificationServices().get(0), emailNotificationService);
         assertEquals(notificationManager.getLoadedNotificationServices().get(1), metricNotificationService);
@@ -128,14 +128,14 @@ public class NotificationManagerTest {
 
         // Test with a single factory
         System.setProperty(NOTIFICATION_PROP_SERVICE_FACTORY_CLASS, emailNotificationFactory);
-        notificationManager = new NotificationManager(notificationTasks, null);
+        notificationManager = new NotificationManager(notificationTasks, null, null, null);
         assertEquals(notificationManager.getLoadedNotificationServices().size(), 1);
         assertEquals(notificationManager.getLoadedNotificationServices().get(0), emailNotificationService);
         assertTrue(notificationManager.isNotificationFeatureAvailable());
 
         // Test with no factories
         System.clearProperty(NOTIFICATION_PROP_SERVICE_FACTORY_CLASS);
-        notificationManager = new NotificationManager(notificationTasks, null);
+        notificationManager = new NotificationManager(notificationTasks, null, null, null);
         assertEquals(notificationManager.getLoadedNotificationServices().size(), 0);
         assertFalse(notificationManager.isNotificationFeatureAvailable());
     }
@@ -144,7 +144,7 @@ public class NotificationManagerTest {
     public void testSendNotificationNullService() {
 
         NotificationServiceFactory testfact = () -> null;
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         Set<String> recipients = new HashSet<>();
         recipients.add("user.joe");
         notification.setRecipients(recipients);
@@ -172,7 +172,8 @@ public class NotificationManagerTest {
 
         NotificationToEmailConverter converter = Mockito.mock(NotificationToEmailConverter.class);
         NotificationToMetricConverter metricConverter = Mockito.mock(NotificationToMetricConverter.class);
-        Notification notification = notificationCommon.createNotification(recipients, details, converter, metricConverter);
+        Notification notification = notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                recipients, details, converter, metricConverter);
         assertNotNull(notification);
 
         assertTrue(notification.getRecipients().contains("user.recipient1"));
@@ -198,7 +199,8 @@ public class NotificationManagerTest {
 
         NotificationToEmailConverter converter = Mockito.mock(NotificationToEmailConverter.class);
         NotificationToMetricConverter metricConverter = Mockito.mock(NotificationToMetricConverter.class);
-        Notification notification = notificationCommon.createNotification(recipient, details, converter, metricConverter);
+        Notification notification = notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                recipient, details, converter, metricConverter);
         Mockito.verify(rolesProvider, Mockito.times(0)).getRolesByDomain(Mockito.any());
         assertNull(notification);
     }
@@ -219,7 +221,8 @@ public class NotificationManagerTest {
 
         NotificationToEmailConverter converter = Mockito.mock(NotificationToEmailConverter.class);
         NotificationToMetricConverter metricConverter = Mockito.mock(NotificationToMetricConverter.class);
-        Notification notification = notificationCommon.createNotification(recipient, details, converter, metricConverter);
+        Notification notification = notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                recipient, details, converter, metricConverter);
         Mockito.verify(rolesProvider, Mockito.times(1)).getRole("test.domain", "admin", false, true, false);
         assertNull(notification);
     }
@@ -229,8 +232,10 @@ public class NotificationManagerTest {
         RolesProvider rolesProvider = Mockito.mock(RolesProvider.class);
         DomainRoleMembersFetcher domainRoleMembersFetcher = new DomainRoleMembersFetcher(rolesProvider, USER_DOMAIN_PREFIX);
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
-        assertNull(notificationCommon.createNotification((Set<String>) null, null, null, null));
-        assertNull(notificationCommon.createNotification(Collections.emptySet(), null, null, null));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                (Set<String>) null, null, null, null));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                Collections.emptySet(), null, null, null));
     }
 
     @Test
@@ -244,7 +249,8 @@ public class NotificationManagerTest {
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
         NotificationToEmailConverter converter = Mockito.mock(NotificationToEmailConverter.class);
         NotificationToMetricConverter metricConverter = Mockito.mock(NotificationToMetricConverter.class);
-        Notification notification = notificationCommon.createNotification(recipients, null, converter, metricConverter);
+        Notification notification = notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                recipients, null, converter, metricConverter);
         assertNull(notification);
     }
 
@@ -291,14 +297,18 @@ public class NotificationManagerTest {
 
         NotificationToEmailConverter converter = Mockito.mock(NotificationToEmailConverter.class);
         NotificationToMetricConverter metricConverter = Mockito.mock(NotificationToMetricConverter.class);
-        assertNull(notificationCommon.createNotification((String) null, details, converter, metricConverter));
-        assertNull(notificationCommon.createNotification("", details, converter, metricConverter));
-        assertNull(notificationCommon.createNotification("athenz", details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                (String) null, details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                "", details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                "athenz", details, converter, metricConverter));
 
         // valid service name but we have no valid domain so we're still
         // going to get null notification
 
-        assertNull(notificationCommon.createNotification("athenz.service", details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                "athenz.service", details, converter, metricConverter));
     }
 
     @Test
@@ -306,13 +316,13 @@ public class NotificationManagerTest {
         RolesProvider rolesProvider = Mockito.mock(RolesProvider.class);
         DomainRoleMembersFetcher domainRoleMembersFetcher = new DomainRoleMembersFetcher(rolesProvider, USER_DOMAIN_PREFIX);
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
-        assertNull(notificationCommon.printNotificationDetailsToLog(null, "descrition", LOGGER));
-        assertNotNull(notificationCommon.printNotificationDetailsToLog(new ArrayList<>(), "descrition", LOGGER));
+        assertNull(notificationCommon.printNotificationDetailsToLog(null, "description"));
+        assertNotNull(notificationCommon.printNotificationDetailsToLog(new ArrayList<>(), "description"));
         List<Notification> notifications = new ArrayList<>();
 
         Map<String, String> details = new HashMap<>();
         details.put("test", "test");
-        notifications.add(new Notification().setDetails(details));
-        assertNotNull(notificationCommon.printNotificationDetailsToLog(notifications, "descrition", LOGGER));
+        notifications.add(new Notification(Notification.Type.ROLE_MEMBER_EXPIRY).setDetails(details));
+        assertNotNull(notificationCommon.printNotificationDetailsToLog(notifications, "description"));
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationTest.java
@@ -26,7 +26,9 @@ public class NotificationTest {
 
     @Test
     public void testNotificationMethods() {
-        Notification obj = new Notification();
+
+        Notification obj = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
+        assertEquals(obj.getType(), Notification.Type.ROLE_MEMBER_EXPIRY);
 
         Map<String, String> details = new HashMap<>();
         details.put("domain", "dom1");
@@ -52,7 +54,7 @@ public class NotificationTest {
         assertTrue(obj.toString().contains("role=role1"));
         assertTrue(obj.toString().contains("domain=dom1"));
 
-        Notification obj2 = new Notification();
+        Notification obj2 = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         obj2.addDetails("role", "role2");
         obj2.addRecipient("user.user5");
         obj2.addRecipient("user.user6");
@@ -61,7 +63,7 @@ public class NotificationTest {
         assertTrue(obj2.getRecipients().contains("user.user5"));
         assertTrue(obj2.getRecipients().contains("user.user6"));
 
-        Notification obj3 = new Notification();
+        Notification obj3 = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         obj3.addDetails("domain", "dom1").addDetails("role", "role1");
         obj3.addRecipient("user.user1");
 
@@ -72,7 +74,7 @@ public class NotificationTest {
 
         assertEquals(obj.hashCode(), obj3.hashCode());
 
-        Notification obj4 = new Notification();
+        Notification obj4 = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         List<String> testlist = Arrays.asList("user.a", "user.a", "user.b");
         obj4.getRecipients().addAll(testlist);
         assertEquals(obj4.getRecipients().size(), 2);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProviderTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProviderTest.java
@@ -165,7 +165,7 @@ public class AWSEmailProviderTest {
         AWSEmailProvider awsEmailProvider = new AWSEmailProvider(ses);
         EmailNotificationService svc = new EmailNotificationService(awsEmailProvider);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         notification.addRecipient("user.user1").addRecipient("user.user2");
         Map<String, String> details = new HashMap<>();
         details.put("domain", "dom1");

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/MetricNotificationServiceTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/MetricNotificationServiceTest.java
@@ -55,7 +55,7 @@ public class MetricNotificationServiceTest {
         NotificationToMetricConverter notificationToMetricConverter = Mockito.mock(NotificationToMetricConverter.class);
         Mockito.when(notificationToMetricConverter.getNotificationAsMetrics(Mockito.any(), Mockito.any())).thenReturn(new NotificationMetric(attributes));
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         notification.setNotificationToMetricConverter(notificationToMetricConverter);
 
         boolean notify = metricNotificationService.notify(notification);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/PrincipalUtilsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/PrincipalUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.common.server.util;
+
+import com.yahoo.athenz.auth.Principal;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class PrincipalUtilsTest {
+
+    @Test
+    public void testPrincipalType() {
+        // Set different strings between user and home domain
+        String userDomain = "user";
+        String userDomain2 = "user2";
+        String homeDomain = "home";
+        String headlessDomain = "headless";
+        String topLevelDomain = "athenz";
+        String groupSep = ":group";
+        List<String> addlUserCheckDomainPrefixList = Arrays.asList(userDomain2);
+
+        // GROUP
+        assertEquals(PrincipalUtils.principalType(homeDomain + ".joe" + groupSep + ".test-group", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
+        assertEquals(PrincipalUtils.principalType(topLevelDomain + groupSep + ".test-group", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
+        // USER
+        assertEquals(PrincipalUtils.principalType(userDomain + ".joe", userDomain, addlUserCheckDomainPrefixList,
+                headlessDomain), Principal.Type.USER);
+        assertEquals(PrincipalUtils.principalType(userDomain2 + ".joe", userDomain, addlUserCheckDomainPrefixList,
+                headlessDomain), Principal.Type.USER);
+        // USER_HEADLESS
+        assertEquals(PrincipalUtils.principalType(headlessDomain + ".joe", userDomain, addlUserCheckDomainPrefixList,
+                headlessDomain), Principal.Type.USER_HEADLESS);
+        // SERVICE
+        assertEquals(PrincipalUtils.principalType(topLevelDomain + ".test-service", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
+        assertEquals(PrincipalUtils.principalType(homeDomain + ".joe" + ".test-service", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
+
+        // Set same strings between user and home domain.
+        userDomain = "personal";
+        homeDomain = userDomain;
+
+        // GROUP
+        assertEquals(PrincipalUtils.principalType(homeDomain + ".joe" + groupSep + ".test-group", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
+        assertEquals(PrincipalUtils.principalType(topLevelDomain + groupSep + ".test-group", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
+        // USER
+        assertEquals(PrincipalUtils.principalType(userDomain + ".joe", userDomain, addlUserCheckDomainPrefixList,
+                headlessDomain), Principal.Type.USER);
+        assertEquals(PrincipalUtils.principalType(userDomain2 + ".joe", userDomain, addlUserCheckDomainPrefixList,
+                headlessDomain), Principal.Type.USER);
+        // USER_HEADLESS
+        assertEquals(PrincipalUtils.principalType(headlessDomain + ".joe", userDomain, addlUserCheckDomainPrefixList,
+                headlessDomain), Principal.Type.USER_HEADLESS);
+        // SERVICE
+        assertEquals(PrincipalUtils.principalType(topLevelDomain + ".test-service", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
+        assertEquals(PrincipalUtils.principalType(homeDomain + ".joe" + ".test-service", userDomain,
+                addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -44,10 +44,7 @@ import com.yahoo.athenz.common.server.rest.Http.AuthorityList;
 import com.yahoo.athenz.common.server.status.StatusCheckException;
 import com.yahoo.athenz.common.server.status.StatusChecker;
 import com.yahoo.athenz.common.server.status.StatusCheckerFactory;
-import com.yahoo.athenz.common.server.util.AuthzHelper;
-import com.yahoo.athenz.common.server.util.ConfigProperties;
-import com.yahoo.athenz.common.server.util.ResourceUtils;
-import com.yahoo.athenz.common.server.util.ServletRequestUtil;
+import com.yahoo.athenz.common.server.util.*;
 import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigBoolean;
 import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigCsv;
 import com.yahoo.athenz.common.server.util.config.providers.ConfigProviderFile;
@@ -764,7 +761,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     private void setNotificationManager() {
         notificationToEmailConverterCommon = new NotificationToEmailConverterCommon(userAuthority);
         ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbService, userDomainPrefix, notificationToEmailConverterCommon);
-        notificationManager = new NotificationManager(zmsNotificationTaskFactory.getNotificationTasks(), userAuthority);
+        notificationManager = new NotificationManager(zmsNotificationTaskFactory.getNotificationTasks(),
+                userAuthority, keyStore, dbService);
     }
 
     void loadSystemProperties() {
@@ -3928,7 +3926,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // at this point one user cannot ask for another user
 
-        if (ZMSUtils.isUserDomainPrincipal(checkPrincipal, userDomainPrefix, addlUserCheckDomainPrefixList)) {
+        if (PrincipalUtils.isUserDomainPrincipal(checkPrincipal, userDomainPrefix, addlUserCheckDomainPrefixList)) {
             return false;
         }
 
@@ -4001,7 +3999,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     }
 
     int principalType(final String principalName) {
-        return ZMSUtils.principalType(principalName, userDomainPrefix, addlUserCheckDomainPrefixList, headlessUserDomainPrefix).getValue();
+        return PrincipalUtils.principalType(principalName, userDomainPrefix, addlUserCheckDomainPrefixList, headlessUserDomainPrefix).getValue();
     }
 
     String normalizeDomainAliasUser(String user) {
@@ -9727,7 +9725,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         for (RoleMember roleMember : ZMSUtils.emptyIfNull(role.getRoleMembers())) {
 
             final String memberName = roleMember.getMemberName();
-            if (ZMSUtils.principalType(memberName, userDomainPrefix, addlUserCheckDomainPrefixList,
+            if (PrincipalUtils.principalType(memberName, userDomainPrefix, addlUserCheckDomainPrefixList,
                     headlessUserDomainPrefix) != Principal.Type.GROUP) {
                 continue;
             }
@@ -10490,7 +10488,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             // we only process users and automatically ignore services which
             // are not handled by user authority
 
-            if (ZMSUtils.isUserDomainPrincipal(groupMember.getMemberName(), userDomainPrefix,
+            if (PrincipalUtils.isUserDomainPrincipal(groupMember.getMemberName(), userDomainPrefix,
                     addlUserCheckDomainPrefixList)) {
 
                 // if we don't have an expiry specified for the user

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTask.java
@@ -80,7 +80,7 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
                 groupExpiryDomainNotificationToEmailConverter,
                 groupExpiryPrincipalNotificationToToMetricConverter,
                 groupExpiryDomainNotificationToMetricConverter);
-        return notificationCommon.printNotificationDetailsToLog(notificationDetails, DESCRIPTION, LOGGER);
+        return notificationCommon.printNotificationDetailsToLog(notificationDetails, DESCRIPTION);
     }
 
     public StringBuilder getDetailString(GroupMember memberGroup) {
@@ -107,7 +107,7 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
         // we're going to collect them into one string and separate
         // with | between those. The format will be:
         // memberGroupsDetails := <group-member-entry>[|<group-member-entry]*
-        // group-member-entry := <domain-name>;<group-name>;<expiration>
+        // group-member-entry := <domain-name>;<group-name>;<member-name>;<expiration>
 
         final List<GroupMember> memberGroups = member.getMemberGroups();
         if (ZMSUtils.isCollectionEmpty(memberGroups)) {
@@ -260,6 +260,7 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
             Map<String, String> details = processGroupReminder(domainAdminMap, consolidatedMembers.get(principal));
             if (!details.isEmpty()) {
                 Notification notification = notificationCommon.createNotification(
+                        Notification.Type.GROUP_MEMBER_EXPIRY,
                         principal, details, principalNotificationToEmailConverter,
                         principalNotificationToMetricConverter);
                 if (notification != null) {
@@ -276,6 +277,7 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
 
             Map<String, String> details = processMemberReminder(null, consolidatedDomainAdmins.get(principal).getMemberGroups());
             Notification notification = notificationCommon.createNotification(
+                    Notification.Type.GROUP_MEMBER_EXPIRY,
                     principal, details, domainAdminNotificationToEmailConverter,
                     domainAdminNotificationToMetricConverter);
             if (notification != null) {
@@ -305,7 +307,9 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
             Map<String, String> details = processGroupReminder(domainAdminMap, groupMember);
             if (!details.isEmpty()) {
                 Notification notification = notificationCommon.createNotification(
-                        groupMember.getMemberName(), details, principalNotificationToEmailConverter, principalNotificationToMetricConverter);
+                        Notification.Type.GROUP_MEMBER_EXPIRY,
+                        groupMember.getMemberName(), details, principalNotificationToEmailConverter,
+                        principalNotificationToMetricConverter);
                 if (notification != null) {
                     notificationList.add(notification);
                 }
@@ -318,8 +322,10 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
 
             Map<String, String> details = processMemberReminder(domainAdmin.getKey(), domainAdmin.getValue());
             Notification notification = notificationCommon.createNotification(
+                    Notification.Type.GROUP_MEMBER_EXPIRY,
                     ResourceUtils.roleResourceName(domainAdmin.getKey(), ADMIN_ROLE_NAME),
-                    details, domainAdminNotificationToEmailConverter, domainAdminNotificationToMetricConverter);
+                    details, domainAdminNotificationToEmailConverter,
+                    domainAdminNotificationToMetricConverter);
             if (notification != null) {
                 notificationList.add(notification);
             }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTask.java
@@ -148,8 +148,7 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
             // next we're going to update our domain admin map
 
             if (!disabledNotificationState.contains(DisableNotificationEnum.ADMIN)) {
-                List<GroupMember> domainGroupMembers = domainAdminMap.computeIfAbsent(domainName, k -> new ArrayList<>());
-                domainGroupMembers.add(memberGroup);
+                addDomainGroupMember(domainAdminMap, domainName, memberGroup);
             }
         }
         if (memberGroupsDetails.length() > 0) {
@@ -158,6 +157,22 @@ public class GroupMemberExpiryNotificationTask implements NotificationTask {
         }
 
         return details;
+    }
+
+    private void addDomainGroupMember(Map<String, List<GroupMember>> domainAdminMap, final String domainName,
+            GroupMember memberGroup) {
+
+        List<GroupMember> domainGroupMembers = domainAdminMap.computeIfAbsent(domainName, k -> new ArrayList<>());
+
+        // make sure we don't have any duplicates
+
+        for (GroupMember group : domainGroupMembers) {
+            if (group.getGroupName().equals(memberGroup.getGroupName())
+                    && group.getMemberName().equals(memberGroup.getMemberName())) {
+                return;
+            }
+        }
+        domainGroupMembers.add(memberGroup);
     }
 
     EnumSet<DisableNotificationEnum> getDisabledNotificationState(GroupMember memberGroup) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingGroupMembershipApprovalNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingGroupMembershipApprovalNotificationTask.java
@@ -54,6 +54,7 @@ public class PendingGroupMembershipApprovalNotificationTask implements Notificat
         dbService.processExpiredPendingGroupMembers(pendingGroupMemberLifespan, monitorIdentity);
         Set<String> recipients = dbService.getPendingGroupMembershipApproverRoles(1);
         return Collections.singletonList(notificationCommon.createNotification(
+                Notification.Type.PENDING_GROUP_APPROVAL,
                 recipients,
                 null,
                 pendingMembershipApprovalNotificationToEmailConverter,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingRoleMembershipApprovalNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingRoleMembershipApprovalNotificationTask.java
@@ -54,6 +54,7 @@ public class PendingRoleMembershipApprovalNotificationTask implements Notificati
         dbService.processExpiredPendingMembers(pendingRoleMemberLifespan, monitorIdentity);
         Set<String> recipients = dbService.getPendingMembershipApproverRoles(1);
         return Collections.singletonList(notificationCommon.createNotification(
+                Notification.Type.PENDING_ROLE_APPROVAL,
                 recipients,
                 null,
                 pendingMembershipApprovalNotificationToEmailConverter,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTask.java
@@ -97,6 +97,7 @@ public class PutGroupMembershipNotificationTask implements NotificationTask {
         // create and process our notification
 
         return Collections.singletonList(notificationCommon.createNotification(
+                Notification.Type.GROUP_MEMBER_APPROVAL,
                 recipients,
                 details,
                 putGroupMembershipNotificationToEmailConverter,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTask.java
@@ -96,6 +96,7 @@ public class PutRoleMembershipNotificationTask implements NotificationTask {
         // create and process our notification
 
         return Collections.singletonList(notificationCommon.createNotification(
+                Notification.Type.ROLE_MEMBER_APPROVAL,
                 recipients,
                 details,
                 putMembershipNotificationToEmailConverter,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
@@ -62,6 +62,7 @@ public class RoleMemberExpiryNotificationTask implements NotificationTask {
         }
 
         return roleMemberNotificationCommon.getNotificationDetails(
+                Notification.Type.ROLE_MEMBER_EXPIRY,
                 expiryMembers,
                 roleExpiryPrincipalNotificationToEmailConverter,
                 roleExpiryDomainNotificationToEmailConverter,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommon.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommon.java
@@ -322,8 +322,7 @@ public class RoleMemberNotificationCommon {
             // next we're going to update our domain admin map
 
             if (!disabledNotificationState.contains(DisableNotificationEnum.ADMIN)) {
-                List<MemberRole> domainRoleMembers = domainAdminMap.computeIfAbsent(domainName, k -> new ArrayList<>());
-                domainRoleMembers.add(memberRole);
+                addDomainRoleMember(domainAdminMap, domainName, memberRole);
             }
         }
         if (memberRolesDetails.length() > 0) {
@@ -332,6 +331,22 @@ public class RoleMemberNotificationCommon {
         }
 
         return details;
+    }
+
+    private void addDomainRoleMember(Map<String, List<MemberRole>> domainAdminMap, final String domainName,
+            MemberRole memberRole) {
+
+        List<MemberRole> domainRoleMembers = domainAdminMap.computeIfAbsent(domainName, k -> new ArrayList<>());
+
+        // make sure we don't have any duplicates
+
+        for (MemberRole role : domainRoleMembers) {
+            if (role.getRoleName().equals(memberRole.getRoleName())
+                    && role.getMemberName().equals(memberRole.getMemberName())) {
+                return;
+            }
+        }
+        domainRoleMembers.add(memberRole);
     }
 
     Map<String, String> processMemberReminder(final String domainName, List<MemberRole> memberRoles,

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommon.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommon.java
@@ -49,7 +49,7 @@ public class RoleMemberNotificationCommon {
         this.notificationCommon = new NotificationCommon(domainRoleMembersFetcher, userDomainPrefix);
     }
 
-    public List<Notification> getNotificationDetails(Map<String, DomainRoleMember> members,
+    public List<Notification> getNotificationDetails(Notification.Type type, Map<String, DomainRoleMember> members,
             NotificationToEmailConverter principalNotificationToEmailConverter,
             NotificationToEmailConverter domainAdminNotificationToEmailConverter,
             RoleMemberDetailStringer roleMemberDetailStringer,
@@ -58,19 +58,20 @@ public class RoleMemberNotificationCommon {
             DisableRoleMemberNotificationFilter disableRoleMemberNotificationFilter) {
 
             if (consolidatedNotifications) {
-                return getConsolidatedNotificationDetails(members, principalNotificationToEmailConverter,
+                return getConsolidatedNotificationDetails(type, members, principalNotificationToEmailConverter,
                         domainAdminNotificationToEmailConverter, roleMemberDetailStringer,
                         principalNotificationToMetricConverter, domainAdminNotificationToMetricConverter,
                         disableRoleMemberNotificationFilter);
             } else {
-                return getIndividualNotificationDetails(members, principalNotificationToEmailConverter,
+                return getIndividualNotificationDetails(type, members, principalNotificationToEmailConverter,
                         domainAdminNotificationToEmailConverter, roleMemberDetailStringer,
                         principalNotificationToMetricConverter, domainAdminNotificationToMetricConverter,
                         disableRoleMemberNotificationFilter);
             }
     }
 
-    public List<Notification> getConsolidatedNotificationDetails(Map<String, DomainRoleMember> members,
+    public List<Notification> getConsolidatedNotificationDetails(Notification.Type type,
+            Map<String, DomainRoleMember> members,
             NotificationToEmailConverter principalNotificationToEmailConverter,
             NotificationToEmailConverter domainAdminNotificationToEmailConverter,
             RoleMemberDetailStringer roleMemberDetailStringer,
@@ -110,7 +111,7 @@ public class RoleMemberNotificationCommon {
                     roleMemberDetailStringer, disableRoleMemberNotificationFilter);
             if (!details.isEmpty()) {
                 Notification notification = notificationCommon.createNotification(
-                        principal, details, principalNotificationToEmailConverter,
+                        type, principal, details, principalNotificationToEmailConverter,
                         principalNotificationToMetricConverter);
                 if (notification != null) {
                     notificationList.add(notification);
@@ -128,7 +129,7 @@ public class RoleMemberNotificationCommon {
                     consolidatedDomainAdmins.get(principal).getMemberRoles(), roleMemberDetailStringer);
             if (!details.isEmpty()) {
                 Notification notification = notificationCommon.createNotification(
-                        principal, details, domainAdminNotificationToEmailConverter,
+                        type, principal, details, domainAdminNotificationToEmailConverter,
                         domainAdminNotificationToMetricConverter);
                 if (notification != null) {
                     notificationList.add(notification);
@@ -209,7 +210,8 @@ public class RoleMemberNotificationCommon {
         }
     }
 
-    public List<Notification> getIndividualNotificationDetails(Map<String, DomainRoleMember> members,
+    public List<Notification> getIndividualNotificationDetails(Notification.Type type,
+            Map<String, DomainRoleMember> members,
             NotificationToEmailConverter principalNotificationToEmailConverter,
             NotificationToEmailConverter domainAdminNotificationToEmailConverter,
             RoleMemberDetailStringer roleMemberDetailStringer,
@@ -240,7 +242,7 @@ public class RoleMemberNotificationCommon {
                     disableRoleMemberNotificationFilter);
             if (!details.isEmpty()) {
                 Notification notification = notificationCommon.createNotification(
-                        roleMember.getMemberName(), details, principalNotificationToEmailConverter,
+                        type, roleMember.getMemberName(), details, principalNotificationToEmailConverter,
                         principalNotificationToMetricConverter);
                 if (notification != null) {
                     notificationList.add(notification);
@@ -256,7 +258,7 @@ public class RoleMemberNotificationCommon {
                     roleMemberDetailStringer);
             if (!details.isEmpty()) {
                 Notification notification = notificationCommon.createNotification(
-                        ResourceUtils.roleResourceName(domainAdmin.getKey(), ADMIN_ROLE_NAME),
+                        type, ResourceUtils.roleResourceName(domainAdmin.getKey(), ADMIN_ROLE_NAME),
                         details, domainAdminNotificationToEmailConverter, domainAdminNotificationToMetricConverter);
                 if (notification != null) {
                     notificationList.add(notification);
@@ -278,7 +280,7 @@ public class RoleMemberNotificationCommon {
         // we're going to collect them into one string and separate
         // with | between those. The format will be:
         // memberRolesDetails := <role-entry>[|<role-entry]*
-        // role-entry := <domain-name>;<role-name>;<expiration>
+        // role-entry := <domain-name>;<role-name>;<member-name>;<expiration>
 
         final List<MemberRole> memberRoles = member.getMemberRoles();
         if (ZMSUtils.isCollectionEmpty(memberRoles)) {
@@ -367,8 +369,8 @@ public class RoleMemberNotificationCommon {
         return details;
     }
 
-    List<Notification> printNotificationDetailsToLog(List<Notification> notificationDetails, String description, Logger logger) {
-        return notificationCommon.printNotificationDetailsToLog(notificationDetails, description, logger);
+    List<Notification> printNotificationDetailsToLog(List<Notification> notificationDetails, String description) {
+        return notificationCommon.printNotificationDetailsToLog(notificationDetails, description);
     }
 
     /**

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTask.java
@@ -64,6 +64,7 @@ public class RoleMemberReviewNotificationTask implements NotificationTask {
         }
 
         List<Notification> notificationDetails = roleMemberNotificationCommon.getNotificationDetails(
+                Notification.Type.ROLE_MEMBER_REVIEW,
                 reviewMembers,
                 roleReviewPrincipalNotificationToEmailConverter,
                 roleReviewDomainNotificationToEmailConverter,
@@ -71,7 +72,7 @@ public class RoleMemberReviewNotificationTask implements NotificationTask {
                 roleReviewPrincipalNotificationToMetricConverter,
                 roleReviewDomainNotificationToMetricConverter,
                 new ReviewDisableRoleMemberNotificationFilter());
-        return roleMemberNotificationCommon.printNotificationDetailsToLog(notificationDetails, DESCRIPTION, LOGGER);
+        return roleMemberNotificationCommon.printNotificationDetailsToLog(notificationDetails, DESCRIPTION);
     }
 
     static class ReviewRoleMemberDetailStringer implements RoleMemberNotificationCommon.RoleMemberDetailStringer {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/AthenzDomain.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/AthenzDomain.java
@@ -18,8 +18,8 @@ package com.yahoo.athenz.zms.store;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.yahoo.athenz.common.server.util.PrincipalUtils;
 import com.yahoo.athenz.zms.*;
-import com.yahoo.athenz.zms.utils.ZMSUtils;
 
 public class AthenzDomain {
 
@@ -105,7 +105,7 @@ public class AthenzDomain {
             List<RoleMember> roleMembers = role.getRoleMembers();
             if (roleMembers != null) {
                 for (RoleMember roleMember: roleMembers) {
-                    roleMember.setPrincipalType(ZMSUtils.principalType(roleMember.getMemberName(),
+                    roleMember.setPrincipalType(PrincipalUtils.principalType(roleMember.getMemberName(),
                             userDomainPrefix, addlUserCheckDomainPrefixList, headlessUserDomainPrefix).getValue());
                 }
             }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -258,42 +258,6 @@ public class ZMSUtils {
         return boolVal;
     }
 
-    public static Principal.Type principalType(final String memberName, final String userDomainPrefix,
-            final List<String> addlUserCheckDomainPrefixList, final String headlessUserDomainPrefix) {
-
-        if (ZMSUtils.isUserDomainPrincipal(memberName, userDomainPrefix, addlUserCheckDomainPrefixList)) {
-            return Principal.Type.USER;
-        } else if (ZMSUtils.isHeadlessUserDomainPrincipal(memberName, headlessUserDomainPrefix)) {
-            return Principal.Type.USER_HEADLESS;
-        } else if (memberName.contains(AuthorityConsts.GROUP_SEP)) {
-            return Principal.Type.GROUP;
-        } else {
-            return Principal.Type.SERVICE;
-        }
-    }
-
-    public static boolean isUserDomainPrincipal(final String memberName, final String userDomainPrefix,
-            final List<String> addlUserCheckDomainPrefixList) {
-
-        if (memberName.startsWith(userDomainPrefix) && StringUtils.countMatches(memberName, '.') == 1) {
-            return true;
-        }
-
-        if (addlUserCheckDomainPrefixList != null) {
-            for (String prefix : addlUserCheckDomainPrefixList) {
-                if (memberName.startsWith(prefix) && StringUtils.countMatches(memberName, '.') == 1) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-    
-    public static boolean isHeadlessUserDomainPrincipal(final String memberName, final String headlessUserDomainPrefix) {
-        return memberName.startsWith(headlessUserDomainPrefix) && StringUtils.countMatches(memberName, '.') == 1;
-    }
-
     public static String extractObjectName(String domainName, String fullName, String objType) {
 
         // generate prefix to compare with

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceOwnershipTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceOwnershipTest.java
@@ -98,12 +98,12 @@ public class ResourceOwnershipTest {
 
         // invalid cases
         try {
-            zmsImpl.validateResourceOwnership((ResourceDomainOwnership) null, "unit-test");
+            zmsImpl.validateResourceOwnership((ResourceRoleOwnership) null, "unit-test");
         } catch (ResourceException ex) {
             assert(ex.getCode() == 400);
         }
         try {
-            zmsImpl.validateResourceOwnership(new ResourceDomainOwnership().setObjectOwner("TF Test"), "unit-test");
+            zmsImpl.validateResourceOwnership(new ResourceRoleOwnership().setObjectOwner("TF Test"), "unit-test");
         } catch (ResourceException ex) {
             assert(ex.getCode() == 400);
         }
@@ -177,12 +177,12 @@ public class ResourceOwnershipTest {
 
         // invalid cases
         try {
-            zmsImpl.validateResourceOwnership((ResourcePolicyOwnership) null, "unit-test");
+            zmsImpl.validateResourceOwnership((ResourceServiceIdentityOwnership) null, "unit-test");
         } catch (ResourceException ex) {
             assert(ex.getCode() == 400);
         }
         try {
-            zmsImpl.validateResourceOwnership(new ResourcePolicyOwnership().setObjectOwner("TF Test"), "unit-test");
+            zmsImpl.validateResourceOwnership(new ResourceServiceIdentityOwnership().setObjectOwner("TF Test"), "unit-test");
         } catch (ResourceException ex) {
             assert(ex.getCode() == 400);
         }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
@@ -16,6 +16,7 @@
 
 package com.yahoo.athenz.zms.notification;
 
+import com.yahoo.athenz.auth.impl.UserAuthority;
 import com.yahoo.athenz.common.server.notification.*;
 import com.yahoo.athenz.zms.*;
 import com.yahoo.athenz.zms.store.AthenzDomain;
@@ -723,5 +724,118 @@ public class GroupMemberExpiryNotificationTaskTest {
 
         details = task.processMemberReminder("athenz", Collections.emptyList());
         assertTrue(details.isEmpty());
+    }
+
+    @Test
+    public void testGetConsolidatedNotificationDetails() {
+
+        // generate our data set
+
+        Map<String, DomainGroupMember> members = new HashMap<>();
+        Timestamp currentTime = Timestamp.fromCurrentTime();
+
+        DomainGroupMember domainGroupMember = new DomainGroupMember().setMemberName("home.joe.openhouse");
+        List<GroupMember> memberGroups = new ArrayList<>();
+        memberGroups.add(new GroupMember().setGroupName("deployment").setDomainName("home.joe")
+                .setMemberName("home.joe.openhouse").setExpiration(currentTime));
+        domainGroupMember.setMemberGroups(memberGroups);
+        members.put("home.joe.openhouse", domainGroupMember);
+
+        domainGroupMember = new DomainGroupMember().setMemberName("athenz.backend");
+        memberGroups = new ArrayList<>();
+        memberGroups.add(new GroupMember().setGroupName("deployment").setDomainName("home.joe")
+                .setMemberName("athenz.backend").setExpiration(currentTime));
+        domainGroupMember.setMemberGroups(memberGroups);
+        members.put("athenz.backend", domainGroupMember);
+
+        domainGroupMember = new DomainGroupMember().setMemberName("athenz.api");
+        memberGroups = new ArrayList<>();
+        memberGroups.add(new GroupMember().setGroupName("deployment").setDomainName("home.joe")
+                .setMemberName("athenz.api").setExpiration(currentTime));
+        domainGroupMember.setMemberGroups(memberGroups);
+        members.put("athenz.api", domainGroupMember);
+
+        DBService dbsvc = Mockito.mock(DBService.class);
+        Role roleHome = new Role().setName("home.joe:role.admin");
+        roleHome.setRoleMembers(Collections.singletonList(new RoleMember().setMemberName("user.joe")));
+        Mockito.when(dbsvc.getRole("home.joe", "admin", Boolean.FALSE, Boolean.TRUE, Boolean.FALSE))
+                .thenReturn(roleHome);
+        Role roleAthenz = new Role().setName("athenz:role.admin");
+        roleAthenz.setRoleMembers(Arrays.asList(new RoleMember().setMemberName("user.joe"),
+                new RoleMember().setMemberName("user.jane")));
+        Mockito.when(dbsvc.getRole("athenz", "admin", Boolean.FALSE, Boolean.TRUE, Boolean.FALSE))
+                .thenReturn(roleAthenz);
+
+        GroupMemberExpiryNotificationTask task = new GroupMemberExpiryNotificationTask(
+                dbsvc, USER_DOMAIN_PREFIX, new NotificationToEmailConverterCommon(null), true);
+
+        UserAuthority userAuthority = Mockito.mock(UserAuthority.class);
+
+        NotificationToEmailConverterCommon notificationToEmailConverterCommon
+                = new NotificationToEmailConverterCommon(userAuthority);
+
+        RoleMemberNotificationCommon.DisableRoleMemberNotificationFilter disableRoleMemberNotificationFilter =
+                Mockito.mock(RoleMemberNotificationCommon.DisableRoleMemberNotificationFilter.class);
+        Mockito.when(disableRoleMemberNotificationFilter.getDisabledNotificationState(any()))
+                .thenReturn(DisableNotificationEnum.getEnumSet(0));
+
+        List<Notification> notifications = task.getConsolidatedNotificationDetails(
+                members,
+                new GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
+                new GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
+                new GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToToMetricConverter(),
+                new GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToMetricConverter());
+
+        // we're supposed to get 3 notifications back - one for user.joe as the
+        // owner of the principals, one for user.joe as the domain admin and another
+        // for user.jane as domain admin
+
+        assertEquals(3, notifications.size());
+
+        // get the notification for user.joe as the admin of the domains
+
+        Notification notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_ROLES_LIST);
+        assertNotNull(notification);
+
+        assertEquals(1, notification.getRecipients().size());
+        assertEquals(2, notification.getDetails().size());
+        assertEquals("user.joe", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
+        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+                        "|home.joe;deployment;home.joe.openhouse;" + currentTime +
+                        "|home.joe;deployment;athenz.backend;" + currentTime,
+                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+
+        // get the notification for user.jane as the admin of the domains
+
+        notification = getNotification(notifications, "user.jane", NOTIFICATION_DETAILS_ROLES_LIST);
+        assertNotNull(notification);
+
+        assertEquals(1, notification.getRecipients().size());
+        assertEquals(2, notification.getDetails().size());
+        assertEquals("user.jane", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
+        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+                        "|home.joe;deployment;athenz.backend;" + currentTime,
+                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+
+        // get the notification for user.joe as the owner of the principals
+
+        notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_MEMBERS_LIST);
+        assertNotNull(notification);
+
+        assertEquals(1, notification.getRecipients().size());
+        assertEquals(1, notification.getDetails().size());
+        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+                        "|home.joe;deployment;home.joe.openhouse;" + currentTime +
+                        "|home.joe;deployment;athenz.backend;" + currentTime,
+                notification.getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST));
+    }
+
+    private Notification getNotification(List<Notification> notifications, String recipient, String detailsKey) {
+        for (Notification notification : notifications) {
+            if (notification.getRecipients().contains(recipient) && notification.getDetails().containsKey(detailsKey)) {
+                return notification;
+            }
+        }
+        return null;
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
@@ -133,7 +133,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST, "athenz1;group1;user.joe;1970-01-01T00:00:00.100Z");
         expectedFirstNotification.addDetails("member", "user.joe");
@@ -143,7 +143,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         expectedFirstNotification.setNotificationToMetricConverter(
                 new GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST, "athenz1;group1;user.joe;1970-01-01T00:00:00.100Z");
         expectedSecondNotification.addDetails("domain", "athenz1");
@@ -230,7 +230,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST, "athenz1;group2;user.joe;" + oneDayExpiry);
         expectedFirstNotification.addDetails("member", "user.joe");
@@ -240,7 +240,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         expectedFirstNotification.setNotificationToMetricConverter(
                 new GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST, "athenz1;group2;user.joe;" + oneDayExpiry);
         expectedSecondNotification.addDetails("domain", "athenz1");
@@ -306,7 +306,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         notification.setDetails(details);
         GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToEmailConverter converter =
                 new GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToEmailConverter(
@@ -347,7 +347,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         assertFalse(body.contains("link.to.athenz.channel.com"));
 
         // now try the expiry groups reminder
-        notification = new Notification();
+        notification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         notification.setDetails(details);
         details.put(NOTIFICATION_DETAILS_ROLES_LIST,
                 "athenz1;group1;user.joe;2020-12-01T12:00:00.000Z|athenz2;group2;user.joe;2020-12-01T12:00:00.000Z");
@@ -376,7 +376,7 @@ public class GroupMemberExpiryNotificationTaskTest {
 
     @Test
     public void testGetEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         NotificationToEmailConverterCommon notificationToEmailConverterCommon = new NotificationToEmailConverterCommon(null);
         GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToEmailConverter converter =
                 new GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToEmailConverter(
@@ -385,7 +385,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         String subject = notificationAsEmail.getSubject();
         assertEquals(subject, "Athenz Domain Group Member Expiration Notification");
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToEmailConverter principalConverter =
                 new GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToEmailConverter(
                         notificationToEmailConverterCommon);
@@ -405,7 +405,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         details.put(NOTIFICATION_DETAILS_MEMBERS_LIST,
                 "dom1;group1;user.joe;" + twentyFiveDaysFromNow + "|dom1;group1;user.jane;" + twentyDaysFromNow + "|dom1;group3;user.bad");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         notification.setDetails(details);
 
         GroupMemberExpiryNotificationTask.GroupExpiryDomainNotificationToMetricConverter domainConverter =
@@ -440,7 +440,7 @@ public class GroupMemberExpiryNotificationTaskTest {
                 "athenz1;group1;user.joe;" + twentyFiveDaysFromNow + "|athenz2;group2;user.joe;" + twentyDaysFromNow);
         details.put(NOTIFICATION_DETAILS_MEMBER, "user.joe");
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         notification.setDetails(details);
 
         GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToToMetricConverter principalConverter =
@@ -531,7 +531,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST,
                 "athenz1;group1;user.joe;1970-01-01T00:00:00.100Z|athenz1;group2;user.joe;1970-01-01T00:00:00.100Z");
@@ -542,7 +542,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         expectedFirstNotification.setNotificationToMetricConverter(
                 new GroupMemberExpiryNotificationTask.GroupExpiryPrincipalNotificationToToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.GROUP_MEMBER_EXPIRY);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST,
                 "athenz1;group1;user.joe;1970-01-01T00:00:00.100Z|athenz1;group2;user.joe;1970-01-01T00:00:00.100Z");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingGroupMembershipApprovalNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingGroupMembershipApprovalNotificationTaskTest.java
@@ -57,7 +57,7 @@ public class PendingGroupMembershipApprovalNotificationTaskTest {
 
         // Verify contents of notification is as expected
         assertEquals(notifications.size(), 1);
-        Notification expectedNotification = new Notification();
+        Notification expectedNotification = new Notification(Notification.Type.PENDING_GROUP_APPROVAL);
         expectedNotification.setNotificationToEmailConverter(new PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToEmailConverter(new NotificationToEmailConverterCommon(null)));
         expectedNotification.setNotificationToMetricConverter(new PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToMetricConverter());
         expectedNotification.addRecipient("user.joe");
@@ -78,7 +78,7 @@ public class PendingGroupMembershipApprovalNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.PENDING_GROUP_APPROVAL);
         notification.setDetails(details);
         PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToEmailConverter converter
                 = new PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
@@ -100,7 +100,7 @@ public class PendingGroupMembershipApprovalNotificationTaskTest {
 
     @Test
     public void getEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.PENDING_GROUP_APPROVAL);
         PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToEmailConverter converter =
                 new PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -112,7 +112,7 @@ public class PendingGroupMembershipApprovalNotificationTaskTest {
     public void testGetNotificationAsMetric() {
         PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToMetricConverter converter =
                 new PendingGroupMembershipApprovalNotificationTask.PendingGroupMembershipApprovalNotificationToMetricConverter();
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.PENDING_GROUP_APPROVAL);
         NotificationMetric notificationAsMetrics = converter.getNotificationAsMetrics(notification, Timestamp.fromMillis(System.currentTimeMillis()));
         String[] record = new String[] {
                 METRIC_NOTIFICATION_TYPE_KEY, "pending_group_membership_approval"

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingRoleMembershipApprovalNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingRoleMembershipApprovalNotificationTaskTest.java
@@ -58,7 +58,7 @@ public class PendingRoleMembershipApprovalNotificationTaskTest {
 
         // Verify contents of notification is as expected
         assertEquals(notifications.size(), 1);
-        Notification expectedNotification = new Notification();
+        Notification expectedNotification = new Notification(Notification.Type.PENDING_ROLE_APPROVAL);
         expectedNotification.setNotificationToEmailConverter(new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter(notificationToEmailConverterCommon));
         expectedNotification.setNotificationToMetricConverter(new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter());
         expectedNotification.addRecipient("user.joe");
@@ -79,7 +79,7 @@ public class PendingRoleMembershipApprovalNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.PENDING_ROLE_APPROVAL);
         notification.setDetails(details);
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter converter =
                 new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
@@ -101,7 +101,7 @@ public class PendingRoleMembershipApprovalNotificationTaskTest {
 
     @Test
     public void getEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.PENDING_ROLE_APPROVAL);
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter converter =
                 new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -113,7 +113,7 @@ public class PendingRoleMembershipApprovalNotificationTaskTest {
     public void testGetNotificationAsMetric() {
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter converter =
                 new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter();
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.PENDING_ROLE_APPROVAL);
         NotificationMetric notificationAsMetrics = converter.getNotificationAsMetrics(notification, Timestamp.fromMillis(System.currentTimeMillis()));
         String[] record = new String[] {
                 METRIC_NOTIFICATION_TYPE_KEY, "pending_role_membership_approval"

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
@@ -99,7 +99,7 @@ public class PutGroupMembershipNotificationTaskTest {
                 notifyGroup, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification.addRecipient("user.domapprover1")
                 .addRecipient("user.domapprover2")
                 .addRecipient("user.orgapprover1")
@@ -160,7 +160,7 @@ public class PutGroupMembershipNotificationTaskTest {
                 notifyGroup, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification
                 .addRecipient("user.orgapprover1")
                 .addRecipient("user.orgapprover2");
@@ -220,7 +220,7 @@ public class PutGroupMembershipNotificationTaskTest {
                 notifyGroup, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification
                 .addRecipient("user.domapprover1")
                 .addRecipient("user.domapprover2");
@@ -280,7 +280,7 @@ public class PutGroupMembershipNotificationTaskTest {
                 notifyGroup, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification
                 .addRecipient("user.domadmin1")
                 .addRecipient("user.domadmin2");
@@ -363,7 +363,7 @@ public class PutGroupMembershipNotificationTaskTest {
                 notifyGroup, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification.addRecipient("user.domapprover1")
                 .addRecipient("user.domapprover2")
                 .addRecipient("user.approver1")
@@ -444,7 +444,7 @@ public class PutGroupMembershipNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification.setDetails(details);
         PutGroupMembershipNotificationTask.PutGroupMembershipNotificationToEmailConverter converter =
                 new PutGroupMembershipNotificationTask.PutGroupMembershipNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
@@ -472,7 +472,7 @@ public class PutGroupMembershipNotificationTaskTest {
 
     @Test
     public void getEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         PutGroupMembershipNotificationTask.PutGroupMembershipNotificationToEmailConverter converter =
                 new PutGroupMembershipNotificationTask.PutGroupMembershipNotificationToEmailConverter(notificationToEmailConverterCommon);
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -489,7 +489,7 @@ public class PutGroupMembershipNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.GROUP_MEMBER_APPROVAL);
         notification.setDetails(details);
 
         PutGroupMembershipNotificationTask.PutGroupMembershipNotificationToMetricConverter converter =

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTaskTest.java
@@ -102,7 +102,7 @@ public class PutRoleMembershipNotificationTaskTest {
         List<Notification> notifications = new PutRoleMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification.addRecipient("user.domapprover1")
                 .addRecipient("user.domapprover2")
                 .addRecipient("user.orgapprover1")
@@ -160,7 +160,7 @@ public class PutRoleMembershipNotificationTaskTest {
         List<Notification> notifications = new PutRoleMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification
                 .addRecipient("user.orgapprover1")
                 .addRecipient("user.orgapprover2");
@@ -217,7 +217,7 @@ public class PutRoleMembershipNotificationTaskTest {
         List<Notification> notifications = new PutRoleMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification
                 .addRecipient("user.domapprover1")
                 .addRecipient("user.domapprover2");
@@ -274,7 +274,7 @@ public class PutRoleMembershipNotificationTaskTest {
         List<Notification> notifications = new PutRoleMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification
                 .addRecipient("user.domadmin1")
                 .addRecipient("user.domadmin2");
@@ -354,7 +354,7 @@ public class PutRoleMembershipNotificationTaskTest {
         List<Notification> notifications = new PutRoleMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon).getNotifications();
         notificationManager.sendNotifications(notifications);
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification.addRecipient("user.domapprover1")
                 .addRecipient("user.domapprover2")
                 .addRecipient("user.approver1")
@@ -436,7 +436,7 @@ public class PutRoleMembershipNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification.setDetails(details);
         PutRoleMembershipNotificationTask.PutMembershipNotificationToEmailConverter converter = new PutRoleMembershipNotificationTask.PutMembershipNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -463,7 +463,7 @@ public class PutRoleMembershipNotificationTaskTest {
 
     @Test
     public void getEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         PutRoleMembershipNotificationTask.PutMembershipNotificationToEmailConverter converter = new PutRoleMembershipNotificationTask.PutMembershipNotificationToEmailConverter(notificationToEmailConverterCommon);
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
         String subject = notificationAsEmail.getSubject();
@@ -479,7 +479,7 @@ public class PutRoleMembershipNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_APPROVAL);
         notification.setDetails(details);
 
         PutRoleMembershipNotificationTask.PutMembershipNotificationToMetricConverter converter =

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
@@ -133,12 +133,11 @@ public class RoleMemberExpiryNotificationTaskTest {
         List<Notification> notifications = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX,
                 new NotificationToEmailConverterCommon(null), false).getNotifications();
 
-
         // we should get 2 notifications - one for user and one for domain
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST, "athenz1;role1;user.joe;1970-01-01T00:00:00.100Z");
         expectedFirstNotification.addDetails("member", "user.joe");
@@ -148,7 +147,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         expectedFirstNotification.setNotificationToMetricConverter(
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST, "athenz1;role1;user.joe;1970-01-01T00:00:00.100Z");
         expectedSecondNotification.addDetails("domain", "athenz1");
@@ -231,7 +230,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST, "athenz1;role2;user.joe;" + oneDayExpiry);
         expectedFirstNotification.addDetails("member", "user.joe");
@@ -241,7 +240,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         expectedFirstNotification.setNotificationToMetricConverter(
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST, "athenz1;role2;user.joe;" + oneDayExpiry);
         expectedSecondNotification.addDetails("domain", "athenz1");
@@ -306,7 +305,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         details.put("reason", "test reason");
         details.put("requester", "user.requester");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         notification.setDetails(details);
         RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter converter =
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(
@@ -347,7 +346,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         assertFalse(body.contains("link.to.athenz.channel.com"));
 
         // now try the expiry roles reminder
-        notification = new Notification();
+        notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         notification.setDetails(details);
         details.put(NOTIFICATION_DETAILS_ROLES_LIST,
                 "athenz1;role1;user.joe;2020-12-01T12:00:00.000Z|athenz2;role2;user.joe;2020-12-01T12:00:00.000Z");
@@ -376,7 +375,7 @@ public class RoleMemberExpiryNotificationTaskTest {
 
     @Test
     public void testGetEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter converter =
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(
                         new NotificationToEmailConverterCommon(null));
@@ -384,7 +383,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         String subject = notificationAsEmail.getSubject();
         assertEquals(subject, "Athenz Domain Role Member Expiration Notification");
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter principalConverter =
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(
                         new NotificationToEmailConverterCommon(null));
@@ -429,7 +428,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         details.put(NOTIFICATION_DETAILS_MEMBERS_LIST,
                 "dom1;role1;user.joe;" + twentyFiveDaysFromNow + "|dom1;role1;user.jane;" + twentyDaysFromNow + "|dom1;role1;user.bad");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         notification.setDetails(details);
 
         RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter domainConverter =
@@ -464,7 +463,7 @@ public class RoleMemberExpiryNotificationTaskTest {
                 "athenz1;role1;user.joe;" + twentyFiveDaysFromNow + "|athenz2;role2;user.joe;" + twentyDaysFromNow);
         details.put(NOTIFICATION_DETAILS_MEMBER, "user.joe");
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         notification.setDetails(details);
 
         RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToMetricConverter principalConverter =

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommonTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommonTest.java
@@ -16,6 +16,7 @@
 
 package com.yahoo.athenz.zms.notification;
 
+import com.yahoo.athenz.auth.impl.UserAuthority;
 import com.yahoo.athenz.common.server.notification.Notification;
 import com.yahoo.athenz.common.server.notification.NotificationToEmailConverterCommon;
 import com.yahoo.athenz.zms.*;
@@ -28,6 +29,7 @@ import java.util.*;
 import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 import static com.yahoo.athenz.zms.ResourceException.NOT_FOUND;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -561,5 +563,119 @@ public class RoleMemberNotificationCommonTest {
                 dbsvc, USER_DOMAIN_PREFIX, true);
         assertTrue(task.processMemberReminder("athenz", null, null).isEmpty());
         assertTrue(task.processMemberReminder("athenz", Collections.emptyList(), null).isEmpty());
+    }
+
+    @Test
+    public void testGetConsolidatedNotificationDetails() {
+
+        // generate our data set
+
+        Map<String, DomainRoleMember> members = new HashMap<>();
+        Timestamp currentTime = Timestamp.fromCurrentTime();
+
+        DomainRoleMember domainRoleMember = new DomainRoleMember().setMemberName("home.joe.openhouse");
+        List<MemberRole> memberRoles = new ArrayList<>();
+        memberRoles.add(new MemberRole().setRoleName("deployment").setDomainName("home.joe")
+                .setMemberName("home.joe.openhouse").setReviewReminder(currentTime));
+        domainRoleMember.setMemberRoles(memberRoles);
+        members.put("home.joe.openhouse", domainRoleMember);
+
+        domainRoleMember = new DomainRoleMember().setMemberName("athenz.backend");
+        memberRoles = new ArrayList<>();
+        memberRoles.add(new MemberRole().setRoleName("deployment").setDomainName("home.joe")
+                .setMemberName("athenz.backend").setReviewReminder(currentTime));
+        domainRoleMember.setMemberRoles(memberRoles);
+        members.put("athenz.backend", domainRoleMember);
+
+        domainRoleMember = new DomainRoleMember().setMemberName("athenz.api");
+        memberRoles = new ArrayList<>();
+        memberRoles.add(new MemberRole().setRoleName("deployment").setDomainName("home.joe")
+                .setMemberName("athenz.api").setReviewReminder(currentTime));
+        domainRoleMember.setMemberRoles(memberRoles);
+        members.put("athenz.api", domainRoleMember);
+
+        DBService dbsvc = Mockito.mock(DBService.class);
+        Role roleHome = new Role().setName("home.joe:role.admin");
+        roleHome.setRoleMembers(Collections.singletonList(new RoleMember().setMemberName("user.joe")));
+        Mockito.when(dbsvc.getRole("home.joe", "admin", Boolean.FALSE, Boolean.TRUE, Boolean.FALSE))
+                .thenReturn(roleHome);
+        Role roleAthenz = new Role().setName("athenz:role.admin");
+        roleAthenz.setRoleMembers(Arrays.asList(new RoleMember().setMemberName("user.joe"),
+                new RoleMember().setMemberName("user.jane")));
+        Mockito.when(dbsvc.getRole("athenz", "admin", Boolean.FALSE, Boolean.TRUE, Boolean.FALSE))
+                .thenReturn(roleAthenz);
+
+        RoleMemberNotificationCommon task = new RoleMemberNotificationCommon(dbsvc, USER_DOMAIN_PREFIX, true);
+
+        UserAuthority userAuthority = Mockito.mock(UserAuthority.class);
+
+        NotificationToEmailConverterCommon notificationToEmailConverterCommon
+                = new NotificationToEmailConverterCommon(userAuthority);
+
+        RoleMemberNotificationCommon.DisableRoleMemberNotificationFilter disableRoleMemberNotificationFilter =
+                Mockito.mock(RoleMemberNotificationCommon.DisableRoleMemberNotificationFilter.class);
+        Mockito.when(disableRoleMemberNotificationFilter.getDisabledNotificationState(any()))
+                .thenReturn(DisableNotificationEnum.getEnumSet(0));
+
+        List<Notification> notifications = task.getConsolidatedNotificationDetails(
+                Notification.Type.ROLE_MEMBER_REVIEW, members,
+                new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
+                new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
+                new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
+                new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToMetricConverter(),
+                new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
+                disableRoleMemberNotificationFilter);
+
+        // we're supposed to get 3 notifications back - one for user.joe as the
+        // owner of the principals, one for user.joe as the domain admin and another
+        // for user.jane as domain admin
+
+        assertEquals(3, notifications.size());
+
+        // get the notification for user.joe as the admin of the domains
+
+        Notification notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_ROLES_LIST);
+        assertNotNull(notification);
+
+        assertEquals(1, notification.getRecipients().size());
+        assertEquals(2, notification.getDetails().size());
+        assertEquals("user.joe", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
+        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+                        "|home.joe;deployment;home.joe.openhouse;" + currentTime +
+                        "|home.joe;deployment;athenz.backend;" + currentTime,
+                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+
+        // get the notification for user.jane as the admin of the domains
+
+        notification = getNotification(notifications, "user.jane", NOTIFICATION_DETAILS_ROLES_LIST);
+        assertNotNull(notification);
+
+        assertEquals(1, notification.getRecipients().size());
+        assertEquals(2, notification.getDetails().size());
+        assertEquals("user.jane", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
+        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+                        "|home.joe;deployment;athenz.backend;" + currentTime,
+                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+
+        // get the notification for user.joe as the owner of the principals
+
+        notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_MEMBERS_LIST);
+        assertNotNull(notification);
+
+        assertEquals(1, notification.getRecipients().size());
+        assertEquals(1, notification.getDetails().size());
+        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+                        "|home.joe;deployment;home.joe.openhouse;" + currentTime +
+                        "|home.joe;deployment;athenz.backend;" + currentTime,
+                notification.getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST));
+    }
+
+    private Notification getNotification(List<Notification> notifications, String recipient, String detailsKey) {
+        for (Notification notification : notifications) {
+            if (notification.getRecipients().contains(recipient) && notification.getDetails().containsKey(detailsKey)) {
+                return notification;
+            }
+        }
+        return null;
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommonTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommonTest.java
@@ -61,7 +61,7 @@ public class RoleMemberNotificationCommonTest {
         groupMember.setMemberName("test.domain:group.testgroup");
         members.put("test.domain:group.testgroup", groupMember);
         List<Notification> notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -75,7 +75,7 @@ public class RoleMemberNotificationCommonTest {
         roleMember.setMemberRoles(Collections.emptyList());
         groupMember.setMemberRoles(Collections.emptyList());
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -98,7 +98,7 @@ public class RoleMemberNotificationCommonTest {
                 .setExpiration(expirationTs).setReviewReminder(reviewTs));
         groupMember.setMemberRoles(groupMemberRoles);
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -124,7 +124,7 @@ public class RoleMemberNotificationCommonTest {
                 .setExpiration(expirationTs).setReviewReminder(reviewTs));
 
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -163,7 +163,7 @@ public class RoleMemberNotificationCommonTest {
         Map<String, DomainRoleMember> members = new HashMap<>();
         members.put("user.joe", roleMember);
         List<Notification> notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -176,7 +176,7 @@ public class RoleMemberNotificationCommonTest {
         // Verify the same result when setting the memberRoles to an empty collection
         roleMember.setMemberRoles(Collections.emptyList());
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -194,7 +194,7 @@ public class RoleMemberNotificationCommonTest {
         roleMember.setMemberRoles(memberRoles);
 
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -220,7 +220,7 @@ public class RoleMemberNotificationCommonTest {
                 .setExpiration(expirationTs).setReviewReminder(reviewTs));
 
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -273,7 +273,7 @@ public class RoleMemberNotificationCommonTest {
 
         // Verify disable notification for users
         List<Notification> notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -290,7 +290,7 @@ public class RoleMemberNotificationCommonTest {
 
         // Verify disable notification for admins
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -307,7 +307,7 @@ public class RoleMemberNotificationCommonTest {
 
         // Verify disable all notifications
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberReviewNotificationTask.ReviewRoleMemberDetailStringer(),
@@ -346,7 +346,7 @@ public class RoleMemberNotificationCommonTest {
         groupMember.setMemberName("test.domain:group.testgroup");
         members.put("test.domain:group.testgroup", groupMember);
         List<Notification> notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -360,7 +360,7 @@ public class RoleMemberNotificationCommonTest {
         roleMember.setMemberRoles(Collections.emptyList());
         groupMember.setMemberRoles(Collections.emptyList());
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -387,7 +387,7 @@ public class RoleMemberNotificationCommonTest {
         members.put("user.joe", roleMember);
 
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),
@@ -412,7 +412,7 @@ public class RoleMemberNotificationCommonTest {
                 .setExpiration(expirationTs).setReviewReminder(reviewTs));
 
         notification = roleMemberNotificationCommon.getNotificationDetails(
-                members,
+                Notification.Type.ROLE_MEMBER_EXPIRY, members,
                 new RoleMemberExpiryNotificationTask.RoleExpiryPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToEmailConverter(notificationToEmailConverterCommon),
                 new RoleMemberExpiryNotificationTask.ExpiryRoleMemberDetailStringer(),

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTaskTest.java
@@ -137,14 +137,14 @@ public class RoleMemberReviewNotificationTaskTest {
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST, "athenz1;role1;user.joe;1970-01-01T00:00:00.100Z");
         expectedFirstNotification.addDetails("member", "user.joe");
         expectedFirstNotification.setNotificationToEmailConverter(new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon));
         expectedFirstNotification.setNotificationToMetricConverter(new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST, "athenz1;role1;user.joe;1970-01-01T00:00:00.100Z");
         expectedSecondNotification.addDetails("domain", "athenz1");
@@ -226,14 +226,14 @@ public class RoleMemberReviewNotificationTaskTest {
         assertEquals(notifications.size(), 2);
 
         // Verify contents of notifications is as expected
-        Notification expectedFirstNotification = new Notification();
+        Notification expectedFirstNotification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         expectedFirstNotification.addRecipient("user.joe");
         expectedFirstNotification.addDetails(NOTIFICATION_DETAILS_ROLES_LIST, "athenz1;role2;user.joe;" + oneDayExpiry);
         expectedFirstNotification.addDetails("member", "user.joe");
         expectedFirstNotification.setNotificationToEmailConverter(new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon));
         expectedFirstNotification.setNotificationToMetricConverter(new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToMetricConverter());
 
-        Notification expectedSecondNotification = new Notification();
+        Notification expectedSecondNotification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         expectedSecondNotification.addRecipient("user.jane");
         expectedSecondNotification.addDetails(NOTIFICATION_DETAILS_MEMBERS_LIST, "athenz1;role2;user.joe;" + oneDayExpiry);
         expectedSecondNotification.addDetails("domain", "athenz1");
@@ -299,7 +299,7 @@ public class RoleMemberReviewNotificationTaskTest {
 
         // First try the review admin reminder
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         notification.setDetails(details);
         RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter converter = new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon);
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -339,7 +339,7 @@ public class RoleMemberReviewNotificationTaskTest {
 
         // now try the review principal reminder
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         notification.setDetails(details);
         details.put(NOTIFICATION_DETAILS_ROLES_LIST,
                 "athenz1;role1;user.joe;2020-12-01T12:00:00.000Z|athenz2;role2;user.joe;2020-12-01T12:00:00.000Z");
@@ -367,14 +367,14 @@ public class RoleMemberReviewNotificationTaskTest {
 
     @Test
     public void testGetEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter converter =
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToEmailConverter(notificationToEmailConverterCommon);
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
         String subject = notificationAsEmail.getSubject();
         assertEquals(subject, "Athenz Domain Role Member Review Notification");
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter principalConverter =
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToEmailConverter(notificationToEmailConverterCommon);
         notificationAsEmail = principalConverter.getNotificationAsEmail(notification);
@@ -505,7 +505,7 @@ public class RoleMemberReviewNotificationTaskTest {
         details.put(NOTIFICATION_DETAILS_MEMBERS_LIST,
                 "dom1;role1;user.joe;" + twentyFiveDaysFromNow + "|dom1;role1;user.jane;" + twentyDaysFromNow + "|dom1;role1;user.bad");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         notification.setDetails(details);
 
         RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter domainConverter =
@@ -539,7 +539,7 @@ public class RoleMemberReviewNotificationTaskTest {
                 "athenz1;role1;user.joe;" + twentyFiveDaysFromNow + "|athenz2;role2;user.joe;" + twentyDaysFromNow);
         details.put(NOTIFICATION_DETAILS_MEMBER, "user.joe");
 
-        notification = new Notification();
+        notification = new Notification(Notification.Type.ROLE_MEMBER_REVIEW);
         notification.setDetails(details);
 
         RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToMetricConverter principalConverter =

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationManagerTest.java
@@ -55,7 +55,7 @@ public class ZMSNotificationManagerTest {
     @Test
     public void testSendNotification() {
         DBService dbsvc = Mockito.mock(DBService.class);
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         Set<String> recipients = new HashSet<>();
         recipients.add("user.joe");
         notification.setRecipients(recipients);
@@ -73,12 +73,14 @@ public class ZMSNotificationManagerTest {
         return getNotificationManagerMultipleServices(dbsvc, notificationServiceFactories);
     }
 
-    public static NotificationManager getNotificationManagerMultipleServices(DBService dbsvc, List<NotificationServiceFactory> notificationServiceFactories) {
-        ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc, USER_DOMAIN_PREFIX, new NotificationToEmailConverterCommon(null));
+    public static NotificationManager getNotificationManagerMultipleServices(DBService dbsvc,
+            List<NotificationServiceFactory> notificationServiceFactories) {
+        ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc,
+                USER_DOMAIN_PREFIX, new NotificationToEmailConverterCommon(null));
         List<NotificationTask> notificationTasks = zmsNotificationTaskFactory.getNotificationTasks();
 
         if (notificationServiceFactories == null) {
-            return new NotificationManager(notificationTasks, null);
+            return new NotificationManager(notificationTasks, null, null, null);
         }
         return new NotificationManager(notificationServiceFactories, notificationTasks, null);
     }
@@ -88,7 +90,7 @@ public class ZMSNotificationManagerTest {
 
         DBService dbsvc = Mockito.mock(DBService.class);
         NotificationServiceFactory testfact = () -> null;
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.ROLE_MEMBER_EXPIRY);
         Set<String> recipients = new HashSet<>();
         recipients.add("user.joe");
         notification.setRecipients(recipients);
@@ -155,7 +157,8 @@ public class ZMSNotificationManagerTest {
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
         PutRoleMembershipNotificationTask.PutMembershipNotificationToEmailConverter converter = new PutRoleMembershipNotificationTask.PutMembershipNotificationToEmailConverter(notificationToEmailConverterCommon);
         PutRoleMembershipNotificationTask.PutMembershipNotificationToMetricConverter metricConverter = new PutRoleMembershipNotificationTask.PutMembershipNotificationToMetricConverter();
-        Notification notification = notificationCommon.createNotification(recipients, details, converter, metricConverter);
+        Notification notification = notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                recipients, details, converter, metricConverter);
         assertNotNull(notification);
 
         // Assert service is not a receipient
@@ -179,8 +182,10 @@ public class ZMSNotificationManagerTest {
 
         DomainRoleMembersFetcher domainRoleMembersFetcher = new DomainRoleMembersFetcher(dbsvc, USER_DOMAIN_PREFIX);
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
-        assertNull(notificationCommon.createNotification((Set<String>) null, null, null, null));
-        assertNull(notificationCommon.createNotification(Collections.emptySet(), null, null, null));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                (Set<String>) null, null, null, null));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                Collections.emptySet(), null, null, null));
     }
 
     @Test
@@ -211,7 +216,8 @@ public class ZMSNotificationManagerTest {
         NotificationCommon notificationCommon = new NotificationCommon(domainRoleMembersFetcher, USER_DOMAIN_PREFIX);
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter converter = new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter(notificationToEmailConverterCommon);
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter metricConverter = new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter();
-        Notification notification = notificationCommon.createNotification(recipients, null, converter, metricConverter);
+        Notification notification = notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                recipients, null, converter, metricConverter);
         assertNull(notification);
     }
 
@@ -280,14 +286,18 @@ public class ZMSNotificationManagerTest {
         Map<String, String> details = new HashMap<>();
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter converter = new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToEmailConverter(notificationToEmailConverterCommon);
         PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter metricConverter = new PendingRoleMembershipApprovalNotificationTask.PendingRoleMembershipApprovalNotificationToMetricConverter();
-        assertNull(notificationCommon.createNotification((String) null, details, converter, metricConverter));
-        assertNull(notificationCommon.createNotification("", details, converter, metricConverter));
-        assertNull(notificationCommon.createNotification("athenz", details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                (String) null, details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                "", details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                "athenz", details, converter, metricConverter));
 
         // valid service name but we have no valid domain so we're still
         // going to get null notification
 
-        assertNull(notificationCommon.createNotification("athenz.service", details, converter, metricConverter));
+        assertNull(notificationCommon.createNotification(Notification.Type.ROLE_MEMBER_EXPIRY,
+                "athenz.service", details, converter, metricConverter));
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -138,46 +138,6 @@ public class ZMSUtilsTest {
         assertNotNull(msgBuilder);
         assertTrue(msgBuilder.who().contains("who-roles=[role1, role2]"), msgBuilder.who());
     }
-    
-    @Test
-    public void testPrincipalType() {
-        // Set different strings between user and home domain
-        String userDomain = "user";
-        String userDomain2 = "user2";
-        String homeDomain = "home";
-        String headlessDomain = "headless";
-        String topLevelDomain = "athenz";
-        String groupSep = ":group";
-        List<String> addlUserCheckDomainPrefixList = Arrays.asList(userDomain2);
-
-        // GROUP
-        assertEquals(ZMSUtils.principalType(homeDomain + ".joe" + groupSep + ".test-group", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
-        assertEquals(ZMSUtils.principalType(topLevelDomain + groupSep + ".test-group", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
-        // USER
-        assertEquals(ZMSUtils.principalType(userDomain + ".joe", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.USER);
-        assertEquals(ZMSUtils.principalType(userDomain2 + ".joe", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.USER);
-        // USER_HEADLESS
-        assertEquals(ZMSUtils.principalType(headlessDomain + ".joe", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.USER_HEADLESS);
-        // SERVICE
-        assertEquals(ZMSUtils.principalType(topLevelDomain + ".test-service", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
-        assertEquals(ZMSUtils.principalType(homeDomain + ".joe" + ".test-service", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
-        
-        // Set same strings between user and home domain.
-        userDomain = "personal";
-        homeDomain = userDomain;
-    
-        // GROUP
-        assertEquals(ZMSUtils.principalType(homeDomain + ".joe" + groupSep + ".test-group", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
-        assertEquals(ZMSUtils.principalType(topLevelDomain + groupSep + ".test-group", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
-        // USER
-        assertEquals(ZMSUtils.principalType(userDomain + ".joe", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.USER);
-        assertEquals(ZMSUtils.principalType(userDomain2 + ".joe", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.USER);
-        // USER_HEADLESS
-        assertEquals(ZMSUtils.principalType(headlessDomain + ".joe", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.USER_HEADLESS);
-        // SERVICE
-        assertEquals(ZMSUtils.principalType(topLevelDomain + ".test-service", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
-        assertEquals(ZMSUtils.principalType(homeDomain + ".joe" + ".test-service", userDomain, addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.SERVICE);
-    }
 
     @Test
     public void testExtractRoleName() {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -494,7 +494,8 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                 httpsPort,
                 new NotificationToEmailConverterCommon(userAuthority));
 
-        notificationManager = new NotificationManager(ztsNotificationTaskFactory.getNotificationTasks(), userAuthority);
+        notificationManager = new NotificationManager(ztsNotificationTaskFactory.getNotificationTasks(),
+                userAuthority, privateKeyStore, null);
 
         // Enable notifications for instanceCertManager
         instanceCertManager.enableCertStoreNotifications(notificationManager, dataStore, serverHostName);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/AWSZTSHealthNotificationTask.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/AWSZTSHealthNotificationTask.java
@@ -59,6 +59,7 @@ public class AWSZTSHealthNotificationTask implements NotificationTask {
         Map<String, String> details = getNotificationDetails();
 
         Notification notification = notificationCommon.createNotification(
+                Notification.Type.AWS_ZTS_HEALTH,
                 ResourceUtils.roleResourceName(athenzAdminDomain, ADMIN_ROLE_NAME),
                 details,
                 awsZTSHealthNotificationToEmailConverter,

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTask.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTask.java
@@ -155,6 +155,7 @@ public class CertFailedRefreshNotificationTask implements NotificationTask {
         domainToCertRecordsMap.forEach((domain, records) -> {
             Map<String, String> details = getNotificationDetails(domain, records);
             Notification notification = notificationCommon.createNotification(
+                    Notification.Type.CERT_FAILED_REFRESH,
                     ResourceUtils.roleResourceName(domain, ADMIN_ROLE_NAME),
                     details,
                     certFailedRefreshNotificationToEmailConverter,

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/AWSZTSHealthNotificationTaskTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/AWSZTSHealthNotificationTaskTest.java
@@ -140,7 +140,7 @@ public class AWSZTSHealthNotificationTaskTest {
         details.put(NOTIFICATION_DETAILS_AWS_ZTS_HEALTH,
                 "zts.url;domain0;role0;Sun Mar 15 15:08:07 IST 2020;Error message");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.AWS_ZTS_HEALTH);
         notification.setDetails(details);
         AWSZTSHealthNotificationTask.AWSZTSHealthNotificationToEmailConverter converter = new AWSZTSHealthNotificationTask.AWSZTSHealthNotificationToEmailConverter(new NotificationToEmailConverterCommon(null));
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -165,7 +165,7 @@ public class AWSZTSHealthNotificationTaskTest {
 
     @Test
     public void getEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.AWS_ZTS_HEALTH);
         AWSZTSHealthNotificationTask.AWSZTSHealthNotificationToEmailConverter converter = new AWSZTSHealthNotificationTask.AWSZTSHealthNotificationToEmailConverter(notificationToEmailConverterCommon);
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
         String subject = notificationAsEmail.getSubject();
@@ -182,7 +182,7 @@ public class AWSZTSHealthNotificationTaskTest {
         details.put(NOTIFICATION_DETAILS_AWS_ZTS_HEALTH,
                 "zts.url;domain0;role0;" + twentyFiveDaysFromNow + ";Error message");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.AWS_ZTS_HEALTH);
         notification.setDetails(details);
 
         AWSZTSHealthNotificationTask.AWSZTSHealthNotificationToMetricConverter converter = new AWSZTSHealthNotificationTask.AWSZTSHealthNotificationToMetricConverter();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
@@ -651,7 +651,7 @@ public class CertFailedRefreshNotificationTaskTest {
                         "bad;instanceID0;Sun Mar 15 15:08:07 IST 2020;;hostBad|" + // bad entry with missing provider
                         "service0;provider;instanceID0;Sun Mar 15 15:08:07 IST 2020;;secondHostName0");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.CERT_FAILED_REFRESH);
         notification.setDetails(details);
         CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToEmailConverter converter =
                 new CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToEmailConverter(serverName, httpsPort, new NotificationToEmailConverterCommon(null));
@@ -683,7 +683,7 @@ public class CertFailedRefreshNotificationTaskTest {
         details.put(NOTIFICATION_DETAILS_UNREFRESHED_CERTS,
                 "service1;provider1;instanceid1;Sun Mar 15 15:08:07 IST 2020;;hostName1");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.CERT_FAILED_REFRESH);
         notification.setDetails(details);
         CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToEmailConverter converter = new CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToEmailConverter(serverName, httpsPort, new NotificationToEmailConverterCommon(null));
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
@@ -700,7 +700,7 @@ public class CertFailedRefreshNotificationTaskTest {
 
     @Test
     public void getEmailSubject() {
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.CERT_FAILED_REFRESH);
         CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToEmailConverter converter = new CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToEmailConverter(serverName, httpsPort, notificationToEmailConverterCommon);
         NotificationEmail notificationAsEmail = converter.getNotificationAsEmail(notification);
         String subject = notificationAsEmail.getSubject();
@@ -719,7 +719,7 @@ public class CertFailedRefreshNotificationTaskTest {
                         "service0;provider0;instanceID0;" + fiveDaysAgo + ";" + twentyFiveDaysFromNow + ";hostName1|" +
                         "service1;provider1;instanceID1;" + fiveDaysAgo + ";" + twentyFiveDaysFromNow + ";hostName2");
 
-        Notification notification = new Notification();
+        Notification notification = new Notification(Notification.Type.CERT_FAILED_REFRESH);
         notification.setDetails(details);
 
         CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToMetricConverter converter = new CertFailedRefreshNotificationTask.CertFailedRefreshNotificationToMetricConverter();


### PR DESCRIPTION
# Description

extend the notification support provided in Athenz:
- each notification now includes a unique type so the notification service can quickly determine if it needs to process the notification or ignore it
- the notification service is now created with private key store to support fetching any necessary secrets to create its objects
- there is now a new DomainProvider interface to provide the notification server the capability to fetch domain meta attributes for a given domain 
 
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

