### PR TITLE
UI fix: group review submitted for wrong domain

### DIFF
--- a/ui/src/__tests__/redux/thunk/groups.test.js
+++ b/ui/src/__tests__/redux/thunk/groups.test.js
@@ -511,6 +511,7 @@ describe('reviewGroup method', () => {
         const fakeDispatch = sinon.spy();
 
         await reviewGroup(
+            domainName,
             'singlegroup',
             { name: 'singlegroup' },
             'auditRef',

--- a/ui/src/__tests__/server/handlers/api.test.js
+++ b/ui/src/__tests__/server/handlers/api.test.js
@@ -307,7 +307,7 @@ describe('Fetchr Server API Test', () => {
                                           principal: 'user.dummy1',
                                           assertions: [
                                               {
-                                                  dummyProperty: 'dummyValue'
+                                                  dummyProperty: 'dummyValue',
                                               },
                                           ],
                                       },
@@ -1312,7 +1312,7 @@ describe('Fetchr Server API Test', () => {
                             principal: 'user.dummy1',
                             assertions: [
                                 {
-                                    dummyProperty: 'dummyValue'
+                                    dummyProperty: 'dummyValue',
                                 },
                             ],
                         },

--- a/ui/src/components/denali/TabGroup.js
+++ b/ui/src/components/denali/TabGroup.js
@@ -166,7 +166,8 @@ class TabGroup extends React.PureComponent {
                 onClick(tab);
             };
 
-            let shouldSplitOnParentheses = typeof(label) === 'string' && label.includes('(');
+            let shouldSplitOnParentheses =
+                typeof label === 'string' && label.includes('(');
             if (shouldSplitOnParentheses) {
                 let splitLabel = label.split('(');
                 label = (
@@ -175,7 +176,7 @@ class TabGroup extends React.PureComponent {
                         <br />({splitLabel[1]}
                     </span>
                 );
-            };
+            }
 
             return (
                 <div

--- a/ui/src/components/domain/UserDomains.js
+++ b/ui/src/components/domain/UserDomains.js
@@ -145,7 +145,11 @@ class UserDomains extends React.Component {
                                 verticalAlign={'baseline'}
                             />
                         </UserAdminLogoDiv>
-                        <Link href={PageUtils.rolePage(domainName)} passHref legacyBehavior>
+                        <Link
+                            href={PageUtils.rolePage(domainName)}
+                            passHref
+                            legacyBehavior
+                        >
                             <StyledAnchor active={currentDomain === domainName}>
                                 {domainName}
                             </StyledAnchor>
@@ -177,11 +181,19 @@ class UserDomains extends React.Component {
                                 My Domains
                             </ManageDomainsTitleDiv>
                             <div>
-                                <Link href={PageUtils.createDomainPage()} passHref legacyBehavior>
+                                <Link
+                                    href={PageUtils.createDomainPage()}
+                                    passHref
+                                    legacyBehavior
+                                >
                                     <StyledAnchor>Create</StyledAnchor>
                                 </Link>
                                 <DividerSpan> | </DividerSpan>
-                                <Link href={PageUtils.manageDomainPage()} passHref legacyBehavior>
+                                <Link
+                                    href={PageUtils.manageDomainPage()}
+                                    passHref
+                                    legacyBehavior
+                                >
                                     <StyledAnchor>Manage</StyledAnchor>
                                 </Link>
                             </div>

--- a/ui/src/components/group/GroupReviewTable.js
+++ b/ui/src/components/group/GroupReviewTable.js
@@ -160,6 +160,7 @@ class GroupReviewTable extends React.Component {
         });
         this.props
             .reviewGroup(
+                this.props.domain,
                 this.props.groupName,
                 group,
                 this.state.justification,
@@ -356,8 +357,10 @@ const mapStateToProps = (state, props) => {
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    reviewGroup: (groupName, group, justification, _csrf) =>
-        dispatch(reviewGroup(groupName, group, justification, _csrf)),
+    reviewGroup: (domainName, groupName, group, justification, _csrf) =>
+        dispatch(
+            reviewGroup(domainName, groupName, group, justification, _csrf)
+        ),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(GroupReviewTable);

--- a/ui/src/components/group/GroupRoleTable.js
+++ b/ui/src/components/group/GroupRoleTable.js
@@ -20,7 +20,7 @@ import { GROUP_ROLES_CATEGORY } from '../constants/constants';
 import { selectIsLoading } from '../../redux/selectors/loading';
 import { connect } from 'react-redux';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
-import {selectTimeZone} from "../../redux/selectors/domains";
+import { selectTimeZone } from '../../redux/selectors/domains';
 
 const StyleTable = styled.div`
     width: 100%;
@@ -153,7 +153,6 @@ const mapStateToProps = (state, props) => {
         ...props,
         isLoading: selectIsLoading(state),
         timeZone: selectTimeZone(state),
-
     };
 };
 

--- a/ui/src/components/header/NameHeader.js
+++ b/ui/src/components/header/NameHeader.js
@@ -96,12 +96,20 @@ class NameHeader extends React.Component {
                 <TitleDiv data-testid='collection-name-header'>
                     {roleTypeIcon}
                     {roleAuditIcon}
-                    <Link href={PageUtils.rolePage(domain)} passHref legacyBehavior>
+                    <Link
+                        href={PageUtils.rolePage(domain)}
+                        passHref
+                        legacyBehavior
+                    >
                         <StyledAnchor>{domain}</StyledAnchor>
                     </Link>
                     :role.{collection}
                     {' (Delegated to '}
-                    <Link href={PageUtils.rolePage(deDomain)} passHref legacyBehavior>
+                    <Link
+                        href={PageUtils.rolePage(deDomain)}
+                        passHref
+                        legacyBehavior
+                    >
                         <StyledAnchor>{deDomain}</StyledAnchor>
                     </Link>
                     {')'}
@@ -111,7 +119,11 @@ class NameHeader extends React.Component {
         let link;
         if (this.props.category === 'group') {
             link = (
-                <Link href={PageUtils.groupPage(domain)} passHref legacyBehavior>
+                <Link
+                    href={PageUtils.groupPage(domain)}
+                    passHref
+                    legacyBehavior
+                >
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );
@@ -123,13 +135,21 @@ class NameHeader extends React.Component {
             );
         } else if (this.props.category === 'policy') {
             link = (
-                <Link href={PageUtils.servicePage(domain)} passHref legacyBehavior>
+                <Link
+                    href={PageUtils.servicePage(domain)}
+                    passHref
+                    legacyBehavior
+                >
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );
         } else if (this.props.category === 'service') {
             link = (
-                <Link href={PageUtils.servicePage(domain)} passHref legacyBehavior>
+                <Link
+                    href={PageUtils.servicePage(domain)}
+                    passHref
+                    legacyBehavior
+                >
                     <StyledAnchor>{domain}</StyledAnchor>
                 </Link>
             );

--- a/ui/src/components/history/HistoryList.js
+++ b/ui/src/components/history/HistoryList.js
@@ -418,7 +418,9 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = (dispatch) => ({
     getHistory: (domainName, startDate, endDate, _csrf, roleName) =>
-        dispatch(getDomainHistory(domainName, startDate, endDate, _csrf, roleName)),
+        dispatch(
+            getDomainHistory(domainName, startDate, endDate, _csrf, roleName)
+        ),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(HistoryList);

--- a/ui/src/components/microsegmentation/AddSegmentation.js
+++ b/ui/src/components/microsegmentation/AddSegmentation.js
@@ -238,13 +238,13 @@ class AddSegmentation extends React.Component {
             members: this.props.editMode
                 ? this.props.data['category'] === 'inbound'
                     ? this.props.data['source_services'].map((str) => ({
-                        memberName: str,
-                        approved: true,
-                    }))
+                          memberName: str,
+                          approved: true,
+                      }))
                     : this.props.data['destination_services'].map((str) => ({
-                        memberName: str,
-                        approved: true,
-                    }))
+                          memberName: str,
+                          approved: true,
+                      }))
                 : [],
             protocolValid: true,
             action: '',
@@ -1286,19 +1286,19 @@ class AddSegmentation extends React.Component {
     render() {
         let members = this.state.members
             ? this.state.members.map((item, idx) => {
-                // dummy place holder so that it can be be used in the form
-                const newItem = { ...item };
-                newItem.approved = true;
-                let remove = this.deleteMember.bind(this, idx);
-                return (
-                    <Member
-                        key={idx}
-                        item={newItem}
-                        onClickRemove={remove}
-                        noanim
-                    />
-                );
-            })
+                  // dummy place holder so that it can be be used in the form
+                  const newItem = { ...item };
+                  newItem.approved = true;
+                  let remove = this.deleteMember.bind(this, idx);
+                  return (
+                      <Member
+                          key={idx}
+                          item={newItem}
+                          onClickRemove={remove}
+                          noanim
+                      />
+                  );
+              })
             : '';
 
         let sections = (

--- a/ui/src/components/microsegmentation/EnforcementStateList.js
+++ b/ui/src/components/microsegmentation/EnforcementStateList.js
@@ -141,12 +141,12 @@ class EnforcementStateList extends React.Component {
             >
                 <StyleTable>
                     <thead>
-                    <StyledTr>
-                        <StyledTh> Enforcement State </StyledTh>
-                        <StyledTh> Hosts </StyledTh>
-                        <StyledTh> Scope </StyledTh>
-                        <StyledTh> Action </StyledTh>
-                    </StyledTr>
+                        <StyledTr>
+                            <StyledTh> Enforcement State </StyledTh>
+                            <StyledTh> Hosts </StyledTh>
+                            <StyledTh> Scope </StyledTh>
+                            <StyledTh> Action </StyledTh>
+                        </StyledTr>
                     </thead>
                     <tbody>{rows}</tbody>
                 </StyleTable>

--- a/ui/src/components/review/ReviewList.js
+++ b/ui/src/components/review/ReviewList.js
@@ -63,7 +63,9 @@ class ReviewList extends React.Component {
             errorMessage: null,
         });
         this.props.onSuccessReview &&
-            this.props.onSuccessReview(successMessage + ` Removed ${this.props.category} from view.`);
+            this.props.onSuccessReview(
+                successMessage + ` Removed ${this.props.category} from view.`
+            );
         setTimeout(() => {
             this.setState({
                 showSuccess: false,

--- a/ui/src/components/utils/MemberUtils.js
+++ b/ui/src/components/utils/MemberUtils.js
@@ -41,7 +41,9 @@ export default class MemberUtils {
     }
 
     static userSearch(part, userList) {
-        const userDomainOmitPart = part.startsWith(USER_DOMAIN) ? part.substring(USER_DOMAIN.length + 1) : part;
+        const userDomainOmitPart = part.startsWith(USER_DOMAIN)
+            ? part.substring(USER_DOMAIN.length + 1)
+            : part;
         return MemberUtils.getUsers(userDomainOmitPart, userList).then((r) => {
             let usersArr = [];
             r.forEach((u) =>

--- a/ui/src/components/visibility/ServiceDependencyResGroupRoles.js
+++ b/ui/src/components/visibility/ServiceDependencyResGroupRoles.js
@@ -52,7 +52,10 @@ export default class ServiceDependencyResGroupRoles extends React.Component {
                         roleEntry.resourceGroupRole
                     }
                 >
-                    <Link href={roleEntry.roleLink} style={{ textDecoration: 'none' }}>
+                    <Link
+                        href={roleEntry.roleLink}
+                        style={{ textDecoration: 'none' }}
+                    >
                         {roleEntry.resourceGroupRole}
                     </Link>
                     {'  '}
@@ -88,7 +91,10 @@ export default class ServiceDependencyResGroupRoles extends React.Component {
                                 roleEntry.resourceGroupRole
                             }
                         >
-                            <Link href={roleEntry.roleLink} style={{ textDecoration: 'none' }}>
+                            <Link
+                                href={roleEntry.roleLink}
+                                style={{ textDecoration: 'none' }}
+                            >
                                 {roleEntry.resourceGroupRole}
                             </Link>
                             {'  '}

--- a/ui/src/pages/search/[type]/[searchterm].js
+++ b/ui/src/pages/search/[type]/[searchterm].js
@@ -206,7 +206,11 @@ class PageSearchDetails extends React.Component {
             items.push(
                 <ResultsDiv key={domain}>
                     <DomainLogoDiv>{icon}</DomainLogoDiv>
-                    <Link href={PageUtils.rolePage(domain)} passHref legacyBehavior>
+                    <Link
+                        href={PageUtils.rolePage(domain)}
+                        passHref
+                        legacyBehavior
+                    >
                         <StyledAnchor>{domain}</StyledAnchor>
                     </Link>
                 </ResultsDiv>

--- a/ui/src/pages/workflow/domain.js
+++ b/ui/src/pages/workflow/domain.js
@@ -24,7 +24,10 @@ import Error from '../_error';
 import PendingApprovalTabs from '../../components/pending-approval/PendingApprovalTabs';
 import InputDropdown from '../../components/denali/InputDropdown';
 import { withRouter } from 'next/router';
-import { WORKFLOW_DOMAIN_VIEW_DROPDOWN_PLACEHOLDER, WORKFLOW_TITLE } from '../../components/constants/constants';
+import {
+    WORKFLOW_DOMAIN_VIEW_DROPDOWN_PLACEHOLDER,
+    WORKFLOW_TITLE,
+} from '../../components/constants/constants';
 import PageUtils from '../../components/utils/PageUtils';
 import { selectIsLoading } from '../../redux/selectors/loading';
 import { connect } from 'react-redux';

--- a/ui/src/redux/thunks/groups.js
+++ b/ui/src/redux/thunks/groups.js
@@ -110,9 +110,9 @@ export const deleteGroup =
     };
 
 export const reviewGroup =
-    (groupName, group, justification, _csrf) => async (dispatch, getState) => {
+    (domainName, groupName, group, justification, _csrf) =>
+    async (dispatch, getState) => {
         groupName = groupName.toLowerCase();
-        let domainName = getState().groups.domainName;
         await dispatch(getGroup(domainName, groupName));
         try {
             let reviewedGroup = await API().reviewGroup(

--- a/ui/src/redux/thunks/utils/microsegmentation.js
+++ b/ui/src/redux/thunks/utils/microsegmentation.js
@@ -79,7 +79,7 @@ export const buildInboundOutbound = (domainName, state) => {
                                     tempCondition[key] =
                                         condition['conditionsMap'][key][
                                             'value'
-                                            ];
+                                        ];
                                 }
                             );
                             tempCondition['id'] = condition['id'];
@@ -121,11 +121,11 @@ export const buildInboundOutbound = (domainName, state) => {
                         if (category === 'inbound') {
                             jsonData[category][index - 1][
                                 'source_services'
-                                ].push(roleMember.memberName);
+                            ].push(roleMember.memberName);
                         } else if (category === 'outbound') {
                             jsonData[category][index - 1][
                                 'destination_services'
-                                ].push(roleMember.memberName);
+                            ].push(roleMember.memberName);
                         }
                     });
                 }

--- a/ui/src/server/handlers/api.js
+++ b/ui/src/server/handlers/api.js
@@ -2460,102 +2460,102 @@ Fetchr.registerService({
                             let category = '';
 
                             item.assertions &&
-                            item.assertions.forEach(
-                                (assertionItem, assertionIdx) => {
-                                    if (
-                                        !apiUtils
-                                            .getMicrosegmentationActionRegex()
-                                            .test(assertionItem.action)
-                                    ) {
-                                        return;
-                                    }
-                                    let tempData = {};
-                                    let tempProtocol =
-                                        assertionItem.action.split('-');
-                                    tempData['layer'] =
-                                        apiUtils.omitUndefined(
-                                            tempProtocol[0]
-                                        );
-                                    let tempPort =
-                                        assertionItem.action.split(':');
-                                    tempData['source_port'] =
-                                        apiUtils.omitUndefined(tempPort[1]);
-                                    tempData['destination_port'] =
-                                        apiUtils.omitUndefined(tempPort[2]);
-                                    if (assertionItem.conditions) {
-                                        tempData['conditionsList'] = [];
-
-                                        assertionItem.conditions[
-                                            'conditionsList'
-                                            ].forEach((condition) => {
-                                            let tempCondition = {};
-                                            Object.keys(
-                                                condition['conditionsMap']
-                                            ).forEach((key) => {
-                                                tempCondition[key] =
-                                                    condition[
-                                                        'conditionsMap'
-                                                        ][key]['value'];
-                                            });
-                                            tempCondition['id'] =
-                                                condition['id'];
-                                            tempCondition['assertionId'] =
-                                                assertionItem['id'];
-                                            tempCondition['policyName'] =
-                                                item.name;
-                                            tempData['conditionsList'].push(
-                                                tempCondition
+                                item.assertions.forEach(
+                                    (assertionItem, assertionIdx) => {
+                                        if (
+                                            !apiUtils
+                                                .getMicrosegmentationActionRegex()
+                                                .test(assertionItem.action)
+                                        ) {
+                                            return;
+                                        }
+                                        let tempData = {};
+                                        let tempProtocol =
+                                            assertionItem.action.split('-');
+                                        tempData['layer'] =
+                                            apiUtils.omitUndefined(
+                                                tempProtocol[0]
                                             );
-                                        });
-                                    }
-                                    let index = 0;
-                                    if (item.name.includes('inbound')) {
-                                        category = 'inbound';
-                                        tempData['destination_service'] =
-                                            serviceName;
-                                        tempData['source_services'] = [];
-                                        tempData['assertionIdx'] =
-                                            assertionItem.id;
-                                        jsonData['inbound'].push(tempData);
-                                        index = jsonData['inbound'].length;
-                                    } else if (
-                                        item.name.includes('outbound')
-                                    ) {
-                                        category = 'outbound';
-                                        tempData['source_service'] =
-                                            serviceName;
-                                        tempData['destination_services'] =
-                                            [];
-                                        tempData['assertionIdx'] =
-                                            assertionItem.id;
-                                        jsonData['outbound'].push(tempData);
-                                        index = jsonData['outbound'].length;
-                                    }
-                                    //assertion convention for microsegmentation:
-                                    //GRANT [Action: <transport layer>-IN / <transport layer>-OUT]:[Source Port]:[Destination Port] [Resource:<service-name>] ON <role-name>
-                                    // role name will be of the form : <domain>:role.<roleName>
-                                    let roleName =
-                                        assertionItem.role.substring(
-                                            params.domainName.length + 6
-                                        );
-                                    promises.push(
-                                        getRole(
-                                            roleName,
-                                            params.domainName,
-                                            category,
-                                            index
-                                        )
-                                    );
+                                        let tempPort =
+                                            assertionItem.action.split(':');
+                                        tempData['source_port'] =
+                                            apiUtils.omitUndefined(tempPort[1]);
+                                        tempData['destination_port'] =
+                                            apiUtils.omitUndefined(tempPort[2]);
+                                        if (assertionItem.conditions) {
+                                            tempData['conditionsList'] = [];
 
-                                    promises.push(
-                                        getIdentifier(
-                                            roleName,
-                                            category,
-                                            index
-                                        )
-                                    );
-                                }
-                            );
+                                            assertionItem.conditions[
+                                                'conditionsList'
+                                            ].forEach((condition) => {
+                                                let tempCondition = {};
+                                                Object.keys(
+                                                    condition['conditionsMap']
+                                                ).forEach((key) => {
+                                                    tempCondition[key] =
+                                                        condition[
+                                                            'conditionsMap'
+                                                        ][key]['value'];
+                                                });
+                                                tempCondition['id'] =
+                                                    condition['id'];
+                                                tempCondition['assertionId'] =
+                                                    assertionItem['id'];
+                                                tempCondition['policyName'] =
+                                                    item.name;
+                                                tempData['conditionsList'].push(
+                                                    tempCondition
+                                                );
+                                            });
+                                        }
+                                        let index = 0;
+                                        if (item.name.includes('inbound')) {
+                                            category = 'inbound';
+                                            tempData['destination_service'] =
+                                                serviceName;
+                                            tempData['source_services'] = [];
+                                            tempData['assertionIdx'] =
+                                                assertionItem.id;
+                                            jsonData['inbound'].push(tempData);
+                                            index = jsonData['inbound'].length;
+                                        } else if (
+                                            item.name.includes('outbound')
+                                        ) {
+                                            category = 'outbound';
+                                            tempData['source_service'] =
+                                                serviceName;
+                                            tempData['destination_services'] =
+                                                [];
+                                            tempData['assertionIdx'] =
+                                                assertionItem.id;
+                                            jsonData['outbound'].push(tempData);
+                                            index = jsonData['outbound'].length;
+                                        }
+                                        //assertion convention for microsegmentation:
+                                        //GRANT [Action: <transport layer>-IN / <transport layer>-OUT]:[Source Port]:[Destination Port] [Resource:<service-name>] ON <role-name>
+                                        // role name will be of the form : <domain>:role.<roleName>
+                                        let roleName =
+                                            assertionItem.role.substring(
+                                                params.domainName.length + 6
+                                            );
+                                        promises.push(
+                                            getRole(
+                                                roleName,
+                                                params.domainName,
+                                                category,
+                                                index
+                                            )
+                                        );
+
+                                        promises.push(
+                                            getIdentifier(
+                                                roleName,
+                                                category,
+                                                index
+                                            )
+                                        );
+                                    }
+                                );
                         }
                     });
                 } else if (err) {
@@ -2599,11 +2599,11 @@ Fetchr.registerService({
                                     if (category === 'inbound') {
                                         jsonData[category][jsonIndex - 1][
                                             'source_services'
-                                            ].push(roleMember.memberName);
+                                        ].push(roleMember.memberName);
                                     } else if (category === 'outbound') {
                                         jsonData[category][jsonIndex - 1][
                                             'destination_services'
-                                            ].push(roleMember.memberName);
+                                        ].push(roleMember.memberName);
                                     }
                                 });
                                 resolve();
@@ -2696,7 +2696,6 @@ Fetchr.registerService({
                             copyAssertionConditionData['value'] = '*';
                         }
                         condition[key] = copyAssertionConditionData;
-
                     }
                 });
                 assertionCondition['conditionsMap'] = condition;


### PR DESCRIPTION
# Description
When submitting review for groups through UI, the domain name used is wrong which led to the review being submitted for the wrong domain (if group names are same) or no review being submitted since domain+group name is an invalid combination.
Fix for this is for the component to pass the domainName as well instead of relying on redux store to find out the domainName.

The changes are only in 
```
src/redux/thunks/groups.js
src/components/group/GroupReviewTable.js
src/__tests__/redux/thunk/groups.test.js
```

Remaining changes are from npm run fix-lint

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

