### PR TITLE
fix info link for service instances tooltip

### DIFF
--- a/ui/src/__tests__/components/service/__snapshots__/ServiceList.test.js.snap
+++ b/ui/src/__tests__/components/service/__snapshots__/ServiceList.test.js.snap
@@ -284,7 +284,7 @@ exports[`ServiceList should render add service modal after click 1`] = `
             class="emotion-29"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="delete-service-openhouse"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >
@@ -599,7 +599,7 @@ exports[`ServiceList should render delete service modal error(other) after click
             class="emotion-29"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="delete-service-openhouse"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >
@@ -904,7 +904,7 @@ exports[`ServiceList should render delete service modal error(refresh) after cli
             class="emotion-29"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="delete-service-openhouse"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >
@@ -1209,7 +1209,7 @@ exports[`ServiceList should render serviceList again after cancel delete 1`] = `
             class="emotion-29"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="delete-service-openhouse"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >
@@ -1673,7 +1673,7 @@ exports[`ServiceList should render with services 1`] = `
             class="emotion-29"
             data-testid="icon"
             height="1.25em"
-            id=""
+            id="delete-service-openhouse"
             viewBox="0 0 1024 1024"
             width="1.25em"
           >

--- a/ui/src/__tests__/components/service/__snapshots__/ServiceRow.test.js.snap
+++ b/ui/src/__tests__/components/service/__snapshots__/ServiceRow.test.js.snap
@@ -198,7 +198,7 @@ exports[`ServiceRow should render row 1`] = `
       class="emotion-8"
       data-testid="icon"
       height="1.25em"
-      id=""
+      id="delete-service-serviceName"
       viewBox="0 0 1024 1024"
       width="1.25em"
     >

--- a/ui/src/__tests__/pages/domain/[domain]/__snapshots__/service.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/__snapshots__/service.test.js.snap
@@ -1509,7 +1509,7 @@ exports[`ServicePage should render 1`] = `
                       class="emotion-84"
                       data-testid="icon"
                       height="1.25em"
-                      id=""
+                      id="delete-service-bastion"
                       viewBox="0 0 1024 1024"
                       width="1.25em"
                     >
@@ -1632,7 +1632,7 @@ exports[`ServicePage should render 1`] = `
                       class="emotion-84"
                       data-testid="icon"
                       height="1.25em"
-                      id=""
+                      id="delete-service-openhouse"
                       viewBox="0 0 1024 1024"
                       width="1.25em"
                     >

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/dynamic.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/dynamic.test.js.snap
@@ -1090,7 +1090,7 @@ exports[`DynamicInstancePage should render 1`] = `
                   class="emotion-36"
                   data-testid="icon"
                   height="15px"
-                  id=""
+                  id="instances-help-tooltip"
                   viewBox="0 0 1024 1024"
                   width="15px"
                 >

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/static.test.js.snap
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/__snapshots__/static.test.js.snap
@@ -1113,7 +1113,7 @@ exports[`StaticInstancePage should render 1`] = `
                   class="emotion-36"
                   data-testid="icon"
                   height="15px"
-                  id=""
+                  id="instances-help-tooltip"
                   viewBox="0 0 1024 1024"
                   width="15px"
                 >

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/dynamic.test.js
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/dynamic.test.js
@@ -76,10 +76,12 @@ describe('DynamicInstancePage', () => {
             },
         };
         let serviceHeaderDetails = {
-            description:
-                'Here you can add / see instances which can not obtain Athenz identity because of limitations, but would be associated with your service.',
-            url: '',
-            target: '_blank',
+            dynamic : {
+                description:
+                    'Here you can see instances which are running with this service identity',
+                url: '',
+                target: '_blank',
+            }
         };
         let services = {
             'dom.serv': {

--- a/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/static.test.js
+++ b/ui/src/__tests__/pages/domain/[domain]/service/[service]/instance/static.test.js
@@ -76,10 +76,12 @@ describe('StaticInstancePage', () => {
         };
 
         let serviceHeaderDetails = {
-            description:
-                'Here you can add / see instances which can not obtain Athenz identity because of limitations, but would be associated with your service.',
-            url: '',
-            target: '_blank',
+            static: {
+                description:
+                    'Here you can add / see instances which can not obtain Athenz identity because of limitations, but would be associated with your service.',
+                url: '',
+                target: '_blank',
+            }
         };
         let services = {
             'dom.serv': {

--- a/ui/src/__tests__/spec/tests/services.spec.js
+++ b/ui/src/__tests__/spec/tests/services.spec.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('services screen tests', () => {
+    it('when clicking help tooltip link, it should open a tab with athenz guide', async () => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await browser.waitUntil(async () => await testDomain.isClickable());
+        await testDomain.click();
+
+        // open Services
+        let servicesButton = await $('div*=Services');
+        await browser.waitUntil(async () => await servicesButton.isClickable());
+        await servicesButton.click();
+
+        // add service
+        const serviceName = 'tooltip-link-test-service';
+        let addServiceButton = await $('button*=Add Service');
+        await addServiceButton.click();
+        let serviceNameInput = await $('input[id="service-name"]');
+        await serviceNameInput.addValue(serviceName);
+        let submitButton = await $('button*=Submit');
+        await submitButton.click();
+
+        // navigate to tooltip
+        let serviceInstancesButton = await $(`.//*[local-name()="svg" and @id="${'view-instances-' + serviceName}"]`);
+        await serviceInstancesButton.click();
+        // open tooltip
+        let instanceHelpTooltipButton = await $(`.//*[local-name()="svg" and @id="instances-help-tooltip"]`);
+        await instanceHelpTooltipButton.click();
+        // click athenz guide link
+        await browser.pause(1000); // wait a little so that onclick function is assigned to the anchor
+        let athenzGuideAnchor = await $('a*=here');
+        await athenzGuideAnchor.click();
+        await browser.pause(1000); // Just to ensure the new tab opens
+        // switch to opened tab
+        const windowHandles = await browser.getWindowHandles();
+        expect(windowHandles.length).toBeGreaterThan(1);
+        await browser.switchToWindow(windowHandles[1]);
+        // verify the URL of the new tab
+        const url = await browser.getUrl();
+        expect(url).toContain('athenz-guide');
+    });
+
+    // after - runs after the last test in order of declaration
+    after(async() => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/`);
+        // select domain
+        let domain = 'athenz.dev.functional-test';
+        let testDomain = await $(`a*=${domain}`);
+        await browser.waitUntil(async () => await testDomain.isClickable());
+        await testDomain.click();
+
+        // open Services
+        let servicesButton = await $('div*=Services');
+        await browser.waitUntil(async () => await servicesButton.isClickable());
+        await servicesButton.click();
+
+        // delete service created for the test
+        let serviceDeleteButton = await $('.//*[local-name()="svg" and @id="delete-service-tooltip-link-test-service"]');
+        await serviceDeleteButton.click();
+        let modalDeleteButton = await $('button*=Delete');
+        await modalDeleteButton.click();
+    });
+})

--- a/ui/src/components/header/ServiceNameHeader.js
+++ b/ui/src/components/header/ServiceNameHeader.js
@@ -62,6 +62,7 @@ export default function ServiceNameHeader(props) {
         message.push(' For more information click ');
         var urlLink = (
             <StyledAnchor
+                id={'athenz-guide-anchor'}
                 key={Date.now()}
                 onClick={() =>
                     window.open(
@@ -85,6 +86,7 @@ export default function ServiceNameHeader(props) {
                     padding-bottom='10px'
                     trigger={({ getTriggerProps, triggerRef }) => (
                         <Icon
+                            id={'instances-help-tooltip'}
                             icon={'help-circle'}
                             {...getTriggerProps({ innerRef: triggerRef })}
                             isLink

--- a/ui/src/components/service/ServiceRow.js
+++ b/ui/src/components/service/ServiceRow.js
@@ -132,6 +132,7 @@ class ServiceRow extends React.Component {
                 {this.props.featureFlag ? (
                     <TdStyled color={color} align={center}>
                         <Icon
+                            id={'view-instances-' + this.props.serviceName}
                             icon={'data-source'}
                             onClick={this.toggleInstances}
                             color={colors.icons}
@@ -183,6 +184,7 @@ class ServiceRow extends React.Component {
                 </TdStyled>
                 <TdStyled color={color} align={center}>
                     <Icon
+                        id={'delete-service-' + this.props.serviceName}
                         icon={'trash'}
                         onClick={this.props.onClickDeleteService}
                         color={colors.icons}

--- a/ui/src/pages/domain/[domain]/service/[service]/instance/dynamic.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/instance/dynamic.js
@@ -247,8 +247,8 @@ const mapStateToProps = (state, props) => {
         ),
         serviceHeaderDetails: selectDynamicServiceHeaderDetails(
             state,
-            props.domain,
-            props.service
+            props.domainName,
+            props.serviceName
         ),
         isLoading: selectIsLoading(state),
         featureFlag: selectFeatureFlag(state),

--- a/ui/src/pages/domain/[domain]/service/[service]/instance/static.js
+++ b/ui/src/pages/domain/[domain]/service/[service]/instance/static.js
@@ -247,8 +247,8 @@ const mapStateToProps = (state, props) => {
         ),
         serviceHeaderDetails: selectStaticServiceHeaderDetails(
             state,
-            props.domain,
-            props.service
+            props.domainName,
+            props.serviceName
         ),
         isLoading: selectIsLoading(state),
         featureFlag: selectFeatureFlag(state),


### PR DESCRIPTION
# Description
Fixes info link to point to athenz guide where before it used to open a blank tab.
- Main change is in the [static.js](https://github.com/AthenZ/athenz/pull/2750/files#diff-09f3f6ef1dd729d9ad34592ad085adfbe330ba2286f63e1086ee412c15a3c014L250) and [dynamic.js](https://github.com/AthenZ/athenz/pull/2750/files#diff-90c27b6c7f60ac261bffb44a6be42da9e03324bfd8d40d7bba442bf8b31dc5b8L250) where domainName and serviceName were incorrectly referenced.
- added a file with a functional test
- fixed dynamic.test.js and static.test.js
- rest of the changes are to support ease of writing functional test
- recreated snapshots

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

