### PR TITLE
UI - use authorization check to determine launch provider access

### DIFF
--- a/ui/src/__tests__/api.test.js
+++ b/ui/src/__tests__/api.test.js
@@ -1189,26 +1189,26 @@ describe('Fetchr Client API Test', () => {
     describe('getProvider test', () => {
         it('getProvider test success', async () => {
             myDataService = {
-                name: 'provider',
+                name: 'access',
                 read: function (req, resource, params, config, callback) {
                     callback(null, DATA);
                 },
             };
             fetchrStub = sinon.stub(Fetchr, 'isRegistered');
             fetchrStub.returns(myDataService);
-            result = await api.getProvider('dummyDom', 'dummySvc');
+            result = await api.getProviderAccess('dummyDom', 'dummySvc');
             expect(result).toEqual(DATA);
         });
         it('getProvider test error', async () => {
             myDataServiceErr = {
-                name: 'provider',
+                name: 'access',
                 read: function (req, resource, params, config, callback) {
                     return callback({}, null);
                 },
             };
             fetchrStub = sinon.stub(Fetchr, 'isRegistered');
             fetchrStub.returns(myDataServiceErr);
-            await api.getProvider('dummyDom', 'dummySvc').catch((err) => {
+            await api.getProviderAccess('dummyDom', 'dummySvc').catch((err) => {
                 expect(err).not.toBeNull();
             });
         });

--- a/ui/src/__tests__/components/service/ServiceRow.test.js
+++ b/ui/src/__tests__/components/service/ServiceRow.test.js
@@ -146,7 +146,9 @@ describe('ServiceRow', () => {
             getServices: jest
                 .fn()
                 .mockReturnValue(Promise.resolve([{ name: fullServiceName }])),
-            getProvider: jest.fn().mockReturnValue(Promise.resolve(toReturn)),
+            getProviderAccess: jest
+                .fn()
+                .mockReturnValue(Promise.resolve(toReturn)),
         };
         MockApi.setMockApi(api);
         const color = '';

--- a/ui/src/__tests__/redux/thunk/services.test.js
+++ b/ui/src/__tests__/redux/thunk/services.test.js
@@ -627,20 +627,22 @@ describe('getProvider method', () => {
             provider: {},
         });
         let myMockApi = {
-            getProvider: jest
+            getProviderAccess: jest
                 .fn()
                 .mockReturnValue(
                     Promise.resolve({ provider: {}, allProviders: [] })
                 ),
         };
         MockApi.setMockApi(myMockApi);
-        sinon.spy(myMockApi, 'getProvider');
+        sinon.spy(myMockApi, 'getProviderAccess');
         const fakeDispatch = sinon.spy();
         const getState = () => {};
         await getProvider(domainName, 'service1')(fakeDispatch, getState);
         expect(fakeDispatch.getCall(0).args[0]).toBeTruthy();
         expect(
-            myMockApi.getProvider.getCall(0).calledWith(domainName, 'service1')
+            myMockApi.getProviderAccess
+                .getCall(0)
+                .calledWith(domainName, 'service1')
         ).toBeTruthy();
         expect(fakeDispatch.getCall(1).args[0]).toEqual(
             loadProvidersToStore('dom.service1', {}, [])

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -1058,10 +1058,10 @@ const Api = (req) => {
             });
         },
 
-        getProvider(domainName, serviceName) {
+        getProviderAccess(domainName, serviceName) {
             return new Promise((resolve, reject) => {
                 fetchr
-                    .read('provider')
+                    .read('access')
                     .params({ domainName, serviceName })
                     .end((err, data) => {
                         if (err) {

--- a/ui/src/config/default-config.js
+++ b/ui/src/config/default-config.js
@@ -109,6 +109,7 @@ const config = {
             {
                 id: 'aws_instance_launch_provider',
                 name: 'AWS EC2/EKS/Fargate launches instances for the service',
+                service: 'athens.aws.us-east-1',
             },
         ],
         createDomainMessage:

--- a/ui/src/pages/domain/[domain]/group/[group]/roles.js
+++ b/ui/src/pages/domain/[domain]/group/[group]/roles.js
@@ -28,9 +28,7 @@ import GroupTabs from '../../../../../components/header/GroupTabs';
 import GroupRoleTable from '../../../../../components/group/GroupRoleTable';
 import SearchInput from '../../../../../components/denali/SearchInput';
 import { getDomainData } from '../../../../../redux/thunks/domain';
-import {
-    getGroup,
-} from '../../../../../redux/thunks/groups';
+import { getGroup } from '../../../../../redux/thunks/groups';
 import { connect } from 'react-redux';
 import { selectIsLoading } from '../../../../../redux/selectors/loading';
 import {

--- a/ui/src/redux/thunks/services.js
+++ b/ui/src/redux/thunks/services.js
@@ -228,7 +228,10 @@ export const getProvider =
             return Promise.resolve();
         } else {
             try {
-                let data = await API().getProvider(domainName, serviceName);
+                let data = await API().getProviderAccess(
+                    domainName,
+                    serviceName
+                );
                 dispatch(
                     loadProvidersToStore(
                         getFullName(domainName, serviceDelimiter, serviceName),


### PR DESCRIPTION
# Description
UI - use access api to determine if the service provider is enabled or not to support access enabled via Terraform. 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**