### PR TITLE
disable member extension in role and group review

### DIFF
--- a/ui/src/__tests__/components/denali/__snapshots__/Alert.test.js.snap
+++ b/ui/src/__tests__/components/denali/__snapshots__/Alert.test.js.snap
@@ -208,6 +208,7 @@ exports[`Alert should disable animations 1`] = `
             </div>
             <div
               class="close-button"
+              data-wdio="alert-close"
             >
               <svg
                 class="emotion-3"
@@ -446,6 +447,7 @@ exports[`Alert should render all alert types 1`] = `
             </div>
             <div
               class="close-button"
+              data-wdio="alert-close"
             >
               <svg
                 class="emotion-3"
@@ -677,6 +679,7 @@ exports[`Alert should render all alert types 2`] = `
             </div>
             <div
               class="close-button"
+              data-wdio="alert-close"
             >
               <svg
                 class="emotion-3"
@@ -908,6 +911,7 @@ exports[`Alert should render all alert types 3`] = `
             </div>
             <div
               class="close-button"
+              data-wdio="alert-close"
             >
               <svg
                 class="emotion-3"
@@ -1139,6 +1143,7 @@ exports[`Alert should render all alert types 4`] = `
             </div>
             <div
               class="close-button"
+              data-wdio="alert-close"
             >
               <svg
                 class="emotion-3"
@@ -1367,6 +1372,7 @@ exports[`Alert should render open state 1`] = `
             </div>
             <div
               class="close-button"
+              data-wdio="alert-close"
             >
               <svg
                 class="emotion-3"

--- a/ui/src/__tests__/components/group/__snapshots__/GroupRow.test.js.snap
+++ b/ui/src/__tests__/components/group/__snapshots__/GroupRow.test.js.snap
@@ -123,7 +123,7 @@ exports[`GroupRow should render 1`] = `
       <svg
         class="emotion-12"
         data-testid="icon"
-        data-wdio=""
+        data-wdio="testui-review"
         height="1.25em"
         id=""
         viewBox="0 0 1024 1024"

--- a/ui/src/__tests__/components/group/__snapshots__/GroupTable.test.js.snap
+++ b/ui/src/__tests__/components/group/__snapshots__/GroupTable.test.js.snap
@@ -256,7 +256,7 @@ exports[`GroupTable should render 1`] = `
           <svg
             class="emotion-34"
             data-testid="icon"
-            data-wdio=""
+            data-wdio="a-review"
             height="1.25em"
             id=""
             viewBox="0 0 1024 1024"
@@ -465,7 +465,7 @@ exports[`GroupTable should render 1`] = `
           <svg
             class="emotion-34"
             data-testid="icon"
-            data-wdio=""
+            data-wdio="b-review"
             height="1.25em"
             id=""
             viewBox="0 0 1024 1024"

--- a/ui/src/__tests__/components/review/__snapshots__/ReviewRow.test.js.snap
+++ b/ui/src/__tests__/components/review/__snapshots__/ReviewRow.test.js.snap
@@ -147,7 +147,7 @@ exports[`ReviewRow should render 1`] = `
       data-testid="radiobutton-wrapper"
     >
       <input
-        checked=""
+        disabled=""
         id="radiobutton-undefined50-extend"
         name="undefined50"
         type="radio"
