### PR TITLE
Omit specifying trust store or CA cert when generating KeyRefresher

### DIFF
--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
@@ -125,7 +125,8 @@ public class KeyRefresher {
             // run loop contents here
             while (!shutdown) {
                 try {
-                    if (haveFilesBeenChanged(trustStore.getFilePath(), lastTrustManagerChecksum)) {
+                    if (trustStore != null && trustManagerProxy != null
+                            && haveFilesBeenChanged(trustStore.getFilePath(), lastTrustManagerChecksum)) {
                         trustManagerProxy.setTrustManager(trustStore.getTrustManagers());
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug("KeyRefresher detected changes. Reloaded Trust Managers");

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
@@ -244,8 +244,10 @@ public class Utils {
                                                     final char[] trustStorePassword, final String athenzPublicCert,
                                                     final String athenzPrivateKey, final KeyRefresherListener keyRefresherListener)
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
-        TrustStore trustStore = new TrustStore(trustStorePath,
-                new JavaKeyStoreProvider(trustStorePath, trustStorePassword));
+        TrustStore trustStore = null;
+        if (trustStorePath != null && !trustStorePath.isEmpty()) {
+            trustStore = new TrustStore(trustStorePath, new JavaKeyStoreProvider(trustStorePath, trustStorePassword));
+        }
         return getKeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore, keyRefresherListener);
     }
 
@@ -269,7 +271,10 @@ public class Utils {
     public static KeyRefresher generateKeyRefresherFromCaCert(final String caCertPath,
             final String athenzPublicCert, final String athenzPrivateKey)
             throws IOException, InterruptedException, KeyRefresherException {
-        TrustStore trustStore = new TrustStore(caCertPath, new CaCertKeyStoreProvider(caCertPath));
+        TrustStore trustStore = null;
+        if (caCertPath != null && !caCertPath.isEmpty()) {
+            trustStore = new TrustStore(caCertPath, new CaCertKeyStoreProvider(caCertPath));
+        }
         return getKeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore);
     }
 
@@ -284,7 +289,10 @@ public class Utils {
         KeyRefresher keyRefresher;
         KeyManagerProxy keyManagerProxy =
                 new KeyManagerProxy(getKeyManagers(athenzPublicCert, athenzPrivateKey));
-        TrustManagerProxy trustManagerProxy = new TrustManagerProxy(trustStore.getTrustManagers());
+        TrustManagerProxy trustManagerProxy = null;
+        if (trustStore != null) {
+            trustManagerProxy = new TrustManagerProxy(trustStore.getTrustManagers());
+        }
         try {
             keyRefresher = new KeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore,
                     keyManagerProxy, trustManagerProxy, keyRefresherListener);

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyRefresherTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyRefresherTest.java
@@ -170,6 +170,13 @@ public class KeyRefresherTest {
                 "unit_test_gdpr.aws.core.key.pem");
         assertNotNull(keyRefresher);
 
+        keyRefresher = Utils.generateKeyRefresher(null, "gdpr.aws.core.cert.pem", "unit_test_gdpr.aws.core.key.pem");
+        assertNotNull(keyRefresher);
+
+        keyRefresher = Utils.generateKeyRefresherFromCaCert(null, "gdpr.aws.core.cert.pem",
+                "unit_test_gdpr.aws.core.key.pem");
+        assertNotNull(keyRefresher);
+
         final String caCertPath = Objects.requireNonNull(classLoader.getResource("ca.cert.pem")).getFile();
         keyRefresher = Utils.generateKeyRefresherFromCaCert(caCertPath, "gdpr.aws.core.cert.pem",
                 "unit_test_gdpr.aws.core.key.pem");


### PR DESCRIPTION
# Description

We create and use an instance of `KeyRefresher` in the following way:
```java
KeyRefresher keyRefresher = Utils.generateKeyRefresherFromCaCert(caCert, publicCert, privateKey);
keyRefresher.startup();
SSLContext sslContext = Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(), keyRefresher.getTrustManagerProxy());
ZTSClient ztsClient = new ZTSClient(ztsUrl, sslContext);
```
The certificate used by our ZTS server is trusted by default, so it would be nice to be able to omit specifying the CA certificate. However, even if the first argument of `Utils.generateKeyRefresherFromCaCert` is null, `NullPointerException` is thrown.
```
Exception in thread "main" java.lang.NullPointerException
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:149)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:112)
        at com.oath.auth.CaCertKeyStoreProvider.provide(CaCertKeyStoreProvider.java:37)
        at com.oath.auth.TrustStore.getTrustManagers(TrustStore.java:40)
        at com.oath.auth.Utils.getKeyRefresher(Utils.java:252)
        at com.oath.auth.Utils.getKeyRefresher(Utils.java:243)
        at com.oath.auth.Utils.generateKeyRefresherFromCaCert(Utils.java:238)
        at Sample.main(Sample.java:16)
```
So I made it possible to pass null as the CA certificate path when generating `KeyRefresher`. Note that the second argument of `Utils.buildSSLContext` is allowed to be null.
https://github.com/AthenZ/athenz/blob/c9dda08fef00fc9eef85dbaa9ca86815ab9a1611/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java#L315

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

