### PR TITLE
Enable SSH Host certificate for AWS EC2 instances

### DIFF
--- a/provider/gcp/sia-gce/cmd/siad/main.go
+++ b/provider/gcp/sia-gce/cmd/siad/main.go
@@ -152,7 +152,16 @@ func main() {
 	// Better defaults
 	opts.RotateKey = true
 	opts.GenerateRoleKey = true
-	opts.SshHostKeyType = hostkey.Ecdsa
+
+	if config != nil && config.Ssh != nil {
+		opts.Ssh = *config.Ssh
+	}
+
+	hostKeyType := hostkey.Ecdsa
+	if config != nil && config.SshHostKeyType != 0 {
+		hostKeyType = config.SshHostKeyType
+	}
+	opts.SshHostKeyType = hostKeyType
 	opts.SshCertFile = hostkey.CertFile(sshDir, opts.SshHostKeyType)
 	opts.SshPubKeyFile = hostkey.PubKeyFile(sshDir, opts.SshHostKeyType)
 


### PR DESCRIPTION
Use same SSH Host certificate default values in GCP and AWS, and support disable SSH host certificate requests from config.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**
