### PR TITLE
extend gcp functions identity method to be generic for vm workloads

### DIFF
--- a/libs/java/gcp_zts_creds/examples/gcp-sia-creds/README.md
+++ b/libs/java/gcp_zts_creds/examples/gcp-sia-creds/README.md
@@ -1,0 +1,26 @@
+# Athenz GCP SIA Credentials Examples
+
+This repo contains examples showing the use of fetching GCP SIA Credentials
+
+The utility supports the following command line options:
+
+```
+usage: gcp-workload-credentials
+ -d,--domain <arg>      domain name
+ -n,--dnsdomain <arg>   san dns domain
+ -r,--region <arg>      gcp region
+ -s,--service <arg>     service name
+ -z,--ztsurl <arg>      ZTS Server url
+```
+
+First build the example by executing `mvn clean package` and then run
+from the current directory by replacing `<cwd>` with your current working
+directory path and `<java-home>` with your java home directory path.
+
+```
+java -cp <cwd>/target/example-gcp-workload-credentials-1.0.jar:<cwd>/target/dependency/* com.yahoo.athenz.example.zts.gcp.GCPWorkloadCredentials -d {domain-name} -s {service-name} -z {zts-url} -r {gcp-region} -n {san-dns-domain}
+```
+
+Copyright The Athenz Authors
+
+Licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/libs/java/gcp_zts_creds/examples/gcp-sia-creds/logback.xml
+++ b/libs/java/gcp_zts_creds/examples/gcp-sia-creds/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration scan="true">
+  <property name="LOG_DIR" value="/var/log/zts_server" />
+
+  <appender name="SERVER" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>[ZTS-CLIENT] %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.eclipse" level="INFO"/>
+
+  <root>
+    <level value="DEBUG" />
+    <appender-ref ref="SERVER" />
+  </root>
+</configuration>

--- a/libs/java/gcp_zts_creds/examples/gcp-sia-creds/pom.xml
+++ b/libs/java/gcp_zts_creds/examples/gcp-sia-creds/pom.xml
@@ -18,37 +18,19 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.yahoo.athenz</groupId>
-  <artifactId>example-zts-gcp-creds</artifactId>
+  <artifactId>example-gcp-workload-credentials</artifactId>
   <packaging>jar</packaging>
   <version>1.0</version>
-  <name>athenz-example-zts-gcp-creds</name>
-  <description>Athenz ZTS GCP Creds Example</description>
+  <name>athenz-example-gcp-sia-creds</name>
+  <description>Athenz GCP SIA Creds Example</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <athenz.version>1.11.58</athenz.version>
-    <gcp.bom.version>26.37.0</gcp.bom.version>
   </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>${gcp.bom.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
-    <dependency>
-      <groupId>com.yahoo.athenz</groupId>
-      <artifactId>athenz-zts-java-client</artifactId>
-      <version>${athenz.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.yahoo.athenz</groupId>
       <artifactId>athenz-gcp-zts-creds</artifactId>
@@ -68,22 +50,6 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.5.6</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auth</groupId>
-      <artifactId>google-auth-library-oauth2-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api-client</groupId>
-      <artifactId>google-api-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-storage</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-dns</artifactId>
     </dependency>
   </dependencies>
 
@@ -120,5 +86,12 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>maven_central</id>
+      <name>Maven Central</name>
+      <url>https://repo.maven.apache.org/maven2/</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/libs/java/gcp_zts_creds/examples/gcp-sia-creds/src/main/java/com/yahoo/athenz/example/zts/gcp/GCPWorkloadCredentials.java
+++ b/libs/java/gcp_zts_creds/examples/gcp-sia-creds/src/main/java/com/yahoo/athenz/example/zts/gcp/GCPWorkloadCredentials.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.example.zts.gcp;
+
+import com.yahoo.athenz.creds.gcp.GCPSIACredentials;
+import org.apache.commons.cli.*;
+
+public class GCPWorkloadCredentials {
+    
+    public static void main(String[] args) throws Exception {
+        
+        // parse our command line to retrieve required input
+        
+        CommandLine cmd = parseCommandLine(args);
+
+        final String domainName = cmd.getOptionValue("domain");
+        final String serviceName = cmd.getOptionValue("service");
+        final String region = cmd.getOptionValue("region");
+        final String ztsUrl = cmd.getOptionValue("ztsurl");
+        final String sanDNSDomain = cmd.getOptionValue("dnsdomain");
+
+        // generate our provider id
+        final String athenzProvider = "sys.gcp." + region;
+
+        // fetch and return our athenz identity that includes the private key
+        // and x.509 certificate in both object and PEM formats. The returned
+        // object also returns the list of CA certificates in PEM format.
+        GCPSIACredentials.X509KeyPair x509KeyPair = GCPSIACredentials.getGCPWorkloadServiceCertificate(
+                domainName, serviceName, athenzProvider, ztsUrl, sanDNSDomain,
+                null, null, null, null, null, null);
+
+        System.out.println("Service Identity X.509 Certificate: \n" + x509KeyPair.certificatePem);
+    }
+
+    private static CommandLine parseCommandLine(String[] args) {
+        
+        Options options = new Options();
+        
+        Option domain = new Option("d", "domain", true, "domain name");
+        domain.setRequired(true);
+        options.addOption(domain);
+        
+        Option service = new Option("s", "service", true, "service name");
+        service.setRequired(true);
+        options.addOption(service);
+        
+        Option region = new Option("r", "region", true, "gcp region");
+        region.setRequired(true);
+        options.addOption(region);
+
+        Option ztsUrl = new Option("z", "ztsurl", true, "ZTS Server url");
+        ztsUrl.setRequired(true);
+        options.addOption(ztsUrl);
+
+        Option dnsDomain = new Option("n", "dnsdomain", true, "san dns domain");
+        dnsDomain.setRequired(true);
+        options.addOption(dnsDomain);
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+
+        try {
+            return parser.parse(options, args);
+        } catch (ParseException e) {
+            System.out.println(e.getMessage());
+            formatter.printHelp("gcp-workload-credentials", options);
+            System.exit(1);
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
# Description

New getGCPWorkloadServiceCertificate method in GCPSIACredentials class that supports not only Functions but also other workloads running within GCP that may need to fetch identity certificate using Java code instead of relying on the sia agent.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

