### PR TITLE
for role/group member expiry support all restrictions

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/PrincipalRole.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/PrincipalRole.java
@@ -20,6 +20,7 @@ public class PrincipalRole {
     private String domainName;
     private String roleName;
     private String domainUserAuthorityFilter;
+    private int domainMemberExpiryDays;
     
     public String getDomainName() {
         return domainName;
@@ -43,5 +44,13 @@ public class PrincipalRole {
 
     public void setDomainUserAuthorityFilter(String domainUserAuthorityFilter) {
         this.domainUserAuthorityFilter = domainUserAuthorityFilter;
+    }
+
+    public int getDomainMemberExpiryDays() {
+        return domainMemberExpiryDays;
+    }
+
+    public void setDomainMemberExpiryDays(int domainMemberExpiryDays) {
+        this.domainMemberExpiryDays = domainMemberExpiryDays;
     }
 }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -403,8 +403,8 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "WHERE role_member.review_last_notified_time=? AND role_member.review_server=?;";
     private static final String SQL_UPDATE_ROLE_REVIEW_TIMESTAMP = "UPDATE role SET last_reviewed_time=CURRENT_TIMESTAMP(3) WHERE role_id=?;";
     private static final String SQL_LIST_ROLES_WITH_RESTRICTIONS = "SELECT domain.name as domain_name, "
-            + "role.name as role_name, domain.user_authority_filter as domain_user_authority_filter FROM role "
-            + "JOIN domain ON role.domain_id=domain.domain_id WHERE role.user_authority_filter!='' "
+            + "role.name as role_name, domain.user_authority_filter as domain_user_authority_filter, domain.member_expiry_days "
+            + "FROM role JOIN domain ON role.domain_id=domain.domain_id WHERE role.user_authority_filter!='' "
             + "OR role.user_authority_expiration!='' OR domain.user_authority_filter!='';";
     private static final String SQL_GET_GROUP = "SELECT * FROM principal_group "
             + "JOIN domain ON domain.domain_id=principal_group.domain_id "
@@ -6000,6 +6000,7 @@ public class JDBCConnection implements ObjectStoreConnection {
                     prRole.setDomainName(rs.getString(ZMSConsts.DB_COLUMN_AS_DOMAIN_NAME));
                     prRole.setRoleName(rs.getString(ZMSConsts.DB_COLUMN_AS_ROLE_NAME));
                     prRole.setDomainUserAuthorityFilter(rs.getString(ZMSConsts.DB_COLUMN_AS_DOMAIN_USER_AUTHORITY_FILTER));
+                    prRole.setDomainMemberExpiryDays(rs.getInt(ZMSConsts.DB_COLUMN_MEMBER_EXPIRY_DAYS));
                     roles.add(prRole);
                 }
             }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -25,6 +25,7 @@ import com.yahoo.athenz.common.server.log.AuditLogger;
 import com.yahoo.athenz.common.server.util.ResourceUtils;
 import com.yahoo.athenz.common.server.util.ServletRequestUtil;
 import com.yahoo.athenz.zms.*;
+import com.yahoo.rdl.Timestamp;
 import com.yahoo.rdl.Validator;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.jetty.util.StringUtil;
@@ -521,4 +522,24 @@ public class ZMSUtils {
         }
     }
 
