### PR TITLE
fix ui role and group review radio button affecting members of other roles

### DIFF
--- a/ui/src/__tests__/components/review/__snapshots__/ReviewRow.test.js.snap
+++ b/ui/src/__tests__/components/review/__snapshots__/ReviewRow.test.js.snap
@@ -148,13 +148,13 @@ exports[`ReviewRow should render 1`] = `
     >
       <input
         disabled=""
-        id="radiobutton-undefined50-extend"
-        name="undefined50"
+        id="radiobutton-50-extend"
+        name="50"
         type="radio"
         value="extend"
       />
       <label
-        for="radiobutton-undefined50-extend"
+        for="radiobutton-50-extend"
       />
     </div>
   </td>
@@ -168,13 +168,13 @@ exports[`ReviewRow should render 1`] = `
     >
       <input
         checked=""
-        id="radiobutton-undefined50-no-action"
-        name="undefined50"
+        id="radiobutton-50-no-action"
+        name="50"
         type="radio"
         value="no-action"
       />
       <label
-        for="radiobutton-undefined50-no-action"
+        for="radiobutton-50-no-action"
       />
     </div>
   </td>
@@ -187,13 +187,13 @@ exports[`ReviewRow should render 1`] = `
       data-testid="radiobutton-wrapper"
     >
       <input
-        id="radiobutton-undefined50-delete"
-        name="undefined50"
+        id="radiobutton-50-delete"
+        name="50"
         type="radio"
         value="delete"
       />
       <label
-        for="radiobutton-undefined50-delete"
+        for="radiobutton-50-delete"
       />
     </div>
   </td>

--- a/ui/src/__tests__/components/review/__snapshots__/ReviewTable.test.js.snap
+++ b/ui/src/__tests__/components/review/__snapshots__/ReviewTable.test.js.snap
@@ -402,13 +402,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser1-extend"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-extend"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-extend"
+              for="radiobutton-role-review_domain_roleName_user1-extend"
             />
           </div>
         </td>
@@ -422,13 +422,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser1-no-action"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-no-action"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-no-action"
+              for="radiobutton-role-review_domain_roleName_user1-no-action"
             />
           </div>
         </td>
@@ -441,13 +441,13 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser1-delete"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-delete"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-delete"
+              for="radiobutton-role-review_domain_roleName_user1-delete"
             />
           </div>
         </td>
@@ -488,13 +488,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser2-extend"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-extend"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-extend"
+              for="radiobutton-role-review_domain_roleName_user2-extend"
             />
           </div>
         </td>
@@ -508,13 +508,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser2-no-action"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-no-action"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-no-action"
+              for="radiobutton-role-review_domain_roleName_user2-no-action"
             />
           </div>
         </td>
@@ -527,13 +527,13 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser2-delete"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-delete"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-delete"
+              for="radiobutton-role-review_domain_roleName_user2-delete"
             />
           </div>
         </td>
@@ -574,13 +574,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser3-extend"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-extend"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-extend"
+              for="radiobutton-role-review_domain_roleName_user3-extend"
             />
           </div>
         </td>
@@ -594,13 +594,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser3-no-action"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-no-action"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-no-action"
+              for="radiobutton-role-review_domain_roleName_user3-no-action"
             />
           </div>
         </td>
@@ -613,13 +613,13 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser3-delete"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-delete"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-delete"
+              for="radiobutton-role-review_domain_roleName_user3-delete"
             />
           </div>
         </td>
@@ -660,13 +660,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser4-extend"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-extend"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-extend"
+              for="radiobutton-role-review_domain_roleName_user4-extend"
             />
           </div>
         </td>
@@ -680,13 +680,13 @@ exports[`ReviewTable should render review table 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser4-no-action"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-no-action"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-no-action"
+              for="radiobutton-role-review_domain_roleName_user4-no-action"
             />
           </div>
         </td>
