### PR TITLE
during delete tenancy check the primary db instance

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -3457,8 +3457,11 @@ public class DBService implements RolesProvider, DomainProvider {
     }
 
     List<String> listRoles(String domainName) {
+        return listRoles(domainName, false);
+    }
 
-        try (ObjectStoreConnection con = store.getConnection(true, false)) {
+    List<String> listRoles(String domainName, boolean readWrite) {
+        try (ObjectStoreConnection con = store.getConnection(true, readWrite)) {
             return con.listRoles(domainName);
         }
     }
@@ -9145,7 +9148,11 @@ public class DBService implements RolesProvider, DomainProvider {
     }
 
     public ServiceIdentityList listServiceDependencies(String domainName) {
-        try (ObjectStoreConnection con = store.getConnection(true, false)) {
+        return listServiceDependencies(domainName, false);
+    }
+
+    public ServiceIdentityList listServiceDependencies(String domainName, boolean readWrite) {
+        try (ObjectStoreConnection con = store.getConnection(true, readWrite)) {
             ServiceIdentityList serviceIdentityList = new ServiceIdentityList();
             serviceIdentityList.setNames(con.listServiceDependencies(domainName));
             return serviceIdentityList;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -7820,13 +7820,15 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     }
 
     private void tenancyDeregisterDomainDependency(ResourceContext ctx, String tenantDomain, String provSvcDomain,
-                                                   String provSvcName, String auditRef, String caller) {
+            String provSvcName, String auditRef, String caller) {
         final String serviceToDeregister = provSvcDomain + "." + provSvcName;
         if (serviceProviderManager.isServiceProvider(serviceToDeregister)) {
-            boolean tenantDomainRolesExist = isTenantDomainRolesExist(tenantDomain, provSvcDomain, provSvcName);
-            DomainList domainList = dbService.listDomainDependencies(serviceToDeregister);
-            if (!tenantDomainRolesExist && domainList.getNames().contains(tenantDomain)) {
-                dbService.deleteDomainDependency(ctx, tenantDomain, serviceToDeregister, auditRef, caller);
+            ServiceIdentityList serviceIdentityList = dbService.listServiceDependencies(tenantDomain, true);
+            if (serviceIdentityList.getNames().contains(serviceToDeregister)) {
+                boolean tenantDomainRolesExist = isTenantDomainRolesExist(tenantDomain, provSvcDomain, provSvcName);
+                if (!tenantDomainRolesExist) {
+                    dbService.deleteDomainDependency(ctx, tenantDomain, serviceToDeregister, auditRef, caller);
+                }
             }
         }
     }
@@ -8432,15 +8434,15 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         }
     }
 
-    private boolean isTenantDomainRolesExist(String tenantDomain, String provSvcDomain, String provSvcName) {
-        final String provider = provSvcDomain + "." + provSvcName;
-        List<String> dependentResourceGroups = getDependentServiceResourceGroupList(tenantDomain).getServiceAndResourceGroups().stream()
-                .filter(dependency -> dependency.getDomain().equals(tenantDomain) && dependency.getService().equals(provider))
-                .findAny()
-                .map(DependentServiceResourceGroup::getResourceGroups)
-                .orElse(new ArrayList<>());
-
-        return !dependentResourceGroups.isEmpty();
+    private boolean isTenantDomainRolesExist(final String tenantDomain, final String provSvcDomain, final String provSvcName) {
+        final String rolePrefix = ZMSUtils.getTenantResourceGroupRolePrefix(provSvcName, tenantDomain, "");
+        final List<String> tenantDomainRoles = dbService.listRoles(provSvcDomain, true);
+        for (String tenantDomainRole : tenantDomainRoles) {
+            if (tenantDomainRole.startsWith(rolePrefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public ProviderResourceGroupRoles getProviderResourceGroupRoles(ResourceContext ctx, String tenantDomain,


### PR DESCRIPTION
# Description
 when we're checking the tenancy registration, the server would update the primary db instance with the role deletions but then would check the replica for any role existence to remove the domain dependency. if the db was slow and the changes were not propagated immediately, it would think there are still valid resource groups and not remove the dependency. Now we're checking the primary instance as well. Also simplified the calls to look for the roles and remove any unnecessary lookups.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

