### PR TITLE
email notifications improvements with notify roles and groups

### DIFF
--- a/core/zms/src/main/java/com/yahoo/athenz/zms/GroupMember.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/GroupMember.java
@@ -54,6 +54,9 @@ public class GroupMember {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String pendingState;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String notifyRoles;
 
     public GroupMember setMemberName(String memberName) {
         this.memberName = memberName;
@@ -153,6 +156,13 @@ public class GroupMember {
     public String getPendingState() {
         return pendingState;
     }
+    public GroupMember setNotifyRoles(String notifyRoles) {
+        this.notifyRoles = notifyRoles;
+        return this;
+    }
+    public String getNotifyRoles() {
+        return notifyRoles;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -201,6 +211,9 @@ public class GroupMember {
                 return false;
             }
             if (pendingState == null ? a.pendingState != null : !pendingState.equals(a.pendingState)) {
+                return false;
+            }
+            if (notifyRoles == null ? a.notifyRoles != null : !notifyRoles.equals(a.notifyRoles)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/MemberRole.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/MemberRole.java
@@ -46,6 +46,9 @@ public class MemberRole {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String trustRoleName;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String notifyRoles;
 
     public MemberRole setRoleName(String roleName) {
         this.roleName = roleName;
@@ -131,6 +134,13 @@ public class MemberRole {
     public String getTrustRoleName() {
         return trustRoleName;
     }
+    public MemberRole setNotifyRoles(String notifyRoles) {
+        this.notifyRoles = notifyRoles;
+        return this;
+    }
+    public String getNotifyRoles() {
+        return notifyRoles;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -173,6 +183,9 @@ public class MemberRole {
                 return false;
             }
             if (trustRoleName == null ? a.trustRoleName != null : !trustRoleName.equals(a.trustRoleName)) {
+                return false;
+            }
+            if (notifyRoles == null ? a.notifyRoles != null : !notifyRoles.equals(a.notifyRoles)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -284,7 +284,8 @@ public class ZMSSchema {
             .field("requestTime", "Timestamp", true, "for pending membership requests, the request time")
             .field("systemDisabled", "Int32", true, "user disabled by system based on configured role setting")
             .field("pendingState", "String", true, "for pending membership requests, the request state - e.g. add, delete")
-            .field("trustRoleName", "ResourceName", true, "name of the role that handles the membership delegation for the role specified in roleName");
+            .field("trustRoleName", "ResourceName", true, "name of the role that handles the membership delegation for the role specified in roleName")
+            .field("notifyRoles", "String", true, "list of roles whose members should be notified for member review/approval/expiry");
 
         sb.structType("DomainRoleMember")
             .field("memberName", "MemberName", false, "name of the member")
@@ -521,7 +522,8 @@ public class ZMSSchema {
             .field("reviewLastNotifiedTime", "Timestamp", true, "for pending membership requests, time when last notification was sent (for file store)")
             .field("systemDisabled", "Int32", true, "user disabled by system based on configured group setting")
             .field("principalType", "Int32", true, "server use only - principal type: unknown(0), user(1) or service(2)")
-            .field("pendingState", "String", true, "for pending membership requests, the request state - e.g. add, delete");
+            .field("pendingState", "String", true, "for pending membership requests, the request state - e.g. add, delete")
+            .field("notifyRoles", "String", true, "list of roles whose members should be notified for member review/approval/expiry");
 
         sb.structType("GroupMembership")
             .comment("The representation for a group membership.")

--- a/core/zms/src/main/rdl/Group.tdl
+++ b/core/zms/src/main/rdl/Group.tdl
@@ -27,6 +27,7 @@ type GroupMember Struct {
     Int32 systemDisabled (optional); //user disabled by system based on configured group setting
     Int32 principalType (optional); //server use only - principal type: unknown(0), user(1) or service(2)
     String pendingState (optional); //for pending membership requests, the request state - e.g. add, delete
+    String notifyRoles (optional); //list of roles whose members should be notified for member review/approval/expiry
 }
 
 //The representation for a group membership.

--- a/core/zms/src/main/rdl/Role.tdl
+++ b/core/zms/src/main/rdl/Role.tdl
@@ -123,6 +123,7 @@ type MemberRole Struct {
     Int32 systemDisabled (optional); //user disabled by system based on configured role setting
     String pendingState (optional); //for pending membership requests, the request state - e.g. add, delete
     ResourceName trustRoleName (optional); //name of the role that handles the membership delegation for the role specified in roleName
+    String notifyRoles (optional); //list of roles whose members should be notified for member review/approval/expiry
 }
 
 type DomainRoleMember Struct {

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/GroupTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/GroupTest.java
@@ -275,7 +275,8 @@ public class GroupTest {
                 .setReviewLastNotifiedTime(Timestamp.fromMillis(123456789127L))
                 .setSystemDisabled(1)
                 .setPrincipalType(1)
-                .setPendingState("ADD");
+                .setPendingState("ADD")
+                .setNotifyRoles("role1,role2");
 
         assertEquals(rm, rm);
         assertNotEquals("data", rm);
@@ -298,6 +299,7 @@ public class GroupTest {
         assertEquals(rm.getSystemDisabled(), Integer.valueOf(1));
         assertEquals(rm.getPrincipalType(), Integer.valueOf(1));
         assertEquals(rm.getPendingState(), "ADD");
+        assertEquals(rm.getNotifyRoles(), "role1,role2");
 
         GroupMember rm2 = new GroupMember()
                 .setGroupName("group1")
@@ -313,7 +315,8 @@ public class GroupTest {
                 .setReviewLastNotifiedTime(Timestamp.fromMillis(123456789127L))
                 .setSystemDisabled(1)
                 .setPrincipalType(1)
-                .setPendingState("ADD");
+                .setPendingState("ADD")
+                .setNotifyRoles("role1,role2");
         assertEquals(rm, rm2);
 
         rm2.setRequestPrincipal("user.test2");
@@ -412,6 +415,13 @@ public class GroupTest {
         rm2.setPrincipalType(null);
         assertNotEquals(rm, rm2);
         rm2.setPrincipalType(1);
+        assertEquals(rm, rm2);
+
+        rm2.setNotifyRoles("role2,role3");
+        assertNotEquals(rm, rm2);
+        rm2.setNotifyRoles(null);
+        assertNotEquals(rm, rm2);
+        rm2.setNotifyRoles("role1,role2");
         assertEquals(rm, rm2);
 
         assertNotEquals(rm2, null);

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/MemberRoleTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/MemberRoleTest.java
@@ -39,6 +39,7 @@ public class MemberRoleTest {
         mbr1.setReviewReminder(Timestamp.fromMillis(100));
         mbr1.setPendingState("ADD");
         mbr1.setTrustRoleName("domain:role.trust");
+        mbr1.setNotifyRoles("role1,role2");
 
         assertEquals("role1", mbr1.getRoleName());
         assertEquals(Timestamp.fromMillis(100), mbr1.getExpiration());
@@ -52,6 +53,7 @@ public class MemberRoleTest {
         assertEquals(Timestamp.fromMillis(100), mbr1.getReviewReminder());
         assertEquals(mbr1.getPendingState(), "ADD");
         assertEquals(mbr1.getTrustRoleName(), "domain:role.trust");
+        assertEquals(mbr1.getNotifyRoles(), "role1,role2");
 
         assertEquals(mbr1, mbr1);
         assertNotEquals(null, mbr1);
@@ -69,7 +71,8 @@ public class MemberRoleTest {
                 .setSystemDisabled(1)
                 .setReviewReminder(Timestamp.fromMillis(100))
                 .setPendingState("ADD")
-                .setTrustRoleName("domain:role.trust");
+                .setTrustRoleName("domain:role.trust")
+                .setNotifyRoles("role1,role2");
 
         assertEquals(mbr1, mbr2);
 
@@ -155,6 +158,13 @@ public class MemberRoleTest {
         mbr2.setTrustRoleName(null);
         assertNotEquals(mbr1, mbr2);
         mbr2.setTrustRoleName("domain:role.trust");
+        assertEquals(mbr1, mbr2);
+
+        mbr2.setNotifyRoles("role2,role3");
+        assertNotEquals(mbr1, mbr2);
+        mbr2.setNotifyRoles(null);
+        assertNotEquals(mbr1, mbr2);
+        mbr2.setNotifyRoles("role1,role2");
         assertEquals(mbr1, mbr2);
     }
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationCommon.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationCommon.java
@@ -19,7 +19,6 @@ package com.yahoo.athenz.common.server.notification;
 import com.yahoo.athenz.auth.AuthorityConsts;
 import com.yahoo.athenz.auth.util.AthenzUtils;
 import com.yahoo.athenz.common.ServerCommonConsts;
-import com.yahoo.athenz.common.server.util.ResourceUtils;
 import com.yahoo.athenz.zms.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +113,8 @@ public class NotificationCommon {
 
         int roleDomainIndex = recipient.indexOf(AuthorityConsts.ROLE_SEP);
         if (roleDomainIndex != -1) {
-            addDomainRoleRecipients(notification, recipient.substring(0, roleDomainIndex), recipient);
+            addDomainRoleRecipients(notification, recipient.substring(0, roleDomainIndex),
+                    recipient.substring(roleDomainIndex + AuthorityConsts.ROLE_SEP.length()));
         } else if (recipient.contains(AuthorityConsts.GROUP_SEP)) {
             // Do nothing. Group members will not get individual notifications.
         } else if (recipient.startsWith(userDomainPrefix)) {
@@ -122,7 +122,7 @@ public class NotificationCommon {
         } else if (!ignoreService) {
             final String domainName = AthenzUtils.extractPrincipalDomainName(recipient);
             if (domainName != null) {
-                addDomainRoleRecipients(notification, domainName, ResourceUtils.roleResourceName(domainName, ServerCommonConsts.ADMIN_ROLE_NAME));
+                addDomainRoleRecipients(notification, domainName, ServerCommonConsts.ADMIN_ROLE_NAME);
             }
         }
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/DomainRoleMembersFetcherCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/DomainRoleMembersFetcherCommonTest.java
@@ -132,7 +132,7 @@ public class DomainRoleMembersFetcherCommonTest {
     public void testDomainRoleMembersFetcherNotImpl() {
 
         Role role1 = new Role();
-        role1.setName("role1");
+        role1.setName("domain1:role.role1");
         List<RoleMember> role1MemberList = Collections.singletonList(new RoleMember().setMemberName("user.user1"));
         role1.setRoleMembers(role1MemberList);
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTask.java
@@ -16,13 +16,9 @@
 
 package com.yahoo.athenz.zms.notification;
 
-import com.google.common.base.Splitter;
-import com.yahoo.athenz.auth.AuthorityConsts;
 import com.yahoo.athenz.common.server.notification.*;
-import com.yahoo.athenz.common.server.util.ResourceUtils;
 import com.yahoo.athenz.zms.DBService;
 import com.yahoo.athenz.zms.Group;
-import com.yahoo.athenz.zms.ZMSConsts;
 import com.yahoo.rdl.Timestamp;
 
 import java.text.MessageFormat;
@@ -63,36 +59,8 @@ public class PutGroupMembershipNotificationTask implements NotificationTask {
         //          role list for notification and if not present then default
         //          to the admin role from the domain
 
-        Set<String> recipients = new HashSet<>();
-        if (group.getAuditEnabled() == Boolean.TRUE) {
-
-            recipients.add(ResourceUtils.roleResourceName(ZMSConsts.SYS_AUTH_AUDIT_BY_DOMAIN, domain));
-            recipients.add(ResourceUtils.roleResourceName(ZMSConsts.SYS_AUTH_AUDIT_BY_ORG, org));
-
-        } else {
-
-            // if we're given a notify role list then we're going
-            // to add those role members to the recipient list
-            // otherwise use the admin role for the domain
-
-            final String notifyRoles = group.getNotifyRoles();
-            if (notifyRoles == null || notifyRoles.isEmpty()) {
-                recipients.add(ResourceUtils.roleResourceName(domain, ZMSConsts.ADMIN_ROLE_NAME));
-            } else {
-                Iterable<String> roleNames = Splitter.on(',')
-                        .omitEmptyStrings()
-                        .trimResults()
-                        .split(notifyRoles);
-
-                for (String roleName : roleNames) {
-                    if (!roleName.contains(AuthorityConsts.ROLE_SEP)) {
-                        recipients.add(ResourceUtils.roleResourceName(domain, roleName));
-                    } else {
-                        recipients.add(roleName);
-                    }
-                }
-            }
-        }
+        Set<String> recipients = NotificationUtils.getRecipientRoles(group.getAuditEnabled(),
+                domain, org, group.getNotifyRoles());
 
         // create and process our notification
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTask.java
@@ -16,13 +16,9 @@
 
 package com.yahoo.athenz.zms.notification;
 
-import com.google.common.base.Splitter;
-import com.yahoo.athenz.auth.AuthorityConsts;
 import com.yahoo.athenz.common.server.notification.*;
-import com.yahoo.athenz.common.server.util.ResourceUtils;
 import com.yahoo.athenz.zms.DBService;
 import com.yahoo.athenz.zms.Role;
-import com.yahoo.athenz.zms.ZMSConsts;
 import com.yahoo.rdl.Timestamp;
 
 import java.text.MessageFormat;
@@ -62,36 +58,8 @@ public class PutRoleMembershipNotificationTask implements NotificationTask {
         //          role list for notification and if not present then default
         //          to the admin role from the domain
 
-        Set<String> recipients = new HashSet<>();
-        if (role.getAuditEnabled() == Boolean.TRUE) {
-
-            recipients.add(ResourceUtils.roleResourceName(ZMSConsts.SYS_AUTH_AUDIT_BY_DOMAIN, domain));
-            recipients.add(ResourceUtils.roleResourceName(ZMSConsts.SYS_AUTH_AUDIT_BY_ORG, org));
-
-        } else {
-
-            // if we're given a notify role list then we're going
-            // to add those role members to the recipient list
-            // otherwise use the admin role for the domain
-
-            final String notifyRoles = role.getNotifyRoles();
-            if (notifyRoles == null || notifyRoles.isEmpty()) {
-                recipients.add(ResourceUtils.roleResourceName(domain, ZMSConsts.ADMIN_ROLE_NAME));
-            } else {
-                Iterable<String> roleNames = Splitter.on(',')
-                        .omitEmptyStrings()
-                        .trimResults()
-                        .split(notifyRoles);
-
-                for (String roleName : roleNames) {
-                    if (!roleName.contains(AuthorityConsts.ROLE_SEP)) {
-                        recipients.add(ResourceUtils.roleResourceName(domain, roleName));
-                    } else {
-                        recipients.add(roleName);
-                    }
-                }
-            }
-        }
+        Set<String> recipients = NotificationUtils.getRecipientRoles(role.getAuditEnabled(),
+                domain, org, role.getNotifyRoles());
 
         // create and process our notification
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnection.java
@@ -391,7 +391,7 @@ public class JDBCConnection implements ObjectStoreConnection {
               "UPDATE role_member SET last_notified_time=?, server=? "
             + "WHERE expiration > CURRENT_TIME AND DATEDIFF(expiration, CURRENT_TIME) IN (0,1,3,7,14,21,28);";
     private static final String SQL_LIST_NOTIFY_TEMPORARY_ROLE_MEMBERS = "SELECT domain.name AS domain_name, role.name AS role_name, "
-            + "principal.name AS principal_name, role_member.expiration, role_member.review_reminder FROM role_member "
+            + "principal.name AS principal_name, role_member.expiration, role_member.review_reminder, role.notify_roles FROM role_member "
             + "JOIN role ON role.role_id=role_member.role_id "
             + "JOIN principal ON principal.principal_id=role_member.principal_id "
             + "JOIN domain ON domain.domain_id=role.domain_id "
@@ -400,7 +400,7 @@ public class JDBCConnection implements ObjectStoreConnection {
               "UPDATE role_member SET review_last_notified_time=?, review_server=? "
             + "WHERE review_reminder > CURRENT_TIME AND expiration IS NULL AND DATEDIFF(review_reminder, CURRENT_TIME) IN (0,1,3,7,14,21,28);";
     private static final String SQL_LIST_NOTIFY_REVIEW_ROLE_MEMBERS = "SELECT domain.name AS domain_name, role.name AS role_name, "
-            + "principal.name AS principal_name, role_member.expiration, role_member.review_reminder FROM role_member "
+            + "principal.name AS principal_name, role_member.expiration, role_member.review_reminder, role.notify_roles FROM role_member "
             + "JOIN role ON role.role_id=role_member.role_id "
             + "JOIN principal ON principal.principal_id=role_member.principal_id "
             + "JOIN domain ON domain.domain_id=role.domain_id "
@@ -548,7 +548,7 @@ public class JDBCConnection implements ObjectStoreConnection {
               "UPDATE principal_group_member SET last_notified_time=?, server=? "
             + "WHERE expiration > CURRENT_TIME AND DATEDIFF(expiration, CURRENT_TIME) IN (0,1,3,7,14,21,28);";
     private static final String SQL_LIST_NOTIFY_TEMPORARY_GROUP_MEMBERS = "SELECT domain.name AS domain_name, principal_group.name AS group_name, "
-            + "principal.name AS principal_name, principal_group_member.expiration FROM principal_group_member "
+            + "principal.name AS principal_name, principal_group_member.expiration, principal_group.notify_roles FROM principal_group_member "
             + "JOIN principal_group ON principal_group.group_id=principal_group_member.group_id "
             + "JOIN principal ON principal.principal_id=principal_group_member.principal_id "
             + "JOIN domain ON domain.domain_id=principal_group.domain_id "
@@ -5872,6 +5872,7 @@ public class JDBCConnection implements ObjectStoreConnection {
                     memberGroup.setMemberName(memberName);
                     memberGroup.setGroupName(rs.getString(ZMSConsts.DB_COLUMN_AS_GROUP_NAME));
                     memberGroup.setDomainName(rs.getString(ZMSConsts.DB_COLUMN_DOMAIN_NAME));
+                    memberGroup.setNotifyRoles(saveValue(rs.getString(ZMSConsts.DB_COLUMN_NOTIFY_ROLES)));
                     if (expiration != null) {
                         memberGroup.setExpiration(Timestamp.fromMillis(expiration.getTime()));
                     }
@@ -5964,6 +5965,7 @@ public class JDBCConnection implements ObjectStoreConnection {
                     memberRole.setMemberName(memberName);
                     memberRole.setRoleName(rs.getString(ZMSConsts.DB_COLUMN_ROLE_NAME));
                     memberRole.setDomainName(rs.getString(ZMSConsts.DB_COLUMN_DOMAIN_NAME));
+                    memberRole.setNotifyRoles(saveValue(rs.getString(ZMSConsts.DB_COLUMN_NOTIFY_ROLES)));
                     if (expiration != null) {
                         memberRole.setExpiration(Timestamp.fromMillis(expiration.getTime()));
                     }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
@@ -10684,6 +10684,10 @@ public class JDBCConnectionTest {
                 .thenReturn("athenz1")
                 .thenReturn("athenz1")
                 .thenReturn("athenz2");
+        Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_NOTIFY_ROLES))
+                .thenReturn("")
+                .thenReturn("")
+                .thenReturn("");
         java.sql.Timestamp ts = new java.sql.Timestamp(System.currentTimeMillis());
         Mockito.when(mockResultSet.getTimestamp(ZMSConsts.DB_COLUMN_EXPIRATION))
                 .thenReturn(ts);
@@ -13325,6 +13329,10 @@ public class JDBCConnectionTest {
                 .thenReturn("athenz1")
                 .thenReturn("athenz1")
                 .thenReturn("athenz2");
+        Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_NOTIFY_ROLES))
+                .thenReturn("")
+                .thenReturn("")
+                .thenReturn("");
         java.sql.Timestamp ts = new java.sql.Timestamp(System.currentTimeMillis());
         Mockito.when(mockResultSet.getTimestamp(ZMSConsts.DB_COLUMN_EXPIRATION))
                 .thenReturn(ts);


### PR DESCRIPTION
# Description

1) We have notifyRoles attribute per role/group which configures ZMS to send email notifications to the configured role members instead of the admin of the domain when new members are added. however, when sending regular expiry notifications, ZMS was not looking at the attribute and always sending to the domain admins. Now, ZMS sends the admin expiry notification to the configured role members and if it's not configured, then to the admins of the domain

2) when processing members, the server automatically skipped group members from the expiry. however with consolidated notifications even the domain admins didn't receive notifications. Now the server correctly generates expiry notifications for both group members and their respective admins

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