+    public static Timestamp smallestExpiry(Timestamp memberExpiry, Timestamp userAuthorityExpiry) {
+
+        // if we have no user authority expiry then we'll use the member expiry
+
+        if (userAuthorityExpiry == null) {
+            return memberExpiry;
+        }
+
+        // if we have no member expiry then we'll use the user authority expiry
+
+        if (memberExpiry == null) {
+            return userAuthorityExpiry;
+        }
+
+        if (memberExpiry.millis() < userAuthorityExpiry.millis()) {
+            return memberExpiry;
+        } else {
+            return userAuthorityExpiry;
+        }
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalRoleTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalRoleTest.java
@@ -27,9 +27,11 @@ public class PrincipalRoleTest {
         prRole.setRoleName("role");
         prRole.setDomainName("domain");
         prRole.setDomainUserAuthorityFilter("authority");
+        prRole.setDomainMemberExpiryDays(10);
 
-        assertEquals("role", prRole.getRoleName());
-        assertEquals("domain", prRole.getDomainName());
-        assertEquals("authority", prRole.getDomainUserAuthorityFilter());
+        assertEquals(prRole.getRoleName(), "role");
+        assertEquals(prRole.getDomainName(), "domain");
+        assertEquals(prRole.getDomainUserAuthorityFilter(), "authority");
+        assertEquals(prRole.getDomainMemberExpiryDays(), 10);
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSExpiryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSExpiryTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.yahoo.athenz.zms;
+
+import com.yahoo.athenz.auth.Authority;
+import com.yahoo.rdl.Timestamp;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+import static org.testng.Assert.assertTrue;
+
+public class ZMSExpiryTest {
+
+    private final ZMSTestInitializer zmsTestInitializer = new ZMSTestInitializer();
+
+    @BeforeClass
+    public void startMemoryMySQL() {
+        zmsTestInitializer.startMemoryMySQL();
+    }
+
+    @AfterClass
+    public void stopMemoryMySQL() {
+        zmsTestInitializer.stopMemoryMySQL();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        zmsTestInitializer.setUp();
+    }
+
+    @Test
+    public void testRoleExpiryWithAuthority() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // add a role with an elevated clearance option
+
+        final String domainName = "role-expiry-with-authority";
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        // create a role with 2 members with no expiry
+
+        List<RoleMember> roleMembers = new ArrayList<>();
+        roleMembers.add(new RoleMember().setMemberName("user.john"));
+        roleMembers.add(new RoleMember().setMemberName("user.jane"));
+        roleMembers.add(new RoleMember().setMemberName("user.joe"));
+
+        final String roleName1 = "expiry-role1";
+        Role role1 = zmsTestInitializer.createRoleObject(domainName, roleName1, null, roleMembers);
+        zmsImpl.putRole(ctx, domainName, roleName1, auditRef, false, null, role1);
+
+        final String roleName2 = "expiry-role2";
+        Role role2 = zmsTestInitializer.createRoleObject(domainName, roleName2, null, roleMembers);
+        zmsImpl.putRole(ctx, domainName, roleName2, auditRef, false, null, role2);
+
+        Authority savedAuthority = zmsImpl.userAuthority;
+        Authority authority = Mockito.mock(Authority.class);
+        Set<String> attrs = new HashSet<>();
+        attrs.add("elevated-clearance");
+        when(authority.dateAttributesSupported()).thenReturn(attrs);
+        Timestamp days15 = ZMSTestUtils.addDays(Timestamp.fromCurrentTime(), 15);
+        Timestamp days45 = ZMSTestUtils.addDays(Timestamp.fromCurrentTime(), 45);
+        when(authority.getDateAttribute("user.john", "elevated-clearance")).thenReturn(days45.toDate());
+        when(authority.getDateAttribute("user.jane", "elevated-clearance")).thenReturn(days15.toDate());
+        when(authority.getDateAttribute("user.joe", "elevated-clearance")).thenReturn(null);
+        when(authority.getDateAttribute("user.john1", "elevated-clearance")).thenReturn(days45.toDate());
+        when(authority.getDateAttribute("user.jane1", "elevated-clearance")).thenReturn(days15.toDate());
+        when(authority.getDateAttribute("user.joe1", "elevated-clearance")).thenReturn(null);
+        zmsImpl.userAuthority = authority;
+        zmsImpl.dbService.zmsConfig.setUserAuthority(authority);
+
+        // let's set the meta attributes for expiry and authority expiry
+
+        RoleMeta rm1 = new RoleMeta().setMemberExpiryDays(30).setUserAuthorityExpiration("elevated-clearance");
+        zmsImpl.putRoleMeta(ctx, domainName, roleName1, auditRef, null, rm1);
+
+        RoleMeta rm2 = new RoleMeta().setUserAuthorityExpiration("elevated-clearance");
+        zmsImpl.putRoleMeta(ctx, domainName, roleName2, auditRef, null, rm2);
+
+        // now let's retrieve the roles and verify the expiry
+
+        Role role1Res = zmsImpl.getRole(ctx, domainName, roleName1, false, false, false);
+        assertNotNull(role1Res);
+
+        // john should have 30 days user expiry since elevated clearance is 45
+        RoleMember userJohn = ZMSTestUtils.getRoleMember(role1Res, "user.john");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn.getExpiration().millis(), 30L * 24 * 60 * 60 * 1000));
+
+        // jane should have 15 days user expiry since elevated clearance is 15
+        RoleMember userJane = ZMSTestUtils.getRoleMember(role1Res, "user.jane");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        // joe has no expiry so it must be expired
+        RoleMember userJoe = ZMSTestUtils.getRoleMember(role1Res, "user.joe");
+        assertTrue(ZMSTestUtils.validateDueDate(userJoe.getExpiration().millis(), 0));
+
+        // role2 is standard user authority expiry
+
+        Role role2Res = zmsImpl.getRole(ctx, domainName, roleName2, false, false, false);
+        assertNotNull(role2Res);
+
+        userJohn = ZMSTestUtils.getRoleMember(role2Res, "user.john");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn.getExpiration().millis(), 45L * 24 * 60 * 60 * 1000));
+
+        userJane = ZMSTestUtils.getRoleMember(role2Res, "user.jane");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        userJoe = ZMSTestUtils.getRoleMember(role2Res, "user.joe");
+        assertTrue(ZMSTestUtils.validateDueDate(userJoe.getExpiration().millis(), 0));
+
+        // add a new member john1 to both roles and verify expected outcome
+
+        Membership mbrJohn1 = new Membership().setRoleName(roleName1).setMemberName("user.john1");
+        zmsImpl.putMembership(ctx, domainName, roleName1, "user.john1", auditRef, false, null, mbrJohn1);
+        role1Res = zmsImpl.getRole(ctx, domainName, roleName1, false, false, false);
+        RoleMember userJohn1 = ZMSTestUtils.getRoleMember(role1Res, "user.john1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn1.getExpiration().millis(), 30L * 24 * 60 * 60 * 1000));
+
+        mbrJohn1 = new Membership().setRoleName(roleName2).setMemberName("user.john1");
+        zmsImpl.putMembership(ctx, domainName, roleName2, "user.john1", auditRef, false, null, mbrJohn1);
+        role2Res = zmsImpl.getRole(ctx, domainName, roleName2, false, false, false);
+        userJohn1 = ZMSTestUtils.getRoleMember(role2Res, "user.john1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn1.getExpiration().millis(), 45L * 24 * 60 * 60 * 1000));
+
+        // add jane1 to both roles and verify expected outcome
+
+        Membership mbrJane1 = new Membership().setRoleName(roleName1).setMemberName("user.jane1");
+        zmsImpl.putMembership(ctx, domainName, roleName1, "user.jane1", auditRef, false, null, mbrJane1);
+        role1Res = zmsImpl.getRole(ctx, domainName, roleName1, false, false, false);
+        RoleMember userJane1 = ZMSTestUtils.getRoleMember(role1Res, "user.jane1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane1.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        mbrJane1 = new Membership().setRoleName(roleName2).setMemberName("user.jane1");
+        zmsImpl.putMembership(ctx, domainName, roleName2, "user.jane1", auditRef, false, null, mbrJane1);
+        role2Res = zmsImpl.getRole(ctx, domainName, roleName2, false, false, false);
+        userJane1 = ZMSTestUtils.getRoleMember(role2Res, "user.jane1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane1.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        // add joe1 to both roles and verify expected outcome
+
+        try {
+            Membership mbrJoe1 = new Membership().setRoleName(roleName1).setMemberName("user.joe1");
+            zmsImpl.putMembership(ctx, domainName, roleName1, "user.joe1", auditRef, false, null, mbrJoe1);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("User does not have required user authority expiry configured"));
+        }
+
+        try {
+            Membership mbrJoe1 = new Membership().setRoleName(roleName2).setMemberName("user.joe1");
+            zmsImpl.putMembership(ctx, domainName, roleName2, "user.joe1", auditRef, false, null, mbrJoe1);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("User does not have required user authority expiry configured"));
+        }
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+        zmsImpl.dbService.zmsConfig.setUserAuthority(savedAuthority);
+        zmsImpl.userAuthority = savedAuthority;
+    }
+
+    @Test
+    public void testGroupExpiryWithAuthority() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        // add a role with an elevated clearance option
+
+        final String domainName = "group-expiry-with-authority";
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        // create a role with 2 members with no expiry
+
+        List<GroupMember> groupMembers = new ArrayList<>();
+        groupMembers.add(new GroupMember().setMemberName("user.john"));
+        groupMembers.add(new GroupMember().setMemberName("user.jane"));
+        groupMembers.add(new GroupMember().setMemberName("user.joe"));
+
+        final String groupName1 = "expiry-group1";
+        Group group1 = zmsTestInitializer.createGroupObject(domainName, groupName1, groupMembers);
+        zmsImpl.putGroup(ctx, domainName, groupName1, auditRef, false, null, group1);
+
+        final String groupName2 = "expiry-group2";
+        Group group2 = zmsTestInitializer.createGroupObject(domainName, groupName2, groupMembers);
+        zmsImpl.putGroup(ctx, domainName, groupName2, auditRef, false, null, group2);
+
+        Authority savedAuthority = zmsImpl.userAuthority;
+        Authority authority = Mockito.mock(Authority.class);
+        Set<String> attrs = new HashSet<>();
+        attrs.add("elevated-clearance");
+        when(authority.dateAttributesSupported()).thenReturn(attrs);
+        when(authority.isValidUser(any())).thenReturn(true);
+        Timestamp days15 = ZMSTestUtils.addDays(Timestamp.fromCurrentTime(), 15);
+        Timestamp days45 = ZMSTestUtils.addDays(Timestamp.fromCurrentTime(), 45);
+        when(authority.getDateAttribute("user.john", "elevated-clearance")).thenReturn(days45.toDate());
+        when(authority.getDateAttribute("user.jane", "elevated-clearance")).thenReturn(days15.toDate());
+        when(authority.getDateAttribute("user.joe", "elevated-clearance")).thenReturn(null);
+        when(authority.getDateAttribute("user.john1", "elevated-clearance")).thenReturn(days45.toDate());
+        when(authority.getDateAttribute("user.jane1", "elevated-clearance")).thenReturn(days15.toDate());
+        when(authority.getDateAttribute("user.joe1", "elevated-clearance")).thenReturn(null);
+
+        zmsImpl.userAuthority = authority;
+        zmsImpl.dbService.zmsConfig.setUserAuthority(authority);
+
+        // let's set the meta attributes for expiry and authority expiry
+
+        GroupMeta gm1 = new GroupMeta().setMemberExpiryDays(30).setUserAuthorityExpiration("elevated-clearance");
+        zmsImpl.putGroupMeta(ctx, domainName, groupName1, auditRef, null, gm1);
+
+        GroupMeta gm2 = new GroupMeta().setUserAuthorityExpiration("elevated-clearance");
+        zmsImpl.putGroupMeta(ctx, domainName, groupName2, auditRef, null, gm2);
+
+        // now let's retrieve the roles and verify the expiry
+
+        Group group1Res = zmsImpl.getGroup(ctx, domainName, groupName1, false, false);
+        assertNotNull(group1Res);
+
+        // john should have 30 days user expiry since elevated clearance is 45
+        GroupMember userJohn = ZMSTestUtils.getGroupMember(group1Res, "user.john");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn.getExpiration().millis(), 30L * 24 * 60 * 60 * 1000));
+
+        // jane should have 15 days user expiry since elevated clearance is 15
+        GroupMember userJane = ZMSTestUtils.getGroupMember(group1Res, "user.jane");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        // joe has no expiry so it must be expired
+        GroupMember userJoe = ZMSTestUtils.getGroupMember(group1Res, "user.joe");
+        assertTrue(ZMSTestUtils.validateDueDate(userJoe.getExpiration().millis(), 0));
+
+        // role2 is standard user authority expiry
+
+        Group group2Res = zmsImpl.getGroup(ctx, domainName, groupName2, false, false);
+        assertNotNull(group2Res);
+
+        userJohn = ZMSTestUtils.getGroupMember(group2Res, "user.john");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn.getExpiration().millis(), 45L * 24 * 60 * 60 * 1000));
+
+        userJane = ZMSTestUtils.getGroupMember(group2Res, "user.jane");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        userJoe = ZMSTestUtils.getGroupMember(group2Res, "user.joe");
+        assertTrue(ZMSTestUtils.validateDueDate(userJoe.getExpiration().millis(), 0));
+
+        // add a new member john1 to both roles and verify expected outcome
+
+        GroupMembership mbrJohn1 = new GroupMembership().setGroupName(groupName1).setMemberName("user.john1");
+        zmsImpl.putGroupMembership(ctx, domainName, groupName1, "user.john1", auditRef, false, null, mbrJohn1);
+        group1Res = zmsImpl.getGroup(ctx, domainName, groupName1, false, false);
+        GroupMember userJohn1 = ZMSTestUtils.getGroupMember(group1Res, "user.john1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn1.getExpiration().millis(), 30L * 24 * 60 * 60 * 1000));
+
+        mbrJohn1 = new GroupMembership().setGroupName(groupName2).setMemberName("user.john1");
+        zmsImpl.putGroupMembership(ctx, domainName, groupName2, "user.john1", auditRef, false, null, mbrJohn1);
+        group2Res = zmsImpl.getGroup(ctx, domainName, groupName2, false, false);
+        userJohn1 = ZMSTestUtils.getGroupMember(group2Res, "user.john1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJohn1.getExpiration().millis(), 45L * 24 * 60 * 60 * 1000));
+
+        // add jane1 to both roles and verify expected outcome
+
+        GroupMembership mbrJane1 = new GroupMembership().setGroupName(groupName1).setMemberName("user.jane1");
+        zmsImpl.putGroupMembership(ctx, domainName, groupName1, "user.jane1", auditRef, false, null, mbrJane1);
+        group1Res = zmsImpl.getGroup(ctx, domainName, groupName1, false, false);
+        GroupMember userJane1 = ZMSTestUtils.getGroupMember(group1Res, "user.jane1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane1.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        mbrJane1 = new GroupMembership().setGroupName(groupName2).setMemberName("user.jane1");
+        zmsImpl.putGroupMembership(ctx, domainName, groupName2, "user.jane1", auditRef, false, null, mbrJane1);
+        group2Res = zmsImpl.getGroup(ctx, domainName, groupName2, false, false);
+        userJane1 = ZMSTestUtils.getGroupMember(group2Res, "user.jane1");
+        assertTrue(ZMSTestUtils.validateDueDate(userJane1.getExpiration().millis(), 15L * 24 * 60 * 60 * 1000));
+
+        // add joe1 to both roles and verify expected outcome
+
+        try {
+            GroupMembership mbrJoe1 = new GroupMembership().setGroupName(groupName1).setMemberName("user.joe1");
+            zmsImpl.putGroupMembership(ctx, domainName, groupName1, "user.joe1", auditRef, false, null, mbrJoe1);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("User does not have required user authority expiry configured"));
+        }
+
+        try {
+            GroupMembership mbrJoe1 = new GroupMembership().setGroupName(groupName2).setMemberName("user.joe1");
+            zmsImpl.putGroupMembership(ctx, domainName, groupName2, "user.joe1", auditRef, false, null, mbrJoe1);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("User does not have required user authority expiry configured"));
+        }
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+        zmsImpl.dbService.zmsConfig.setUserAuthority(savedAuthority);
+        zmsImpl.userAuthority = savedAuthority;
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
@@ -211,4 +211,28 @@ public class ZMSTestUtils {
         }
         return meta;
     }
