### PR TITLE
implement domain group members api

### DIFF
--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -1960,6 +1960,17 @@ func init() {
 	mPutResourceGroupOwnership.Exception("UNAUTHORIZED", "ResourceError", "")
 	sb.AddResource(mPutResourceGroupOwnership.Build())
 
+	mGetDomainGroupMembers := rdl.NewResourceBuilder("DomainGroupMembers", "GET", "/domain/{domainName}/group/member")
+	mGetDomainGroupMembers.Comment("Get list of principals defined in groups in the given domain")
+	mGetDomainGroupMembers.Input("domainName", "DomainName", true, "", "", false, nil, "name of the domain")
+	mGetDomainGroupMembers.Auth("", "", true, "")
+	mGetDomainGroupMembers.Exception("BAD_REQUEST", "ResourceError", "")
+	mGetDomainGroupMembers.Exception("FORBIDDEN", "ResourceError", "")
+	mGetDomainGroupMembers.Exception("NOT_FOUND", "ResourceError", "")
+	mGetDomainGroupMembers.Exception("TOO_MANY_REQUESTS", "ResourceError", "")
+	mGetDomainGroupMembers.Exception("UNAUTHORIZED", "ResourceError", "")
+	sb.AddResource(mGetDomainGroupMembers.Build())
+
 	mGetPolicyList := rdl.NewResourceBuilder("PolicyList", "GET", "/domain/{domainName}/policy")
 	mGetPolicyList.Comment("List policies provisioned in this namespace.")
 	mGetPolicyList.Input("domainName", "DomainName", true, "", "", false, nil, "name of the domain")

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
@@ -3760,6 +3760,25 @@ public class ZMSClient implements Closeable {
     }
 
     /**
+     * Retrieve the list of all members provisioned for a domain
+     * in groups
+     *
+     * @param domainName name of the domain
+     * @return DomainGroupMembers object that includes the list of members with their groups
+     * @throws ZMSClientException in case of failure
+     */
+    public DomainGroupMembers getDomainGroupMembers(String domainName) {
+        updatePrincipal();
+        try {
+            return client.getDomainGroupMembers(domainName);
+        } catch (ResourceException ex) {
+            throw new ZMSClientException(ex.getCode(), ex.getData());
+        } catch (Exception ex) {
+            throw new ZMSClientException(ResourceException.BAD_REQUEST, ex.getMessage());
+        }
+    }
+
+    /**
      * Fetch all the groups across domains by either calling or specified principal
      * @param principal - Requested principal. If null will return groups for the user making the call
      * @param domainName - Requested domain. If null will return groups from all domains

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
@@ -2105,6 +2105,34 @@ public class ZMSRDLGeneratedClient {
         }
     }
 
+    public DomainGroupMembers getDomainGroupMembers(String domainName) throws URISyntaxException, IOException {
+        UriTemplateBuilder uriTemplateBuilder = new UriTemplateBuilder(baseUrl, "/domain/{domainName}/group/member")
+            .resolveTemplate("domainName", domainName);
+        URIBuilder uriBuilder = new URIBuilder(uriTemplateBuilder.getUri());
+        HttpUriRequest httpUriRequest = RequestBuilder.get()
+            .setUri(uriBuilder.build())
+            .build();
+        if (credsHeader != null) {
+            httpUriRequest.addHeader(credsHeader, credsToken);
+        }
+        HttpEntity httpResponseEntity = null;
+        try (CloseableHttpResponse httpResponse = client.execute(httpUriRequest, httpContext)) {
+            int code = httpResponse.getStatusLine().getStatusCode();
+            httpResponseEntity = httpResponse.getEntity();
+            switch (code) {
+            case 200:
+                return jsonMapper.readValue(httpResponseEntity.getContent(), DomainGroupMembers.class);
+            default:
+                final String errorData = (httpResponseEntity == null) ? null : EntityUtils.toString(httpResponseEntity);
+                throw (errorData != null && !errorData.isEmpty())
+                    ? new ResourceException(code, jsonMapper.readValue(errorData, ResourceError.class))
+                    : new ResourceException(code);
+            }
+        } finally {
+            EntityUtils.consumeQuietly(httpResponseEntity);
+        }
+    }
+
     public PolicyList getPolicyList(String domainName, Integer limit, String skip) throws URISyntaxException, IOException {
         UriTemplateBuilder uriTemplateBuilder = new UriTemplateBuilder(baseUrl, "/domain/{domainName}/policy")
             .resolveTemplate("domainName", domainName);

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -2069,6 +2069,22 @@ public class ZMSSchema {
             .exception("UNAUTHORIZED", "ResourceError", "")
 ;
 
+        sb.resource("DomainGroupMembers", "GET", "/domain/{domainName}/group/member")
+            .comment("Get list of principals defined in groups in the given domain")
+            .pathParam("domainName", "DomainName", "name of the domain")
+            .auth("", "", true)
+            .expected("OK")
+            .exception("BAD_REQUEST", "ResourceError", "")
+
+            .exception("FORBIDDEN", "ResourceError", "")
+
+            .exception("NOT_FOUND", "ResourceError", "")
+
+            .exception("TOO_MANY_REQUESTS", "ResourceError", "")
+
+            .exception("UNAUTHORIZED", "ResourceError", "")
+;
+
         sb.resource("PolicyList", "GET", "/domain/{domainName}/policy")
             .comment("List policies provisioned in this namespace.")
             .pathParam("domainName", "DomainName", "name of the domain")

--- a/core/zms/src/main/rdl/Group.rdli
+++ b/core/zms/src/main/rdl/Group.rdli
@@ -295,3 +295,16 @@ resource ResourceGroupOwnership PUT "/domain/{domainName}/group/{groupName}/owne
         ResourceError TOO_MANY_REQUESTS;
     }
 }
+
+//Get list of principals defined in groups in the given domain
+resource DomainGroupMembers GET "/domain/{domainName}/group/member" {
+    DomainName domainName; //name of the domain
+    authenticate;
+    exceptions {
+        ResourceError BAD_REQUEST;
+        ResourceError NOT_FOUND;
+        ResourceError FORBIDDEN;
+        ResourceError UNAUTHORIZED;
+        ResourceError TOO_MANY_REQUESTS;
+    }
+}

--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -644,6 +644,10 @@ func (cli Zms) EvalCommand(params []string) (*string, error) {
 			if argc == 0 {
 				return cli.ListDomainRoleMembers(dn)
 			}
+		case "list-domain-group-members":
+			if argc == 0 {
+				return cli.ListDomainGroupMembers(dn)
+			}
 		case "list-group", "list-groups":
 			return cli.ListGroups(dn)
 		case "show-group":
@@ -2253,6 +2257,15 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   role   : name of the role to be deleted\n")
 		buf.WriteString(" examples:\n")
 		buf.WriteString("   " + domainExample + " delete-role readers\n")
+	case "list-domain-group-members":
+		buf.WriteString(" syntax:\n")
+		buf.WriteString("   " + domainParam + " list-domain-group-members\n")
+		buf.WriteString(" parameters:\n")
+		if !interactive {
+			buf.WriteString("   domain            : name of the domain\n")
+		}
+		buf.WriteString(" examples:\n")
+		buf.WriteString("   " + domainExample + " list-domain-group-members\n")
 	case "list-group":
 		buf.WriteString(" syntax:\n")
 		buf.WriteString("   " + domainParam + " list-group\n")

--- a/libs/go/zmscli/group.go
+++ b/libs/go/zmscli/group.go
@@ -699,3 +699,20 @@ func (cli Zms) SetGroupPrincipalDomainFilter(dn, gn, domainFilter string) (*stri
 
 	return cli.dumpByFormat(message, cli.buildYAMLOutput)
 }
+
+func (cli Zms) ListDomainGroupMembers(dn string) (*string, error) {
+	groupMembers, err := cli.Zms.GetDomainGroupMembers(zms.DomainName(dn))
+	if err != nil {
+		return nil, err
+	}
+
+	oldYamlConverter := func(res interface{}) (*string, error) {
+		var buf bytes.Buffer
+		buf.WriteString("group members:\n")
+		cli.dumpDomainGroupMembers(&buf, groupMembers, false)
+		s := buf.String()
+		return &s, nil
+	}
+
+	return cli.dumpByFormat(groupMembers, oldYamlConverter)
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -3503,6 +3503,12 @@ public class DBService implements RolesProvider, DomainProvider {
         }
     }
 
+    DomainGroupMembers listDomainGroupMembers(String domainName) {
+        try (ObjectStoreConnection con = store.getConnection(true, false)) {
+            return con.listDomainGroupMembers(domainName);
+        }
+    }
+
     DomainRoleMember getPrincipalRoles(String principal, String domainName, Boolean expand) {
 
         DomainRoleMember principalRoles;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
@@ -69,6 +69,7 @@ public interface ZMSHandler {
     Response putGroupReview(ResourceContext context, String domainName, String groupName, String auditRef, Boolean returnObj, String resourceOwner, Group group);
     DomainGroupMembership getPendingDomainGroupMembersList(ResourceContext context, String principal, String domainName);
     void putResourceGroupOwnership(ResourceContext context, String domainName, String groupName, String auditRef, ResourceGroupOwnership resourceOwnership);
+    DomainGroupMembers getDomainGroupMembers(ResourceContext context, String domainName);
     PolicyList getPolicyList(ResourceContext context, String domainName, Integer limit, String skip);
     Policies getPolicies(ResourceContext context, String domainName, Boolean assertions, Boolean includeNonActive, String tagKey, String tagValue);
     Policy getPolicy(ResourceContext context, String domainName, String policyName);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -3902,6 +3902,25 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     }
 
     @Override
+    public DomainGroupMembers getDomainGroupMembers(ResourceContext ctx, String domainName) {
+
+        final String caller = ctx.getApiName();
+        logPrincipal(ctx);
+
+        validateRequest(ctx.request(), caller);
+        validate(domainName, TYPE_DOMAIN_NAME, caller);
+
+        // for consistent handling of all requests, we're going to convert
+        // all incoming object values into lower case (e.g. domain, role,
+        // policy, service, etc name)
+
+        domainName = domainName.toLowerCase();
+        setRequestDomain(ctx, domainName);
+
+        return dbService.listDomainGroupMembers(domainName);
+    }
+
+    @Override
     public DomainRoleMember getPrincipalRoles(ResourceContext context, String principal, String domainName, Boolean expand) {
         final String caller = context.getApiName();
         logPrincipal(context);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -2167,6 +2167,40 @@ public class ZMSResources {
     }
 
     @GET
+    @Path("/domain/{domainName}/group/member")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Get list of principals defined in groups in the given domain")
+    public DomainGroupMembers getDomainGroupMembers(
+        @Parameter(description = "name of the domain", required = true) @PathParam("domainName") String domainName) {
+        int code = ResourceException.OK;
+        ResourceContext context = null;
+        try {
+            context = this.delegate.newResourceContext(this.servletContext, this.request, this.response, "getDomainGroupMembers");
+            context.authenticate();
+            return this.delegate.getDomainGroupMembers(context, domainName);
+        } catch (ResourceException e) {
+            code = e.getCode();
+            switch (code) {
+            case ResourceException.BAD_REQUEST:
+                throw typedException(code, e, ResourceError.class);
+            case ResourceException.FORBIDDEN:
+                throw typedException(code, e, ResourceError.class);
+            case ResourceException.NOT_FOUND:
+                throw typedException(code, e, ResourceError.class);
+            case ResourceException.TOO_MANY_REQUESTS:
+                throw typedException(code, e, ResourceError.class);
+            case ResourceException.UNAUTHORIZED:
+                throw typedException(code, e, ResourceError.class);
+            default:
+                System.err.println("*** Warning: undeclared exception (" + code + ") for resource getDomainGroupMembers");
+                throw typedException(code, e, ResourceError.class);
+            }
+        } finally {
+            this.delegate.recordMetrics(context, code);
+        }
+    }
+
+    @GET
     @Path("/domain/{domainName}/policy")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "List policies provisioned in this namespace.")

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/ObjectStoreConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/ObjectStoreConnection.java
@@ -127,6 +127,7 @@ public interface ObjectStoreConnection extends Closeable {
     boolean deletePendingGroupMember(String domainName, String groupName, String member, String principal, String auditRef);
     boolean confirmGroupMember(String domainName, String groupName, GroupMember groupMember, String principal, String auditRef);
 
+    DomainGroupMembers listDomainGroupMembers(String domainName);
     DomainGroupMember getPrincipalGroups(String principal, String domainName);
     List<PrincipalGroup> listGroupsWithUserAuthorityRestrictions();
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalGroupTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalGroupTest.java
@@ -15,11 +15,36 @@
  */
 package com.yahoo.athenz.zms;
 
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class PrincipalGroupTest {
+
+    private final ZMSTestInitializer zmsTestInitializer = new ZMSTestInitializer();
+
+    @BeforeClass
+    public void startMemoryMySQL() {
+        zmsTestInitializer.startMemoryMySQL();
+    }
+
+    @AfterClass
+    public void stopMemoryMySQL() {
+        zmsTestInitializer.stopMemoryMySQL();
+    }
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        zmsTestInitializer.setUp();
+    }
 
     @Test
     public void testPrincipalGroup() {
@@ -31,5 +56,47 @@ public class PrincipalGroupTest {
         assertEquals("role", prGroup.getGroupName());
         assertEquals("domain", prGroup.getDomainName());
         assertEquals("authority", prGroup.getDomainUserAuthorityFilter());
+    }
+
+    @Test
+    public void testListDomainGroupMembers() {
+
+        String domainName = "listdomaingroupmembers";
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        Group group1 = zmsTestInitializer.createGroupObject(domainName, "group1", "user.jack", "user.janie");
+        zmsImpl.putGroup(ctx, domainName, "group1", auditRef, false, null, group1);
+
+        Group group2 = zmsTestInitializer.createGroupObject(domainName, "group2", "user.janie", "user.jane");
+        zmsImpl.putGroup(ctx, domainName, "group2", auditRef, false, null, group2);
+
+        Group group3 = zmsTestInitializer.createGroupObject(domainName, "group3", "user.jack", "user.jane");
+        zmsImpl.putGroup(ctx, domainName, "group3", auditRef, false, null, group3);
+
+        Group group4 = zmsTestInitializer.createGroupObject(domainName, "group4", "user.jack", null);
+        zmsImpl.putGroup(ctx, domainName, "group4", auditRef, false, null, group4);
+
+        Group group5 = zmsTestInitializer.createGroupObject(domainName, "group5", "user.jack-service", "user.jane");
+        zmsImpl.putGroup(ctx, domainName, "group5", auditRef, false, null, group5);
+
+        DomainGroupMembers domainGroupMembers = zmsImpl.getDomainGroupMembers(ctx, domainName);
+        assertEquals(domainName, domainGroupMembers.getDomainName());
+
+        List<DomainGroupMember> members = domainGroupMembers.getMembers();
+        assertNotNull(members);
+        assertEquals(4, members.size());
+        ZMSTestUtils.verifyDomainGroupMember(members, "user.jack", "role1", "role3", "role4");
+        ZMSTestUtils.verifyDomainGroupMember(members, "user.janie", "role1", "role2");
+        ZMSTestUtils.verifyDomainGroupMember(members, "user.jane", "role2", "role3", "role5");
+        ZMSTestUtils.verifyDomainGroupMember(members, "user.jack-service", "role5");
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -19575,6 +19575,20 @@ public class ZMSImplTest {
     }
 
     @Test
+    public void testGetDomainGroupMembersInvalidDomain() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+
+        try {
+            zmsImpl.getDomainGroupMembers(ctx, "invalid-domain");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(404, ex.getCode());
+        }
+    }
+
+    @Test
     public void testPutQuota() {
 
         String domainName = "putquota";

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestUtils.java
@@ -235,4 +235,58 @@ public class ZMSTestUtils {
         }
         return null;
     }
+
+    public static boolean verifyDomainGroupMember(DomainGroupMember domainGroupMember, GroupMember groupMember) {
+        for (GroupMember grpMember : domainGroupMember.getMemberGroups()) {
+            if (grpMember.equals(groupMember)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean verifyDomainGroupMember(List<DomainGroupMember> members, String memberName,
+            String... groups) {
+
+        for (DomainGroupMember member : members) {
+            if (member.getMemberName().equals(memberName)) {
+                List<GroupMember> memberGroups = member.getMemberGroups();
+                if (memberGroups.size() != groups.length) {
+                    return false;
+                }
+                for (String group : groups) {
+                    boolean bMatchFound = false;
+                    for (GroupMember memberGroup : memberGroups) {
+                        if (memberGroup.getGroupName().equals(group)) {
+                            bMatchFound = true;
+                            break;
+                        }
+                    }
+                    if (!bMatchFound) {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean verifyDomainGroupMemberTimestamp(List<DomainGroupMember> members,
+            final String memberName, final String groupName, Timestamp timestamp) {
+
+        for (DomainGroupMember member : members) {
+            if (member.getMemberName().equals(memberName)) {
+                for (GroupMember groupMember : member.getMemberGroups()) {
+                    if (groupMember.getGroupName().equals(groupName)) {
+                        return groupMember.getExpiration().equals(timestamp);
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
# Description

we already had getDomainRoleMembers api so implemented similar API for Groups - it returns the all the members defined in the domain in all the groups

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

