### PR TITLE
fix refresh role and group history displays no history

### DIFF
--- a/ui/src/__tests__/components/group/__snapshots__/GroupRow.test.js.snap
+++ b/ui/src/__tests__/components/group/__snapshots__/GroupRow.test.js.snap
@@ -197,7 +197,7 @@ exports[`GroupRow should render 1`] = `
         class="emotion-12"
         data-testid="icon"
         height="1.25em"
-        id=""
+        id="group-history-icon-testui"
         viewBox="0 0 1024 1024"
         width="1.25em"
       >

--- a/ui/src/__tests__/components/group/__snapshots__/GroupTable.test.js.snap
+++ b/ui/src/__tests__/components/group/__snapshots__/GroupTable.test.js.snap
@@ -330,7 +330,7 @@ exports[`GroupTable should render 1`] = `
             class="emotion-34"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="group-history-icon-a"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >
@@ -532,7 +532,7 @@ exports[`GroupTable should render 1`] = `
             class="emotion-34"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="group-history-icon-b"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >

--- a/ui/src/__tests__/components/role/__snapshots__/RoleRow.test.js.snap
+++ b/ui/src/__tests__/components/role/__snapshots__/RoleRow.test.js.snap
@@ -210,7 +210,7 @@ exports[`RoleRow should render 1`] = `
         class="emotion-12"
         data-testid="icon"
         height="1.25em"
-        id=""
+        id="ztssia_cert_rotate-history-role-button"
         viewBox="0 0 1024 1024"
         width="1.25em"
       >

--- a/ui/src/__tests__/components/role/__snapshots__/RoleTable.test.js.snap
+++ b/ui/src/__tests__/components/role/__snapshots__/RoleTable.test.js.snap
@@ -289,7 +289,7 @@ exports[`RoleTable should render 1`] = `
           class="emotion-36"
           data-testid="icon"
           height="1.25em"
-          id=""
+          id="a-history-role-button"
           viewBox="0 0 1024 1024"
           width="1.25em"
         >
@@ -482,7 +482,7 @@ exports[`RoleTable should render 1`] = `
           class="emotion-36"
           data-testid="icon"
           height="1.25em"
-          id=""
+          id="b-history-role-button"
           viewBox="0 0 1024 1024"
           width="1.25em"
         >

--- a/ui/src/__tests__/redux/reducers/groups.test.js
+++ b/ui/src/__tests__/redux/reducers/groups.test.js
@@ -91,7 +91,7 @@ describe('Groups Reducer', () => {
     });
     it('should load group into the store', () => {
         const initialState = {
-            groups: {},
+            // not creating groups field here - expecting it to be created by the tested function
             domainName: domainName,
             expiry: expiry,
         };

--- a/ui/src/__tests__/redux/reducers/roles.test.js
+++ b/ui/src/__tests__/redux/reducers/roles.test.js
@@ -102,6 +102,7 @@ describe('Roles Reducer', () => {
         };
         const expectedState = AppUtils.deepClone(initialState);
         expectedState.roles['singlerole'] = AppUtils.deepClone(singleStoreRole);
+        delete initialState.roles; // if initial state doesn't have roles field, it should be created
         const newState = roles(initialState, action);
         expect(_.isEqual(newState, expectedState)).toBeTruthy();
     });

--- a/ui/src/__tests__/spec/tests/groups.spec.js
+++ b/ui/src/__tests__/spec/tests/groups.spec.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+describe('group screen tests', () => {
+    it('group history should be visible when navigating to it and after page refresh', async () => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await testDomain.click();
+
+        // ADD test group
+        // navigate to groups page
+        let groups = await $('div*=Groups');
+        await groups.click();
+        // open Add Group screen
+        let addGroupButton = await $('button*=Add Group');
+        await addGroupButton.click();
+        // add group info
+        let inputGroupName = await $('#group-name-input');
+        let groupName = 'history-test-group';
+        await inputGroupName.addValue(groupName);
+        // add user
+        let addMemberInput = await $('[name="member-name"]'); //TODO rename the field
+        await addMemberInput.addValue('unix.yahoo');
+        let userOption = await $('div*=unix.yahoo');
+        await userOption.click();
+        // submit role
+        let buttonSubmit = await $('button*=Submit');
+        await buttonSubmit.click();
+
+        // Verify history entry of added group member is present
+        // open history
+        let historySvg = await $('.//*[local-name()="svg" and @id="group-history-icon-history-test-group"]');
+        await historySvg.click();
+        // find row with 'ADD'
+        let addTd = await $('td=ADD');
+        await expect(addTd).toHaveText('ADD');
+        // find row with 'unix.yahoo' present
+        let spanUnix = await $('span*=unix.yahoo');
+        await expect(spanUnix).toHaveText('unix.yahoo');
+
+        // Verify history is displayed after page refresh
+        // refresh page
+        await browser.refresh();
+        // find row with 'ADD'
+        addTd = await $('td=ADD');
+        await expect(addTd).toHaveText('ADD');
+        // find row with 'unix.yahoo' present
+        spanUnix = await $('span*=unix.yahoo');
+        await expect(spanUnix).toHaveText('unix.yahoo');
+    });
+
+    // after - runs after the last test in order of declaration
+    after(async() => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await testDomain.click();
+
+        // navigate to groups page
+        let groups = await $('div*=Groups');
+        await groups.click();
+
+        // delete the group used in the test
+        let buttonDeleteGroup = await $('.//*[local-name()="svg" and @id="delete-group-icon-history-test-group"]');
+        await buttonDeleteGroup.click();
+        let modalDeleteButton = await $('button*=Delete');
+        await modalDeleteButton.click();
+    });
+})