+
+    public static RoleMember getRoleMember(Role role, final String memberName) {
+        if (role.getRoleMembers() == null) {
+            return null;
+        }
+        for (RoleMember roleMember : role.getRoleMembers()) {
+            if (roleMember.getMemberName().equals(memberName)) {
+                return roleMember;
+            }
+        }
+        return null;
+    }
+
+    public static GroupMember getGroupMember(Group group, final String memberName) {
+        if (group.getGroupMembers() == null) {
+            return null;
+        }
+        for (GroupMember groupMember : group.getGroupMembers()) {
+            if (groupMember.getMemberName().equals(memberName)) {
+                return groupMember;
+            }
+        }
+        return null;
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -24,6 +24,7 @@ import com.yahoo.athenz.common.server.log.AuditLogger;
 import com.yahoo.athenz.common.server.log.AuditLoggerFactory;
 import com.yahoo.athenz.common.server.log.impl.DefaultAuditLoggerFactory;
 import com.yahoo.athenz.zms.*;
+import com.yahoo.rdl.Timestamp;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -407,5 +408,20 @@ public class ZMSUtilsTest {
 
         l = emptyIfNull(Collections.singletonList("s"));
         assertEquals(l.size(), 1);
+    }
+
+    @Test
+    public void testSmallestExpiry() {
+
+        Timestamp currentExpiry = Timestamp.fromCurrentTime();
+        assertEquals(ZMSUtils.smallestExpiry(null, null), null);
+        assertEquals(ZMSUtils.smallestExpiry(currentExpiry, null), currentExpiry);
+        assertEquals(ZMSUtils.smallestExpiry(null, currentExpiry), currentExpiry);
+
+        Timestamp expiry1 = Timestamp.fromMillis(System.currentTimeMillis() + 1000);
+        Timestamp expiry2 = Timestamp.fromMillis(System.currentTimeMillis() - 1000);
+
+        assertEquals(ZMSUtils.smallestExpiry(expiry1, expiry2), expiry2);
+        assertEquals(ZMSUtils.smallestExpiry(expiry2, expiry1), expiry2);
     }
 }


### PR DESCRIPTION
# Description

Currently the server treats user authority expiry and role/group level expiry as mutually exclusive which is not what teams want. 

For example, the authority has elevated clearance good for 1 year, but the role/group limit requires the membership to be reviewed every 90 days.

This is now fixed that that the server supports both expiry options set on a role/group and picks the lowest value when determining the expiry.
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

