### PR TITLE
for sia settings from env, set the config service field

### DIFF
--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -469,7 +469,9 @@ func InitEnvConfig(config *Config) (*Config, *ConfigAccount, error) {
 	if account == "" || domain == "" || service == "" {
 		return config, nil, fmt.Errorf("invalid role arn - missing components: %s", roleArn)
 	}
-
+	if config.Service == "" {
+		config.Service = service
+	}
 	var configRoles map[string]ConfigRole
 	rolesEnv := os.Getenv("ATHENZ_SIA_ACCOUNT_ROLES")
 	if rolesEnv != "" {


### PR DESCRIPTION
# Description

when processing sia settings from the environment and get the arn for the aws role, we should check and set the config service field is it's empty

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

