### PR TITLE
allow groups in admin role based on config setting

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -567,6 +567,10 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # without faking the ownership value for the operation to complete.
 #athenz.zms.resource_owner_ignore_value=ignore
 
-# The setting specifies whther the server should enforce resource ownership
+# The setting specifies whether the server should enforce resource ownership
 # checks or not. The default value is true.
 #athenz.zms.enforce_resource_ownership=true
+
+# The setting specifies whether the server disallows groups to be added
+# as members in the admin role. The default value is true.
+#athenz.zms.disallow_groups_in_admin_role=true

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -112,6 +112,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_MASTER_COPY_FOR_SIGNED_DOMAINS        = "athenz.zms.master_copy_for_signed_domains";
     public static final String ZMS_PROP_ALLOW_UNDERSCORE_IN_SERVICE_NAMES     = "athenz.zms.allow_underscore_in_service_names";
     public static final String ZMS_PROP_DOMAIN_DELETE_META_ATTRIBUTES         = "athenz.zms.domain_delete_meta_attributes";
+    public static final String ZMS_PROP_DISALLOW_GROUPS_IN_ADMIN_ROLE         = "athenz.zms.disallow_groups_in_admin_role";
 
     // properties used to over-ride default Audit logger
  


### PR DESCRIPTION
# Description

new setting athenz.zms.disallow_groups_in_admin_role to allow inclusion of groups in the admin role if the system admins wants to provide that capability.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

