### PR TITLE
set resource ownership when generating JWS domain

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -7042,6 +7042,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         domainData.setCertDnsDomain(domain.getCertDnsDomain());
         domainData.setMemberPurgeExpiryDays(domain.getMemberPurgeExpiryDays());
         domainData.setContacts(domain.getContacts());
+        domainData.setResourceOwnership(domain.getResourceOwnership());
     }
 
     SignedDomain retrieveSignedDomain(Domain domain, final String metaAttr, boolean setMetaDataOnly, boolean masterCopy, boolean includeConditions) {


### PR DESCRIPTION
# Description
While generating JWS domain object, the domain resource ownership field was missing. This led to an issue when using `zms-cli reset-domain-resource-ownership domain` command since we check if resource ownership is already empty or not
https://github.com/AthenZ/athenz/blob/c97c1b5fcf4df2ca9b1409f2dfa38368f6e29848/libs/go/zmscli/domain.go#L1497 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