--- a/ui/src/__tests__/spec/tests/roles.spec.js
+++ b/ui/src/__tests__/spec/tests/roles.spec.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+describe('role screen tests', () => {
+    it('role history should be visible when navigating to it and after page refresh', async () => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await testDomain.click();
+
+        // ADD test role
+        // open Add Role screen
+        let addiRoleButton = await $('button*=Add Role');
+        await addiRoleButton.click();
+        // add group info
+        let inputRoleName = await $('#role-name-input');
+        let roleName = 'history-test-role';
+        await inputRoleName.addValue(roleName);
+        // add user
+        let addMemberInput = await $('[name="member-name"]');
+        await addMemberInput.addValue('unix.yahoo');
+        let userOption = await $('div*=unix.yahoo');
+        await userOption.click();
+        // submit role
+        let buttonSubmit = await $('button*=Submit');
+        await buttonSubmit.click();
+
+        // Verify history entry of added role member is present
+        // open history
+        let historySvg = await $('.//*[local-name()="svg" and @id="history-test-role-history-role-button"]');
+        await historySvg.click();
+        // find row with 'ADD'
+        let addTd = await $('td=ADD');
+        await expect(addTd).toHaveText('ADD');
+        // find row with 'unix.yahoo' present
+        let spanUnix = await $('span*=unix.yahoo');
+        await expect(spanUnix).toHaveText('unix.yahoo');
+
+        // Verify history is displayed after page refresh
+        // refresh page
+        await browser.refresh();
+        // find row with 'ADD'
+        addTd = await $('td=ADD');
+        await expect(addTd).toHaveText('ADD');
+        // find row with 'unix.yahoo' present
+        spanUnix = await $('span*=unix.yahoo');
+        await expect(spanUnix).toHaveText('unix.yahoo');
+    });
+
+    // after - runs after the last test in order of declaration
+    after(async() => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await testDomain.click();
+
+        // delete the role used in the test
+        let buttonDeleteRole = await $('.//*[local-name()="svg" and @id="history-test-role-delete-role-button"]');
+        await buttonDeleteRole.click();
+        let modalDeleteButton = await $('button*=Delete');
+        await modalDeleteButton.click();
+    });
+})

--- a/ui/src/components/group/GroupRow.js
+++ b/ui/src/components/group/GroupRow.js
@@ -358,6 +358,7 @@ class GroupRow extends React.Component {
                         trigger={
                             <span>
                                 <Icon
+                                    id={`group-history-icon-${this.state.name}`}
                                     icon={'time-history'}
                                     onClick={clickHistory}
                                     color={colors.icons}

--- a/ui/src/components/role/RoleRow.js
+++ b/ui/src/components/role/RoleRow.js
@@ -434,6 +434,7 @@ class RoleRow extends React.Component {
                         trigger={
                             <span>
                                 <Icon
+                                    id={`${this.state.name}-history-role-button`}
                                     icon={'time-history'}
                                     onClick={clickHistory}
                                     color={colors.icons}

--- a/ui/src/redux/reducers/groups.js
+++ b/ui/src/redux/reducers/groups.js
@@ -159,11 +159,12 @@ export const groups = (state = {}, action) => {
             return newState;
         }
         case LOAD_GROUP: {
-            const { groupData, groupName } = payload;
-            let newState = produce(state, (draft) => {
-                draft.groups[groupName] = groupData;
+            return produce(state, (draft) => {
+                if (!!!draft.groups) {
+                    draft.groups = {};
+                }
+                draft.groups[payload.groupName] = payload.groupData;
             });
-            return newState;
         }
         case UPDATE_SETTING_TO_STORE: {
             const { collectionName, collectionSettings, category } = payload;

--- a/ui/src/redux/reducers/roles.js
+++ b/ui/src/redux/reducers/roles.js
@@ -65,11 +65,12 @@ export const roles = (state = {}, action) => {
             return newState;
         }
         case LOAD_ROLE: {
-            const { roleData, roleName } = payload;
-            let newState = produce(state, (draft) => {
-                draft.roles[roleName] = roleData;
+            return produce(state, (draft) => {
+                if (!!!draft.roles) {
+                    draft.roles = {};
+                }
+                draft.roles[payload.roleName] = payload.roleData;
             });
-            return newState;
         }
         case LOAD_ROLES_TO_REVIEW: {
             const { rolesToReview } = payload;


### PR DESCRIPTION
# Description
When a particular Roles or Groups history page is refreshed - it displays no history.
The change fixes this bug.
- changed reducers - payload expansion for some reason was not assigning values, so assigning from payload directly to new state.
- added functional tests for group and roles screens

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 
https://github.com/user-attachments/assets/9317f16c-342f-4a21-babf-e445ad7108e1