### PR TITLE
refactor functional test to use conditional afterEach

### DIFF
--- a/ui/src/__tests__/spec/tests/domain.spec.js
+++ b/ui/src/__tests__/spec/tests/domain.spec.js
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
+const TEST_ADD_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR =
+    'modal to add business service - should preserve input on blur, make input bold when selected in dropdown, reject unselected input, allow submission of empty input';
+const TEST_MANAGE_DOMAINS_CHANGE_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR =
+    'Manage Domains - modal to change add business service - should preserve input on blur, make input bold when selected in dropdown, reject unselected input';
+
 describe('Domain', () => {
+    let currentTest;
+
     it('should successfully add domain point of contact and security poc', async () => {
         await browser.newUser();
         await browser.url(`/`);
@@ -51,7 +58,9 @@ describe('Domain', () => {
         await expect(securityPocAnchor).toHaveTextContaining('Chandu Raman');
     });
 
-    it('modal to add business service - should preserve input on blur, make input bold when selected in dropdown, reject unselected input, allow submission of empty input', async () => {
+    it(TEST_ADD_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR, async () => {
+        currentTest =
+            TEST_ADD_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR;
         await browser.newUser();
         await browser.url(`/domain/athenz.dev.functional-test/role`);
         await expect(browser).toHaveUrlContaining('athenz');
@@ -133,132 +142,94 @@ describe('Domain', () => {
         await expect(addBusinessService).toHaveTextContaining(
             'PolicyEnforcementService.GLB'
         );
-
-        // click add business service
-        await browser.waitUntil(
-            async () => await addBusinessService.isClickable()
-        );
-        await addBusinessService.click();
-
-        // clear current input
-        clearInput = await $(
-            `.//*[local-name()="svg" and @data-wdio="clear-input"]`
-        );
-        await browser.waitUntil(async () => await clearInput.isClickable());
-        await clearInput.click();
-
-        // submit empty input
-        submitButton = await $('button*=Submit');
-        await submitButton.click();
-
-        // business service for the domain should be empty
-        await browser.waitUntil(
-            async () => await addBusinessService.isClickable()
-        );
-        expect(addBusinessService).toHaveTextContaining('add');
     });
 
-    it('Manage Domains - modal to change add business service - should preserve input on blur, make input bold when selected in dropdown, reject unselected input', async () => {
-        await browser.newUser();
+    it(
+        TEST_MANAGE_DOMAINS_CHANGE_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR,
+        async () => {
+            currentTest =
+                TEST_MANAGE_DOMAINS_CHANGE_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR;
 
-        // open athenz manage domains page
-        await browser.url(`/domain/manage`);
-        await expect(browser).toHaveUrlContaining('athenz');
+            await browser.newUser();
 
-        // click add business service
-        let addBusinessService = await $(
-            'a[data-testid="business-service-athenz.dev.functional-test"]'
-        );
-        await browser.waitUntil(
-            async () => await addBusinessService.isClickable()
-        );
-        await addBusinessService.click();
+            // open athenz manage domains page
+            await browser.url(`/domain/manage`);
+            await expect(browser).toHaveUrlContaining('athenz');
 
-        await browser.pause(4000); // wait to make sure dropdown options are loaded
+            // click add business service
+            let addBusinessService = await $(
+                'a[data-testid="business-service-athenz.dev.functional-test"]'
+            );
+            await browser.waitUntil(
+                async () => await addBusinessService.isClickable()
+            );
+            await addBusinessService.click();
 
-        // add random text
-        let bsInput = await $('input[name="business-service-drop"]');
-        await bsInput.addValue('nonexistent.service');
+            await browser.pause(4000); // wait to make sure dropdown options are loaded
 
-        // blur
-        await browser.keys('Tab');
+            // add random text
+            let bsInput = await $('input[name="business-service-drop"]');
+            await bsInput.addValue('nonexistent.service');
 
-        // input did not change
-        expect(await bsInput.getValue()).toBe('nonexistent.service');
+            // blur
+            await browser.keys('Tab');
 
-        // input is not bold
-        let fontWeight = await bsInput.getCSSProperty('font-weight').value;
-        expect(fontWeight).toBeUndefined();
+            // input did not change
+            expect(await bsInput.getValue()).toBe('nonexistent.service');
 
-        // submit (item in dropdown is not selected)
-        let submitButton = await $('button*=Submit');
-        await submitButton.click();
+            // input is not bold
+            let fontWeight = await bsInput.getCSSProperty('font-weight').value;
+            expect(fontWeight).toBeUndefined();
 
-        // verify error message
-        let errorMessage = await $('div[data-testid="error-message"]');
-        expect(await errorMessage.getText()).toBe(
-            'Business Service must be selected in the dropdown'
-        );
+            // submit (item in dropdown is not selected)
+            let submitButton = await $('button*=Submit');
+            await submitButton.click();
 
-        let clearInput = await $(
-            `.//*[local-name()="svg" and @data-wdio="clear-input"]`
-        );
-        await clearInput.click();
+            // verify error message
+            let errorMessage = await $('div[data-testid="error-message"]');
+            expect(await errorMessage.getText()).toBe(
+                'Business Service must be selected in the dropdown'
+            );
 
-        let checkbox = await $('input[id="checkbox-show-all-bservices"]');
-        await browser.execute(function (checkboxElem) {
-            checkboxElem.click();
-        }, checkbox);
+            let clearInput = await $(
+                `.//*[local-name()="svg" and @data-wdio="clear-input"]`
+            );
+            await clearInput.click();
 
-        // make dropdown visible
-        await bsInput.click();
-        // type valid input and select item in dropdown
-        await bsInput.addValue('PolicyEnforcementService.GLB');
-        let dropdownOption = await $('div*=PolicyEnforcementService.GLB');
-        await dropdownOption.click();
+            let checkbox = await $('input[id="checkbox-show-all-bservices"]');
+            await browser.execute(function (checkboxElem) {
+                checkboxElem.click();
+            }, checkbox);
 
-        // verify input contains pes service
-        expect(await bsInput.getValue()).toBe('PolicyEnforcementService.GLB');
+            // make dropdown visible
+            await bsInput.click();
+            // type valid input and select item in dropdown
+            await bsInput.addValue('PolicyEnforcementService.GLB');
+            let dropdownOption = await $('div*=PolicyEnforcementService.GLB');
+            await dropdownOption.click();
 
-        // verify input is in bold
-        fontWeight = await bsInput.getCSSProperty('font-weight');
-        expect(fontWeight.value === 700).toBe(true);
+            // verify input contains pes service
+            expect(await bsInput.getValue()).toBe(
+                'PolicyEnforcementService.GLB'
+            );
 
-        // submit
-        submitButton = await $('button*=Submit');
-        await submitButton.click();
+            // verify input is in bold
+            fontWeight = await bsInput.getCSSProperty('font-weight');
+            expect(fontWeight.value === 700).toBe(true);
 
-        // business service can be seen added to domain
-        addBusinessService = await $(
-            'a[data-testid="business-service-athenz.dev.functional-test"]'
-        );
-        await expect(addBusinessService).toHaveTextContaining(
-            'PolicyEnforcementService.GLB'
-        );
+            // submit
+            submitButton = await $('button*=Submit');
+            await submitButton.click();
 
-        // click add business service
-        await browser.waitUntil(
-            async () => await addBusinessService.isClickable()
-        );
-        await addBusinessService.click();
-
-        // clear current input
-        clearInput = await $(
-            `.//*[local-name()="svg" and @data-wdio="clear-input"]`
-        );
-        await browser.waitUntil(async () => await clearInput.isClickable());
-        await clearInput.click();
-
-        // submit empty input
-        submitButton = await $('button*=Submit');
-        await submitButton.click();
-
-        // business service for the domain should be empty
-        await browser.waitUntil(
-            async () => await addBusinessService.isClickable()
-        );
-        expect(addBusinessService).toHaveTextContaining('add');
-    });
+            // business service can be seen added to domain
+            addBusinessService = await $(
+                'a[data-testid="business-service-athenz.dev.functional-test"]'
+            );
+            await expect(addBusinessService).toHaveTextContaining(
+                'PolicyEnforcementService.GLB'
+            );
+        }
+    );
 
     it('Domain History - modal to change add business service - should preserve input on blur, make input bold when selected in dropdown', async () => {
         await browser.newUser();
@@ -341,5 +312,55 @@ describe('Domain', () => {
         // verify input is in bold
         fontWeight = await input.getCSSProperty('font-weight');
         expect(fontWeight.value === 700).toBe(true);
+    });
+
+    afterEach(async () => {
+        // runs after each test and checks what currentTest value was set and executes appropriate cleanup logic if defined
+        if (
+            currentTest ===
+                TEST_ADD_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR ||
+            currentTest ===
+                TEST_MANAGE_DOMAINS_CHANGE_BUSINESS_SERVICE_INPUT_PRESERVES_CONTENTS_ON_BLUR
+        ) {
+            // remove business service name that was added during test
+            await browser.newUser();
+            await browser.url(`/domain/athenz.dev.functional-test/role`);
+
+            // expand domain details
+            let expand = await $(
+                `.//*[local-name()="svg" and @data-wdio="domain-details-expand-icon"]`
+            );
+            await browser.waitUntil(async () => await expand.isClickable());
+            await expand.click();
+
+            // click add business service
+            let addBusinessService = await $(
+                'a[data-testid="add-business-service"]'
+            );
+            await browser.waitUntil(
+                async () => await addBusinessService.isClickable()
+            );
+            await addBusinessService.click();
+
+            let bsInput = await $('input[name="business-service-drop"]');
+            let inputText = await bsInput.getValue();
+            console.log(inputText);
+            // if business service is present - clear and submit
+            if (inputText !== '') {
+                // clear current input
+                let clearInput = await $(
+                    `.//*[local-name()="svg" and @data-wdio="clear-input"]`
+                );
+                await browser.waitUntil(
+                    async () => await clearInput.isClickable()
+                );
+                await clearInput.click();
+
+                let submitButton = await $('button*=Submit');
+                await submitButton.click();
+            }
+        }
+        // reset current test name
+        currentTest = '';
     });
 });

--- a/ui/src/__tests__/spec/tests/groups.spec.js
+++ b/ui/src/__tests__/spec/tests/groups.spec.js
@@ -16,8 +16,18 @@
 
 const reviewExtendTest = 'review-extend-test';
 
+const TEST_NAME_GROUP_HISTORY_VISIBLE_AFTER_REFRESH =
+    'group history should be visible when navigating to it and after page refresh';
+const TEST_NAME_GROUP_ADD_USER_INPUT =
+    'dropdown input for adding user during group creation - should preserve input on blur, make input bold when selected in dropdown, reject unselected input';
+const TEST_NAME_GROUP_REVIEW_EXTEND =
+    'Group Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings';
+
 describe('group screen tests', () => {
-    it('group history should be visible when navigating to it and after page refresh', async () => {
+    let currentTest;
+
+    it(TEST_NAME_GROUP_HISTORY_VISIBLE_AFTER_REFRESH, async () => {
+        currentTest = TEST_NAME_GROUP_HISTORY_VISIBLE_AFTER_REFRESH;
         // open browser
         await browser.newUser();
         await browser.url(`/`);
@@ -70,30 +80,8 @@ describe('group screen tests', () => {
         await expect(spanUnix).toHaveText('unix.yahoo');
     });
 
-    // after - runs after the last test in order of declaration
-    after(async () => {
-        // open browser
-        await browser.newUser();
-        await browser.url(`/`);
-        // select domain
-        let domain = 'athenz.dev.functional-test';
-        let testDomain = await $(`a*=${domain}`);
-        await testDomain.click();
-
-        // navigate to groups page
-        let groups = await $('div*=Groups');
-        await groups.click();
-
-        // delete the group used in the test
-        let buttonDeleteGroup = await $(
-            './/*[local-name()="svg" and @id="delete-group-icon-history-test-group"]'
-        );
-        await buttonDeleteGroup.click();
-        let modalDeleteButton = await $('button*=Delete');
-        await modalDeleteButton.click();
-    });
-
-    it('dropdown input for adding user during group creation - should preserve input on blur, make input bold when selected in dropdown, reject unselected input', async () => {
+    it(TEST_NAME_GROUP_ADD_USER_INPUT, async () => {
+        currentTest = TEST_NAME_GROUP_ADD_USER_INPUT;
         // open browser
         await browser.newUser();
         await browser.url(`/domain/athenz.dev.functional-test/group`);
@@ -142,7 +130,8 @@ describe('group screen tests', () => {
         expect(fontWeight.value === 700).toBe(true);
     });
 
-    it('Group Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings', async () => {
+    it(TEST_NAME_GROUP_REVIEW_EXTEND, async () => {
+        currentTest = TEST_NAME_GROUP_REVIEW_EXTEND;
         // open browser
         await browser.newUser();
         await browser.url(`/domain/athenz.dev.functional-test/group`);
@@ -211,15 +200,40 @@ describe('group screen tests', () => {
         await expect(extendRadio).toBeEnabled();
     });
 
-    // delete group created in previous test
-    after(async () => {
-        await browser.newUser();
-        await browser.url(`/domain/athenz.dev.functional-test/group`);
-        await expect(browser).toHaveUrlContaining('athenz');
+    afterEach(async () => {
+        // runs after each test and checks which test was run to perform corresponding cleanup logic
+        if (currentTest === TEST_NAME_GROUP_HISTORY_VISIBLE_AFTER_REFRESH) {
+            // open browser
+            await browser.newUser();
+            await browser.url(`/`);
+            // select domain
+            let domain = 'athenz.dev.functional-test';
+            let testDomain = await $(`a*=${domain}`);
+            await testDomain.click();
 
-        await $(
-            `.//*[local-name()="svg" and @id="delete-group-icon-${reviewExtendTest}"]`
-        ).click();
-        await $('button*=Delete').click();
+            // navigate to groups page
+            let groups = await $('div*=Groups');
+            await groups.click();
+
+            // delete the group used in the test
+            let buttonDeleteGroup = await $(
+                './/*[local-name()="svg" and @id="delete-group-icon-history-test-group"]'
+            );
+            await buttonDeleteGroup.click();
+            let modalDeleteButton = await $('button*=Delete');
+            await modalDeleteButton.click();
+        } else if (currentTest === TEST_NAME_GROUP_REVIEW_EXTEND) {
+            await browser.newUser();
+            await browser.url(`/domain/athenz.dev.functional-test/group`);
+            await expect(browser).toHaveUrlContaining('athenz');
+
+            await $(
+                `.//*[local-name()="svg" and @id="delete-group-icon-${reviewExtendTest}"]`
+            ).click();
+            await $('button*=Delete').click();
+        }
+
+        // to reset currentTest after running cleanup
+        currentTest = '';
     });
 });

--- a/ui/src/__tests__/spec/tests/policies.spec.js
+++ b/ui/src/__tests__/spec/tests/policies.spec.js
@@ -15,9 +15,14 @@
  */
 
 const dropdownTestPolicyName = 'policy-dropdown-test';
+const TEST_NAME_ADD_POLICY_TO_ROLE_SHOULD_PRESERVE_INPUT_ON_BLUR =
+    'add policy to new role and existing role - should preserve input on blur, make input bold when selected in dropdown, reject unselected input';
 
 describe('Policies Screen', () => {
-    it('add policy to new role and existing role - should preserve input on blur, make input bold when selected in dropdown, reject unselected input', async () => {
+    let currentTest;
+    it(TEST_NAME_ADD_POLICY_TO_ROLE_SHOULD_PRESERVE_INPUT_ON_BLUR, async () => {
+        currentTest =
+            TEST_NAME_ADD_POLICY_TO_ROLE_SHOULD_PRESERVE_INPUT_ON_BLUR;
         await browser.newUser();
         await browser.url(`/domain/athenz.dev.functional-test/policy`);
         await expect(browser).toHaveUrlContaining('athenz');
@@ -149,15 +154,23 @@ describe('Policies Screen', () => {
         );
     });
 
-    after(async () => {
-        // delete policy created in previous test
-        await browser.newUser();
-        await browser.url(`/domain/athenz.dev.functional-test/policy`);
-        await expect(browser).toHaveUrlContaining('athenz');
+    afterEach(async () => {
+        if (
+            currentTest ===
+            TEST_NAME_ADD_POLICY_TO_ROLE_SHOULD_PRESERVE_INPUT_ON_BLUR
+        ) {
+            // delete policy created in previous test
+            await browser.newUser();
+            await browser.url(`/domain/athenz.dev.functional-test/policy`);
+            await expect(browser).toHaveUrlContaining('athenz');
 
-        await $(
-            `.//*[local-name()="svg" and @data-wdio="${dropdownTestPolicyName}-delete"]`
-        ).click();
-        await $('button*=Delete').click();
+            await $(
+                `.//*[local-name()="svg" and @data-wdio="${dropdownTestPolicyName}-delete"]`
+            ).click();
+            await $('button*=Delete').click();
+        }
+
+        // reset current test value
+        currentTest = '';
     });
 });

--- a/ui/src/__tests__/spec/tests/roles.spec.js
+++ b/ui/src/__tests__/spec/tests/roles.spec.js
@@ -17,8 +17,20 @@
 const dropdownTestRoleName = 'dropdown-test-role';
 const reviewExtendTest = 'review-extend-test';
 
+const TEST_NAME_HISTORY_VISIBLE_AFTER_PAGE_REFRESH =
+    'role history should be visible when navigating to it and after page refresh';
+const TEST_NAME_DELEGATED_ROLE_ADDITIONAL_SETTINGS_ARE_DISABLED =
+    'when creating or editing a delegated role, all additional settings except description must be disabled';
+const TEST_NAME_ADD_ROLE_MEMBER_INPUT_PRESERVES_CONTENTS_ON_BLUR =
+    'member dropdown when creating a role and adding to existing role - should preserve input on blur, make input bold when selected in dropdown, reject unselected input';
+const TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED =
+    'Role Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings';
+
 describe('role screen tests', () => {
-    it('role history should be visible when navigating to it and after page refresh', async () => {
+    let currentTest;
+
+    it(TEST_NAME_HISTORY_VISIBLE_AFTER_PAGE_REFRESH, async () => {
+        currentTest = TEST_NAME_HISTORY_VISIBLE_AFTER_PAGE_REFRESH;
         // open browser
         await browser.newUser();
         await browser.url(`/`);
@@ -67,26 +79,9 @@ describe('role screen tests', () => {
         spanUnix = await $('span*=unix.yahoo');
         await expect(spanUnix).toHaveText('unix.yahoo');
     });
-    // after - runs after the last test in order of declaration
-    after(async () => {
-        // open browser
-        await browser.newUser();
-        await browser.url(`/`);
-        // select domain
-        let domain = 'athenz.dev.functional-test';
-        let testDomain = await $(`a*=${domain}`);
-        await testDomain.click();
 
-        // delete the role used in the test
-        let buttonDeleteRole = await $(
-            './/*[local-name()="svg" and @id="history-test-role-delete-role-button"]'
-        );
-        await buttonDeleteRole.click();
-        let modalDeleteButton = await $('button*=Delete');
-        await modalDeleteButton.click();
-    });
-
-    it('when creating or editing a delegated role, all additional settings except description must be disabled', async () => {
+    it(TEST_NAME_DELEGATED_ROLE_ADDITIONAL_SETTINGS_ARE_DISABLED, async () => {
+        currentTest = TEST_NAME_DELEGATED_ROLE_ADDITIONAL_SETTINGS_ARE_DISABLED;
         // open browser
         await browser.newUser();
         await browser.url(`/`);
@@ -206,28 +201,9 @@ describe('role screen tests', () => {
         await expect(inputMaxMembers).toBeDisabled();
     });
 
-    // after - runs after the last test in order of declaration
-    after(async () => {
-        // open browser
-        await browser.newUser();
-        await browser.url(`/`);
-        // select domain
-        let domain = 'athenz.dev.functional-test';
-        let testDomain = await $(`a*=${domain}`);
-        await browser.waitUntil(async () => await testDomain.isClickable());
-        await testDomain.click();
-
-        // delete the delegate role used in the test
-        // find row with 'delegated-role' in name and click delete on svg
-        let buttonDeleteDelegatedRole = await $(
-            './/*[local-name()="svg" and @id="delegated-role-delete-role-button"]'
-        );
-        await buttonDeleteDelegatedRole.click();
-        let modalDeleteButton = await $('button*=Delete');
-        await modalDeleteButton.click();
-    });
-
-    it('member dropdown when creating a role and adding to existing role - should preserve input on blur, make input bold when selected in dropdown, reject unselected input', async () => {
+    it(TEST_NAME_ADD_ROLE_MEMBER_INPUT_PRESERVES_CONTENTS_ON_BLUR, async () => {
+        currentTest =
+            TEST_NAME_ADD_ROLE_MEMBER_INPUT_PRESERVES_CONTENTS_ON_BLUR;
         await browser.newUser();
         await browser.url(`/domain/athenz.dev.functional-test/role`);
         await expect(browser).toHaveUrlContaining('athenz');
@@ -368,19 +344,8 @@ describe('role screen tests', () => {
         expect(validMemberTd).toHaveText(`${validMember}`);
     });
 
-    after(async () => {
-        // delete role created in previous test
-        await browser.newUser();
-        await browser.url(`/domain/athenz.dev.functional-test/role`);
-        await expect(browser).toHaveUrlContaining('athenz');
-
-        await $(
-            `.//*[local-name()="svg" and @id="${dropdownTestRoleName}-delete-role-button"]`
-        ).click();
-        await $('button*=Delete').click();
-    });
-
-    it('Role Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings', async () => {
+    it(TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED, async () => {
+        currentTest = TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED;
         // open browser
         await browser.newUser();
         await browser.url(`/domain/athenz.dev.functional-test/role`);
@@ -523,16 +488,70 @@ describe('role screen tests', () => {
         await expect(extendRadio).toBeEnabled();
     });
 
-    // delete role created in previous test
-    after(async () => {
-        // delete role created in previous test
-        await browser.newUser();
-        await browser.url(`/domain/athenz.dev.functional-test/role`);
-        await expect(browser).toHaveUrlContaining('athenz');
+    afterEach(async () => {
+        if (currentTest === TEST_NAME_HISTORY_VISIBLE_AFTER_PAGE_REFRESH) {
+            // open browser
+            await browser.newUser();
+            await browser.url(`/`);
+            // select domain
+            let domain = 'athenz.dev.functional-test';
+            let testDomain = await $(`a*=${domain}`);
+            await testDomain.click();
 
-        await $(
-            `.//*[local-name()="svg" and @id="${reviewExtendTest}-delete-role-button"]`
-        ).click();
-        await $('button*=Delete').click();
+            // delete the role used in the test
+            let buttonDeleteRole = await $(
+                './/*[local-name()="svg" and @id="history-test-role-delete-role-button"]'
+            );
+            await buttonDeleteRole.click();
+            let modalDeleteButton = await $('button*=Delete');
+            await modalDeleteButton.click();
+        } else if (
+            currentTest ===
+            TEST_NAME_DELEGATED_ROLE_ADDITIONAL_SETTINGS_ARE_DISABLED
+        ) {
+            // open browser
+            await browser.newUser();
+            await browser.url(`/`);
+            // select domain
+            let domain = 'athenz.dev.functional-test';
+            let testDomain = await $(`a*=${domain}`);
+            await browser.waitUntil(async () => await testDomain.isClickable());
+            await testDomain.click();
+
+            // delete the delegate role used in the test
+            // find row with 'delegated-role' in name and click delete on svg
+            let buttonDeleteDelegatedRole = await $(
+                './/*[local-name()="svg" and @id="delegated-role-delete-role-button"]'
+            );
+            await buttonDeleteDelegatedRole.click();
+            let modalDeleteButton = await $('button*=Delete');
+            await modalDeleteButton.click();
+        } else if (
+            currentTest ===
+            TEST_NAME_ADD_ROLE_MEMBER_INPUT_PRESERVES_CONTENTS_ON_BLUR
+        ) {
+            // delete role created during test
+            await browser.newUser();
+            await browser.url(`/domain/athenz.dev.functional-test/role`);
+            await expect(browser).toHaveUrlContaining('athenz');
+
+            await $(
+                `.//*[local-name()="svg" and @id="${dropdownTestRoleName}-delete-role-button"]`
+            ).click();
+            await $('button*=Delete').click();
+        } else if (currentTest === TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED) {
+            // delete role created during test
+            await browser.newUser();
+            await browser.url(`/domain/athenz.dev.functional-test/role`);
+            await expect(browser).toHaveUrlContaining('athenz');
+
+            await $(
+                `.//*[local-name()="svg" and @id="${reviewExtendTest}-delete-role-button"]`
+            ).click();
+            await $('button*=Delete').click();
+        }
+
+        // reset current test
+        currentTest = '';
     });
 });

--- a/ui/src/__tests__/spec/tests/services.spec.js
+++ b/ui/src/__tests__/spec/tests/services.spec.js
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+const TEST_NAME_TOOLTIP_LINK_OPENS_NEW_TAB =
+    'when clicking help tooltip link, it should open a tab with athenz guide';
+
 describe('services screen tests', () => {
-    it('when clicking help tooltip link, it should open a tab with athenz guide', async () => {
+    let currentTest;
+
+    it(TEST_NAME_TOOLTIP_LINK_OPENS_NEW_TAB, async () => {
+        currentTest = TEST_NAME_TOOLTIP_LINK_OPENS_NEW_TAB;
         // open browser
         await browser.newUser();
         await browser.url(`/`);
@@ -67,31 +73,6 @@ describe('services screen tests', () => {
         ).toBe(true);
     });
 
-    // after - runs after the last test in order of declaration
-    after(async () => {
-        // open browser
-        await browser.newUser();
-        await browser.url(`/`);
-        // select domain
-        let domain = 'athenz.dev.functional-test';
-        let testDomain = await $(`a*=${domain}`);
-        await browser.waitUntil(async () => await testDomain.isClickable());
-        await testDomain.click();
-
-        // open Services
-        let servicesButton = await $('div*=Services');
-        await browser.waitUntil(async () => await servicesButton.isClickable());
-        await servicesButton.click();
-
-        // delete service created for the test
-        let serviceDeleteButton = await $(
-            './/*[local-name()="svg" and @id="delete-service-tooltip-link-test-service"]'
-        );
-        await serviceDeleteButton.click();
-        let modalDeleteButton = await $('button*=Delete');
-        await modalDeleteButton.click();
-    });
-
     it('when clicking "Allow" button on a provider without having appropriate authorisation, the error should be displayed to the right of the button', async () => {
         await console.log(`testtesttest inside second test`);
         // open browser
@@ -121,5 +102,36 @@ describe('services screen tests', () => {
             `//td[text()="AWS EC2/EKS/Fargate launches instances for the service"]/following-sibling::td//div[text()="Status: 403. Message: Forbidden"]`
         );
         await expect(warning).toHaveText('Status: 403. Message: Forbidden');
+    });
+
+    afterEach(async () => {
+        if (currentTest === TEST_NAME_TOOLTIP_LINK_OPENS_NEW_TAB) {
+            // open browser
+            await browser.newUser();
+            await browser.url(`/`);
+            // select domain
+            let domain = 'athenz.dev.functional-test';
+            let testDomain = await $(`a*=${domain}`);
+            await browser.waitUntil(async () => await testDomain.isClickable());
+            await testDomain.click();
+
+            // open Services
+            let servicesButton = await $('div*=Services');
+            await browser.waitUntil(
+                async () => await servicesButton.isClickable()
+            );
+            await servicesButton.click();
+
+            // delete service created for the test
+            let serviceDeleteButton = await $(
+                './/*[local-name()="svg" and @id="delete-service-tooltip-link-test-service"]'
+            );
+            await serviceDeleteButton.click();
+            let modalDeleteButton = await $('button*=Delete');
+            await modalDeleteButton.click();
+        }
+
+        // reset current test
+        currentTest = '';
     });
 });


### PR DESCRIPTION
# Description
refactor ui functional tests - moved cleanup out of the test into `afterEach` step.
`afterEach` checks which test was run and executes corresponding cleanup logic.
Cannot use `after` step because these run after execution of all tests in the file and it doesn't help when separate tests test same functionality and require it to be in clean state.


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

