### PR TITLE
switch to using mysql 8.0 image from 5.7 for unit tests

### DIFF
--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
@@ -50,7 +50,7 @@ public class ZMSTestUtils {
             FileUtils.copyFile(new File(externalInitScriptPath), destinationInitScript);
             LOG.info("Copied {} to {}", externalInitScriptPath, destinationInitScript.getAbsolutePath());
 
-            mysql = new MySQLContainer<>(DockerImageName.parse("mysql/mysql-server:5.7").asCompatibleSubstituteFor("mysql"))
+            mysql = new MySQLContainer<>(DockerImageName.parse("mysql/mysql-server:8.0").asCompatibleSubstituteFor("mysql"))
                     .withDatabaseName("zms_server")
                     .withUsername(userName)
                     .withPassword(password)


### PR DESCRIPTION
# Description

switch to using mysql 8.0 image from 5.7 for unit tests

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