@@ -167,6 +167,7 @@ exports[`ReviewRow should render 1`] = `
       data-testid="radiobutton-wrapper"
     >
       <input
+        checked=""
         id="radiobutton-undefined50-no-action"
         name="undefined50"
         type="radio"

--- a/ui/src/__tests__/components/review/__snapshots__/ReviewTable.test.js.snap
+++ b/ui/src/__tests__/components/review/__snapshots__/ReviewTable.test.js.snap
@@ -401,7 +401,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser1-extend"
               name="undefinedrole-review-roleNameuser1"
               type="radio"
@@ -421,6 +421,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser1-no-action"
               name="undefinedrole-review-roleNameuser1"
               type="radio"
@@ -486,7 +487,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser2-extend"
               name="undefinedrole-review-roleNameuser2"
               type="radio"
@@ -506,6 +507,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser2-no-action"
               name="undefinedrole-review-roleNameuser2"
               type="radio"
@@ -571,7 +573,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser3-extend"
               name="undefinedrole-review-roleNameuser3"
               type="radio"
@@ -591,6 +593,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser3-no-action"
               name="undefinedrole-review-roleNameuser3"
               type="radio"
@@ -656,7 +659,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser4-extend"
               name="undefinedrole-review-roleNameuser4"
               type="radio"
@@ -676,6 +679,7 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser4-no-action"
               name="undefinedrole-review-roleNameuser4"
               type="radio"
@@ -1172,7 +1176,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser1-extend"
               name="undefinedrole-review-roleNameuser1"
               type="radio"
@@ -1192,6 +1196,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser1-no-action"
               name="undefinedrole-review-roleNameuser1"
               type="radio"
@@ -1257,7 +1262,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser2-extend"
               name="undefinedrole-review-roleNameuser2"
               type="radio"
@@ -1277,6 +1282,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser2-no-action"
               name="undefinedrole-review-roleNameuser2"
               type="radio"
@@ -1342,7 +1348,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser3-extend"
               name="undefinedrole-review-roleNameuser3"
               type="radio"
@@ -1362,6 +1368,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser3-no-action"
               name="undefinedrole-review-roleNameuser3"
               type="radio"
@@ -1427,7 +1434,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser4-extend"
               name="undefinedrole-review-roleNameuser4"
               type="radio"
@@ -1447,6 +1454,7 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser4-no-action"
               name="undefinedrole-review-roleNameuser4"
               type="radio"
@@ -1943,7 +1951,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser1-extend"
               name="undefinedrole-review-roleNameuser1"
               type="radio"
@@ -1963,6 +1971,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser1-no-action"
               name="undefinedrole-review-roleNameuser1"
               type="radio"
@@ -2028,7 +2037,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser2-extend"
               name="undefinedrole-review-roleNameuser2"
               type="radio"
@@ -2048,6 +2057,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser2-no-action"
               name="undefinedrole-review-roleNameuser2"
               type="radio"
@@ -2113,7 +2123,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser3-extend"
               name="undefinedrole-review-roleNameuser3"
               type="radio"
@@ -2133,6 +2143,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser3-no-action"
               name="undefinedrole-review-roleNameuser3"
               type="radio"
@@ -2198,7 +2209,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              checked=""
+              disabled=""
               id="radiobutton-undefinedrole-review-roleNameuser4-extend"
               name="undefinedrole-review-roleNameuser4"
               type="radio"
@@ -2218,6 +2229,7 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
+              checked=""
               id="radiobutton-undefinedrole-review-roleNameuser4-no-action"
               name="undefinedrole-review-roleNameuser4"
               type="radio"

--- a/ui/src/__tests__/components/role/__snapshots__/RoleRow.test.js.snap
+++ b/ui/src/__tests__/components/role/__snapshots__/RoleRow.test.js.snap
@@ -114,7 +114,7 @@ exports[`RoleRow should render 1`] = `
       <svg
         class="emotion-12"
         data-testid="icon"
-        data-wdio=""
+        data-wdio="ztssia_cert_rotate-review"
         height="1.25em"
         id=""
         viewBox="0 0 1024 1024"

--- a/ui/src/__tests__/components/role/__snapshots__/RoleTable.test.js.snap
+++ b/ui/src/__tests__/components/role/__snapshots__/RoleTable.test.js.snap
@@ -197,7 +197,7 @@ exports[`RoleTable should render 1`] = `
         <svg
           class="emotion-36"
           data-testid="icon"
-          data-wdio=""
+          data-wdio="a-review"
           height="1.25em"
           id=""
           viewBox="0 0 1024 1024"
@@ -398,7 +398,7 @@ exports[`RoleTable should render 1`] = `
         <svg
           class="emotion-36"
           data-testid="icon"
-          data-wdio=""
+          data-wdio="b-review"
           height="1.25em"
           id=""
           viewBox="0 0 1024 1024"

