### PR TITLE
remove dependency on jetty from client libraries

### DIFF
--- a/libs/java/client_common/pom.xml
+++ b/libs/java/client_common/pom.xml
@@ -64,12 +64,6 @@
       <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
-      <scope>test</scope>
-    </dependency>    
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${commons.codec.version}</version>

--- a/libs/java/client_common/src/main/java/com/yahoo/athenz/common/utils/SSLUtils.java
+++ b/libs/java/client_common/src/main/java/com/yahoo/athenz/common/utils/SSLUtils.java
@@ -166,7 +166,7 @@ public class SSLUtils {
             return keystore;
         }
         
-        private static KeyManager[] getAliasedKeyManagers(KeyManager[] managers, String alias) {
+        static KeyManager[] getAliasedKeyManagers(KeyManager[] managers, String alias) {
             if (managers != null) {
                 if (alias != null) {
                     for (int idx = 0; idx < managers.length; idx++) {


### PR DESCRIPTION
# Description

when we move to jetty 12.x we need to build using jdk17.x but we still want to release our client libraries with jdk 11.x
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

