### PR TITLE
disable advanced settings for delegated roles during role creation or editing

### DIFF
--- a/ui/src/__tests__/components/role/__snapshots__/RoleRow.test.js.snap
+++ b/ui/src/__tests__/components/role/__snapshots__/RoleRow.test.js.snap
@@ -185,7 +185,7 @@ exports[`RoleRow should render 1`] = `
         class="emotion-12"
         data-testid="icon"
         height="1.25em"
-        id=""
+        id="ztssia_cert_rotate-setting-role-button"
         viewBox="0 0 1024 1024"
         width="1.25em"
       >

--- a/ui/src/__tests__/components/role/__snapshots__/RoleTable.test.js.snap
+++ b/ui/src/__tests__/components/role/__snapshots__/RoleTable.test.js.snap
@@ -265,7 +265,7 @@ exports[`RoleTable should render 1`] = `
           class="emotion-36"
           data-testid="icon"
           height="1.25em"
-          id=""
+          id="a-setting-role-button"
           viewBox="0 0 1024 1024"
           width="1.25em"
         >
@@ -458,7 +458,7 @@ exports[`RoleTable should render 1`] = `
           class="emotion-36"
           data-testid="icon"
           height="1.25em"
-          id=""
+          id="b-setting-role-button"
           viewBox="0 0 1024 1024"
           width="1.25em"
         >

--- a/ui/src/__tests__/spec/tests/role.spec.js
+++ b/ui/src/__tests__/spec/tests/role.spec.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('role screen tests', () => {
+    it('when creating or editing a delegated role, all additional settings except description must be disabled', async () => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await browser.waitUntil(async () => await testDomain.isClickable());
+        await testDomain.click();
+
+        // open Add Role screen
+        let addRoleButton = await $('button*=Add Role');
+        await browser.waitUntil(async () => await addRoleButton.isClickable());
+        await addRoleButton.click();
+        // select Delegated
+        let delegatedButton = await $('div*=Delegated');
+        await delegatedButton.click();
+        // verify all settings except Description are disabled
+        let advancedSettingsIcon = await $('#advanced-settings-icon');
+        await advancedSettingsIcon.click();
+        let switchSettingAuditEnabled = await $('#switch-settingauditEnabled');
+        await expect(switchSettingAuditEnabled).toBeDisabled();
+        let switchSettingReviewEnabled = await $('#switch-settingreviewEnabled');
+        await expect(switchSettingReviewEnabled).toBeDisabled();
+        let switchSettingDeleteProtection = await $('#switch-settingdeleteProtection');
+        await expect(switchSettingDeleteProtection).toBeDisabled();
+        let switchSettingSelfServe = await $('#switch-settingselfServe');
+        await expect(switchSettingSelfServe).toBeDisabled();
+        let switchSettingSelfRenew = await $('#switch-settingselfRenew');
+        await expect(switchSettingSelfRenew).toBeDisabled();
+        let inputSelfRenewMins = await $('#setting-selfRenewMins');
+        await expect(inputSelfRenewMins).toBeDisabled();
+        let inputMemberExpiryDays = await $('#setting-memberExpiryDays');
+        await expect(inputMemberExpiryDays).toBeDisabled();
+        let inputGroupExpiryDays = await $('#setting-groupExpiryDays');
+        await expect(inputGroupExpiryDays).toBeDisabled();
+        let inputGroupReviewDays = await $('#setting-groupReviewDays');
+        await expect(inputGroupReviewDays).toBeDisabled();
+        let inputServiceExpiryDays = await $('#setting-serviceExpiryDays');
+        await expect(inputServiceExpiryDays).toBeDisabled();
+        let inputServiceReviewDays = await $('#setting-serviceReviewDays');
+        await expect(inputServiceReviewDays).toBeDisabled();
+        let inputTokenExpiryMins = await $('#setting-tokenExpiryMins');
+        await expect(inputTokenExpiryMins).toBeDisabled();
+        let inputCertExpiryMins = await $('#setting-certExpiryMins');
+        await expect(inputCertExpiryMins).toBeDisabled();
+        let dropdownUserAuthorityFilter = await $('[name="setting-userAuthorityFilter"]');
+        await expect(dropdownUserAuthorityFilter).toBeDisabled();
+        let dropdownUserAuthorityExpiration = await $('[name="setting-userAuthorityExpiration"]');
+        await expect(dropdownUserAuthorityExpiration).toBeDisabled();
+        let inputSettingDescription = await $('#setting-description');
+        await expect(inputSettingDescription).toBeEnabled();
+        let inputMaxMembers = await $('#setting-maxMembers');
+        await expect(inputMaxMembers).toBeDisabled();
+
+        // add role info
+        let inputRoleName = await $('#role-name-input');
+        let roleName = 'delegated-role';
+        await inputRoleName.addValue(roleName);
+        let inputDelegateTo = await $('#delegated-to-input');
+        await inputDelegateTo.addValue('athenz.dev');
+        let buttonSubmit = await $('button*=Submit');
+        // submit role
+        await buttonSubmit.click();
+
+        // find row with 'delegated-role' in name and click settings svg
+        let buttonSettingsOfDelegatedRole = await $('.//*[local-name()="svg" and @id="delegated-role-setting-role-button"]');
+        await buttonSettingsOfDelegatedRole.click();
+
+        // verify all settings except Description are disabled
+        switchSettingReviewEnabled = await $('#switch-settingreviewEnabled');
+        await expect(switchSettingReviewEnabled).toBeDisabled();
+        switchSettingDeleteProtection = await $('#switch-settingdeleteProtection');
+        await expect(switchSettingDeleteProtection).toBeDisabled();
+        switchSettingSelfServe = await $('#switch-settingselfServe');
+        await expect(switchSettingSelfServe).toBeDisabled();
+        switchSettingSelfRenew = await $('#switch-settingselfRenew');
+        await expect(switchSettingSelfRenew).toBeDisabled();
+        inputSelfRenewMins = await $('#setting-selfRenewMins');
+        await expect(inputSelfRenewMins).toBeDisabled();
+        inputMemberExpiryDays = await $('#setting-memberExpiryDays');
+        await expect(inputMemberExpiryDays).toBeDisabled();
+        inputGroupExpiryDays = await $('#setting-groupExpiryDays');
+        await expect(inputGroupExpiryDays).toBeDisabled();
+        inputGroupReviewDays = await $('#setting-groupReviewDays');
+        await expect(inputGroupReviewDays).toBeDisabled();
+        inputServiceExpiryDays = await $('#setting-serviceExpiryDays');
+        await expect(inputServiceExpiryDays).toBeDisabled();
+        inputServiceReviewDays = await $('#setting-serviceReviewDays');
+        await expect(inputServiceReviewDays).toBeDisabled();
+        inputTokenExpiryMins = await $('#setting-tokenExpiryMins');
+        await expect(inputTokenExpiryMins).toBeDisabled();
+        inputCertExpiryMins = await $('#setting-certExpiryMins');
+        await expect(inputCertExpiryMins).toBeDisabled();
+        dropdownUserAuthorityFilter = await $('[name="setting-userAuthorityFilter"]');
+        await expect(dropdownUserAuthorityFilter).toBeDisabled();
+        dropdownUserAuthorityExpiration = await $('[name="setting-userAuthorityExpiration"]');
+        await expect(dropdownUserAuthorityExpiration).toBeDisabled();
+        inputSettingDescription = await $('#setting-description');
+        await expect(inputSettingDescription).toBeEnabled();
+        inputMaxMembers = await $('#setting-maxMembers');
+        await expect(inputMaxMembers).toBeDisabled();
+    });
+
+    // after - runs after the last test in order of declaration
+    after(async() => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await browser.waitUntil(async () => await testDomain.isClickable());
+        await testDomain.click();
+
+        // delete the delegate role used in the test
+        // find row with 'delegated-role' in name and click delete on svg
+        let buttonDeleteDelegatedRole = await $('.//*[local-name()="svg" and @id="delegated-role-delete-role-button"]');
+        await buttonDeleteDelegatedRole.click();
+        let modalDeleteButton = await $('button*=Delete');
+        await modalDeleteButton.click();
+    });
+})

--- a/ui/src/__tests__/spec/wdio.conf.js
+++ b/ui/src/__tests__/spec/wdio.conf.js
@@ -79,6 +79,15 @@ if (!sauceLabsUser) {
     localOrRemote.capabilities = [
         {
             browserName: 'chrome',
+            'goog:chromeOptions': {
+                args: [
+                    '--disable-infobars',           // Disables "Chrome is being controlled by automated software" infobar
+                    '--disable-default-apps',        // Disables default apps (including search engine prompts)
+                    '--no-first-run',                // Bypass first-time setup including "Choose your search engine"
+                    '--disable-popup-blocking',      // Disables popup blocking
+                    '--disable-search-engine-choice-screen' // Disables choose your search engine popup
+                ]
+            },
             browserVersion: 'latest',
             acceptInsecureCerts: true,
         },

--- a/ui/src/components/role/AddRole.js
+++ b/ui/src/components/role/AddRole.js
@@ -545,6 +545,7 @@ class AddRole extends React.Component {
                         <StyledInputLabel>Delegated to</StyledInputLabel>
                         <ContentDiv>
                             <StyledInput
+                                id={'delegated-to-input'}
                                 placeholder={
                                     ADD_ROLE_DELEGATED_DOMAIN_PLACEHOLDER
                                 }
@@ -593,6 +594,8 @@ class AddRole extends React.Component {
                                 members={members}
                                 role={this.state.role}
                                 reviewEnabled={this.state.reviewEnabled}
+                                // to disable all settings except description for delegated role
+                                delegated={this.state.category === 'delegated'}
                             />
                         </tbody>
                     </StyleTable>

--- a/ui/src/components/role/AddRoleAdvancedSettings.js
+++ b/ui/src/components/role/AddRoleAdvancedSettings.js
@@ -90,6 +90,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 label='Audit'
                 type='switch'
                 disabled={
+                    this.props.delegated ||
                     !this.props.isDomainAuditEnabled ||
                     this.props.members.length > 0
                 }
@@ -111,6 +112,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
                 tooltip={ADD_ROLE_REVIEW_ENABLED_TOOLTIP}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-deleteProtection'}
@@ -122,6 +124,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 value={this.props.role['deleteProtection']}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-selfServe'}
@@ -133,6 +136,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 value={this.props.role['selfServe']}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-selfRenew'}
@@ -144,6 +148,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 value={this.props.role['selfRenew']}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-selfRenewMins'}
@@ -152,7 +157,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 type='input'
                 desc={SELF_RENEW_MINS_DESC}
                 unit='Mins'
-                disabled={!this.props.role['selfRenew']}
+                disabled={this.props.delegated || !this.props.role['selfRenew']}
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
@@ -167,6 +172,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-memberReviewDays'}
@@ -178,6 +184,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-groupExpiryDays'}
@@ -189,6 +196,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-groupReviewDays'}
@@ -200,6 +208,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-serviceExpiryDays'}
@@ -211,6 +220,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-serviceReviewDays'}
@@ -222,6 +232,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-tokenExpiryMins'}
@@ -233,6 +244,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-certExpiryMins'}
@@ -244,6 +256,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-userAuthorityFilter'}
@@ -256,6 +269,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-userAuthorityExpiration'}
@@ -268,6 +282,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-description'}
@@ -278,6 +293,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
             <SettingRow
                 key={'setting-row-maxmembers'}
@@ -289,6 +305,7 @@ export default class AddRoleAdvancedSettings extends React.Component {
                 onValueChange={this.advancedSettingsChanged}
                 userProfileLink={this.props.userProfileLink}
                 inModal={true}
+                disabled={this.props.delegated}
             />,
         ];
     }

--- a/ui/src/components/role/RoleRow.js
+++ b/ui/src/components/role/RoleRow.js
@@ -415,6 +415,7 @@ class RoleRow extends React.Component {
                         trigger={
                             <span>
                                 <Icon
+                                    id={`${this.state.name}-setting-role-button`}
                                     icon={'setting'}
                                     onClick={clickSettings}
                                     color={colors.icons}

--- a/ui/src/components/settings/SettingRow.js
+++ b/ui/src/components/settings/SettingRow.js
@@ -149,6 +149,7 @@ export default class SettingRow extends React.Component {
                             filterable
                             onChange={this.onDropDownChange}
                             defaultSelectedValue={this.props.value}
+                            disabled={this.props.disabled || false}
                         />
                     </StyledDiv>
                 );

--- a/ui/src/components/settings/SettingTable.js
+++ b/ui/src/components/settings/SettingTable.js
@@ -388,6 +388,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.reviewEnabled}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -401,6 +402,7 @@ class SettingTable extends React.Component {
                 <StyledSettingRow
                     key={'setting-row-auditEnabled'}
                     disabled={
+                        this.props.roleIsDelegated ||
                         this.state.originalCollectionDetails.auditEnabled ||
                         this.state.copyCollectionDetails.hasRoleMembers ||
                         this.state.copyCollectionDetails.hasGroupMembers
@@ -432,6 +434,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.deleteProtection}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
         let selfServiceDesc =
@@ -450,6 +453,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.selfServe}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -469,6 +473,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.selfRenew}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -483,7 +488,7 @@ class SettingTable extends React.Component {
                     unit='Mins'
                     desc={SELF_RENEW_MINS_DESC}
                     value={this.state.copyCollectionDetails.selfRenewMins}
-                    disabled={!this.state.copyCollectionDetails.selfRenew}
+                    disabled={this.props.roleIsDelegated || !this.state.copyCollectionDetails.selfRenew}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
                 />
@@ -505,6 +510,7 @@ class SettingTable extends React.Component {
                 value={this.state.copyCollectionDetails.memberExpiryDays}
                 onValueChange={this.onValueChange}
                 _csrf={this.props._csrf}
+                disabled={this.props.roleIsDelegated || false}
             />
         );
 
@@ -521,6 +527,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.memberReviewDays}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -541,6 +548,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.groupExpiryDays}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -557,6 +565,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.groupReviewDays}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -576,6 +585,7 @@ class SettingTable extends React.Component {
                 value={this.state.copyCollectionDetails.serviceExpiryDays}
                 onValueChange={this.onValueChange}
                 _csrf={this.props._csrf}
+                disabled={this.props.roleIsDelegated || false}
             />
         );
 
@@ -592,6 +602,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.serviceReviewDays}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -612,6 +623,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.tokenExpiryMins}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -628,6 +640,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.certExpiryMins}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -663,6 +676,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.userAuthorityFilter}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -682,6 +696,7 @@ class SettingTable extends React.Component {
                     }
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 
@@ -717,6 +732,7 @@ class SettingTable extends React.Component {
                     value={this.state.copyCollectionDetails.maxMembers}
                     onValueChange={this.onValueChange}
                     _csrf={this.props._csrf}
+                    disabled={this.props.roleIsDelegated || false}
                 />
             );
 

--- a/ui/src/pages/domain/[domain]/role/[role]/settings.js
+++ b/ui/src/pages/domain/[domain]/role/[role]/settings.js
@@ -174,6 +174,8 @@ class SettingPage extends React.Component {
                                         collectionDetails={roleDetails}
                                         _csrf={_csrf}
                                         category={'role'}
+                                        // to disable all settings except description for delegated role
+                                        roleIsDelegated={!!this.props.roleDetails.trust}
                                     />
                                 </RolesContentDiv>
                             </RolesContainerDiv>


### PR DESCRIPTION
# Description
- Disabled advanced settings except description during role creation.
- Disabled settings except description on role editing screen. 
- Added functional test. 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots
### Role Creation - Advanced settings except Description are disabled:
<img width="815" alt="Screenshot 2024-09-16 at 14 44 39" src="https://github.com/user-attachments/assets/eb0f23ba-ed33-4e6e-a520-11bdb5dfce68">
<img width="820" alt="Screenshot 2024-09-16 at 14 45 11" src="https://github.com/user-attachments/assets/b760b51c-5e31-43b2-a4f1-67ab8a8eff55">

### Role Settings editing - All settings except Description are disabled:
<img width="1209" alt="Screenshot 2024-09-16 at 14 46 01" src="https://github.com/user-attachments/assets/b19abba2-311f-4f4c-810a-22b763065e54">
<img width="1209" alt="Screenshot 2024-09-16 at 14 46 20" src="https://github.com/user-attachments/assets/feea675b-1aba-4a62-b025-06d56db6f2c6">