--- a/ui/src/__tests__/spec/tests/groups.spec.js
+++ b/ui/src/__tests__/spec/tests/groups.spec.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const reviewExtendTest = 'review-extend-test';
+
 describe('group screen tests', () => {
     it('group history should be visible when navigating to it and after page refresh', async () => {
         // open browser
@@ -138,5 +140,86 @@ describe('group screen tests', () => {
         // verify input is in bold
         fontWeight = await addMemberInput.getCSSProperty('font-weight');
         expect(fontWeight.value === 700).toBe(true);
+    });
+
+    it('Group Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings', async () => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/domain/athenz.dev.functional-test/group`);
+
+        // ADD GROUP WITH USER
+        let addGroupBttn = await $('button*=Add Group');
+        await addGroupBttn.click();
+        // add group info
+        let inputGroupName = await $('#group-name-input');
+        await inputGroupName.addValue(reviewExtendTest);
+        // add user
+        let addMemberInput = await $('[name="member-name"]');
+        await addMemberInput.addValue('unix.yahoo');
+        let userOption = await $('div*=unix.yahoo');
+        await userOption.click();
+        // submit role
+        let buttonSubmit = await $('button*=Submit');
+        await buttonSubmit.click();
+
+        // go to review - the extend radio should be disabled
+        let reviewSvg = await $(
+            `.//*[local-name()="svg" and @data-wdio="${reviewExtendTest}-review"]`
+        );
+        await reviewSvg.click();
+        let extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeDisabled();
+
+        // go to settings set user expiry days, submit
+        let settingsDiv = await $('div*=Settings');
+        await settingsDiv.click();
+        let memberExpiryDays = await $('input[id="setting-memberExpiryDays"]');
+        await memberExpiryDays.addValue(10);
+        let submitBtn = await $('button*=Submit');
+        await submitBtn.click();
+        let confirmSubmit = await $(
+            'button[data-testid="update-modal-update"]'
+        );
+        await confirmSubmit.click();
+        let alertClose = await $('div[data-wdio="alert-close"]');
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        let reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+
+        // go to settings, set service expiry days, submit
+        await settingsDiv.click();
+        memberExpiryDays = await $('input[id="setting-memberExpiryDays"]');
+        await memberExpiryDays.clearValue();
+        await memberExpiryDays.setValue(0);
+        let serviceExpiryDays = await $(
+            'input[id="setting-serviceExpiryDays"]'
+        );
+        await serviceExpiryDays.addValue(10);
+        await submitBtn.click();
+        confirmSubmit = await $('button[data-testid="update-modal-update"]');
+        await confirmSubmit.click();
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+    });
+
+    // delete group created in previous test
+    after(async () => {
+        await browser.newUser();
+        await browser.url(`/domain/athenz.dev.functional-test/group`);
+        await expect(browser).toHaveUrlContaining('athenz');
+
+        await $(
+            `.//*[local-name()="svg" and @id="delete-group-icon-${reviewExtendTest}"]`
+        ).click();
+        await $('button*=Delete').click();
     });
 });

--- a/ui/src/__tests__/spec/tests/roles.spec.js
+++ b/ui/src/__tests__/spec/tests/roles.spec.js
@@ -15,6 +15,7 @@
  */
 
 const dropdownTestRoleName = 'dropdown-test-role';
