### PR TITLE
update ZTS to honor domain's x509/ssh signer key ids

### DIFF
--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9476</code.coverage.min>
+    <code.coverage.min>0.9482</code.coverage.min>
     <commons.dbcp2.version>2.12.0</commons.dbcp2.version>
     <commons.pool2.version>2.12.0</commons.pool2.version>
     <jakarta.mail.version>2.1.3</jakarta.mail.version>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertSigner.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertSigner.java
@@ -66,9 +66,30 @@ public interface CertSigner {
      * @param priority requested priority for processing the request signing service
      * @return X509 Certificate in PEM format
      */
+    @Deprecated
     default String generateX509Certificate(String provider, String certIssuer, String csr,
                                            String keyUsage, int expiryTime, Priority priority) {
         return generateX509Certificate(csr, keyUsage, expiryTime);
+    }
+
+    /**
+     * Generate a signed X509 Certificate based on the given request. The
+     * signer imposes how long the certificate is valid for. The result
+     * must be the certificate in PEM format.
+     * @param provider (optional) Athenz provider that validated certificate request
+     * @param certIssuer (optional) Request to have cert signed by given issuer
+     * @param csr Certificate request
+     * @param keyUsage Requested key usage (null for both server and client,
+     * otherwise specified usage type: server or client)
+     * @param expiryTime Requested certificate expiration time in minutes.
+     * CertSigner might override this value with a smaller value.
+     * @param priority requested priority for processing the request signing service
+     * @param signerKeyId requested signer key id if configured for the domain
+     * @return X509 Certificate in PEM format
+     */
+    default String generateX509Certificate(String provider, String certIssuer, String csr,
+            String keyUsage, int expiryTime, Priority priority, String signerKeyId) {
+        return generateX509Certificate(provider, certIssuer, csr, keyUsage, expiryTime, priority);
     }
 
     /**
@@ -88,8 +109,21 @@ public interface CertSigner {
      * @param provider (optional) CA certificate for given Athenz provider
      * @return the CA Certificate in PEM format
      */
+    @Deprecated
     default String getCACertificate(String provider) {
         return getCACertificate();
+    }
+
+    /**
+     * Retrieve the CA certificate in PEM format. This will be returned
+     * along with the x509 certificate back to the client. The function
+     * should return all the CAs defined for the provider
+     * @param provider (optional) CA certificate for given Athenz provider
+     * @param signerKeyId requested signer key id if configured for the domain
+     * @return the CA Certificate in PEM format
+     */
+    default String getCACertificate(String provider, String signerKeyId) {
+        return getCACertificate(provider);
     }
 
     /** Retrieve the certificate max expiry time supported

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/ssh/SSHSigner.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/ssh/SSHSigner.java
@@ -34,9 +34,28 @@ public interface SSHSigner {
      * @return SSH Certificates. Any error conditions are handled
      * by throwing com.yahoo.athenz.common.rest.ResourceExceptions
      */
+    @Deprecated
     default SSHCertificates generateCertificate(Principal principal, SSHCertRequest certRequest,
             SSHCertRecord certRecord, final String certType) {
         return null;
+    }
+
+    /**
+     * Generate an SSH Certificate based on the given request
+     * for a given principal
+     * @param principal Principal requesting the ssh certificates
+     * @param certRequest SSH Certificate Request
+     * @param certRecord SSH Host Certificate Record if server had one
+     * @param certType requested certificate type: user or host or null. If null,
+     *                 no verification is necessary otherwise the implementation
+     *                 must verify that the certRequest matches the requested type.
+     * @param signerKeyId requested signer key id if configured for the domain
+     * @return SSH Certificates. Any error conditions are handled
+     * by throwing com.yahoo.athenz.common.rest.ResourceExceptions
+     */
+    default SSHCertificates generateCertificate(Principal principal, SSHCertRequest certRequest,
+            SSHCertRecord certRecord, String certType, String signerKeyId) {
+        return generateCertificate(principal, certRequest, certRecord, certType);
     }
 
     /**
@@ -45,8 +64,20 @@ public interface SSHSigner {
      * @return SSH Signer Certificate. Any error conditions are handled
      * by throwing com.yahoo.athenz.common.rest.ResourceExceptions
      */
+    @Deprecated
     default String getSignerCertificate(String certType) {
         return null;
+    }
+
+    /**
+     * Retrieve the SSH Signer certificate for the given type
+     * @param certType signer type: user or host
+     * @param signerKeyId requested signer key id if configured for the domain
+     * @return SSH Signer Certificate. Any error conditions are handled
+     * by throwing com.yahoo.athenz.common.rest.ResourceExceptions
+     */
+    default String getSignerCertificate(String certType, String signerKeyId) {
+        return getSignerCertificate(certType);
     }
 
     /**

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/CertSignerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/CertSignerTest.java
@@ -41,9 +41,13 @@ public class CertSignerTest {
 
         assertNull(signer.generateX509Certificate("csr", "client", 60));
         assertNull(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 60));
-        assertNull(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 60, Priority.Unspecified_priority));
+        assertNull(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 60,
+                Priority.Unspecified_priority));
+        assertNull(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 60,
+                Priority.Unspecified_priority, "keyid"));
         assertNull(signer.getCACertificate());
         assertNull(signer.getCACertificate("aws"));
+        assertNull(signer.getCACertificate("aws", "keyid"));
         assertEquals(signer.getMaxCertExpiryTimeMins(), 0);
         signer.close();
     }
@@ -54,9 +58,13 @@ public class CertSignerTest {
         CertSigner signer = Mockito.mock(CertSigner.class);
         Mockito.when(signer.generateX509Certificate("csr", "client", 100)).thenReturn("cert");
         Mockito.when(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 100)).thenReturn("cert1");
-        Mockito.when(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 100, Priority.High)).thenReturn("cert2");
+        Mockito.when(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 100, Priority.High))
+                .thenReturn("cert2");
+        Mockito.when(signer.generateX509Certificate("aws", "us-west-2", "csr", "client", 100, Priority.High, "keyid"))
+                .thenReturn("cert2-keyid");
         Mockito.when(signer.getCACertificate()).thenReturn("ca-cert");
         Mockito.when(signer.getCACertificate("aws")).thenReturn("ca-cert1");
+        Mockito.when(signer.getCACertificate("aws", "keyid")).thenReturn("ca-cert1-keyid");
         Mockito.when(signer.getMaxCertExpiryTimeMins()).thenReturn(60);
 
         CertSignerFactory factory = () -> signer;
@@ -65,11 +73,23 @@ public class CertSignerTest {
         assertNotNull(testSigner);
         assertEquals("cert", testSigner.generateX509Certificate("csr", "client", 100));
         assertEquals("cert1", testSigner.generateX509Certificate("aws", "us-west-2", "csr", "client", 100));
-        assertEquals("cert2", testSigner.generateX509Certificate("aws", "us-west-2", "csr", "client", 100, Priority.High));
+        assertEquals("cert2", testSigner.generateX509Certificate("aws", "us-west-2", "csr", "client", 100,
+                Priority.High));
+        assertEquals("cert2-keyid", testSigner.generateX509Certificate("aws", "us-west-2", "csr", "client", 100,
+                Priority.High, "keyid"));
         assertEquals("ca-cert", testSigner.getCACertificate());
         assertEquals("ca-cert1", testSigner.getCACertificate("aws"));
+        assertEquals("ca-cert1-keyid", testSigner.getCACertificate("aws", "keyid"));
         assertEquals(60, testSigner.getMaxCertExpiryTimeMins());
 
         testSigner.close();
+    }
+
+    @Test
+    public void testPriority() {
+        assertEquals(Priority.Unspecified_priority.getPriorityValue(), 0);
+        assertEquals(Priority.High.getPriorityValue(), 5);
+        assertEquals(Priority.Medium.getPriorityValue(), 10);
+        assertEquals(Priority.Low.getPriorityValue(), 15);
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHSignerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHSignerTest.java
@@ -42,7 +42,9 @@ public class SSHSignerTest {
         };
 
         assertNull(signer.generateCertificate(null, null, null, "client"));
+        assertNull(signer.generateCertificate(null, null, null, "client", "keyid"));
         assertNull(signer.getSignerCertificate("host"));
+        assertNull(signer.getSignerCertificate("host", "keyid"));
         signer.setAuthorizer(null);
         signer.close();
     }
@@ -54,8 +56,10 @@ public class SSHSignerTest {
         SSHCertRequest certRequest = new SSHCertRequest();
         Principal principal = Mockito.mock(Principal.class);
         SSHCertificates certs = new SSHCertificates();
+        Mockito.when(signer.generateCertificate(principal, certRequest, null, "user", "keyid")).thenReturn(certs);
         Mockito.when(signer.generateCertificate(principal, certRequest, null, "user")).thenReturn(certs);
         Mockito.when(signer.getSignerCertificate("user")).thenReturn("ssh-cert");
+        Mockito.when(signer.getSignerCertificate("user", "keyid")).thenReturn("ssh-cert-keyid");
 
         SSHSignerFactory factory = () -> signer;
 
@@ -63,7 +67,9 @@ public class SSHSignerTest {
         assertNotNull(testSigner);
 
         assertEquals(certs, testSigner.generateCertificate(principal, certRequest, null, "user"));
+        assertEquals(certs, testSigner.generateCertificate(principal, certRequest, null, "user", "keyid"));
         assertEquals("ssh-cert", testSigner.getSignerCertificate("user"));
+        assertEquals("ssh-cert-keyid", testSigner.getSignerCertificate("user", "keyid"));
         testSigner.close();
     }
 }

--- a/servers/zts/pom.xml
+++ b/servers/zts/pom.xml
@@ -29,7 +29,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <code.coverage.min>0.9957</code.coverage.min>
+    <code.coverage.min>0.9958</code.coverage.min>
   </properties>
 
   <dependencyManagement>

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/KeyStoreCertSigner.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/KeyStoreCertSigner.java
@@ -43,17 +43,27 @@ public class KeyStoreCertSigner implements CertSigner, AutoCloseable {
     @Override
     public String generateX509Certificate(String provider, String certIssuer, String csr, String keyUsage,
             int certExpiryMins, Priority priority) {
+        return generateX509Certificate(provider, certIssuer, csr, keyUsage, certExpiryMins, priority, null);
+    }
+
+    @Override
+    public String generateX509Certificate(String provider, String certIssuer, String csr, String keyUsage,
+            int certExpiryMins, Priority priority, String signerKeyId) {
 
         int certExpiryTime = (certExpiryMins == 0) ? this.maxCertExpiryTimeMins : certExpiryMins;
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
-        X509Certificate cert = Crypto.generateX509Certificate(certReq, caPrivateKey, caCertificate, certExpiryTime, false);
-
-        return Crypto.convertToPEMFormat(cert);
+        return Crypto.convertToPEMFormat(Crypto.generateX509Certificate(certReq, caPrivateKey,
+                caCertificate, certExpiryTime, false));
     }
 
     @Override
     public String getCACertificate(String provider) {
+        return getCACertificate(provider, null);
+    }
+
+    @Override
+    public String getCACertificate(String provider, String signerKeyId) {
         return Crypto.convertToPEMFormat(caCertificate);
     }
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -287,13 +287,13 @@ public class ZTSUtils {
     
     public static Identity generateIdentity(InstanceCertManager certManager, final String provider,
             final String certIssuer, final String csr, final String cn, final String certUsage,
-            int expiryTime) {
+            int expiryTime, final String signerKeyId) {
         
         // generate a certificate for this certificate request
 
         String pemCert = certManager.generateX509Certificate(provider, certIssuer, csr, certUsage, expiryTime,
-                Priority.Unspecified_priority);
-        if (pemCert == null || pemCert.isEmpty()) {
+                Priority.Unspecified_priority, signerKeyId);
+        if (StringUtil.isEmpty(pemCert)) {
             return null;
         }
         

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -4737,7 +4737,7 @@ public class ZTSImplTest {
 
         InstanceCertManager certManager = Mockito.mock(InstanceCertManager.class);
         Mockito.when(certManager.generateIdentity("aws", null, ROLE_CERT_CORETECH_REQUEST,
-                "coretech.weathers", "client", 3600, Priority.Unspecified_priority)).thenReturn(null);
+                "coretech.weathers", "client", 3600, Priority.Unspecified_priority, null)).thenReturn(null);
         zts.instanceCertManager = certManager;
 
         try {
@@ -5039,8 +5039,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5131,8 +5131,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5193,8 +5193,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
         Mockito.doReturn(true).when(instanceManager).insertWorkloadRecord(any(WorkloadRecord.class));
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
@@ -5266,8 +5266,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5329,8 +5329,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5389,15 +5389,16 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.doThrow(new ResourceException(500, "Invalid SSH")).when(instanceManager)
                 .generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-                        Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anySet());
+                        Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(),
+                        Mockito.anySet(), Mockito.any());
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5452,7 +5453,8 @@ public class ZTSImplTest {
         Mockito.when(providerClient.confirmInstance(Mockito.any())).thenReturn(confirmation);
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anySet())).thenReturn(true);
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(),
+                Mockito.anySet(), Mockito.any())).thenReturn(true);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -5460,8 +5462,8 @@ public class ZTSImplTest {
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem)
                 .setSshCertificate("test ssh host certificate");
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5527,8 +5529,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5594,8 +5596,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5655,8 +5657,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -5750,8 +5752,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6083,8 +6085,8 @@ public class ZTSImplTest {
 
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
 
-        Mockito.doReturn(null).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(null).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6138,8 +6140,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6149,8 +6151,9 @@ public class ZTSImplTest {
                 .setDomain("athenz").setService("production")
                 .setProvider("athenz.provider").setToken(false);
 
-        Mockito.doReturn(false).when(instanceManager).generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anySet());
+        Mockito.doReturn(false).when(instanceManager).generateSSHIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(),
+                Mockito.anySet(), Mockito.any());
 
         ResourceContext context = createResourceContext(null);
 
@@ -6192,8 +6195,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6254,8 +6257,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6331,15 +6334,16 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.getX509CertRecord("athenz.provider", "1001", "athenz.production")).thenReturn(certRecord);
         Mockito.when(instanceManager.updateX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.anySet())).thenReturn(true);
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(),
+                Mockito.anySet(), Mockito.any())).thenReturn(true);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem)
                 .setSshCertificate("test ssh host certificate");
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6432,8 +6436,8 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6601,8 +6605,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6667,8 +6671,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6749,8 +6753,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6851,8 +6855,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -6942,8 +6946,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7007,14 +7011,15 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.getX509CertRecord("athenz.provider", "1001", "athenz.production")).thenReturn(certRecord);
         Mockito.when(instanceManager.updateX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), eq("ssh-csr"),
-                Mockito.any(), Mockito.any(), eq("user"), Mockito.anyBoolean(), Mockito.anySet())).thenReturn(false);
+                Mockito.any(), Mockito.any(), eq("user"), Mockito.anyBoolean(), Mockito.anySet(),
+                Mockito.any())).thenReturn(false);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7078,8 +7083,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7222,8 +7227,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7290,8 +7295,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7353,8 +7358,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7423,8 +7428,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7493,8 +7498,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7563,8 +7568,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7627,8 +7632,8 @@ public class ZTSImplTest {
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
-        Mockito.doReturn(null).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(null).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7697,8 +7702,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7899,8 +7904,8 @@ public class ZTSImplTest {
         String pem = new String(Files.readAllBytes(path));
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production")
                 .setX509Certificate(pem);
-        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+        Mockito.doReturn(identity).when(instanceManager).generateIdentity(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any());
 
         ztsImpl.instanceProviderManager = instanceProviderManager;
         ztsImpl.instanceCertManager = instanceManager;
@@ -7961,7 +7966,7 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
         Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr",
-                null, null, "user", true, null)).thenReturn(true);
+                null, null, "user", true, null, null)).thenReturn(true);
 
         ztsImpl.instanceCertManager = instanceManager;
 
@@ -8012,7 +8017,7 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
         Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr",
-                null, null, "user", true, null)).thenReturn(true);
+                null, null, "user", true, null, null)).thenReturn(true);
 
         ztsImpl.instanceCertManager = instanceManager;
 
@@ -8063,7 +8068,7 @@ public class ZTSImplTest {
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
         Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr",
-                null, null, "user", true, Collections.emptySet())).thenReturn(false);
+                null, null, "user", true, Collections.emptySet(), null)).thenReturn(false);
 
         ztsImpl.instanceCertManager = instanceManager;
 
@@ -8692,7 +8697,7 @@ public class ZTSImplTest {
         ztsImpl.statusCertSigner = true;
 
         InstanceCertManager certManager = Mockito.mock(InstanceCertManager.class);
-        Mockito.when(certManager.getCACertificate(null)).thenReturn("ca-cert");
+        Mockito.when(certManager.getCACertificate(null, null)).thenReturn("ca-cert");
         ztsImpl.instanceCertManager = certManager;
 
         Principal principal = SimplePrincipal.create("user_domain", "user1",
@@ -8716,7 +8721,7 @@ public class ZTSImplTest {
         ztsImpl.statusCertSigner = true;
 
         InstanceCertManager certManager = Mockito.mock(InstanceCertManager.class);
-        Mockito.when(certManager.getCACertificate("aws")).thenReturn(null);
+        Mockito.when(certManager.getCACertificate("aws", null)).thenReturn(null);
         ztsImpl.instanceCertManager = certManager;
 
         Principal principal = SimplePrincipal.create("user_domain", "user1",
@@ -8854,7 +8859,8 @@ public class ZTSImplTest {
 
         InstanceCertManager certManager = Mockito.mock(InstanceCertManager.class);
         Mockito.when(certManager.generateX509Certificate(Mockito.anyString(), Mockito.anyString(),
-                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.any())).thenReturn(null);
+                Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.any(),
+                Mockito.any())).thenReturn(null);
         ztsImpl.instanceCertManager = certManager;
 
         try {
@@ -9501,7 +9507,7 @@ public class ZTSImplTest {
         certRequest.setCertRequestMeta(meta);
 
         InstanceCertManager instanceManager = Mockito.spy(ztsImpl.instanceCertManager);
-        Mockito.when(instanceManager.generateSSHCertificates(Mockito.any(), eq(certRequest)))
+        Mockito.when(instanceManager.generateSSHCertificates(Mockito.any(), eq(certRequest), Mockito.any()))
                 .thenReturn(certs);
 
         ztsImpl.instanceCertManager = instanceManager;
@@ -9555,7 +9561,7 @@ public class ZTSImplTest {
         certRequest.setCertRequestMeta(meta);
 
         InstanceCertManager instanceManager = Mockito.spy(ztsImpl.instanceCertManager);
-        Mockito.when(instanceManager.generateSSHCertificates(Mockito.any(), eq(certRequest)))
+        Mockito.when(instanceManager.generateSSHCertificates(Mockito.any(), eq(certRequest), Mockito.any()))
                 .thenThrow(new com.yahoo.athenz.common.server.rest.ResourceException(400, "Failed to get ssh certs"));
 
         ztsImpl.instanceCertManager = instanceManager;
@@ -10900,7 +10906,7 @@ public class ZTSImplTest {
 
         InstanceCertManager certManager = Mockito.mock(InstanceCertManager.class);
         Mockito.when(certManager.generateIdentity("aws", null, ROLE_CERT_CORETECH_REQUEST,
-                "user_domain.user1", "client", 3600, Priority.Unspecified_priority)).thenReturn(null);
+                "user_domain.user1", "client", 3600, Priority.Unspecified_priority, null)).thenReturn(null);
         zts.instanceCertManager = certManager;
 
         try {
@@ -14950,5 +14956,35 @@ public class ZTSImplTest {
         assertTrue(principals.contains("127.0.0.4"));
         assertTrue(principals.contains("127.0.0.5"));
         assertTrue(principals.contains("127.0.0.6"));
+    }
+
+    @Test
+    public void testGetPrincipalDomainSignerKeyId() {
+
+        ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        // unknown domains return null
+
+        assertNull(ztsImpl.getPrincipalDomainSignerKeyId("unknown_domain", false));
+        assertNull(ztsImpl.getPrincipalDomainSignerKeyId("unknown_domain", true));
+
+        // add a new domain
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "sports", "api", true, null);
+        signedDomain.getDomain().setX509CertSignerKeyId("x509-keyid");
+        signedDomain.getDomain().setSshCertSignerKeyId("ssh-keyid");
+        store.processDomainData(signedDomain.getDomain());
+
+        // get the x509 key id
+
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId("coretech", true), "x509-keyid");
+
+        // get the ssh key id
+
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId("coretech", false), "ssh-keyid");
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -61,12 +61,13 @@ public class InstanceCertManagerTest {
         final String cert = "cert";
         final String caCert = "caCert";
         CertSigner certSigner = Mockito.mock(com.yahoo.athenz.common.server.cert.CertSigner.class);
-        when(certSigner.generateX509Certificate(any(), any(), any(), any(), Mockito.anyInt(), Mockito.any())).thenReturn(cert);
-        when(certSigner.getCACertificate(any())).thenReturn(caCert);
+        when(certSigner.generateX509Certificate(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(cert);
+        when(certSigner.getCACertificate(any(), any())).thenReturn(caCert);
         
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
         instanceManager.setCertSigner(certSigner);
-        InstanceIdentity identity = instanceManager.generateIdentity("aws", "us-west-2", "csr", "cn", null, 0, Priority.Unspecified_priority);
+        InstanceIdentity identity = instanceManager.generateIdentity("aws", "us-west-2", "csr", "cn", null, 0,
+                Priority.Unspecified_priority, null);
         
         assertNotNull(identity);
         assertEquals(identity.getName(), "cn");
@@ -81,17 +82,17 @@ public class InstanceCertManagerTest {
         final String caCert = "caCert";
         System.clearProperty(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME);
         CertSigner certSigner = Mockito.mock(com.yahoo.athenz.common.server.cert.CertSigner.class);
-        when(certSigner.getCACertificate("aws")).thenReturn(caCert);
+        when(certSigner.getCACertificate("aws", null)).thenReturn(caCert);
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
         instanceManager.setCertSigner(certSigner);
 
         // first time our signer was null and we should get back the cert
         instanceManager.resetX509CertificateSigner();
-        assertEquals("caCert", instanceManager.getX509CertificateSigner("aws"));
+        assertEquals("caCert", instanceManager.getX509CertificateSigner("aws", null));
 
         // second time it should be a no-op
-        assertEquals("caCert", instanceManager.getX509CertificateSigner("aws"));
+        assertEquals("caCert", instanceManager.getX509CertificateSigner("aws", null));
 
         instanceManager.shutdown();
     }
@@ -101,15 +102,15 @@ public class InstanceCertManagerTest {
 
         System.clearProperty(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME);
         CertSigner certSigner = Mockito.mock(com.yahoo.athenz.common.server.cert.CertSigner.class);
-        when(certSigner.getCACertificate("aws")).thenReturn(null);
+        when(certSigner.getCACertificate("aws", null)).thenReturn(null);
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
         instanceManager.setCertSigner(certSigner);
 
-        assertNull(instanceManager.getX509CertificateSigner("aws"));
+        assertNull(instanceManager.getX509CertificateSigner("aws", null));
 
         // second time it should be null again
-        assertNull(instanceManager.getX509CertificateSigner("aws"));
+        assertNull(instanceManager.getX509CertificateSigner("aws", null));
 
         instanceManager.shutdown();
     }
@@ -127,10 +128,10 @@ public class InstanceCertManagerTest {
 
         // first time our signer was null and we should get back the cert
         instanceManager.resetX509CertificateSigner();
-        assertNotNull(instanceManager.getX509CertificateSigner("aws"));
+        assertNotNull(instanceManager.getX509CertificateSigner("aws", null));
 
         // second time it should be a no-op
-        assertNotNull(instanceManager.getX509CertificateSigner("aws"));
+        assertNotNull(instanceManager.getX509CertificateSigner("aws", null));
 
         instanceManager.shutdown();
 
@@ -152,7 +153,7 @@ public class InstanceCertManagerTest {
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
 
         instanceManager.resetX509CertificateSigner();
-        assertNull(instanceManager.getX509CertificateSigner("aws"));
+        assertNull(instanceManager.getX509CertificateSigner("aws", null));
 
         instanceManager.shutdown();
 
@@ -166,11 +167,12 @@ public class InstanceCertManagerTest {
     public void testGenerateIdentityNullCert() {
         
         CertSigner certSigner = Mockito.mock(com.yahoo.athenz.common.server.cert.CertSigner.class);
-        when(certSigner.generateX509Certificate(any(), any(), any(), any(), Mockito.anyInt())).thenReturn(null);
+        when(certSigner.generateX509Certificate(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn(null);
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
         instanceManager.setCertSigner(certSigner);
-        InstanceIdentity identity = instanceManager.generateIdentity("aws", "us-west-2", "csr", "cn", null, 0, Priority.Unspecified_priority);
+        InstanceIdentity identity = instanceManager.generateIdentity("aws", "us-west-2", "csr", "cn", null, 0,
+                Priority.Unspecified_priority, null);
         assertNull(identity);
         instanceManager.shutdown();
     }
@@ -179,11 +181,12 @@ public class InstanceCertManagerTest {
     public void testGenerateIdentityEmptyCert() {
         
         CertSigner certSigner = Mockito.mock(com.yahoo.athenz.common.server.cert.CertSigner.class);
-        when(certSigner.generateX509Certificate(any(), any(), any(), any(), Mockito.anyInt())).thenReturn("");
+        when(certSigner.generateX509Certificate(any(), any(), any(), any(), anyInt(), any(), any())).thenReturn("");
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
         instanceManager.setCertSigner(certSigner);
-        InstanceIdentity identity = instanceManager.generateIdentity("aws", "us-west-2", "csr", "cn", null, 0, Priority.Unspecified_priority);
+        InstanceIdentity identity = instanceManager.generateIdentity("aws", "us-west-2", "csr", "cn", null, 0,
+                Priority.Unspecified_priority, null);
         assertNull(identity);
         instanceManager.shutdown();
     }
@@ -359,21 +362,71 @@ public class InstanceCertManagerTest {
     public void testGetSSHCertificateSigner() {
         
         SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
-        assertEquals(instanceManager.getSSHCertificateSigner("host"), "ssh-host");
-        assertEquals(instanceManager.getSSHCertificateSigner("user"), "ssh-user");
+        assertEquals(instanceManager.getSSHCertificateSigner("host", null), "ssh-host");
+        assertEquals(instanceManager.getSSHCertificateSigner("user", null), "ssh-user");
         
         // second time we should not fetch from certsigner and use fetched copies
         
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn(null);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn(null);
-        assertEquals(instanceManager.getSSHCertificateSigner("host"), "ssh-host");
-        assertEquals(instanceManager.getSSHCertificateSigner("user"), "ssh-user");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn(null);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn(null);
+        assertEquals(instanceManager.getSSHCertificateSigner("host", null), "ssh-host");
+        assertEquals(instanceManager.getSSHCertificateSigner("user", null), "ssh-user");
+        instanceManager.shutdown();
+    }
+
+    @Test
+    public void testGetSSHCertificateSignerCAFiles() {
+
+        System.setProperty("athenz.zts.ssh_host_ca_cert_fname", "src/test/resources/ssh-host-file");
+        System.setProperty("athenz.zts.ssh_user_ca_cert_fname", "src/test/resources/ssh-user-file");
+
+        SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
+        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
+        instanceManager.setSSHSigner(sshSigner);
+
+        assertEquals(instanceManager.getSSHCertificateSigner("host", null), "ssh-host");
+        assertEquals(instanceManager.getSSHCertificateSigner("host", "key-id"), "ssh-host");
+
+        assertEquals(instanceManager.getSSHCertificateSigner("user", null), "ssh-user");
+        assertEquals(instanceManager.getSSHCertificateSigner("user", "key-id"), "ssh-user");
+
+        instanceManager.shutdown();
+        System.clearProperty("athenz.zts.ssh_host_ca_cert_fname");
+        System.clearProperty("athenz.zts.ssh_user_ca_cert_fname");
+    }
+
+    @Test
+    public void testGetSSHCertificateSignerKeyId() {
+
+        SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, "key1")).thenReturn("ssh-host")
+                .thenThrow(new ResourceException(403, "Forbidden"));
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, "key2")).thenReturn("ssh-user")
+                .thenThrow(new ResourceException(403, "Forbidden"));
+
+        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
+        instanceManager.setSSHSigner(sshSigner);
+
+        assertNull(instanceManager.getSSHCertificateSigner("host", null));
+        assertNull(instanceManager.getSSHCertificateSigner("user", null));
+
+        assertEquals(instanceManager.getSSHCertificateSigner("host", "key1"), "ssh-host");
+        assertNull(instanceManager.getSSHCertificateSigner("host", "key2"));
+
+        assertEquals(instanceManager.getSSHCertificateSigner("user", "key2"), "ssh-user");
+        assertNull(instanceManager.getSSHCertificateSigner("user", "key1"));
+
+        // second time calling should return from the cache so no exceptions
+
+        assertEquals(instanceManager.getSSHCertificateSigner("host", "key1"), "ssh-host");
+        assertEquals(instanceManager.getSSHCertificateSigner("user", "key2"), "ssh-user");
+
         instanceManager.shutdown();
     }
 
@@ -381,15 +434,15 @@ public class InstanceCertManagerTest {
     public void testGetSSHCertificateSignerWhenDisabled() {
 
         SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
 
         System.setProperty(ZTSConsts.ZTS_PROP_RESP_SSH_SIGNER_CERTS, "false");
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
-        assertNull(instanceManager.getSSHCertificateSigner("host"));
-        assertNull(instanceManager.getSSHCertificateSigner("user"));
+        assertNull(instanceManager.getSSHCertificateSigner("host", null));
+        assertNull(instanceManager.getSSHCertificateSigner("user", null));
 
         System.clearProperty(ZTSConsts.ZTS_PROP_RESP_SSH_SIGNER_CERTS);
         instanceManager.shutdown();
@@ -402,12 +455,12 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(null);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity, null, null, null, null, null,
-                true, Collections.emptySet());
+                true, Collections.emptySet(), null);
         assertTrue(result);
         assertNull(identity.getSshCertificate());
         
         result = instanceManager.generateSSHIdentity(null, identity, null, "", null, null, null,
-                true, Collections.emptySet());
+                true, Collections.emptySet(), null);
         assertTrue(result);
         assertNull(identity.getSshCertificate());
         instanceManager.shutdown();
@@ -421,7 +474,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity, "host.athenz.com", "{\"csr\":\"csr\"}",
-                null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST, true, Collections.emptySet());
+                null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST, true, Collections.emptySet(), null);
         assertFalse(result);
     }
     
@@ -431,16 +484,16 @@ public class InstanceCertManagerTest {
         SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
         SSHCertRequest sshRequest = new SSHCertRequest();
         sshRequest.setCsr(sshCsr);
-        when(sshSigner.generateCertificate(null, sshRequest, null, "host")).thenReturn(null);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.generateCertificate(null, sshRequest, null, "host", null)).thenReturn(null);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
         
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         boolean result = instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, new SSHCertRecord(), "host", true, Collections.emptySet());
+                null, new SSHCertRecord(), "host", true, Collections.emptySet(), null);
         assertFalse(result);
         instanceManager.shutdown();
     }
@@ -451,7 +504,7 @@ public class InstanceCertManagerTest {
         SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
         SSHCertRequest sshRequest = new SSHCertRequest();
         sshRequest.setCsr(sshCsr);
-        when(sshSigner.generateCertificate(null, sshRequest, null, "host"))
+        when(sshSigner.generateCertificate(null, sshRequest, null, "host", null))
                 .thenThrow(new com.yahoo.athenz.common.server.rest.ResourceException(403, "Forbidden"))
                 .thenThrow(new RuntimeException("IO error"));
 
@@ -462,12 +515,12 @@ public class InstanceCertManagerTest {
 
         // first we should get the resource exception
         boolean result = instanceManager.generateSSHIdentity(null, identity, "", sshCsr, null,
-                new SSHCertRecord(), "host", true, Collections.emptySet());
+                new SSHCertRecord(), "host", true, Collections.emptySet(), null);
         assertFalse(result);
 
         // next we should get the io exception
         result = instanceManager.generateSSHIdentity(null, identity, "", sshCsr, null, new SSHCertRecord(),
-                "host", true, Collections.emptySet());
+                "host", true, Collections.emptySet(), null);
         assertFalse(result);
 
         instanceManager.shutdown();
@@ -481,16 +534,16 @@ public class InstanceCertManagerTest {
         sshRequest.setCsr(sshCsr);
         SSHCertificates certs = new SSHCertificates();
         certs.setCertificates(Collections.emptyList());
-        when(sshSigner.generateCertificate(null, sshRequest, null, "host")).thenReturn(certs);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.generateCertificate(null, sshRequest, null, "host", null)).thenReturn(certs);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
         
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         boolean result = instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, new SSHCertRecord(), "host", true, Collections.emptySet());
+                null, new SSHCertRecord(), "host", true, Collections.emptySet(), null);
         assertFalse(result);
         instanceManager.shutdown();
     }
@@ -508,15 +561,15 @@ public class InstanceCertManagerTest {
         SSHCertRecord sshCertRecord = new SSHCertRecord();
         sshCertRecord.setPrincipals("127.0.0.1");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
         
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, sshCertRecord, "host", true, Collections.emptySet()));
+                null, sshCertRecord, "host", true, Collections.emptySet(), null));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
         instanceManager.shutdown();
@@ -533,16 +586,16 @@ public class InstanceCertManagerTest {
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         SSHCertRecord sshCertRecord = new SSHCertRecord();
         sshCertRecord.setPrincipals("127.0.0.1");
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host"))
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host", null))
                 .thenThrow(new ResourceException(400, "invalid request"));
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
         assertFalse(instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, sshCertRecord, "host", true, Collections.emptySet()));
+                null, sshCertRecord, "host", true, Collections.emptySet(), null));
         instanceManager.shutdown();
     }
 
@@ -559,15 +612,15 @@ public class InstanceCertManagerTest {
         SSHCertRecord sshCertRecord = new SSHCertRecord();
         sshCertRecord.setPrincipals("127.0.0.1");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "user")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "user", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER, null)).thenReturn("ssh-user");
 
         InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, null, sshCsr,
-                null, sshCertRecord, "user", true, Collections.emptySet()));
+                null, sshCertRecord, "user", true, Collections.emptySet(), null));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-user");
         instanceManager.shutdown();
@@ -589,8 +642,8 @@ public class InstanceCertManagerTest {
         sshCertRecord.setService("athenz.service");
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
 
         // setup the hostname resolver for our request
         String hostname = "host1.athenz.cloud";
@@ -607,7 +660,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity, hostname, sshCsr,
-                null, sshCertRecord, "host", true, Collections.emptySet());
+                null, sshCertRecord, "host", true, Collections.emptySet(), null);
         assertTrue(result);
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
@@ -627,8 +680,8 @@ public class InstanceCertManagerTest {
         cert.setCertificate("ssh-cert");
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, null, "host")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
+        when(sshSigner.generateCertificate(null, sshRequest, null, "host", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
 
         // setup the hostname resolver for our request
         String hostname = "host1.athenz.cloud";
@@ -648,7 +701,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         boolean result = instanceManager.generateSSHIdentity(null, identity, hostname, sshCsr,
-                null, new SSHCertRecord(), "host", true, Collections.emptySet());
+                null, new SSHCertRecord(), "host", true, Collections.emptySet(), null);
         assertFalse(result);
         instanceManager.shutdown();
     }
@@ -676,8 +729,8 @@ public class InstanceCertManagerTest {
         sshCertRecord.setService("athenz.service");
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
 
         // setup the hostname resolver for our request
         String hostname = "host1.athenz.cloud";
@@ -694,7 +747,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, hostname, null,
-                sshRequest, sshCertRecord, "host", true, Collections.emptySet()));
+                sshRequest, sshCertRecord, "host", true, Collections.emptySet(), null));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
         instanceManager.shutdown();
@@ -723,8 +776,8 @@ public class InstanceCertManagerTest {
         sshCertRecord.setService("athenz.service");
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
 
         HostnameResolver hostnameResolver = Mockito.mock(HostnameResolver.class);
         List<String> apiList = Arrays.asList("host1.athenz.cloud", "cname.athenz.info", "vip.athenz.info");
@@ -735,7 +788,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertTrue(instanceManager.generateSSHIdentity(null, identity, null, null,
-                sshRequest, sshCertRecord, "host", true, Collections.emptySet()));
+                sshRequest, sshCertRecord, "host", true, Collections.emptySet(), null));
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
         instanceManager.shutdown();
@@ -764,8 +817,8 @@ public class InstanceCertManagerTest {
         sshCertRecord.setService("athenz.service");
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         final SSHCertificates sshCertificates = certs.setCertificates(Collections.singletonList(cert));
-        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host")).thenReturn(sshCertificates);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
+        when(sshSigner.generateCertificate(null, sshRequest, sshCertRecord, "host", null)).thenReturn(sshCertificates);
+        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST, null)).thenReturn("ssh-host");
 
         // setup the hostname resolver for our request
         String hostname = "host1.athenz.cloud";
@@ -782,7 +835,7 @@ public class InstanceCertManagerTest {
         instanceManager.setSSHSigner(sshSigner);
 
         assertFalse(instanceManager.generateSSHIdentity(null, identity, hostname, null,
-                sshRequest, sshCertRecord, "host", true, Collections.emptySet()));
+                sshRequest, sshCertRecord, "host", true, Collections.emptySet(), null));
         instanceManager.shutdown();
     }
 
@@ -801,7 +854,7 @@ public class InstanceCertManagerTest {
         String sshCsr = "{\"pubkey\":\"key\",\"certtype\":\"host\"";
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.test");
         boolean result = instanceManager.generateSSHIdentity(null, identity, hostname,
-                sshCsr, null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST, true, Collections.emptySet());
+                sshCsr, null, new SSHCertRecord(), ZTSConsts.ZTS_SSH_HOST, true, Collections.emptySet(), null);
         assertFalse(result);
     }
 
@@ -1219,7 +1272,7 @@ public class InstanceCertManagerTest {
         InstanceCertManager instanceCertManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
         instanceCertManager.setSSHSigner(null);
 
-        assertNull(instanceCertManager.generateSSHCertificates(null, null));
+        assertNull(instanceCertManager.generateSSHCertificates(null, null, null));
 
         SSHSigner signer = Mockito.mock(SSHSigner.class);
 
@@ -1227,10 +1280,10 @@ public class InstanceCertManagerTest {
         SSHCertRequest certRequest = new SSHCertRequest();
         certRequest.setCertRequestMeta(new SSHCertRequestMeta());
         SSHCertificates certs = new SSHCertificates();
-        when(signer.generateCertificate(principal, certRequest, null, null)).thenReturn(certs);
+        when(signer.generateCertificate(principal, certRequest, null, null, null)).thenReturn(certs);
         instanceCertManager.setSSHSigner(signer);
 
-        assertEquals(certs, instanceCertManager.generateSSHCertificates(principal, certRequest));
+        assertEquals(certs, instanceCertManager.generateSSHCertificates(principal, certRequest, null));
         instanceCertManager.shutdown();
     }
 
@@ -1295,7 +1348,7 @@ public class InstanceCertManagerTest {
         // no exceptions here since with empty factory class
         // we're not going to process any ssh certs
 
-        assertNull(manager.generateSSHCertificates(null, null));
+        assertNull(manager.generateSSHCertificates(null, null, null));
         System.clearProperty(ZTSConsts.ZTS_PROP_SSH_RECORD_STORE_FACTORY_CLASS);
     }
 
@@ -1328,7 +1381,7 @@ public class InstanceCertManagerTest {
         InstanceCertManager instance = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
         instance.setCertSigner(null);
 
-        assertNull(instance.getSSHCertificateSigner("host"));
+        assertNull(instance.getSSHCertificateSigner("host", null));
         instance.shutdown();
     }
 
@@ -1337,36 +1390,10 @@ public class InstanceCertManagerTest {
         System.setProperty(ZTSConsts.ZTS_PROP_SSH_SIGNER_FACTORY_CLASS, "com.yahoo.athenz.zts.cert.impl.MockSSHSignerFactory");
         InstanceCertManager instance = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
 
-        assertNull(instance.getSSHCertificateSigner("host"));
-        assertNull(instance.getSSHCertificateSigner("user"));
+        assertNull(instance.getSSHCertificateSigner("host", null));
+        assertNull(instance.getSSHCertificateSigner("user", null));
         instance.shutdown();
         System.clearProperty(ZTSConsts.ZTS_PROP_SSH_SIGNER_FACTORY_CLASS);
-    }
-
-    @Test
-    public void testUpdateSSHCertificateSigner() {
-
-        SSHSigner sshSigner = Mockito.mock(com.yahoo.athenz.common.server.ssh.SSHSigner.class);
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_HOST)).thenReturn("ssh-host");
-        when(sshSigner.getSignerCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn("ssh-user");
-
-        InstanceCertManager instanceManager = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
-        instanceManager.setSSHSigner(sshSigner);
-
-        // first time we have nulls so we should get valid data
-
-        instanceManager.updateSSHHostCertificateSigner();
-        instanceManager.updateSSHUserCertificateSigner();
-
-        // second time we should have no-ops
-
-        instanceManager.updateSSHHostCertificateSigner();
-        instanceManager.updateSSHUserCertificateSigner();
-
-        assertEquals(instanceManager.getSSHCertificateSigner("host"), "ssh-host");
-        assertEquals(instanceManager.getSSHCertificateSigner("user"), "ssh-user");
-
-        instanceManager.shutdown();
     }
 
     @Test
@@ -1827,10 +1854,10 @@ public class InstanceCertManagerTest {
         // during the function call we'll add the principals
         // field so for mock we're going to remove that
 
-        when(sshSigner.generateCertificate(any(), any(), any(), any())).thenReturn(sshCertificates);
+        when(sshSigner.generateCertificate(any(), any(), any(), any(), any())).thenReturn(sshCertificates);
         instanceManager.setSSHSigner(sshSigner);
 
-        assertEquals(instanceManager.generateSSHCertificates(principal, certRequest), sshCertificates);
+        assertEquals(instanceManager.generateSSHCertificates(principal, certRequest, null), sshCertificates);
         instanceManager.shutdown();
     }
 
@@ -2150,6 +2177,22 @@ public class InstanceCertManagerTest {
         // make sure no exceptions are thrown
 
         instance.logX509Cert(null, null, null, null, null);
+        instance.shutdown();
+    }
+
+    @Test
+    public void testGetSignerPrimaryKey() {
+        InstanceCertManager instance = new InstanceCertManager(null, null, null, new DynamicConfigBoolean(true));
+
+        assertEquals(instance.getSignerPrimaryKey("provider", "keyid1"), "keyid1");
+        assertEquals(instance.getSignerPrimaryKey("", "keyid1"), "keyid1");
+        assertEquals(instance.getSignerPrimaryKey(null, "keyid1"), "keyid1");
+
+        assertEquals(instance.getSignerPrimaryKey("provider", ""), "provider");
+        assertEquals(instance.getSignerPrimaryKey("provider", null), "provider");
+        assertEquals(instance.getSignerPrimaryKey("", null), "default");
+        assertEquals(instance.getSignerPrimaryKey("", ""), "default");
+
         instance.shutdown();
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -168,12 +168,13 @@ public class ZTSUtilsTest {
         
         InstanceCertManager certManager = Mockito.mock(InstanceCertManager.class);
         Mockito.when(certManager.generateX509Certificate(Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any())).thenReturn(null);
+                Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any(), Mockito.any())).thenReturn(null);
         
         Path path = Paths.get("src/test/resources/valid.csr");
         String csr = new String(Files.readAllBytes(path));
         
-        Identity identity = ZTSUtils.generateIdentity(certManager, "aws", "us-west-2", csr, "unknown.syncer", null, 0);
+        Identity identity = ZTSUtils.generateIdentity(certManager, "aws", "us-west-2", csr, "unknown.syncer",
+                null, 0, null);
         assertNull(identity);
     }
     
@@ -643,5 +644,10 @@ public class ZTSUtilsTest {
         assertTrue(ZTSUtils.valueEndsWith("test.athenz.cloud", Arrays.asList(".athenz2.cloud", "athenz.cloud")));
         assertFalse(ZTSUtils.valueEndsWith("test.athenz1.cloud", Collections.singletonList(".athenz2.cloud")));
         assertFalse(ZTSUtils.valueEndsWith("test.athenz1.cloud", Arrays.asList(".athenz2.cloud", "athenz.cloud")));
+    }
+
+    @Test
+    public void testConstructor() {
+        new ZTSUtils();
     }
 }

--- a/servers/zts/src/test/resources/ssh-host-file
+++ b/servers/zts/src/test/resources/ssh-host-file
@@ -1,0 +1,1 @@
+ssh-host

--- a/servers/zts/src/test/resources/ssh-user-file
+++ b/servers/zts/src/test/resources/ssh-user-file
@@ -1,0 +1,1 @@
+ssh-user


### PR DESCRIPTION
# Description

ZTS changes for supporting per-domain signer key ids: issue #2651 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