@@ -699,13 +699,13 @@ exports[`ReviewTable should render review table 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser4-delete"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-delete"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-delete"
+              for="radiobutton-role-review_domain_roleName_user4-delete"
             />
           </div>
         </td>
@@ -1177,13 +1177,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser1-extend"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-extend"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-extend"
+              for="radiobutton-role-review_domain_roleName_user1-extend"
             />
           </div>
         </td>
@@ -1197,13 +1197,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser1-no-action"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-no-action"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-no-action"
+              for="radiobutton-role-review_domain_roleName_user1-no-action"
             />
           </div>
         </td>
@@ -1216,13 +1216,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser1-delete"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-delete"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-delete"
+              for="radiobutton-role-review_domain_roleName_user1-delete"
             />
           </div>
         </td>
@@ -1263,13 +1263,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser2-extend"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-extend"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-extend"
+              for="radiobutton-role-review_domain_roleName_user2-extend"
             />
           </div>
         </td>
@@ -1283,13 +1283,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser2-no-action"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-no-action"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-no-action"
+              for="radiobutton-role-review_domain_roleName_user2-no-action"
             />
           </div>
         </td>
@@ -1302,13 +1302,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser2-delete"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-delete"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-delete"
+              for="radiobutton-role-review_domain_roleName_user2-delete"
             />
           </div>
         </td>
@@ -1349,13 +1349,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser3-extend"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-extend"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-extend"
+              for="radiobutton-role-review_domain_roleName_user3-extend"
             />
           </div>
         </td>
@@ -1369,13 +1369,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser3-no-action"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-no-action"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-no-action"
+              for="radiobutton-role-review_domain_roleName_user3-no-action"
             />
           </div>
         </td>
@@ -1388,13 +1388,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser3-delete"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-delete"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-delete"
+              for="radiobutton-role-review_domain_roleName_user3-delete"
             />
           </div>
         </td>
@@ -1435,13 +1435,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser4-extend"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-extend"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-extend"
+              for="radiobutton-role-review_domain_roleName_user4-extend"
             />
           </div>
         </td>
@@ -1455,13 +1455,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser4-no-action"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-no-action"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-no-action"
+              for="radiobutton-role-review_domain_roleName_user4-no-action"
             />
           </div>
         </td>
@@ -1474,13 +1474,13 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser4-delete"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-delete"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-delete"
+              for="radiobutton-role-review_domain_roleName_user4-delete"
             />
           </div>
         </td>
@@ -1952,13 +1952,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser1-extend"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-extend"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-extend"
+              for="radiobutton-role-review_domain_roleName_user1-extend"
             />
           </div>
         </td>
@@ -1972,13 +1972,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser1-no-action"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-no-action"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-no-action"
+              for="radiobutton-role-review_domain_roleName_user1-no-action"
             />
           </div>
         </td>
@@ -1991,13 +1991,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser1-delete"
-              name="undefinedrole-review-roleNameuser1"
+              id="radiobutton-role-review_domain_roleName_user1-delete"
+              name="role-review_domain_roleName_user1"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser1-delete"
+              for="radiobutton-role-review_domain_roleName_user1-delete"
             />
           </div>
         </td>
@@ -2038,13 +2038,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser2-extend"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-extend"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-extend"
+              for="radiobutton-role-review_domain_roleName_user2-extend"
             />
           </div>
         </td>
@@ -2058,13 +2058,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser2-no-action"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-no-action"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-no-action"
+              for="radiobutton-role-review_domain_roleName_user2-no-action"
             />
           </div>
         </td>
@@ -2077,13 +2077,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser2-delete"
-              name="undefinedrole-review-roleNameuser2"
+              id="radiobutton-role-review_domain_roleName_user2-delete"
+              name="role-review_domain_roleName_user2"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser2-delete"
+              for="radiobutton-role-review_domain_roleName_user2-delete"
             />
           </div>
         </td>
@@ -2124,13 +2124,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser3-extend"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-extend"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-extend"
+              for="radiobutton-role-review_domain_roleName_user3-extend"
             />
           </div>
         </td>
@@ -2144,13 +2144,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser3-no-action"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-no-action"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-no-action"
+              for="radiobutton-role-review_domain_roleName_user3-no-action"
             />
           </div>
         </td>
@@ -2163,13 +2163,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser3-delete"
-              name="undefinedrole-review-roleNameuser3"
+              id="radiobutton-role-review_domain_roleName_user3-delete"
+              name="role-review_domain_roleName_user3"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser3-delete"
+              for="radiobutton-role-review_domain_roleName_user3-delete"
             />
           </div>
         </td>
@@ -2210,13 +2210,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               disabled=""
-              id="radiobutton-undefinedrole-review-roleNameuser4-extend"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-extend"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="extend"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-extend"
+              for="radiobutton-role-review_domain_roleName_user4-extend"
             />
           </div>
         </td>
@@ -2230,13 +2230,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
           >
             <input
               checked=""
-              id="radiobutton-undefinedrole-review-roleNameuser4-no-action"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-no-action"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="no-action"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-no-action"
+              for="radiobutton-role-review_domain_roleName_user4-no-action"
             />
           </div>
         </td>
@@ -2249,13 +2249,13 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
             data-testid="radiobutton-wrapper"
           >
             <input
-              id="radiobutton-undefinedrole-review-roleNameuser4-delete"
-              name="undefinedrole-review-roleNameuser4"
+              id="radiobutton-role-review_domain_roleName_user4-delete"
+              name="role-review_domain_roleName_user4"
               type="radio"
               value="delete"
             />
             <label
-              for="radiobutton-undefinedrole-review-roleNameuser4-delete"
+              for="radiobutton-role-review_domain_roleName_user4-delete"
             />
           </div>
         </td>

--- a/ui/src/__tests__/server/handlers/api.test.js
+++ b/ui/src/__tests__/server/handlers/api.test.js
@@ -44,7 +44,10 @@ const secrets = {};
 const expressApp = require('express')();
 const request = require('supertest');
 const bodyParser = require('body-parser');
-const { listUserDomains_response, getPrincipalRoles_response } = require('../../../mock/MockData');
+const {
+    listUserDomains_response,
+    getPrincipalRoles_response,
+} = require('../../../mock/MockData');
 
 describe('Fetchr Server API Test', () => {
     describe('success tests', () => {
@@ -109,8 +112,8 @@ describe('Fetchr Server API Test', () => {
                         },
                         getPrincipalRoles: (params, callback) => {
                             callback(undefined, {
-                                ...getPrincipalRoles_response
-                            })
+                                ...getPrincipalRoles_response,
+                            });
                         },
                         getSignedDomains: (params, callback) =>
                             params.forcefail

--- a/ui/src/components/group/GroupReviewTable.js
+++ b/ui/src/components/group/GroupReviewTable.js
@@ -214,16 +214,8 @@ class GroupReviewTable extends React.Component {
                           return (
                               <ReviewRow
                                   category={'group'}
-                                  key={
-                                      'group-review-' +
-                                      this.props.groupName +
-                                      item.memberName
-                                  }
-                                  idx={
-                                      'group-review-' +
-                                      this.props.groupName +
-                                      item.memberName
-                                  }
+                                  key={`group-review_${this.props.domain}_${this.props.groupName}_${item.memberName}`}
+                                  idx={`group-review_${this.props.domain}_${this.props.groupName}_${item.memberName}`}
                                   details={item}
                                   collection={this.props.groupName}
                                   color={color}

--- a/ui/src/components/review/ReviewRow.js
+++ b/ui/src/components/review/ReviewRow.js
@@ -126,7 +126,7 @@ export default class ReviewRow extends React.Component {
                 )}
                 <TDStyled color={color} align={center}>
                     <RadioButton
-                        name={this.props.collection + this.props.idx}
+                        name={this.props.idx}
                         value='extend'
                         checked={this.state.selectedOption === 'extend'}
                         onChange={this.onReview}
@@ -135,7 +135,7 @@ export default class ReviewRow extends React.Component {
                 </TDStyled>
                 <TDStyled color={color} align={center}>
                     <RadioButton
-                        name={this.props.collection + this.props.idx}
+                        name={this.props.idx}
                         value='no-action'
                         checked={this.state.selectedOption === 'no-action'}
                         onChange={this.onReview}
@@ -143,7 +143,7 @@ export default class ReviewRow extends React.Component {
                 </TDStyled>
                 <TDStyled color={color} align={center}>
                     <RadioButton
-                        name={this.props.collection + this.props.idx}
+                        name={this.props.idx}
                         value='delete'
                         checked={this.state.selectedOption === 'delete'}
                         onChange={this.onReview}

--- a/ui/src/components/review/ReviewTable.js
+++ b/ui/src/components/review/ReviewTable.js
@@ -320,16 +320,8 @@ export class ReviewTable extends React.Component {
                           return (
                               <ReviewRow
                                   category={'role'}
-                                  key={
-                                      'role-review-' +
-                                      this.props.role +
-                                      item.memberName
-                                  }
-                                  idx={
-                                      'role-review-' +
-                                      this.props.role +
-                                      item.memberName
-                                  }
+                                  key={`role-review_${this.props.domain}_${this.props.role}_${item.memberName}`}
+                                  idx={`role-review_${this.props.domain}_${this.props.role}_${item.memberName}`}
                                   details={item}
                                   role={this.props.role}
                                   color={color}


### PR DESCRIPTION
# Description
When 2 Roles with same names and same Member but belonging to different domains are displayed on Action Required > Role Review page, clicking Extend / No Action / Delete radio buttons causes radio button for same Member in other Role to switch too.
This change makes member rows unique and should fix this problem.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**
