### PR TITLE
fix not able to update POC in domain

### DIFF
--- a/ui/src/components/header/DomainDetails.js
+++ b/ui/src/components/header/DomainDetails.js
@@ -491,6 +491,7 @@ class DomainDetails extends React.Component {
                 onPocUpdateSuccessCb={this.onPocUpdateSuccessCb.bind(this)}
                 csrf={this.props._csrf}
                 contacts={this.props.domainDetails.contacts || {}}
+                api={this.api}
             />
         ) : (
             ''


### PR DESCRIPTION
# Description
Due to missing api, the putMeta call to set the POC/SecurityPOC isn't working


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