+const reviewExtendTest = 'review-extend-test';
 
 describe('role screen tests', () => {
     it('role history should be visible when navigating to it and after page refresh', async () => {
@@ -66,7 +67,6 @@ describe('role screen tests', () => {
         spanUnix = await $('span*=unix.yahoo');
         await expect(spanUnix).toHaveText('unix.yahoo');
     });
-
     // after - runs after the last test in order of declaration
     after(async () => {
         // open browser
@@ -376,6 +376,162 @@ describe('role screen tests', () => {
 
         await $(
             `.//*[local-name()="svg" and @id="${dropdownTestRoleName}-delete-role-button"]`
+        ).click();
+        await $('button*=Delete').click();
+    });
+
+    it('Role Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings', async () => {
+        // open browser
+        await browser.newUser();
+        await browser.url(`/domain/athenz.dev.functional-test/role`);
+
+        // ADD ROLE WITH USER
+        let addiRoleButton = await $('button*=Add Role');
+        await addiRoleButton.click();
+        // add group info
+        let inputRoleName = await $('#role-name-input');
+        await inputRoleName.addValue(reviewExtendTest);
+        // add user
+        let addMemberInput = await $('[name="member-name"]');
+        await addMemberInput.addValue('unix.yahoo');
+        let userOption = await $('div*=unix.yahoo');
+        await userOption.click();
+        // submit role
+        let buttonSubmit = await $('button*=Submit');
+        await buttonSubmit.click();
+
+        // go to review - the extend radio should be disabled
+        let reviewSvg = await $(
+            `.//*[local-name()="svg" and @data-wdio="${reviewExtendTest}-review"]`
+        );
+        await reviewSvg.click();
+        let extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeDisabled();
+
+        // go to settings set user expiry days, submit
+        let settingsDiv = await $('div*=Settings');
+        await settingsDiv.click();
+        let memberExpiryDays = await $('input[id="setting-memberExpiryDays"]');
+        await memberExpiryDays.addValue(10);
+        let submitBtn = await $('button*=Submit');
+        await submitBtn.click();
+        let confirmSubmit = await $(
+            'button[data-testid="update-modal-update"]'
+        );
+        await confirmSubmit.click();
+        let alertClose = await $('div[data-wdio="alert-close"]');
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        let reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+
+        // go to settings, set user review days, submit
+        await settingsDiv.click();
+        memberExpiryDays = await $('input[id="setting-memberExpiryDays"]');
+        await memberExpiryDays.clearValue();
+        await memberExpiryDays.setValue(0);
+        let memberReviewDays = await $('input[id="setting-memberReviewDays"]');
+        await memberReviewDays.addValue(10);
+        await submitBtn.click();
+        confirmSubmit = await $('button[data-testid="update-modal-update"]');
+        await confirmSubmit.click();
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+
+        // go to settings, set group expiry days, submit
+        await settingsDiv.click();
+        memberReviewDays = await $('input[id="setting-memberReviewDays"]');
+        await memberReviewDays.clearValue();
+        await memberReviewDays.setValue(0);
+        let groupExpiryDays = await $('input[id="setting-groupExpiryDays"]');
+        await groupExpiryDays.addValue(10);
+        await submitBtn.click();
+        confirmSubmit = await $('button[data-testid="update-modal-update"]');
+        await confirmSubmit.click();
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+
+        // go to settings, set group review days, submit
+        await settingsDiv.click();
+        groupExpiryDays = await $('input[id="setting-groupExpiryDays"]');
+        await groupExpiryDays.clearValue();
+        await groupExpiryDays.setValue(0);
+        let groupReviewDays = await $('input[id="setting-groupReviewDays"]');
+        await groupReviewDays.addValue(10);
+        await submitBtn.click();
+        confirmSubmit = await $('button[data-testid="update-modal-update"]');
+        await confirmSubmit.click();
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+
+        // go to settings, set service review days, submit
+        await settingsDiv.click();
+        groupReviewDays = await $('input[id="setting-groupReviewDays"]');
+        await groupReviewDays.clearValue();
+        await groupReviewDays.setValue(0);
+        let serviceExpiryDays = await $(
+            'input[id="setting-serviceExpiryDays"]'
+        );
+        await serviceExpiryDays.addValue(10);
+        await submitBtn.click();
+        confirmSubmit = await $('button[data-testid="update-modal-update"]');
+        await confirmSubmit.click();
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+
+        // go to settings, set service expiry days, submit
+        await settingsDiv.click();
+        serviceExpiryDays = await $('input[id="setting-serviceExpiryDays"]');
+        await serviceExpiryDays.clearValue();
+        await serviceExpiryDays.setValue(0);
+        let serviceReviewDays = await $(
+            'input[id="setting-serviceReviewDays"]'
+        );
+        await serviceReviewDays.addValue(10);
+        await submitBtn.click();
+        confirmSubmit = await $('button[data-testid="update-modal-update"]');
+        await confirmSubmit.click();
+        await alertClose.click();
+
+        // go to review - the extend radio should be enabled
+        reviewDiv = await $('div*=Review');
+        await reviewDiv.click();
+        extendRadio = await $('input[value="extend"]');
+        await expect(extendRadio).toBeEnabled();
+    });
+
+    // delete role created in previous test
+    after(async () => {
+        // delete role created in previous test
+        await browser.newUser();
+        await browser.url(`/domain/athenz.dev.functional-test/role`);
+        await expect(browser).toHaveUrlContaining('athenz');
+
+        await $(
+            `.//*[local-name()="svg" and @id="${reviewExtendTest}-delete-role-button"]`
         ).click();
         await $('button*=Delete').click();
     });

--- a/ui/src/components/denali/Alert.js
+++ b/ui/src/components/denali/Alert.js
@@ -226,6 +226,7 @@ class Alert extends React.Component {
                         <div
                             className='close-button'
                             onClick={this.props.onClose}
+                            data-wdio={'alert-close'}
                         >
                             <Icon
                                 color={rgba(colors.grey800, 0.4)}

--- a/ui/src/components/group/GroupReviewTable.js
+++ b/ui/src/components/group/GroupReviewTable.js
@@ -230,6 +230,9 @@ class GroupReviewTable extends React.Component {
                                   onUpdate={this.onUpdate}
                                   submittedReview={this.state.submittedReview}
                                   timeZone={this.props.timeZone}
+                                  expiryOrReviewSettingIsSet={
+                                      this.props.expiryOrReviewSettingIsSet
+                                  }
                               />
                           );
                       })

--- a/ui/src/components/group/GroupRow.js
+++ b/ui/src/components/group/GroupRow.js
@@ -310,6 +310,7 @@ class GroupRow extends React.Component {
                                     size={'1.25em'}
                                     verticalAlign={'text-bottom'}
                                     enableTitle={false}
+                                    dataWdio={`${this.state.name}-review`}
                                 />
                             </span>
                         }

--- a/ui/src/components/review/ReviewList.js
+++ b/ui/src/components/review/ReviewList.js
@@ -24,6 +24,7 @@ import { selectTimeZone } from '../../redux/selectors/domains';
 import { connect } from 'react-redux';
 import { ReduxPageLoader } from '../denali/ReduxPageLoader';
 import { withRouter } from 'next/router';
+import { getSmallestExpiryOrReview } from '../utils/ReviewUtils';
 
 const RolesSectionDiv = styled.div`
     margin: 20px;
@@ -97,6 +98,12 @@ class ReviewList extends React.Component {
                         _csrf={this.props._csrf}
                         onUpdateSuccess={this.submitSuccess}
                         justification={this.props.justification}
+                        expiryOrReviewSettingIsSet={
+                            0 <
+                            getSmallestExpiryOrReview(
+                                this.props.collectionDetails
+                            )
+                        }
                     />
                 )}
                 {this.props.category === 'role' && (
@@ -109,6 +116,12 @@ class ReviewList extends React.Component {
                         _csrf={this.props._csrf}
                         onUpdateSuccess={this.submitSuccess}
                         justification={this.props.justification}
+                        expiryOrReviewSettingIsSet={
+                            0 <
+                            getSmallestExpiryOrReview(
+                                this.props.collectionDetails
+                            )
+                        }
                     />
                 )}
                 {this.state.showSuccess ? (

--- a/ui/src/components/review/ReviewRow.js
+++ b/ui/src/components/review/ReviewRow.js
@@ -44,7 +44,9 @@ export default class ReviewRow extends React.Component {
         super(props);
         this.api = this.props.api;
         this.onReview = this.onReview.bind(this);
-        let selectedOption = 'extend';
+        let selectedOption = this.props.expiryOrReviewSettingIsSet
+            ? 'extend'
+            : 'no-action';
         this.state = {
             selectedOption: selectedOption,
         };
@@ -128,6 +130,7 @@ export default class ReviewRow extends React.Component {
                         value='extend'
                         checked={this.state.selectedOption === 'extend'}
                         onChange={this.onReview}
+                        disabled={!this.props.expiryOrReviewSettingIsSet}
                     />
                 </TDStyled>
                 <TDStyled color={color} align={center}>

--- a/ui/src/components/review/ReviewTable.js
+++ b/ui/src/components/review/ReviewTable.js
@@ -336,6 +336,9 @@ export class ReviewTable extends React.Component {
                                   onUpdate={this.onUpdate}
                                   submittedReview={this.state.submittedReview}
                                   timeZone={this.props.timeZone}
+                                  expiryOrReviewSettingIsSet={
+                                      this.props.expiryOrReviewSettingIsSet
+                                  }
                               />
                           );
                       })

--- a/ui/src/components/role/RoleRow.js
+++ b/ui/src/components/role/RoleRow.js
@@ -370,6 +370,7 @@ class RoleRow extends React.Component {
                                     size={'1.25em'}
                                     verticalAlign={'text-bottom'}
                                     enableTitle={false}
+                                    dataWdio={`${this.state.name}-review`}
                                 />
                             </span>
                         }


### PR DESCRIPTION
# Description
disable member extension in role and group review when extension or review (days) are not set role/group in settings

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

