### PR TITLE
improve communication in expiry/review notification emails

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/JDBCConsts.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/JDBCConsts.java
@@ -159,6 +159,12 @@ public final class JDBCConsts {
     public static final String SYS_AUTH_AUDIT_BY_ORG    = "sys.auth.audit.org";
     public static final String SYS_AUTH_AUDIT_BY_DOMAIN = "sys.auth.audit.domain";
 
+    public static final String ZMS_PROP_JDBC_NOTIFY_DETAILS_SELF_SERVE_ROLE  = "athenz.zms.jdbc.notify_details_self_serve_role";
+    public static final String ZMS_PROP_JDBC_NOTIFY_DETAILS_SELF_SERVE_GROUP = "athenz.zms.jdbc.notify_details_self_serve_group";
+
+    public static final String NOTIFY_DETAILS_SELF_SERVE_ROLE = "self-serve role";
+    public static final String NOTIFY_DETAILS_SELF_SERVE_GROUP = "self-serve group";
+
     //pending member
     public static final String PENDING_REQUEST_ADD_STATE = "ADD";
     public static final String PENDING_REQUEST_DELETE_STATE = "DELETE";

--- a/libs/java/server_common/src/main/resources/emails/base.css
+++ b/libs/java/server_common/src/main/resources/emails/base.css
@@ -11,31 +11,31 @@ body {
     -webkit-font-smoothing: antialiased;
     background-color: rgba(231, 232, 231, 1.0);
 }
-.athenz-wrapper .mbrapproval.unrefreshedcerts {
+.athenz-wrapper .athenz-body.unrefreshedcerts {
     width: 900px;
     height: auto;
     min-height: 402px;
 }
-.athenz-wrapper .mbrapproval {
+.athenz-wrapper .athenz-body {
     width: 100%;
     min-height: 402px;
     margin: auto;
     background-color:white;
     border-radius: 5px;
 }
-.mbrapproval .logo {
+.athenz-body .logo {
     background-color: rgb(1,36,57);
     height: 45px;
     width: 100%;
     border-radius: 5px;
 }
-.mbrapproval .athenzlogowhite {
+.athenz-body .athenzlogowhite {
     background-color: rgba(255,255,255,0.0);
     height: 26px;
     width: 110px;
     padding: 10px;
 }
-.mbrapproval .hdr {
+.athenz-body .hdr {
     background-color: rgba(255, 255, 255, 0.0);
     height: auto;
     width: 440px;
@@ -46,40 +46,40 @@ body {
     text-align: left;
     line-height: 24px;
 }
-.mbrapproval .bt.unrefreshedcerts {
+.athenz-body .bt.unrefreshedcerts {
     width: 640px;
 }
-.mbrapproval .bt {
+.athenz-body .bt {
     background-color: rgba(255, 255, 255, 0.0);
     height: auto;
-    width: 100%;
+    width: 92%;
     margin: 20px;
     font-size: 14px;
     color: rgba(47, 48, 47, 1.0);
     text-align: left;
     line-height: 18px;
 }
-.mbrapproval table {
+.athenz-body table {
     width: 97%;
     margin-left: 20px;
 }
-.mbrapproval td {
+.athenz-body td {
     padding: 5px;
     text-align: left;
 }
-.mbrapproval th {
+.athenz-body th {
     padding: 5px;
     text-align: left;
     font-weight: bold;
 }
-.mbrapproval div {
+.athenz-body div {
     -webkit-text-size-adjust: none;
 }
-.mbrapproval a {
+.athenz-body a {
     text-decoration: none;
     color: rgba(54, 151, 242, 1.0);
 }
-.mbrapproval .cv, table#t01 td:nth-child(even) {
+.athenz-body .cv, table#t01 td:nth-child(even) {
     background-color: rgba(255, 255, 255, 0.0);
     height: auto;
     width: 300px;
@@ -89,7 +89,7 @@ body {
     text-align: left;
     line-height: 17px;
 }
-.mbrapproval .ch, table#t01 td:nth-child(odd) {
+.athenz-body .ch, table#t01 td:nth-child(odd) {
     background-color: rgba(255, 255, 255, 0.0);
     height: auto;
     width: 120px;
@@ -103,15 +103,15 @@ body {
 .footer-container .footer {
     background-color: rgba(255, 255, 255, 0.0);
     height: auto;
-    width: 440px;
+    width: 92%;
     margin: 15px 0 0 20px;
     font-size: 12px;
     color: rgba(48, 48, 48, 1.0);
-    text-align: left;
+    text-align: center;
     line-height: 14px;
     display: inline-block;
 }
-.mbrapproval hr {
+.athenz-body hr {
     margin: 20px;
     width: 92%;
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCConnectionTest.java
@@ -10774,7 +10774,7 @@ public class JDBCConnectionTest {
                 .thenReturn("user.jane");
         Mockito.when(mockResultSet.getString(JDBCConsts.DB_COLUMN_ROLE_NAME))
                 .thenReturn("role1")
-                .thenReturn("rols2")
+                .thenReturn("role2")
                 .thenReturn("role3");
         Mockito.when(mockResultSet.getString(JDBCConsts.DB_COLUMN_DOMAIN_NAME))
                 .thenReturn("athenz1")
@@ -10785,9 +10785,11 @@ public class JDBCConnectionTest {
                 .thenReturn("")
                 .thenReturn("");
         Mockito.when(mockResultSet.getString(JDBCConsts.DB_COLUMN_NOTIFY_DETAILS))
+                .thenReturn("notify details")
                 .thenReturn("")
-                .thenReturn("")
-                .thenReturn("");
+                .thenReturn("notify for self serve");
+        Mockito.when(mockResultSet.getBoolean(JDBCConsts.DB_COLUMN_SELF_SERVE))
+                .thenReturn(true); // will be called for the second call - user.joe and role2
         java.sql.Timestamp ts = new java.sql.Timestamp(System.currentTimeMillis());
         Mockito.when(mockResultSet.getTimestamp(JDBCConsts.DB_COLUMN_EXPIRATION))
                 .thenReturn(ts);
@@ -10807,6 +10809,21 @@ public class JDBCConnectionTest {
         assertEquals(memberMap.size(), 2);
         assertTrue(memberMap.containsKey("user.joe"));
         assertTrue(memberMap.containsKey("user.jane"));
+
+        DomainRoleMember member = memberMap.get("user.joe");
+        assertEquals(member.getMemberName(), "user.joe");
+        assertEquals(member.getMemberRoles().size(), 2);
+        assertEquals(member.getMemberRoles().get(0).getRoleName(), "role1");
+        assertEquals(member.getMemberRoles().get(0).getNotifyDetails(), "notify details");
+        assertEquals(member.getMemberRoles().get(1).getRoleName(), "role2");
+        assertEquals(member.getMemberRoles().get(1).getNotifyDetails(), "self-serve role");
+
+        member = memberMap.get("user.jane");
+        assertEquals(member.getMemberName(), "user.jane");
+        assertEquals(member.getMemberRoles().size(), 1);
+        assertEquals(member.getMemberRoles().get(0).getRoleName(), "role3");
+        assertEquals(member.getMemberRoles().get(0).getNotifyDetails(), "notify for self serve");
+
         jdbcConn.close();
     }
 
@@ -13446,9 +13463,11 @@ public class JDBCConnectionTest {
                 .thenReturn("")
                 .thenReturn("");
         Mockito.when(mockResultSet.getString(JDBCConsts.DB_COLUMN_NOTIFY_DETAILS))
+                .thenReturn("notify details")
                 .thenReturn("")
-                .thenReturn("")
-                .thenReturn("");
+                .thenReturn("notify for self serve");
+        Mockito.when(mockResultSet.getBoolean(JDBCConsts.DB_COLUMN_SELF_SERVE))
+                .thenReturn(true); // will be called for the second call - user.joe and group2
         java.sql.Timestamp ts = new java.sql.Timestamp(System.currentTimeMillis());
         Mockito.when(mockResultSet.getTimestamp(JDBCConsts.DB_COLUMN_EXPIRATION))
                 .thenReturn(ts);
@@ -13465,6 +13484,20 @@ public class JDBCConnectionTest {
         assertEquals(memberMap.size(), 2);
         assertTrue(memberMap.containsKey("user.joe"));
         assertTrue(memberMap.containsKey("user.jane"));
+
+        DomainGroupMember member = memberMap.get("user.joe");
+        assertEquals(member.getMemberName(), "user.joe");
+        assertEquals(member.getMemberGroups().size(), 2);
+        assertEquals(member.getMemberGroups().get(0).getGroupName(), "group1");
+        assertEquals(member.getMemberGroups().get(0).getNotifyDetails(), "notify details");
+        assertEquals(member.getMemberGroups().get(1).getGroupName(), "group2");
+        assertEquals(member.getMemberGroups().get(1).getNotifyDetails(), "self-serve group");
+
+        member = memberMap.get("user.jane");
+        assertEquals(member.getMemberName(), "user.jane");
+        assertEquals(member.getMemberGroups().size(), 1);
+        assertEquals(member.getMemberGroups().get(0).getGroupName(), "group3");
+        assertEquals(member.getMemberGroups().get(0).getNotifyDetails(), "notify for self serve");
         jdbcConn.close();
     }
 

--- a/libs/java/server_common/src/test/resources/messages/role-member-expiry-email.html
+++ b/libs/java/server_common/src/test/resources/messages/role-member-expiry-email.html
@@ -16,31 +16,31 @@
         -webkit-font-smoothing: antialiased;
         background-color: rgba(231, 232, 231, 1.0);
     }
-    .athenz-wrapper .mbrapproval.unrefreshedcerts {
+    .athenz-wrapper .athenz-body.unrefreshedcerts {
         width: 900px;
         height: auto;
         min-height: 402px;
     }
-    .athenz-wrapper .mbrapproval {
+    .athenz-wrapper .athenz-body {
         width: 100%;
         min-height: 402px;
         margin: auto;
         background-color:white;
         border-radius: 5px;
     }
-    .mbrapproval .logo {
+    .athenz-body .logo {
         background-color: rgb(1,36,57);
         height: 45px;
         width: 100%;
         border-radius: 5px;
     }
-    .mbrapproval .athenzlogowhite {
+    .athenz-body .athenzlogowhite {
         background-color: rgba(255,255,255,0.0);
         height: 26px;
         width: 110px;
         padding: 10px;
     }
-    .mbrapproval .hdr {
+    .athenz-body .hdr {
         background-color: rgba(255, 255, 255, 0.0);
         height: auto;
         width: 440px;
@@ -51,40 +51,40 @@
         text-align: left;
         line-height: 24px;
     }
-    .mbrapproval .bt.unrefreshedcerts {
+    .athenz-body .bt.unrefreshedcerts {
         width: 640px;
     }
-    .mbrapproval .bt {
+    .athenz-body .bt {
         background-color: rgba(255, 255, 255, 0.0);
         height: auto;
-        width: 100%;
+        width: 92%;
         margin: 20px;
         font-size: 14px;
         color: rgba(47, 48, 47, 1.0);
         text-align: left;
         line-height: 18px;
     }
-    .mbrapproval table {
+    .athenz-body table {
         width: 97%;
         margin-left: 20px;
     }
-    .mbrapproval td {
+    .athenz-body td {
         padding: 5px;
         text-align: left;
     }
-    .mbrapproval th {
+    .athenz-body th {
         padding: 5px;
         text-align: left;
         font-weight: bold;
     }
-    .mbrapproval div {
+    .athenz-body div {
         -webkit-text-size-adjust: none;
     }
-    .mbrapproval a {
+    .athenz-body a {
         text-decoration: none;
         color: rgba(54, 151, 242, 1.0);
     }
-    .mbrapproval .cv, table#t01 td:nth-child(even) {
+    .athenz-body .cv, table#t01 td:nth-child(even) {
         background-color: rgba(255, 255, 255, 0.0);
         height: auto;
         width: 300px;
@@ -94,7 +94,7 @@
         text-align: left;
         line-height: 17px;
     }
-    .mbrapproval .ch, table#t01 td:nth-child(odd) {
+    .athenz-body .ch, table#t01 td:nth-child(odd) {
         background-color: rgba(255, 255, 255, 0.0);
         height: auto;
         width: 120px;
@@ -108,15 +108,15 @@
     .footer-container .footer {
         background-color: rgba(255, 255, 255, 0.0);
         height: auto;
-        width: 440px;
+        width: 92%;
         margin: 15px 0 0 20px;
         font-size: 12px;
         color: rgba(48, 48, 48, 1.0);
-        text-align: left;
+        text-align: center;
         line-height: 14px;
         display: inline-block;
     }
-    .mbrapproval hr {
+    .athenz-body hr {
         margin: 20px;
         width: 92%;
     }
@@ -140,7 +140,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/libs/java/server_common/src/test/resources/messages/role-member-expiry.html
+++ b/libs/java/server_common/src/test/resources/messages/role-member-expiry.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/domain-group-member-expiry.html
+++ b/servers/zms/src/main/resources/messages/domain-group-member-expiry.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/domain-role-member-expiry.html
+++ b/servers/zms/src/main/resources/messages/domain-role-member-expiry.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/domain-role-member-review.html
+++ b/servers/zms/src/main/resources/messages/domain-role-member-review.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/group-member-expiry.html
+++ b/servers/zms/src/main/resources/messages/group-member-expiry.html
@@ -7,12 +7,20 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>
         <div class="hdr">Group Member Expiry Details</div>
-        <div class="bt">Access for the principals you manage in the following groups will expire soon:</div>
+        <div class="hdr">Principal Expiry Details</div>
+        <div class="bt">Access for the principals you manage in the listed groups will expire soon.</div>
+        <div class="bt">Failure to extend the expiry for these principals before the listed date will cause
+            these principals to lose access to the configured resources and likely result in a production incident.</div>
+        <div class="bt">Please review this list and, if necessary, follow up with their respective domain
+            administrators to extend those expiration dates. If the domain administrator has specified any details
+            how to extend the expiry, they will be included in the NOTES column. If the domain administrator has
+            not specified any details, but the group is marked as a "self-serve" group, you can click on the group
+            name and request an extension for your principals yourself using Athenz UI.</div>
         <hr>
         <div class="divScroll">
             <table id="t03">
@@ -29,7 +37,6 @@
             </table>
         </div>
         <hr>
-        <div class="bt"><br>Please review this list and, if necessary, follow up with their respective domain administrators to extend those expiration dates.</div>
     </div>
     <div class="footer-container">
         <div class="footer">This is a generated email from <a href="{1}">Athenz</a>. Please do not respond.</div>

--- a/servers/zms/src/main/resources/messages/group-membership-approval-reminder.html
+++ b/servers/zms/src/main/resources/messages/group-membership-approval-reminder.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/group-membership-approval.html
+++ b/servers/zms/src/main/resources/messages/group-membership-approval.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/membership-approval-reminder.html
+++ b/servers/zms/src/main/resources/messages/membership-approval-reminder.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/membership-approval.html
+++ b/servers/zms/src/main/resources/messages/membership-approval.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/pending-group-membership-approve.html
+++ b/servers/zms/src/main/resources/messages/pending-group-membership-approve.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/pending-group-membership-reject.html
+++ b/servers/zms/src/main/resources/messages/pending-group-membership-reject.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/pending-role-membership-approve.html
+++ b/servers/zms/src/main/resources/messages/pending-role-membership-approve.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/pending-role-membership-reject.html
+++ b/servers/zms/src/main/resources/messages/pending-role-membership-reject.html
@@ -7,7 +7,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zms/src/main/resources/messages/role-member-expiry.html
+++ b/servers/zms/src/main/resources/messages/role-member-expiry.html
@@ -7,12 +7,19 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>
         <div class="hdr">Principal Expiry Details</div>
-        <div class="bt">Access for the principals you manage in the following roles will expire soon:</div>
+        <div class="bt">Access for the principals you manage in the listed roles will expire soon.</div>
+        <div class="bt">Failure to extend the expiry for these principals before the listed date will cause
+            these principals to lose access to the configured resources and likely result in a production incident.</div>
+        <div class="bt">Please review this list and, if necessary, follow up with their respective domain
+            administrators to extend those expiration dates. If the domain administrator has specified any details
+            how to extend the expiry, they will be included in the NOTES column. If the domain administrator has
+            not specified any details, but the role is marked as a "self-serve" role, you can click on the role
+            name and request an extension for your principals yourself using Athenz UI.</div>
         <hr>
         <div class="divScroll">
             <table id="t03">
@@ -29,7 +36,6 @@
             </table>
         </div>
         <hr>
-        <div class="bt"><br>Please review this list and, if necessary, follow up with their respective domain administrators to extend those expiration dates.</div>
     </div>
     <div class="footer-container">
         <div class="footer">This is a generated email from <a href="{1}">Athenz</a>. Please do not respond.</div>

--- a/servers/zms/src/main/resources/messages/role-member-review.html
+++ b/servers/zms/src/main/resources/messages/role-member-review.html
@@ -7,12 +7,20 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval">
+    <div class="athenz-body">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>
         <div class="hdr">Principal Review Details</div>
-        <div class="bt">Review is required for the principals you manage in the following roles:</div>
+        <div class="bt">Review is required for the principals you manage in the listed roles.</div>
+        <div class="bt">Review must be carried out by the domain administrators where your principal is referenced
+            to satisfy governance and compliance requirements. Failure to extend the review dates will not cause
+            your principals to lose any access.</div>
+        <div class="bt">If the domain administrator has specified any details how to extend the review date,
+            they will be included in the NOTES column. If the domain administrator has not specified any details,
+            but the role is marked as a "self-serve" role, you can click on the role name and request an extension
+            for your principals yourself using Athenz UI. Otherwise, no action is required from you and this email
+            is for informational purposes only.</div>
         <hr>
         <div class="divScroll">
             <table id="t03">
@@ -29,7 +37,6 @@
             </table>
         </div>
         <hr>
-        <div class="bt"><br>Please review this list and, if necessary, follow up with their respective domain administrators to extend those review dates.</div>
     </div>
     <div class="footer-container">
         <div class="footer">This is a generated email from <a href="{1}">Athenz</a>. Please do not respond.</div>

--- a/servers/zts/src/main/resources/messages/unrefreshed-certs.html
+++ b/servers/zts/src/main/resources/messages/unrefreshed-certs.html
@@ -23,7 +23,7 @@
 </head>
 <body style="margin: 0; background: rgba(231, 232, 231, 1.0);">
 <div class="athenz-wrapper">
-    <div class="mbrapproval unrefreshedcerts">
+    <div class="athenz-body unrefreshedcerts">
         <div class="logo">
             <img src="cid:logo" class="athenzlogowhite" alt="Athenz logo"/>
         </div>

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
@@ -53,7 +53,7 @@ public class CertFailedRefreshNotificationTaskTest {
     private final int httpsPort = 4443;
     private final String htmlSeveralRecords =
             "<div class=\"athenz-wrapper\">\n" +
-                    "    <div class=\"mbrapproval unrefreshedcerts\">\n" +
+                    "    <div class=\"athenz-body unrefreshedcerts\">\n" +
                     "        <div class=\"logo\">\n" +
                     "            <img src=\"cid:logo\" class=\"athenzlogowhite\" alt=\"Athenz logo\"/>\n" +
                     "        </div>\n" +
@@ -101,7 +101,7 @@ public class CertFailedRefreshNotificationTaskTest {
                     "</html>\n";
     private final String htmlSingleRecord =
             "<div class=\"athenz-wrapper\">\n" +
-                    "    <div class=\"mbrapproval unrefreshedcerts\">\n" +
+                    "    <div class=\"athenz-body unrefreshedcerts\">\n" +
                     "        <div class=\"logo\">\n" +
                     "            <img src=\"cid:logo\" class=\"athenzlogowhite\" alt=\"Athenz logo\"/>\n" +
                     "        </div>\n" +


### PR DESCRIPTION
# Description
provide more details for the user how to handle expiry/review notification emails. Also if the role/group is marked as self-serve then this is indicated in the email so the user knows they can extend the expiry themselves unless the role/group administrator has included specific details.
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

