### PR TITLE
bcprov-ext does not have 1.78.1 version

### DIFF
--- a/containers/jetty/pom.xml
+++ b/containers/jetty/pom.xml
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-ext-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
+      <version>1.78</version>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-ext-jdk18on</artifactId>
-      <version>${bouncycastle.version}</version>
+      <version>1.78</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
# Description

hopefully with 1.79 they'll sync up again so we'll go back to using our variable version numbers.
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

