### PR TITLE
[documentation/github actions provider] Fix service name for prs

### DIFF
--- a/docs/provider_github_actions.md
+++ b/docs/provider_github_actions.md
@@ -102,7 +102,7 @@ Member: `news.prod.api-pr`
 Policy Name: `github.actions`
 Assertions:
     `grant github.push to github.actions.api on news.prod:repo:yahoo-news/api:ref:refs/heads/main`
-    `grant github.pull_request to github.actions.api on news.prod:repo:yahoo-news/api:pull_request`
+    `grant github.pull_request to github.actions.api-pr on news.prod:repo:yahoo-news/api:pull_request`
 
 To simplify the setup process, the domain administrator should provide a GitHub-Actions template where the
 user will just need to provide the service name, event_type and resource values to automatically create


### PR DESCRIPTION
# Description
I believe the service used in the example should be `api-pr` and not `api`

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

