### PR TITLE
correct order or arguments to assertEquals call in tests

### DIFF
--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ClientResourceExceptionTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ClientResourceExceptionTest.java
@@ -24,31 +24,31 @@ public class ClientResourceExceptionTest {
     @Test
     public void testCodeToString() {
 
-        assertEquals("OK", ClientResourceException.codeToString(200));
-        assertEquals("Created", ClientResourceException.codeToString(201));
-        assertEquals("Accepted", ClientResourceException.codeToString(202));
-        assertEquals("No Content", ClientResourceException.codeToString(204));
-        assertEquals("Moved Permanently", ClientResourceException.codeToString(301));
-        assertEquals("Found", ClientResourceException.codeToString(302));
-        assertEquals("See Other", ClientResourceException.codeToString(303));
-        assertEquals("Not Modified", ClientResourceException.codeToString(304));
-        assertEquals("Temporary Redirect", ClientResourceException.codeToString(307));
-        assertEquals("Bad Request", ClientResourceException.codeToString(400));
-        assertEquals("Unauthorized", ClientResourceException.codeToString(401));
-        assertEquals("Forbidden", ClientResourceException.codeToString(403));
-        assertEquals("Not Found", ClientResourceException.codeToString(404));
-        assertEquals("Conflict", ClientResourceException.codeToString(409));
-        assertEquals("Gone", ClientResourceException.codeToString(410));
-        assertEquals("Precondition Failed", ClientResourceException.codeToString(412));
-        assertEquals("Unsupported Media Type", ClientResourceException.codeToString(415));
-        assertEquals("Precondition Required", ClientResourceException.codeToString(428));
-        assertEquals("Too Many Requests", ClientResourceException.codeToString(429));
-        assertEquals("Request Header Fields Too Large", ClientResourceException.codeToString(431));
-        assertEquals("Internal Server Error", ClientResourceException.codeToString(500));
-        assertEquals("Not Implemented", ClientResourceException.codeToString(501));
-        assertEquals("Service Unavailable", ClientResourceException.codeToString(503));
-        assertEquals("Network Authentication Required", ClientResourceException.codeToString(511));
-        assertEquals("1001", ClientResourceException.codeToString(1001));
+        assertEquals(ClientResourceException.codeToString(200), "OK");
+        assertEquals(ClientResourceException.codeToString(201), "Created");
+        assertEquals(ClientResourceException.codeToString(202), "Accepted");
+        assertEquals(ClientResourceException.codeToString(204), "No Content");
+        assertEquals(ClientResourceException.codeToString(301), "Moved Permanently");
+        assertEquals(ClientResourceException.codeToString(302), "Found");
+        assertEquals(ClientResourceException.codeToString(303), "See Other");
+        assertEquals(ClientResourceException.codeToString(304), "Not Modified");
+        assertEquals(ClientResourceException.codeToString(307), "Temporary Redirect");
+        assertEquals(ClientResourceException.codeToString(400), "Bad Request");
+        assertEquals(ClientResourceException.codeToString(401), "Unauthorized");
+        assertEquals(ClientResourceException.codeToString(403), "Forbidden");
+        assertEquals(ClientResourceException.codeToString(404), "Not Found");
+        assertEquals(ClientResourceException.codeToString(409), "Conflict");
+        assertEquals(ClientResourceException.codeToString(410), "Gone");
+        assertEquals(ClientResourceException.codeToString(412), "Precondition Failed");
+        assertEquals(ClientResourceException.codeToString(415), "Unsupported Media Type");
+        assertEquals(ClientResourceException.codeToString(428), "Precondition Required");
+        assertEquals(ClientResourceException.codeToString(429), "Too Many Requests");
+        assertEquals(ClientResourceException.codeToString(431), "Request Header Fields Too Large");
+        assertEquals(ClientResourceException.codeToString(500), "Internal Server Error");
+        assertEquals(ClientResourceException.codeToString(501), "Not Implemented");
+        assertEquals(ClientResourceException.codeToString(503), "Service Unavailable");
+        assertEquals(ClientResourceException.codeToString(511), "Network Authentication Required");
+        assertEquals(ClientResourceException.codeToString(1001), "1001");
     }
 
     @Test

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientMockTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientMockTest.java
@@ -539,10 +539,10 @@ public class ZMSClientMockTest {
         }
 
         assertNotNull(retRoles);
-        assertEquals(tenantDomain, retRoles.getTenant());
-        assertEquals(providerDomain, retRoles.getDomain());
-        assertEquals(providerService, retRoles.getService());
-        assertEquals(resourceGroup, retRoles.getResourceGroup());
+        assertEquals(retRoles.getTenant(), tenantDomain);
+        assertEquals(retRoles.getDomain(), providerDomain);
+        assertEquals(retRoles.getService(), providerService);
+        assertEquals(retRoles.getResourceGroup(), resourceGroup);
 
         // try to get unknown resource group that would return null
 
@@ -636,10 +636,10 @@ public class ZMSClientMockTest {
         }
 
         assertNotNull(retRoles);
-        assertEquals(tenantDomain, retRoles.getTenant());
-        assertEquals(providerDomain, retRoles.getDomain());
-        assertEquals(providerService, retRoles.getService());
-        assertEquals(resourceGroup, retRoles.getResourceGroup());
+        assertEquals(retRoles.getTenant(), tenantDomain);
+        assertEquals(retRoles.getDomain(), providerDomain);
+        assertEquals(retRoles.getService(), providerService);
+        assertEquals(retRoles.getResourceGroup(), resourceGroup);
 
         // try to get unknown resource group that would return null
 
@@ -671,14 +671,14 @@ public class ZMSClientMockTest {
         assertNotNull(solTemplate);
         List<Role> solRoles = solTemplate.getRoles();
         assertNotNull(solRoles);
-        assertEquals(1, solRoles.size());
-        assertEquals("role1", solRoles.get(0).getName());
-        assertEquals("trust-domain", solRoles.get(0).getTrust());
+        assertEquals(solRoles.size(), 1);
+        assertEquals(solRoles.get(0).getName(), "role1");
+        assertEquals(solRoles.get(0).getTrust(), "trust-domain");
 
         List<Policy> solPolicies = solTemplate.getPolicies();
         assertNotNull(solPolicies);
-        assertEquals(1, solPolicies.size());
-        assertEquals("policy1", solPolicies.get(0).getName());
+        assertEquals(solPolicies.size(), 1);
+        assertEquals(solPolicies.get(0).getName(), "policy1");
     }
 
     @Test
@@ -693,7 +693,7 @@ public class ZMSClientMockTest {
 
         ServerTemplateList solTemplateList = zclt.getServerTemplateList();
         assertNotNull(solTemplateList);
-        assertEquals(2, solTemplateList.getTemplateNames().size());
+        assertEquals(solTemplateList.getTemplateNames().size(), 2);
         assertTrue(solTemplateList.getTemplateNames().contains("mh2"));
         assertTrue(solTemplateList.getTemplateNames().contains("vipng"));
     }
@@ -710,7 +710,7 @@ public class ZMSClientMockTest {
 
         DomainTemplateList domTemplateList = zclt.getDomainTemplateList("iaas.athenz");
         assertNotNull(domTemplateList);
-        assertEquals(2, domTemplateList.getTemplateNames().size());
+        assertEquals(domTemplateList.getTemplateNames().size(), 2);
         assertTrue(domTemplateList.getTemplateNames().contains("mh2"));
         assertTrue(domTemplateList.getTemplateNames().contains("vipng"));
     }
@@ -723,8 +723,8 @@ public class ZMSClientMockTest {
 
         Principal principal = zclt.getPrincipal("v=U1;d=coretech;n=storage;s=signature");
         assertNotNull(principal);
-        assertEquals("storage", principal.getName());
-        assertEquals("coretech", principal.getDomain());
+        assertEquals(principal.getName(), "storage");
+        assertEquals(principal.getDomain(), "coretech");
     }
 
     @Test

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
@@ -3090,7 +3090,7 @@ public class ZMSClientTest {
             client.getPrincipal(null);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
         client.close();
     }
@@ -3103,21 +3103,21 @@ public class ZMSClientTest {
             client.getPrincipal("abcdefg");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         try {
             client.getPrincipal("v=U1;d=coretech;t=12345678;s=signature");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         try {
             client.getPrincipal("v=U1;n=storage;t=12345678;s=signature");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
         client.close();
     }
@@ -3309,7 +3309,7 @@ public class ZMSClientTest {
             client.getStats("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3318,7 +3318,7 @@ public class ZMSClientTest {
             client.getStats("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3346,7 +3346,7 @@ public class ZMSClientTest {
             client.getInfo();
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3355,7 +3355,7 @@ public class ZMSClientTest {
             client.getInfo();
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3382,7 +3382,7 @@ public class ZMSClientTest {
             client.getQuota("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3391,7 +3391,7 @@ public class ZMSClientTest {
             client.getQuota("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3419,7 +3419,7 @@ public class ZMSClientTest {
             client.putQuota("athenz", AUDIT_REF, quota);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3428,7 +3428,7 @@ public class ZMSClientTest {
             client.putQuota("athenz", AUDIT_REF, quota);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3451,7 +3451,7 @@ public class ZMSClientTest {
             client.deleteQuota("athenz", AUDIT_REF);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // finally std exception
@@ -3460,7 +3460,7 @@ public class ZMSClientTest {
             client.deleteQuota("athenz", AUDIT_REF);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3484,7 +3484,7 @@ public class ZMSClientTest {
             client.deleteDomainRoleMember("athenz", "athenz.api", AUDIT_REF);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception - resulting in 400
@@ -3493,7 +3493,7 @@ public class ZMSClientTest {
             client.deleteDomainRoleMember("athenz", "athenz.api", AUDIT_REF);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3534,7 +3534,7 @@ public class ZMSClientTest {
             client.getDomainRoleMembers("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception - resulting in 400
@@ -3543,7 +3543,7 @@ public class ZMSClientTest {
             client.getDomainRoleMembers("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3584,7 +3584,7 @@ public class ZMSClientTest {
             client.getDomainGroupMembers("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception - resulting in 400
@@ -3593,7 +3593,7 @@ public class ZMSClientTest {
             client.getDomainGroupMembers("athenz");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3655,7 +3655,7 @@ public class ZMSClientTest {
             client.getPrincipalRoles(null, null);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception - resulting in 400
@@ -3664,7 +3664,7 @@ public class ZMSClientTest {
             client.getPrincipalRoles(null, null);
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3794,7 +3794,7 @@ public class ZMSClientTest {
             client.getAccess("update", "service1", "athenz", "user.johndoe");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3803,7 +3803,7 @@ public class ZMSClientTest {
             client.getAccess("update", "service1", "athenz", "user.johndoe");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3828,7 +3828,7 @@ public class ZMSClientTest {
             client.getAccessExt("update", "service1", "athenz", "user.johndoe");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3837,7 +3837,7 @@ public class ZMSClientTest {
             client.getAccessExt("update", "service1", "athenz", "user.johndoe");
             fail();
         } catch (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -3859,13 +3859,13 @@ public class ZMSClientTest {
             client.getEntityList("athenz");
             fail();
         } catch  (ZMSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
         try {
             client.getEntityList("athenz");
             fail();
         } catch  (ZMSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/AccessTokenResponseCacheEntryTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/AccessTokenResponseCacheEntryTest.java
@@ -37,11 +37,11 @@ public class AccessTokenResponseCacheEntryTest {
         Thread.sleep(1000);
 
         AccessTokenResponse response = entry.accessTokenResponse();
-        assertEquals("scope", response.getScope());
-        assertEquals("refresh", response.getRefresh_token());
-        assertEquals("Bearer", response.getToken_type());
-        assertEquals("id", response.getId_token());
-        assertEquals("access", response.getAccess_token());
+        assertEquals(response.getScope(), "scope");
+        assertEquals(response.getRefresh_token(), "refresh");
+        assertEquals(response.getToken_type(), "Bearer");
+        assertEquals(response.getId_token(), "id");
+        assertEquals(response.getAccess_token(), "access");
 
         int expiry = response.getExpires_in();
         assertTrue(expiry < 100, response.getExpires_in().toString());

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
@@ -755,7 +755,7 @@ public class ZTSClientTest {
 
         com.yahoo.athenz.auth.token.RoleToken token = new com.yahoo.athenz.auth.token.RoleToken(roleToken.getToken());
         assertEquals(token.getDomain(), "coretech");
-        assertEquals(1, token.getRoles().size());
+        assertEquals(token.getRoles().size(), 1);
         assertTrue(token.getRoles().contains("role1"));
 
         // now we're going to get a token again and this time we should get back
@@ -788,7 +788,7 @@ public class ZTSClientTest {
 
         com.yahoo.athenz.auth.token.RoleToken token = new com.yahoo.athenz.auth.token.RoleToken(roleToken.getToken());
         assertEquals(token.getDomain(), "coretech");
-        assertEquals(1, token.getRoles().size());
+        assertEquals(token.getRoles().size(), 1);
         assertTrue(token.getRoles().contains("role1"));
 
         // now we're going to get a token again and this time we should get back
@@ -1576,7 +1576,7 @@ public class ZTSClientTest {
         // assert notification sent
         ArgumentCaptor<ZTSClientNotification> argument = ArgumentCaptor.forClass(ZTSClientNotification.class);
         Mockito.verify(notificationSender, Mockito.times(1)).sendNotification(argument.capture());
-        assertEquals(domain1, argument.getValue().getDomain());
+        assertEquals(argument.getValue().getDomain(), domain1);
 
         // Restore credentials, now fetching should work fine
         ztsClientMock.setAwsCreds(Timestamp.fromCurrentTime(), domain1, "role1");
@@ -1758,9 +1758,9 @@ public class ZTSClientTest {
         OpenIDConfig openIDConfig = client.getOpenIDConfig();
         assertNotNull(openIDConfig);
 
-        assertEquals("https://athenz.cloud", openIDConfig.getIssuer());
-        assertEquals("https://athenz.cloud/oauth2/keys", openIDConfig.getJwks_uri());
-        assertEquals("https://athenz.cloud/access", openIDConfig.getAuthorization_endpoint());
+        assertEquals(openIDConfig.getIssuer(), "https://athenz.cloud");
+        assertEquals(openIDConfig.getJwks_uri(), "https://athenz.cloud/oauth2/keys");
+        assertEquals(openIDConfig.getAuthorization_endpoint(), "https://athenz.cloud/access");
         assertEquals(Collections.singletonList("RS256"), openIDConfig.getId_token_signing_alg_values_supported());
         assertEquals(Collections.singletonList("id_token"), openIDConfig.getResponse_types_supported());
         assertEquals(Collections.singletonList("public"), openIDConfig.getSubject_types_supported());
@@ -2181,15 +2181,15 @@ public class ZTSClientTest {
 
         AWSTemporaryCredentials awsCreds = client.getAWSTemporaryCredentials("coretech", "role");
         assertNotNull(awsCreds);
-        assertEquals("accessKeyId", awsCreds.getAccessKeyId());
-        assertEquals("secretAccessKey", awsCreds.getSecretAccessKey());
+        assertEquals(awsCreds.getAccessKeyId(), "accessKeyId");
+        assertEquals(awsCreds.getSecretAccessKey(), "secretAccessKey");
         assertTrue(awsCreds.getSessionToken().startsWith("sessionToken"));
         currentTime = awsCreds.getExpiration();
 
         AWSTemporaryCredentials awsCreds2 = client.getAWSTemporaryCredentials("coretech", "role");
         assertNotNull(awsCreds2);
-        assertEquals("accessKeyId", awsCreds2.getAccessKeyId());
-        assertEquals("secretAccessKey", awsCreds2.getSecretAccessKey());
+        assertEquals(awsCreds2.getAccessKeyId(), "accessKeyId");
+        assertEquals(awsCreds2.getSecretAccessKey(), "secretAccessKey");
         assertTrue(awsCreds2.getSessionToken().startsWith("sessionToken"));
         assertEquals(currentTime.millis() / 1000, awsCreds2.getExpiration().millis() / 1000);
 
@@ -2427,7 +2427,7 @@ public class ZTSClientTest {
 
         com.yahoo.athenz.auth.token.RoleToken token = new com.yahoo.athenz.auth.token.RoleToken(roleToken.getToken());
         assertEquals(token.getDomain(), "coretech");
-        assertEquals(1, token.getRoles().size());
+        assertEquals(token.getRoles().size(), 1);
         assertTrue(token.getRoles().contains("role1"));
         assertEquals(token.getProxyUser(), "user_domain.user4");
 
@@ -2834,8 +2834,8 @@ public class ZTSClientTest {
         assertNotNull(req);
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(req.getCsr());
-        assertEquals("coretech.test", Crypto.extractX509CSRCommonName(certReq));
-        assertEquals("test.coretech.aws.athenz.cloud", Crypto.extractX509CSRDnsNames(certReq).get(0));
+        assertEquals(Crypto.extractX509CSRCommonName(certReq), "coretech.test");
+        assertEquals(Crypto.extractX509CSRDnsNames(certReq).get(0), "test.coretech.aws.athenz.cloud");
 
         List<String> uris = Crypto.extractX509CSRURIs(certReq);
         assertEquals(uris.get(0), "spiffe://coretech/sa/test");
@@ -2852,8 +2852,8 @@ public class ZTSClientTest {
         assertNotNull(req);
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(req.getCsr());
-        assertEquals("coretech.test", Crypto.extractX509CSRCommonName(certReq));
-        assertEquals("test.coretech.athenz.io", Crypto.extractX509CSRDnsNames(certReq).get(0));
+        assertEquals(Crypto.extractX509CSRCommonName(certReq), "coretech.test");
+        assertEquals(Crypto.extractX509CSRDnsNames(certReq).get(0), "test.coretech.athenz.io");
 
         List<String> uris = Crypto.extractX509CSRURIs(certReq);
         assertEquals(uris.get(0), "spiffe://athenz.io/ns/prod/sa/coretech.test");
@@ -2870,12 +2870,12 @@ public class ZTSClientTest {
         assertNotNull(req);
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(req.getCsr());
-        assertEquals("coretech.system.test", Crypto.extractX509CSRCommonName(certReq));
+        assertEquals(Crypto.extractX509CSRCommonName(certReq), "coretech.system.test");
 
         X500Name x500name = certReq.getSubject();
         RDN cnRdn = x500name.getRDNs(BCStyle.CN)[0];
-        assertEquals("coretech.system.test", IETFUtils.valueToString(cnRdn.getFirst().getValue()));
-        assertEquals("test.coretech-system.aws.athenz.cloud", Crypto.extractX509CSRDnsNames(certReq).get(0));
+        assertEquals(IETFUtils.valueToString(cnRdn.getFirst().getValue()), "coretech.system.test");
+        assertEquals(Crypto.extractX509CSRDnsNames(certReq).get(0), "test.coretech-system.aws.athenz.cloud");
     }
 
     @Test
@@ -3168,7 +3168,7 @@ public class ZTSClientTest {
         ZTSClientService.RoleTokenDescriptor descr = new ZTSClientService.RoleTokenDescriptor("signedToken");
         assertNotNull(descr);
 
-        assertEquals("signedToken", descr.getSignedToken());
+        assertEquals(descr.getSignedToken(), "signedToken");
     }
 
     @Test
@@ -3178,35 +3178,35 @@ public class ZTSClientTest {
                 "auth_creds", PRINCIPAL_AUTHORITY);
         ZTSClient client = new ZTSClient("http://localhost:4080", principal);
 
-        assertEquals("grant_type=client_credentials&scope=coretech%3Adomain",
-                client.generateAccessTokenRequestBody("coretech", null, null, null, null, null, 0));
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Adomain",
-                client.generateAccessTokenRequestBody("coretech", null, null, null, null, null, 100));
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Adomain",
-                client.generateAccessTokenRequestBody("coretech", null, "", null, null, null, 100));
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Adomain+openid+coretech%3Aservice.api",
-                client.generateAccessTokenRequestBody("coretech", null, "api", null, null, null, 100));
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api",
-                client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", null, null, "", 100));
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api",
-                client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", "", null, null, 100));
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api&proxy_for_principal=user.proxy",
-                client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", "user.proxy", null, "", 100));
+        assertEquals(client.generateAccessTokenRequestBody("coretech", null, null, null, null, null, 0),
+                "grant_type=client_credentials&scope=coretech%3Adomain");
+        assertEquals(client.generateAccessTokenRequestBody("coretech", null, null, null, null, null, 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Adomain");
+        assertEquals(client.generateAccessTokenRequestBody("coretech", null, "", null, null, null, 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Adomain");
+        assertEquals(client.generateAccessTokenRequestBody("coretech", null, "api", null, null, null, 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Adomain+openid+coretech%3Aservice.api");
+        assertEquals(client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", null, null, "", 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api");
+        assertEquals(client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", "", null, null, 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api");
+        assertEquals(client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", "user.proxy", null, "", 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api&proxy_for_principal=user.proxy");
         List<String> roles = new ArrayList<>();
         roles.add("readers");
         roles.add("writers");
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+coretech%3Arole.writers+openid+coretech%3Aservice.api",
-                client.generateAccessTokenRequestBody("coretech", roles, "api", null, null, null, 100));
+        assertEquals(client.generateAccessTokenRequestBody("coretech", roles, "api", null, null, null, 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+coretech%3Arole.writers+openid+coretech%3Aservice.api");
         final String authorizationDetails = "[{\"type\":\"message_access\",\"location\":[\"https://location1\"," +
                 "\"https://location2\"],\"identifier\":\"id1\"}]";
         final String encodedDetails = "%5B%7B%22type%22%3A%22message_access%22%2C%22location%22%3A%5B%22https%3A%2F%2Flocation1%22%2C%22https%3A%2F%2Flocation2%22%5D%2C%22identifier%22%3A%22id1%22%7D%5D";
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api&authorization_details=" + encodedDetails,
-                client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", null, authorizationDetails, null, 100));
+        assertEquals(client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", null, authorizationDetails, null, 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api&authorization_details=" + encodedDetails);
         final String proxyPrincipalsEncoded = "spiffe%3A%2F%2Fathenz%2Fsa%2Fservice1%2Cspiffe%3A%2F%2Fathenz%2Fsa%2Fservice2";
-        assertEquals("grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api&authorization_details="
-                        + encodedDetails + "&proxy_principal_spiffe_uris=" + proxyPrincipalsEncoded,
-                client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", null,
-                        authorizationDetails, "spiffe://athenz/sa/service1,spiffe://athenz/sa/service2", 100));
+        assertEquals(client.generateAccessTokenRequestBody("coretech", Collections.singletonList("readers"), "api", null,
+                authorizationDetails, "spiffe://athenz/sa/service1,spiffe://athenz/sa/service2", 100),
+                "grant_type=client_credentials&expires_in=100&scope=coretech%3Arole.readers+openid+coretech%3Aservice.api&authorization_details="
+                                + encodedDetails + "&proxy_principal_spiffe_uris=" + proxyPrincipalsEncoded);
 
         client.close();
     }
@@ -3262,46 +3262,46 @@ public class ZTSClientTest {
 
         assertNull(ZTSClient.getAccessTokenCacheKey(null, "service", "coretech", null, null, null, null, null));
 
-        assertEquals("p=sports;d=coretech",
-                ZTSClient.getAccessTokenCacheKey("sports", null, "coretech", null, null, null, null, null));
-        assertEquals("p=sports.api;d=coretech",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", null, null, null, null, null));
-        assertEquals("p=sports.api;d=coretech;r=readers",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech",
-                        Collections.singletonList("readers"), null, null, null, null));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", null, "coretech", null, null, null, null, null),
+                "p=sports;d=coretech");
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", null, null, null, null, null),
+                "p=sports.api;d=coretech");
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech",
+                Collections.singletonList("readers"), null, null, null, null),
+                "p=sports.api;d=coretech;r=readers");
 
         List<String> roles = new ArrayList<>();
         roles.add("writers");
         roles.add("readers");
-        assertEquals("p=sports.api;d=coretech;r=readers,writers",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, null, null, null, null));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, null, null, null, null),
+                "p=sports.api;d=coretech;r=readers,writers");
 
-        assertEquals("p=sports.api;d=coretech;r=readers,writers",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "", null, null, null));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "", null, null, null),
+                "p=sports.api;d=coretech;r=readers,writers");
 
-        assertEquals("p=sports.api;d=coretech;r=readers,writers;o=backend",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null, null, null));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null, null, null),
+                "p=sports.api;d=coretech;r=readers,writers;o=backend");
 
         // using tenant domain details from principal object
 
-        assertEquals("p=user_domain.user;d=coretech;r=readers,writers;o=backend",
-                client.getAccessTokenCacheKey("coretech", roles, "backend", null, null, null));
+        assertEquals(client.getAccessTokenCacheKey("coretech", roles, "backend", null, null, null),
+                "p=user_domain.user;d=coretech;r=readers,writers;o=backend");
 
         // using authorization details
 
-        assertEquals("p=sports.api;d=coretech;r=readers,writers;o=backend;z=ZHMaRw4r9BWIPOWxVv9kDcCMTFzXm3nCUzNs9SA5aL8",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null,
-                        "[{\"type\": \"message\",\"uuid\": \"uuid-12345678\"}]", null));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null,
+                "[{\"type\": \"message\",\"uuid\": \"uuid-12345678\"}]", null),
+                "p=sports.api;d=coretech;r=readers,writers;o=backend;z=ZHMaRw4r9BWIPOWxVv9kDcCMTFzXm3nCUzNs9SA5aL8");
 
-        assertEquals("p=sports.api;d=coretech;r=readers,writers;o=backend;z=ZHMaRw4r9BWIPOWxVv9kDcCMTFzXm3nCUzNs9SA5aL8",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null,
-                        "[{\"type\": \"message\",\"uuid\": \"uuid-12345678\"}]", ""));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null,
+                "[{\"type\": \"message\",\"uuid\": \"uuid-12345678\"}]", ""),
+                "p=sports.api;d=coretech;r=readers,writers;o=backend;z=ZHMaRw4r9BWIPOWxVv9kDcCMTFzXm3nCUzNs9SA5aL8");
 
         // using proxy principal spiffe uris
 
-        assertEquals("p=sports.api;d=coretech;r=readers,writers;o=backend;z=ZHMaRw4r9BWIPOWxVv9kDcCMTFzXm3nCUzNs9SA5aL8;s=spiffe://athenz/sa/service1",
-                ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null,
-                        "[{\"type\": \"message\",\"uuid\": \"uuid-12345678\"}]", "spiffe://athenz/sa/service1"));
+        assertEquals(ZTSClient.getAccessTokenCacheKey("sports", "api", "coretech", roles, "backend", null,
+                "[{\"type\": \"message\",\"uuid\": \"uuid-12345678\"}]", "spiffe://athenz/sa/service1"),
+                "p=sports.api;d=coretech;r=readers,writers;o=backend;z=ZHMaRw4r9BWIPOWxVv9kDcCMTFzXm3nCUzNs9SA5aL8;s=spiffe://athenz/sa/service1");
         client.close();
     }
 
@@ -3359,13 +3359,13 @@ public class ZTSClientTest {
 
         AccessTokenResponse accessTokenResponse = client.getAccessToken("coretech", null, 3600);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken", accessTokenResponse.getAccess_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
         assertNull(accessTokenResponse.getId_token());
 
         accessTokenResponse = client.getAccessToken("coretech", Collections.singletonList("role1"), 3600);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken", accessTokenResponse.getAccess_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
         assertNull(accessTokenResponse.getId_token());
 
@@ -3373,7 +3373,7 @@ public class ZTSClientTest {
 
         accessTokenResponse = client.getAccessToken("coretech", Collections.singletonList("role1"), 3600);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken", accessTokenResponse.getAccess_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
         assertNull(accessTokenResponse.getId_token());
 
@@ -3381,24 +3381,24 @@ public class ZTSClientTest {
 
         accessTokenResponse = client.getAccessToken("coretech", null, "backend", 3600, false);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken", accessTokenResponse.getAccess_token());
-        assertEquals("idtoken", accessTokenResponse.getId_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken");
+        assertEquals(accessTokenResponse.getId_token(), "idtoken");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
 
         // now with id token and cache disabled
 
         accessTokenResponse = client.getAccessToken("coretech", null, "backend", 3600, true);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken", accessTokenResponse.getAccess_token());
-        assertEquals("idtoken", accessTokenResponse.getId_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken");
+        assertEquals(accessTokenResponse.getId_token(), "idtoken");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
 
 
         ZTSClient.setCacheDisable(true);
         accessTokenResponse = client.getAccessToken("coretech", null, "backend", 3600, true);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken", accessTokenResponse.getAccess_token());
-        assertEquals("idtoken", accessTokenResponse.getId_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken");
+        assertEquals(accessTokenResponse.getId_token(), "idtoken");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
         ZTSClient.setCacheDisable(false);
 
@@ -3420,14 +3420,14 @@ public class ZTSClientTest {
 
         AccessTokenResponse accessTokenResponse = client.getAccessToken("coretech", "role1", authorizationDetails, 3600);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken-authz-details", accessTokenResponse.getAccess_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken-authz-details");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
 
         // the second request should be addressed from the cache
 
         accessTokenResponse = client.getAccessToken("coretech", "role1", authorizationDetails, 3600);
         assertNotNull(accessTokenResponse);
-        assertEquals("accesstoken-authz-details", accessTokenResponse.getAccess_token());
+        assertEquals(accessTokenResponse.getAccess_token(), "accesstoken-authz-details");
         assertEquals((int) accessTokenResponse.getExpires_in(), 3600);
 
         client.close();
@@ -3447,7 +3447,7 @@ public class ZTSClientTest {
             client.getAccessToken("weather", null, 500);
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // look for regular general exception
@@ -3456,7 +3456,7 @@ public class ZTSClientTest {
             client.getAccessToken("exception", null, 500);
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // add an entry to the cache and expect to find the entry
@@ -3475,7 +3475,7 @@ public class ZTSClientTest {
             client.getAccessToken("weather", null, null, 500, true);
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // look for regular general exception
@@ -3484,7 +3484,7 @@ public class ZTSClientTest {
             client.getAccessToken("exception", null, null, 500, true);
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // with cache enabled we'll get our entries back even if
@@ -3492,11 +3492,11 @@ public class ZTSClientTest {
 
         AccessTokenResponse result = client.getAccessToken("weather", null, 500);
         assertNotNull(result);
-        assertEquals("accesstoken1", result.getAccess_token());
+        assertEquals(result.getAccess_token(), "accesstoken1");
 
         result = client.getAccessToken("exception", null, 500);
         assertNotNull(result);
-        assertEquals("accesstoken1", result.getAccess_token());
+        assertEquals(result.getAccess_token(), "accesstoken1");
 
         client.close();
     }
@@ -3710,7 +3710,7 @@ public class ZTSClientTest {
             client.getInfo();
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -3719,7 +3719,7 @@ public class ZTSClientTest {
             client.getInfo();
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -4109,7 +4109,7 @@ public class ZTSClientTest {
             client.postExternalCredentialsRequest("gcp", "athenz", request);
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
         }
 
         // last time with std exception
@@ -4118,7 +4118,7 @@ public class ZTSClientTest {
             client.postExternalCredentialsRequest("gcp", "athenz", request);
             fail();
         } catch (ZTSClientException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -4227,10 +4227,10 @@ public class ZTSClientTest {
 
         ZTSClient client = new ZTSClient("http://localhost:4080", principal);
 
-        assertEquals(503, client.getExceptionCode(new java.net.UnknownHostException()));
-        assertEquals(503, client.getExceptionCode(new java.net.SocketException()));
-        assertEquals(503, client.getExceptionCode(new java.net.SocketTimeoutException()));
-        assertEquals(400, client.getExceptionCode(new ZTSClientException(403, "Forbidden")));
+        assertEquals(client.getExceptionCode(new java.net.UnknownHostException()), 503);
+        assertEquals(client.getExceptionCode(new java.net.SocketException()), 503);
+        assertEquals(client.getExceptionCode(new java.net.SocketTimeoutException()), 503);
+        assertEquals(client.getExceptionCode(new ZTSClientException(403, "Forbidden")), 400);
 
         client.close();
     }

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/CompositeInstanceTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/CompositeInstanceTest.java
@@ -21,10 +21,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 
-import com.yahoo.rdl.Schema;
 import com.yahoo.rdl.Timestamp;
-import com.yahoo.rdl.Validator;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Collections;

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/KubernetesNetworkPolicyRequestTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/KubernetesNetworkPolicyRequestTest.java
@@ -16,8 +16,6 @@
 package com.yahoo.athenz.msd;
 import org.testng.annotations.Test;
 
-import java.util.Map;
-
 import static org.testng.Assert.*;
 
 public class KubernetesNetworkPolicyRequestTest {

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/TransportPolicyRequestTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/TransportPolicyRequestTest.java
@@ -17,7 +17,6 @@
 package com.yahoo.athenz.msd;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.testng.Assert.*;

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/TransportPolicyValidationRequestTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/TransportPolicyValidationRequestTest.java
@@ -18,7 +18,6 @@ package com.yahoo.athenz.msd;
 
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/TransportPolicyValidationResponseTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/TransportPolicyValidationResponseTest.java
@@ -20,7 +20,6 @@ import com.yahoo.rdl.Timestamp;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.testng.Assert.*;

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/WorkloadOptionsTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/WorkloadOptionsTest.java
@@ -15,11 +15,7 @@
  */
 package com.yahoo.athenz.msd;
 
-import com.yahoo.rdl.Timestamp;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.List;
 
 import static org.testng.Assert.*;
 

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/AssertionConditionOperatorTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/AssertionConditionOperatorTest.java
@@ -30,7 +30,7 @@ public class AssertionConditionOperatorTest {
         assertEquals(op1, op1);
         assertFalse(op1.equals("xyz"));
         AssertionConditionOperator op3 = AssertionConditionOperator.fromString("EQUALS");
-        assertEquals(op1, op3);
+        assertEquals(op3, op1);
         try {
             AssertionConditionOperator.fromString("NOT EQUALS");
             fail();

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/AssertionConditionTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/AssertionConditionTest.java
@@ -51,7 +51,7 @@ public class AssertionConditionTest {
         assertNotEquals(c1, c2);
 
         assertEquals(m1, c1.getConditionsMap());
-        assertEquals((Integer)1, c1.getId());
+        assertEquals(c1.getId(), (Integer)1);
 
         Schema schema = ZMSSchema.instance();
         Validator validator = new Validator(schema);

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/AssertionConditionsTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/AssertionConditionsTest.java
@@ -48,7 +48,7 @@ public class AssertionConditionsTest {
         assertEquals(ac1, ac2);
         assertFalse(ac1.equals("xyz"));
 
-        assertEquals(1, ac1.getConditionsList().size());
+        assertEquals(ac1.getConditionsList().size(), 1);
 
         ac2.setConditionsList(null);
         assertNotEquals(ac2, ac1);

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/DomainTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/DomainTest.java
@@ -365,7 +365,7 @@ public class DomainTest {
 
         assertEquals(dtl.getTemplateNames(), templateNames);
         assertEquals(dtl, dtl);
-        assertNotEquals(new DomainTemplateList(), dtl);
+        assertNotEquals(dtl, new DomainTemplateList());
 
         // TopLevelDomain test
         TopLevelDomain tld = new TopLevelDomain().setDescription("domain desc").setOrg("org:test").setEnabled(true)
@@ -1211,17 +1211,17 @@ public class DomainTest {
         domainMeta.setBusinessService("");
         ObjectMapper om = new ObjectMapper();
         String jsonString = om.writeValueAsString(domainMeta);
-        assertEquals("{\"account\":\"testAccount\",\"businessService\":\"\"}", jsonString);
+        assertEquals(jsonString, "{\"account\":\"testAccount\",\"businessService\":\"\"}");
 
         // Set business service with regular value. Will be part of Json.
         domainMeta.setBusinessService("Now with value");
         jsonString = om.writeValueAsString(domainMeta);
-        assertEquals("{\"account\":\"testAccount\",\"businessService\":\"Now with value\"}", jsonString);
+        assertEquals(jsonString, "{\"account\":\"testAccount\",\"businessService\":\"Now with value\"}");
 
         // Set business service with null. Will NOT be part of Json.
         domainMeta.setBusinessService(null);
         jsonString = om.writeValueAsString(domainMeta);
-        assertEquals("{\"account\":\"testAccount\"}", jsonString);
+        assertEquals(jsonString, "{\"account\":\"testAccount\"}");
     }
 
     @Test

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/ExpiryMemberTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/ExpiryMemberTest.java
@@ -19,10 +19,6 @@ package com.yahoo.athenz.zms;
 import com.yahoo.rdl.Timestamp;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/AuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/AuthorityTest.java
@@ -82,9 +82,9 @@ public class AuthorityTest {
         };
 
         assertNull(authority.getAuthenticateChallenge());
-        assertEquals(Authority.CredSource.HEADER, authority.getCredSource());
+        assertEquals(authority.getCredSource(), Authority.CredSource.HEADER);
         assertTrue(authority.allowAuthorization());
-        assertEquals("user", authority.getUserDomainName("user"));
+        assertEquals(authority.getUserDomainName("user"), "user");
         assertTrue(authority.isValidUser("john"));
         assertEquals(authority.getUserType("john"), Authority.UserType.USER_ACTIVE);
         assertEquals(authority.getUserType("joe"), Authority.UserType.USER_SUSPENDED);
@@ -136,9 +136,9 @@ public class AuthorityTest {
         };
 
         assertNull(authority.getAuthenticateChallenge());
-        assertEquals(Authority.CredSource.HEADER, authority.getCredSource());
+        assertEquals(authority.getCredSource(), Authority.CredSource.HEADER);
         assertTrue(authority.allowAuthorization());
-        assertEquals("user", authority.getUserDomainName("user"));
+        assertEquals(authority.getUserDomainName("user"), "user");
         assertTrue(authority.isValidUser("john"));
         assertEquals(authority.getUserType("john"), Authority.UserType.USER_ACTIVE);
         assertEquals(authority.getUserType("joe"), Authority.UserType.USER_INVALID);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/CertificateAuthorityTest.java
@@ -47,14 +47,14 @@ public class CertificateAuthorityTest {
     public void testGetCredSource() {
         CertificateAuthority authority = new CertificateAuthority();
         authority.initialize();
-        assertEquals(CredSource.CERTIFICATE, authority.getCredSource());
+        assertEquals(authority.getCredSource(), CredSource.CERTIFICATE);
     }
 
     @Test
     public void testGetID() {
         CertificateAuthority authority = new CertificateAuthority();
         authority.initialize();
-        assertEquals("Auth-X509", authority.getID());
+        assertEquals(authority.getID(), "Auth-X509");
     }
 
     @Test
@@ -78,8 +78,8 @@ public class CertificateAuthorityTest {
             certs[0] = cert;
             Principal principal = authority.authenticate(certs, null);
             assertNotNull(principal);
-            assertEquals("athenz", principal.getDomain());
-            assertEquals("syncer", principal.getName());
+            assertEquals(principal.getDomain(), "athenz");
+            assertEquals(principal.getName(), "syncer");
             assertNull(principal.getRoles());
             assertFalse(principal.getMtlsRestricted());
         }
@@ -99,8 +99,8 @@ public class CertificateAuthorityTest {
             certs[0] = cert;
             Principal principal = authority.authenticate(certs, null);
             assertNotNull(principal);
-            assertEquals("athens", principal.getDomain());
-            assertEquals("zts", principal.getName());
+            assertEquals(principal.getDomain(), "athens");
+            assertEquals(principal.getName(), "zts");
             assertTrue(principal.getMtlsRestricted());
         } finally {
             System.clearProperty("athenz.crypto.restricted_ou");
@@ -120,9 +120,9 @@ public class CertificateAuthorityTest {
             certs[0] = cert;
             Principal principal = authority.authenticate(certs, null);
             assertNotNull(principal);
-            assertEquals("athens", principal.getDomain());
-            assertEquals("zts", principal.getName());
-            assertEquals("sports:role.readers", principal.getRoles().get(0));
+            assertEquals(principal.getDomain(), "athens");
+            assertEquals(principal.getName(), "zts");
+            assertEquals(principal.getRoles().get(0), "sports:role.readers");
             assertFalse(principal.getMtlsRestricted());
         }
     }
@@ -316,8 +316,8 @@ public class CertificateAuthorityTest {
             certs[0] = cert;
             Principal principal = authority.authenticate(certs, null);
             assertNotNull(principal);
-            assertEquals("athenz", principal.getDomain());
-            assertEquals("syncer", principal.getName());
+            assertEquals(principal.getDomain(), "athenz");
+            assertEquals(principal.getName(), "syncer");
             assertNull(principal.getRoles());
             assertFalse(principal.getMtlsRestricted());
         } catch (Exception e) {

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/KerberosAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/KerberosAuthorityTest.java
@@ -217,7 +217,7 @@ public class KerberosAuthorityTest {
         
         KerberosAuthority kauth = new KerberosAuthority();
         kauth.initialize();
-        assertEquals("Auth-KERB", kauth.getID());
+        assertEquals(kauth.getID(), "Auth-KERB");
 
         Exception initState = kauth.getInitState();
         assertNull(initState);
@@ -361,7 +361,7 @@ public class KerberosAuthorityTest {
         Class<KerberosAuthority> c = KerberosAuthority.class;
         KerberosAuthority check  = new KerberosAuthority();
         
-        check.setLoginWindow((long)100);
+        check.setLoginWindow(100);
         
         Field f = c.getDeclaredField("loginWindow");
         f.setAccessible(true);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/LDAPAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/LDAPAuthorityTest.java
@@ -89,7 +89,7 @@ public class LDAPAuthorityTest {
     public void testGetID() {
         ldapAuthority = new LDAPAuthority();
         ldapAuthority.initialize();
-        assertEquals("Auth-LDAP", ldapAuthority.getID());
+        assertEquals(ldapAuthority.getID(), "Auth-LDAP");
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/PrincipalAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/PrincipalAuthorityTest.java
@@ -219,7 +219,7 @@ public class PrincipalAuthorityTest {
     @Test
     public void testGetID() {
         PrincipalAuthority authority = new PrincipalAuthority();
-        assertEquals("Auth-NTOKEN", authority.getID());
+        assertEquals(authority.getID(), "Auth-NTOKEN");
     }
 
     @Test
@@ -393,7 +393,7 @@ public class PrincipalAuthorityTest {
     public void testGetCredSource() {
         PrincipalAuthority authority = new PrincipalAuthority();
         authority.initialize();
-        assertEquals(CredSource.HEADER, authority.getCredSource());
+        assertEquals(authority.getCredSource(), CredSource.HEADER);
     }
     
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/RoleAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/RoleAuthorityTest.java
@@ -179,7 +179,7 @@ public class RoleAuthorityTest {
     public void testGetID() {
         RoleAuthority authority = new RoleAuthority();
         authority.initialize();
-        assertEquals("Auth-ROLE", authority.getID());
+        assertEquals(authority.getID(), "Auth-ROLE");
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/AccessTokenTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/AccessTokenTest.java
@@ -97,23 +97,23 @@ public class AccessTokenTest {
 
     void validateAccessTokenCommon(AccessToken accessToken, long now) {
         assertEquals(now, accessToken.getAuthTime());
-        assertEquals("subject", accessToken.getSubject());
-        assertEquals("userid", accessToken.getUserId());
-        assertEquals(now + 3600, accessToken.getExpiryTime());
-        assertEquals(now, accessToken.getIssueTime());
-        assertEquals("mtls", accessToken.getClientId());
-        assertEquals("coretech", accessToken.getAudience());
-        assertEquals(1, accessToken.getVersion());
-        assertEquals("athenz", accessToken.getIssuer());
-        assertEquals("proxy.user", accessToken.getProxyPrincipal());
+        assertEquals(accessToken.getSubject(), "subject");
+        assertEquals(accessToken.getUserId(), "userid");
+        assertEquals(accessToken.getExpiryTime(), now + 3600);
+        assertEquals(accessToken.getIssueTime(), now);
+        assertEquals(accessToken.getClientId(), "mtls");
+        assertEquals(accessToken.getAudience(), "coretech");
+        assertEquals(accessToken.getVersion(), 1);
+        assertEquals(accessToken.getIssuer(), "athenz");
+        assertEquals(accessToken.getProxyPrincipal(), "proxy.user");
         LinkedHashMap<String, Object> confirm = accessToken.getConfirm();
         assertNotNull(confirm);
-        assertEquals("A4DtL2JmUMhAsvJj5tKyn64SqzmuXbMrJa0n761y5v0", confirm.get("x5t#S256"));
-        assertEquals("A4DtL2JmUMhAsvJj5tKyn64SqzmuXbMrJa0n761y5v0", accessToken.getConfirmEntry("x5t#S256"));
-        assertEquals("spiffe://athenz/sa/api", confirm.get("x5t#uri"));
-        assertEquals("spiffe://athenz/sa/api", accessToken.getConfirmEntry("x5t#uri"));
+        assertEquals(confirm.get("x5t#S256"), "A4DtL2JmUMhAsvJj5tKyn64SqzmuXbMrJa0n761y5v0");
+        assertEquals(accessToken.getConfirmEntry("x5t#S256"), "A4DtL2JmUMhAsvJj5tKyn64SqzmuXbMrJa0n761y5v0");
+        assertEquals(confirm.get("x5t#uri"), "spiffe://athenz/sa/api");
+        assertEquals(accessToken.getConfirmEntry("x5t#uri"), "spiffe://athenz/sa/api");
         assertNull(accessToken.getConfirmEntry("unknown"));
-        assertEquals("[{\"type\":\"message_access\",\"data\":\"resource\"}]", accessToken.getAuthorizationDetails());
+        assertEquals(accessToken.getAuthorizationDetails(), "[{\"type\":\"message_access\",\"data\":\"resource\"}]");
 
         try {
             Path path = Paths.get("src/test/resources/mtls_token_spec.cert");
@@ -128,14 +128,14 @@ public class AccessTokenTest {
 
     void validateAccessToken(AccessToken accessToken, long now) {
         validateAccessTokenCommon(accessToken, now);
-        assertEquals(1, accessToken.getScope().size());
+        assertEquals(accessToken.getScope().size(), 1);
         assertTrue(accessToken.getScope().contains("readers"));
         assertEquals(accessToken.getScopeStd(), "readers");
     }
 
     void validateAccessTokenMultipleRoles(AccessToken accessToken, long now) {
         validateAccessTokenCommon(accessToken, now);
-        assertEquals(2, accessToken.getScope().size());
+        assertEquals(accessToken.getScope().size(), 2);
         assertTrue(accessToken.getScope().contains("readers"));
         assertTrue(accessToken.getScope().contains("writers"));
         assertEquals(accessToken.getScopeStd(), "readers writers");
@@ -181,15 +181,15 @@ public class AccessTokenTest {
         JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
         assertNotNull(claimsSet);
 
-        assertEquals("subject", claimsSet.getSubject());
-        assertEquals("coretech", JwtsHelper.getAudience(claimsSet));
-        assertEquals("athenz", claimsSet.getIssuer());
-        assertEquals("jwt-id001", claimsSet.getJWTID());
-        assertEquals("readers", claimsSet.getStringClaim("scope"));
+        assertEquals(claimsSet.getSubject(), "subject");
+        assertEquals(JwtsHelper.getAudience(claimsSet), "coretech");
+        assertEquals(claimsSet.getIssuer(), "athenz");
+        assertEquals(claimsSet.getJWTID(), "jwt-id001");
+        assertEquals(claimsSet.getStringClaim("scope"), "readers");
         List<String> scopes = claimsSet.getStringListClaim("scp");
         assertNotNull(scopes);
-        assertEquals(1, scopes.size());
-        assertEquals("readers", scopes.get(0));
+        assertEquals(scopes.size(), 1);
+        assertEquals(scopes.get(0), "readers");
     }
 
     @Test
@@ -218,16 +218,16 @@ public class AccessTokenTest {
         JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
         assertNotNull(claimsSet);
 
-        assertEquals("subject", claimsSet.getSubject());
-        assertEquals("coretech", JwtsHelper.getAudience(claimsSet));
-        assertEquals("athenz", claimsSet.getIssuer());
-        assertEquals("jwt-id001", claimsSet.getJWTID());
-        assertEquals("readers writers", claimsSet.getStringClaim("scope"));
+        assertEquals(claimsSet.getSubject(), "subject");
+        assertEquals(JwtsHelper.getAudience(claimsSet), "coretech");
+        assertEquals(claimsSet.getIssuer(), "athenz");
+        assertEquals(claimsSet.getJWTID(), "jwt-id001");
+        assertEquals(claimsSet.getStringClaim("scope"), "readers writers");
         List<String> scopes = claimsSet.getStringListClaim("scp");
         assertNotNull(scopes);
-        assertEquals(2, scopes.size());
-        assertEquals("readers", scopes.get(0));
-        assertEquals("writers", scopes.get(1));
+        assertEquals(scopes.size(), 2);
+        assertEquals(scopes.get(0), "readers");
+        assertEquals(scopes.get(1), "writers");
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/IdTokenTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/IdTokenTest.java
@@ -59,14 +59,14 @@ public class IdTokenTest {
 
     void validateIdToken(IdToken token, long now) {
         assertEquals(now, token.getAuthTime());
-        assertEquals("subject", token.getSubject());
-        assertEquals(now + 3600, token.getExpiryTime());
-        assertEquals(now, token.getIssueTime());
-        assertEquals("coretech", token.getAudience());
-        assertEquals(1, token.getVersion());
-        assertEquals("athenz", token.getIssuer());
-        assertEquals("nonce", token.getNonce());
-        assertEquals(Collections.singletonList("dev-team"), token.getGroups());
+        assertEquals(token.getSubject(), "subject");
+        assertEquals(token.getExpiryTime(), now + 3600);
+        assertEquals(token.getIssueTime(), now);
+        assertEquals(token.getAudience(), "coretech");
+        assertEquals(token.getVersion(), 1);
+        assertEquals(token.getIssuer(), "athenz");
+        assertEquals(token.getNonce(), "nonce");
+        assertEquals(token.getGroups(), Collections.singletonList("dev-team"));
     }
 
     @Test
@@ -95,9 +95,9 @@ public class IdTokenTest {
         JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
         assertNotNull(claimsSet);
 
-        assertEquals("subject", claimsSet.getSubject());
-        assertEquals("coretech", claimsSet.getAudience().get(0));
-        assertEquals("athenz", claimsSet.getIssuer());
+        assertEquals(claimsSet.getSubject(), "subject");
+        assertEquals(claimsSet.getAudience().get(0), "coretech");
+        assertEquals(claimsSet.getIssuer(), "athenz");
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/JwtsHelperTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/JwtsHelperTest.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolverTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/JwtsSigningKeyResolverTest.java
@@ -20,7 +20,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.util.Objects;
 
 import static org.testng.Assert.*;

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/KeyTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/KeyTest.java
@@ -37,12 +37,12 @@ public class KeyTest {
 
         assertNotNull(key.getPublicKey());
 
-        assertEquals("0", key.getKid());
-        assertEquals("RS256", key.getAlg());
-        assertEquals("RSA", key.getKty());
-        assertEquals("sig", key.getUse());
-        assertEquals("AQAB", key.getE());
-        assertEquals("AMV3cnZXxYJL-A0TYY8Fy245HKSOBCYt9atNAUQVtbEwx9QaZGj8moYIe4nXgx72Ktwg0Gruh8sS7GQLBizCXg7fCk62sDV_MZINnwON9gsKbxxgn9mLFeYSaatUzk-VRphDoHNIBC-qeDtYnZhsHYcV9Jp0GPkLNquhN1TXA7gT", key.getN());
+        assertEquals(key.getKid(), "0");
+        assertEquals(key.getAlg(), "RS256");
+        assertEquals(key.getKty(), "RSA");
+        assertEquals(key.getUse(), "sig");
+        assertEquals(key.getE(), "AQAB");
+        assertEquals(key.getN(), "AMV3cnZXxYJL-A0TYY8Fy245HKSOBCYt9atNAUQVtbEwx9QaZGj8moYIe4nXgx72Ktwg0Gruh8sS7GQLBizCXg7fCk62sDV_MZINnwON9gsKbxxgn9mLFeYSaatUzk-VRphDoHNIBC-qeDtYnZhsHYcV9Jp0GPkLNquhN1TXA7gT");
     }
 
     @Test
@@ -58,13 +58,13 @@ public class KeyTest {
 
         assertNotNull(key.getPublicKey());
 
-        assertEquals("eckey1", key.getKid());
-        assertEquals("ES256", key.getAlg());
-        assertEquals("EC", key.getKty());
-        assertEquals("sig", key.getUse());
-        assertEquals("prime256v1", key.getCrv());
-        assertEquals("AI0x6wEUk5T0hslaT83DNVy5r98XnG7HAjQynjCrcdCe", key.getX());
-        assertEquals("ATdV2ebpefqBli_SXZwvL3-7OiD3MTryGbR-zRSFZ_s=", key.getY());
+        assertEquals(key.getKid(), "eckey1");
+        assertEquals(key.getAlg(), "ES256");
+        assertEquals(key.getKty(), "EC");
+        assertEquals(key.getUse(), "sig");
+        assertEquals(key.getCrv(), "prime256v1");
+        assertEquals(key.getX(), "AI0x6wEUk5T0hslaT83DNVy5r98XnG7HAjQynjCrcdCe");
+        assertEquals(key.getY(), "ATdV2ebpefqBli_SXZwvL3-7OiD3MTryGbR-zRSFZ_s=");
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/AthenzUtilsTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/AthenzUtilsTest.java
@@ -36,14 +36,14 @@ public class AthenzUtilsTest {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
-            assertEquals("athenz.production", AthenzUtils.extractServicePrincipal(cert));
+            assertEquals(AthenzUtils.extractServicePrincipal(cert), "athenz.production");
         }
 
         try (InputStream inStream = new FileInputStream("src/test/resources/ec_public_x509.cert")) {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
-            assertEquals("athenz.syncer", AthenzUtils.extractServicePrincipal(cert));
+            assertEquals(AthenzUtils.extractServicePrincipal(cert), "athenz.syncer");
         }
     }
 
@@ -53,7 +53,7 @@ public class AthenzUtilsTest {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
-            assertEquals("athens.zts", AthenzUtils.extractServicePrincipal(cert));
+            assertEquals(AthenzUtils.extractServicePrincipal(cert), "athens.zts");
         }
     }
 
@@ -63,7 +63,7 @@ public class AthenzUtilsTest {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
-            assertEquals("athens.zts", AthenzUtils.extractRolePrincipal(cert));
+            assertEquals(AthenzUtils.extractRolePrincipal(cert), "athens.zts");
         }
     }
 
@@ -73,7 +73,7 @@ public class AthenzUtilsTest {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
-            assertEquals("athenz.production", AthenzUtils.extractServicePrincipal(cert));
+            assertEquals(AthenzUtils.extractServicePrincipal(cert), "athenz.production");
         }
     }
 
@@ -83,7 +83,7 @@ public class AthenzUtilsTest {
             CertificateFactory cf = CertificateFactory.getInstance("X.509");
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
-            assertEquals("athenz.production", AthenzUtils.extractRolePrincipal(cert));
+            assertEquals(AthenzUtils.extractRolePrincipal(cert), "athenz.production");
         }
     }
 
@@ -265,13 +265,13 @@ public class AthenzUtilsTest {
         System.setProperty(systemProperty, "aaa, bbb, ccc");
 
         List<String> values = AthenzUtils.splitCommaSeparatedSystemProperty(systemProperty);
-        assertEquals(3, values.size());
-        assertEquals("aaa", values.get(0));
-        assertEquals("bbb", values.get(1));
-        assertEquals("ccc", values.get(2));
+        assertEquals(values.size(), 3);
+        assertEquals(values.get(0), "aaa");
+        assertEquals(values.get(1), "bbb");
+        assertEquals(values.get(2), "ccc");
 
         List<String> values2 = AthenzUtils.splitCommaSeparatedSystemProperty("unset.property");
-        assertEquals(new ArrayList<>(), values2);
+        assertEquals(values2, new ArrayList<>());
 
         System.clearProperty(systemProperty);
     }

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/CryptoTest.java
@@ -953,7 +953,7 @@ public class CryptoTest {
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
             List<String> ips = Crypto.extractX509CertIPAddresses(cert);
-            assertEquals(2, ips.size());
+            assertEquals(ips.size(), 2);
             assertEquals(ips.get(0), "10.11.12.13");
             assertEquals(ips.get(1), "10.11.12.14");
         }
@@ -993,7 +993,7 @@ public class CryptoTest {
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
             List<String> uris = Crypto.extractX509CertURIs(cert);
-            assertEquals(1, uris.size());
+            assertEquals(uris.size(), 1);
             assertEquals(uris.get(0), "spiffe://athenz/domain1/service1");
 
             // single spiffe uri - successfully validated
@@ -1009,7 +1009,7 @@ public class CryptoTest {
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
             List<String> uris = Crypto.extractX509CertURIs(cert);
-            assertEquals(2, uris.size());
+            assertEquals(uris.size(), 2);
             assertEquals(uris.get(0), "spiffe://athenz/domain1/service1");
             assertEquals(uris.get(1), "spiffe://athenz/domain1/service2");
 
@@ -1026,7 +1026,7 @@ public class CryptoTest {
             X509Certificate cert = (X509Certificate) cf.generateCertificate(inStream);
 
             List<String> uris = Crypto.extractX509CertURIs(cert);
-            assertEquals(2, uris.size());
+            assertEquals(uris.size(), 2);
             assertEquals(uris.get(0), "athenz://instanceid/sys.auth.zts/id001");
             assertEquals(uris.get(1), "athenz://principal/athenz.production");
 
@@ -1072,7 +1072,7 @@ public class CryptoTest {
 
         assertEquals(Crypto.extractX509CSRCommonName(certReq), "athenz.production");
         List<String> emails = Crypto.extractX509CSREmails(certReq);
-        assertEquals(2, emails.size());
+        assertEquals(emails.size(), 2);
         assertEquals(emails.get(0), "sports.scores@aws.yahoo.cloud");
         assertEquals(emails.get(1), "nhl.scores@aws.yahoo.cloud");
     }
@@ -1099,7 +1099,7 @@ public class CryptoTest {
         assertNotNull(certReq);
 
         List<String> uris = Crypto.extractX509CSRURIs(certReq);
-        assertEquals(0, uris.size());
+        assertEquals(uris.size(), 0);
     }
 
     @Test
@@ -1111,7 +1111,7 @@ public class CryptoTest {
         assertNotNull(certReq);
 
         List<String> uris = Crypto.extractX509CSRURIs(certReq);
-        assertEquals(1, uris.size());
+        assertEquals(uris.size(), 1);
         assertEquals(uris.get(0), "spiffe://athenz/domain1/service1");
     }
 
@@ -1124,7 +1124,7 @@ public class CryptoTest {
         assertNotNull(certReq);
 
         List<String> uris = Crypto.extractX509CSRURIs(certReq);
-        assertEquals(2, uris.size());
+        assertEquals(uris.size(), 2);
         assertEquals(uris.get(0), "spiffe://athenz/domain1/service1");
         assertEquals(uris.get(1), "spiffe://athenz/domain1/service2");
     }
@@ -1160,7 +1160,7 @@ public class CryptoTest {
         assertNotNull(certReq);
 
         List<String> ips = Crypto.extractX509CSRIPAddresses(certReq);
-        assertEquals(2, ips.size());
+        assertEquals(ips.size(), 2);
         assertEquals(ips.get(0), "10.11.12.13");
         assertEquals(ips.get(1), "10.11.12.14");
     }
@@ -1588,7 +1588,7 @@ public class CryptoTest {
         final String encodedInt1 = "li7dzDacuo67Jg7mtqEm2TRuOMU=";
         final BigInteger bigInt1 = new BigInteger("85739377120809420210425962799" + "0318636601332086981");
 
-        assertEquals(encodedInt1, new String(encoder.encode(Crypto.toIntegerBytes(bigInt1, true))));
+        assertEquals(new String(encoder.encode(Crypto.toIntegerBytes(bigInt1, true))), encodedInt1);
     }
 
     @Test
@@ -1598,7 +1598,7 @@ public class CryptoTest {
         final String encodedInt2 = "9B5ypLY9pMOmtxCeTDHgwdNFeGs=";
         final BigInteger bigInt2 = new BigInteger("13936727572861167254666467268" + "91466679477132949611");
 
-        assertEquals(encodedInt2, new String(encoder.encode(Crypto.toIntegerBytes(bigInt2, true))));
+        assertEquals(new String(encoder.encode(Crypto.toIntegerBytes(bigInt2, true))), encodedInt2);
     }
 
     @Test
@@ -1611,7 +1611,7 @@ public class CryptoTest {
                 "10806548154093873461951748545" + "1196989136416448805819079363524309897749044958112417136240557"
                         + "4495062430572478766856090958495998158114332651671116876320938126");
 
-        assertEquals(encodedInt3, new String(encoder.encode(Crypto.toIntegerBytes(bigInt3, true))));
+        assertEquals(new String(encoder.encode(Crypto.toIntegerBytes(bigInt3, true))), encodedInt3);
     }
 
     @Test
@@ -1628,7 +1628,7 @@ public class CryptoTest {
                         + "338880713818192088877057717530169381044092839402438015097654"
                         + "53542091716518238707344493641683483917");
 
-        assertEquals(encodedInt4, new String(encoder.encode(Crypto.toIntegerBytes(bigInt4, true))));
+        assertEquals(new String(encoder.encode(Crypto.toIntegerBytes(bigInt4, true))), encodedInt4);
     }
 
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/StringUtilsTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/StringUtilsTest.java
@@ -30,16 +30,16 @@ public class StringUtilsTest {
     
     @Test
     public void testPatternFromGlob() {
-        assertEquals("^abc$", StringUtils.patternFromGlob("abc"));
-        assertEquals("^abc.*$", StringUtils.patternFromGlob("abc*"));
-        assertEquals("^abc.$", StringUtils.patternFromGlob("abc?"));
-        assertEquals("^.*abc.$", StringUtils.patternFromGlob("*abc?"));
-        assertEquals("^abc\\.abc:.*$", StringUtils.patternFromGlob("abc.abc:*"));
-        assertEquals("^ab\\[a-c]c$", StringUtils.patternFromGlob("ab[a-c]c"));
-        assertEquals("^ab.*\\.\\(\\)\\^\\$c$", StringUtils.patternFromGlob("ab*.()^$c"));
-        assertEquals("^abc\\\\test\\\\$", StringUtils.patternFromGlob("abc\\test\\"));
-        assertEquals("^ab\\{\\|c\\+$", StringUtils.patternFromGlob("ab{|c+"));
-        assertEquals("^\\^\\$\\[\\(\\)\\\\\\+\\{\\..*.\\|$", StringUtils.patternFromGlob("^$[()\\+{.*?|"));
+        assertEquals(StringUtils.patternFromGlob("abc"), "^abc$");
+        assertEquals(StringUtils.patternFromGlob("abc*"), "^abc.*$");
+        assertEquals(StringUtils.patternFromGlob("abc?"), "^abc.$");
+        assertEquals(StringUtils.patternFromGlob("*abc?"), "^.*abc.$");
+        assertEquals(StringUtils.patternFromGlob("abc.abc:*"), "^abc\\.abc:.*$");
+        assertEquals(StringUtils.patternFromGlob("ab[a-c]c"), "^ab\\[a-c]c$");
+        assertEquals(StringUtils.patternFromGlob("ab*.()^$c"), "^ab.*\\.\\(\\)\\^\\$c$");
+        assertEquals(StringUtils.patternFromGlob("abc\\test\\"), "^abc\\\\test\\\\$");
+        assertEquals(StringUtils.patternFromGlob("ab{|c+"), "^ab\\{\\|c\\+$");
+        assertEquals(StringUtils.patternFromGlob("^$[()\\+{.*?|"), "^\\^\\$\\[\\(\\)\\\\\\+\\{\\..*.\\|$");
     }
     
     @Test

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyRefresherExceptionTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyRefresherExceptionTest.java
@@ -30,12 +30,12 @@ public class KeyRefresherExceptionTest {
         assertNull(keyRefresherException.getMessage());
         
         keyRefresherException = new KeyRefresherException("exception");
-        assertEquals("exception", keyRefresherException.getMessage());
+        assertEquals(keyRefresherException.getMessage(), "exception");
         
         keyRefresherException = new KeyRefresherException(new Throwable("new throwable"));
-        assertEquals("java.lang.Throwable: new throwable", keyRefresherException.getMessage());
+        assertEquals(keyRefresherException.getMessage(), "java.lang.Throwable: new throwable");
 
         keyRefresherException = new KeyRefresherException("exception", new Throwable("new throwable"));
-        assertEquals("exception", keyRefresherException.getMessage());
+        assertEquals(keyRefresherException.getMessage(), "exception");
     }
 }

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyStoreTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyStoreTest.java
@@ -54,11 +54,11 @@ public class KeyStoreTest {
         String alias = null;
         for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
             alias = (String) e.nextElement();
-            assertEquals(ALIAS_NAME, alias);
+            assertEquals(alias, ALIAS_NAME);
         }
         X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
         assertNotNull(chain);
-        assertEquals(1, chain.length);
+        assertEquals(chain.length, 1);
     }
 
     @Test
@@ -68,11 +68,11 @@ public class KeyStoreTest {
         String alias = null;
         for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
             alias = (String) e.nextElement();
-            assertEquals(ALIAS_NAME, alias);
+            assertEquals(alias, ALIAS_NAME);
         }
         X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
         assertNotNull(chain);
-        assertEquals(1, chain.length);
+        assertEquals(chain.length, 1);
     }
 
     @Test
@@ -153,12 +153,12 @@ public class KeyStoreTest {
         String alias = null;
         for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
             alias = (String) e.nextElement();
-            assertEquals(ALIAS_NAME, alias);
+            assertEquals(alias, ALIAS_NAME);
         }
 
         X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
         assertNotNull(chain);
-        assertEquals(2, chain.length);
+        assertEquals(chain.length, 2);
     }
 
     @Test
@@ -172,12 +172,12 @@ public class KeyStoreTest {
         String alias = null;
         for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
             alias = (String) e.nextElement();
-            assertEquals(ALIAS_NAME, alias);
+            assertEquals(alias, ALIAS_NAME);
         }
 
         X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
         assertNotNull(chain);
-        assertEquals(2, chain.length);
+        assertEquals(chain.length, 2);
     }
 
     @Test(expectedExceptions = {KeyRefresherException.class})

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/SocketTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/SocketTest.java
@@ -140,8 +140,8 @@ public class SocketTest {
         //send first call
         s.getOutputStream().write("ping\n".getBytes());
         String response = new BufferedReader(new InputStreamReader(s.getInputStream())).readLine();
-        assertEquals("pong", response);
-        assertEquals("athenz.production", getCN(s.getSession().getPeerCertificates()));
+        assertEquals(response, "pong");
+        assertEquals(getCN(s.getSession().getPeerCertificates()), "athenz.production");
 
         //update the ssl context on the server
         keyRefresher.getKeyManagerProxy().setKeyManager(Utils.getKeyManagers(
@@ -157,14 +157,14 @@ public class SocketTest {
         //send second call
         s2.getOutputStream().write("ping\n".getBytes());
         response = new BufferedReader(new InputStreamReader(s2.getInputStream())).readLine();
-        assertEquals("pong", response);
-        assertEquals("athenz.production", getCN(s2.getSession().getPeerCertificates()));
+        assertEquals(response, "pong");
+        assertEquals(getCN(s2.getSession().getPeerCertificates()), "athenz.production");
 
         //retry the first call, it should still pass
         s.getOutputStream().write("ping\n".getBytes());
         response = new BufferedReader(new InputStreamReader(s.getInputStream())).readLine();
-        assertEquals("pong", response);
-        assertEquals("athenz.production", getCN(s.getSession().getPeerCertificates()));
+        assertEquals(response, "pong");
+        assertEquals(getCN(s.getSession().getPeerCertificates()), "athenz.production");
     }
 
     private void testBuildSSLContextWithBadSpecifiedVersion() {

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/TrustStoreTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/TrustStoreTest.java
@@ -41,13 +41,13 @@ public class TrustStoreTest {
 
         assertEquals(filePath, trustStore.getFilePath());
         TrustManager[] trustManagers = trustStore.getTrustManagers();
-        assertEquals(1, trustManagers.length);
+        assertEquals(trustManagers.length, 1);
         X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
         X509Certificate[] acceptedIssuers = trustManager.getAcceptedIssuers();
-        assertEquals(1, acceptedIssuers.length);
+        assertEquals(acceptedIssuers.length, 1);
         X509Certificate certificate = acceptedIssuers[0];
-        assertEquals("CN=athenz.production,OU=Testing Domain,O=Athenz,ST=CA,C=US",
-            certificate.getIssuerX500Principal().getName());
+        assertEquals(certificate.getIssuerX500Principal().getName(),
+                "CN=athenz.production,OU=Testing Domain,O=Athenz,ST=CA,C=US");
     }
 
     @Test
@@ -60,13 +60,13 @@ public class TrustStoreTest {
 
         assertEquals(filePath, trustStore.getFilePath());
         TrustManager[] trustManagers = trustStore.getTrustManagers();
-        assertEquals(1, trustManagers.length);
+        assertEquals(trustManagers.length, 1);
         X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
         X509Certificate[] acceptedIssuers = trustManager.getAcceptedIssuers();
-        assertEquals(1, acceptedIssuers.length);
+        assertEquals(acceptedIssuers.length, 1);
         X509Certificate certificate = acceptedIssuers[0];
-        assertEquals("CN=athenz.production,OU=Testing Domain,O=Athenz,ST=CA,C=US",
-            certificate.getIssuerX500Principal().getName());
+        assertEquals(certificate.getIssuerX500Principal().getName(),
+                "CN=athenz.production,OU=Testing Domain,O=Athenz,ST=CA,C=US");
     }
 
     @Test
@@ -79,10 +79,10 @@ public class TrustStoreTest {
 
         assertEquals(filePath, trustStore.getFilePath());
         TrustManager[] trustManagers = trustStore.getTrustManagers();
-        assertEquals(1, trustManagers.length);
+        assertEquals(trustManagers.length, 1);
         X509TrustManager trustManager = (X509TrustManager) trustManagers[0];
         X509Certificate[] acceptedIssuers = trustManager.getAcceptedIssuers();
-        assertEquals(3, acceptedIssuers.length);
+        assertEquals(acceptedIssuers.length, 3);
         Set<String> issuers = new HashSet<>();
         for (X509Certificate cert : acceptedIssuers) {
             issuers.add(cert.getIssuerX500Principal().getName());

--- a/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/SSLUtilsTest.java
+++ b/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/SSLUtilsTest.java
@@ -66,8 +66,6 @@ public class SSLUtilsTest {
 
     private static final String DEFAULT_CERT_PWD = "changeit";
     private static final String DEFAULT_SSL_PROTOCOL = "TLSv1.2";
-    private static final String DEFAULT_SSL_STORE_TYPE = "pkcs12";
-    private static final String DEFAULT_CA_TRUST_STORE = "src/test/resources/certs/ca/ca.pkcs12";
     private static final String DEFAULT_SERVER_KEY_STORE = "src/test/resources/certs/server/server.pkcs12";
     private static final String DEFAULT_KEY_STORE_TYPE = "pkcs12";
     private static final String DEFAULT_TRUST_STORE_TYPE = "pkcs12";

--- a/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/X509CertUtilsTest.java
+++ b/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/X509CertUtilsTest.java
@@ -116,7 +116,7 @@ public class X509CertUtilsTest {
         item2.add("instanceid1.instanceid.athenz.test");
         dnsNames.add(item2);
 
-        assertEquals("instanceid1", X509CertUtils.extractRequestInstanceId(cert));
+        assertEquals(X509CertUtils.extractRequestInstanceId(cert), "instanceid1");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class X509CertUtilsTest {
         String pem = new String(Files.readAllBytes(path));
         X509Certificate cert = Crypto.loadX509Certificate(pem);
 
-        assertEquals("id-001", X509CertUtils.extractRequestInstanceId(cert));
+        assertEquals(X509CertUtils.extractRequestInstanceId(cert), "id-001");
     }
 
     @Test

--- a/libs/java/dynamodb_client_factory/src/test/java/com/yahoo/athenz/db/dynamodb/DynamoDBClientSettingsTest.java
+++ b/libs/java/dynamodb_client_factory/src/test/java/com/yahoo/athenz/db/dynamodb/DynamoDBClientSettingsTest.java
@@ -56,14 +56,14 @@ public class DynamoDBClientSettingsTest {
                 null, null, false);
         assertTrue(dynamoDBClientSettings.areCredentialsProvided());
 
-        assertEquals("test.keypath", dynamoDBClientSettings.getKeyPath());
-        assertEquals("test.certpath", dynamoDBClientSettings.getCertPath());
-        assertEquals("test.domain", dynamoDBClientSettings.getDomainName());
-        assertEquals("test.region", dynamoDBClientSettings.getRegion());
-        assertEquals("test.role", dynamoDBClientSettings.getRoleName());
-        assertEquals("test.truststore", dynamoDBClientSettings.getTrustStore());
-        assertEquals("decryptedPassword", String.valueOf(dynamoDBClientSettings.getTrustStorePasswordChars()));
-        assertEquals("test.ztsurl", dynamoDBClientSettings.getZtsURL());
+        assertEquals(dynamoDBClientSettings.getKeyPath(), "test.keypath");
+        assertEquals(dynamoDBClientSettings.getCertPath(), "test.certpath");
+        assertEquals(dynamoDBClientSettings.getDomainName(), "test.domain");
+        assertEquals(dynamoDBClientSettings.getRegion(), "test.region");
+        assertEquals(dynamoDBClientSettings.getRoleName(), "test.role");
+        assertEquals(dynamoDBClientSettings.getTrustStore(), "test.truststore");
+        assertEquals(String.valueOf(dynamoDBClientSettings.getTrustStorePasswordChars()), "decryptedPassword");
+        assertEquals(dynamoDBClientSettings.getZtsURL(), "test.ztsurl");
 
         // Now verify that when keyStore isn't provided, trustStorePassword will be null
         dynamoDBClientSettings = new DynamoDBClientSettings(certPath, domain, role, trustStore,

--- a/libs/java/gcp_zts_creds/src/test/java/com/yahoo/athenz/creds/gcp/GCPSIACredentialsTest.java
+++ b/libs/java/gcp_zts_creds/src/test/java/com/yahoo/athenz/creds/gcp/GCPSIACredentialsTest.java
@@ -253,9 +253,9 @@ public class GCPSIACredentialsTest {
 
     @Test
     public void testGetSpiffeUri() {
-        assertEquals("spiffe://sports/sa/api", GCPSIACredentials.getSpiffeUri(null, "sports", "api"));
-        assertEquals("spiffe://sports/sa/api", GCPSIACredentials.getSpiffeUri("", "sports", "api"));
-        assertEquals("spiffe://athenz.io/ns/default/sa/sports.api", GCPSIACredentials.getSpiffeUri("athenz.io", "sports", "api"));
+        assertEquals(GCPSIACredentials.getSpiffeUri(null, "sports", "api"), "spiffe://sports/sa/api");
+        assertEquals(GCPSIACredentials.getSpiffeUri("", "sports", "api"), "spiffe://sports/sa/api");
+        assertEquals(GCPSIACredentials.getSpiffeUri("athenz.io", "sports", "api"), "spiffe://athenz.io/ns/default/sa/sports.api");
     }
 
     static AutoCloseable startHttpServerForAttestationAndZtsInstance(

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/InstanceConfirmationTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/InstanceConfirmationTest.java
@@ -30,7 +30,7 @@ public class InstanceConfirmationTest {
         assertEquals(confirm, confirm);
         //noinspection ConstantConditions,ObjectEqualsNull,SimplifiedTestNGAssertion
         assertFalse(confirm.equals(null));
-        assertNotEquals("invalid-class", confirm);
+        assertNotEquals(confirm, "invalid-class");
 
         InstanceConfirmation confirm2 = new InstanceConfirmation();
         assertEquals(confirm, confirm2);

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProviderTest.java
@@ -483,7 +483,7 @@ public class InstanceAWSProviderTest {
         
         InstanceAWSProvider provider = new InstanceAWSProvider();
         provider.awsRegion = "us-west-2";
-        assertEquals(InstanceProvider.Scheme.CLASS, provider.getProviderScheme());
+        assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.CLASS);
 
         AWSAttestationData data = new AWSAttestationData();
 

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceCodeSigningProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceCodeSigningProviderTest.java
@@ -113,7 +113,7 @@ public class InstanceCodeSigningProviderTest {
 
     @Test
     public void testGetProviderScheme() {
-        assertEquals(InstanceProvider.Scheme.CLASS, new InstanceCodeSigningProvider().getProviderScheme());
+        assertEquals(new InstanceCodeSigningProvider().getProviderScheme(), InstanceProvider.Scheme.CLASS);
     }
 
     @Test

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceHttpProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceHttpProviderTest.java
@@ -35,7 +35,7 @@ public class InstanceHttpProviderTest {
         
         InstanceHttpProvider provider = new InstanceHttpProvider();
         provider.initialize("provider", "https://localhost:4443/instance", SSLContext.getDefault(), null);
-        assertEquals(InstanceProvider.Scheme.HTTP, provider.getProviderScheme());
+        assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.HTTP);
 
         InstanceProviderClient client = Mockito.mock(InstanceProviderClient.class);
         provider.client = client;

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceProviderTest.java
@@ -47,7 +47,7 @@ public class InstanceProviderTest {
         provider.setHostnameResolver(null);
         provider.setAuthorizer(null);
 
-        assertEquals(InstanceProvider.Scheme.UNKNOWN, provider.getProviderScheme());
+        assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.UNKNOWN);
         provider.close();
     }
 }

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceZTSProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceZTSProviderTest.java
@@ -71,7 +71,7 @@ public class InstanceZTSProviderTest {
         InstanceZTSProvider provider = new InstanceZTSProvider();
         provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceZTSProvider", null, null);
         assertTrue(provider.dnsSuffixes.contains("zts.athenz.cloud"));
-        assertEquals(InstanceProvider.Scheme.CLASS, provider.getProviderScheme());
+        assertEquals(provider.getProviderScheme(), Scheme.CLASS);
         assertNull(provider.keyStore);
         assertNull(provider.principals);
         provider.close();

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/SecureBootProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/SecureBootProviderTest.java
@@ -335,7 +335,7 @@ public class SecureBootProviderTest {
 
     @Test
     public void testGetProviderScheme() {
-        assertEquals(InstanceProvider.Scheme.CLASS, new SecureBootProvider().getProviderScheme());
+        assertEquals(new SecureBootProvider().getProviderScheme(), InstanceProvider.Scheme.CLASS);
     }
 
     @Test

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -212,7 +212,7 @@ public class DynamoDBCertRecordStoreConnectionTest {
         ArgumentCaptor<PutItemRequest> itemCaptor = ArgumentCaptor.forClass(PutItemRequest.class);
         Mockito.verify(dynamoDB, times(1)).putItem(itemCaptor.capture());
         List<PutItemRequest> allValues = itemCaptor.getAllValues();
-        assertEquals(1, allValues.size());
+        assertEquals(allValues.size(), 1);
         Map<String, AttributeValue> item = allValues.get(0).item();
         Assert.assertEquals(DynamoDBUtils.getString(item, "primaryKey"), "athenz.provider:cn:1234");
         Assert.assertEquals(DynamoDBUtils.getString(item, "provider"), "athenz.provider");
@@ -267,7 +267,7 @@ public class DynamoDBCertRecordStoreConnectionTest {
         ArgumentCaptor<PutItemRequest> itemCaptor = ArgumentCaptor.forClass(PutItemRequest.class);
         Mockito.verify(dynamoDB, times(1)).putItem(itemCaptor.capture());
         List<PutItemRequest> allValues = itemCaptor.getAllValues();
-        assertEquals(1, allValues.size());
+        assertEquals(allValues.size(), 1);
         Map<String, AttributeValue> item = allValues.get(0).item();
         Assert.assertEquals(DynamoDBUtils.getString(item, "primaryKey"), "athenz.provider:cn:1234");
         Assert.assertEquals(DynamoDBUtils.getString(item, "provider"), "athenz.provider");
@@ -361,7 +361,7 @@ public class DynamoDBCertRecordStoreConnectionTest {
         ArgumentCaptor<UpdateItemRequest> itemCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
         Mockito.verify(dynamoDB, times(1)).updateItem(itemCaptor.capture());
         List<UpdateItemRequest> allValues = itemCaptor.getAllValues();
-        assertEquals(1, allValues.size());
+        assertEquals(allValues.size(), 1);
 
         assertEquals(allValues.get(0).attributeUpdates().get("provider").value().s(), "athenz.provider");
         assertEquals(allValues.get(0).attributeUpdates().get("instanceId").value().s(),"1234");
@@ -390,7 +390,7 @@ public class DynamoDBCertRecordStoreConnectionTest {
         ArgumentCaptor<UpdateItemRequest> itemCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
         Mockito.verify(dynamoDB, times(1)).updateItem(itemCaptor.capture());
         List<UpdateItemRequest> allValues = itemCaptor.getAllValues();
-        assertEquals(1, allValues.size());
+        assertEquals(allValues.size(), 1);
 
         assertEquals(allValues.get(0).attributeUpdates().get("provider").value().s(), "athenz.provider");
         assertEquals(allValues.get(0).attributeUpdates().get("instanceId").value().s(),"1234");
@@ -420,7 +420,7 @@ public class DynamoDBCertRecordStoreConnectionTest {
         ArgumentCaptor<UpdateItemRequest> itemCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
         Mockito.verify(dynamoDB, times(1)).updateItem(itemCaptor.capture());
         List<UpdateItemRequest> allValues = itemCaptor.getAllValues();
-        assertEquals(1, allValues.size());
+        assertEquals(allValues.size(), 1);
 
         assertEquals(allValues.get(0).attributeUpdates().get("provider").value().s(), "athenz.provider");
         assertEquals(allValues.get(0).attributeUpdates().get("instanceId").value().s(),"1234");
@@ -482,8 +482,8 @@ public class DynamoDBCertRecordStoreConnectionTest {
     @Test
     public void testdeleteExpiredX509CertRecords() {
         DynamoDBCertRecordStoreConnection dbConn = getDBConnection();
-        assertEquals(0, dbConn.deleteExpiredX509CertRecords(100));
-        assertEquals(0, dbConn.deleteExpiredX509CertRecords(100000));
+        assertEquals(dbConn.deleteExpiredX509CertRecords(100), 0);
+        assertEquals(dbConn.deleteExpiredX509CertRecords(100000), 0);
         dbConn.close();
     }
 

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBNotificationsHelperTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBNotificationsHelperTest.java
@@ -203,7 +203,7 @@ public class DynamoDBNotificationsHelperTest {
                     reNotified, "primaryKey", "tableName", dynamoDbClient);
             fail();
         } catch (TimeoutException ex) {
-            assertEquals("Failed too many retries. Check table provisioned throughput settings.", ex.getMessage());
+            assertEquals(ex.getMessage(), "Failed too many retries. Check table provisioned throughput settings.");
         }
 
         System.clearProperty(RetryDynamoDBCommand.ZTS_PROP_CERT_DYNAMODB_RETRIES);

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBSSHRecordStoreConnectionTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBSSHRecordStoreConnectionTest.java
@@ -258,8 +258,8 @@ public class DynamoDBSSHRecordStoreConnectionTest {
     @Test
     public void testDeleteExpiredSSHCertRecords() {
         DynamoDBSSHRecordStoreConnection dbConn = new DynamoDBSSHRecordStoreConnection(dynamoDB, tableName);
-        assertEquals(0, dbConn.deleteExpiredSSHCertRecords(100));
-        assertEquals(0, dbConn.deleteExpiredSSHCertRecords(100000));
+        assertEquals(dbConn.deleteExpiredSSHCertRecords(100), 0);
+        assertEquals(dbConn.deleteExpiredSSHCertRecords(100000), 0);
         dbConn.close();
     }
 }

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBStatusCheckerFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBStatusCheckerFactoryTest.java
@@ -41,8 +41,8 @@ public class DynamoDBStatusCheckerFactoryTest {
             dynamoDBStatusCheckerFactory.create();
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals("DynamoDB table name not specified", ex.getMessage());
-            assertEquals(503, ex.getCode());
+            assertEquals(ex.getMessage(), "DynamoDB table name not specified");
+            assertEquals(ex.getCode(), 503);
         }
     }
 

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBStatusCheckerTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBStatusCheckerTest.java
@@ -123,8 +123,8 @@ public class DynamoDBStatusCheckerTest {
             dynamoDBStatusChecker.check();
             fail();
         } catch (StatusCheckException ex) {
-            assertEquals("Table named " + requestedTable + " wasn't found in DynamoDB", ex.getMsg());
-            assertEquals(200, ex.getCode());
+            assertEquals(ex.getMsg(), "Table named " + requestedTable + " wasn't found in DynamoDB");
+            assertEquals(ex.getCode(), 200);
         }
         Mockito.verify(amazonDynamoDB, times(1)).close();
         Mockito.verify(awsCredentialsProvider, times(1)).close();
@@ -147,7 +147,7 @@ public class DynamoDBStatusCheckerTest {
             fail();
         } catch (StatusCheckException ex) {
             assertNull(ex.getMessage());
-            assertEquals(500, ex.getCode());
+            assertEquals(ex.getCode(), 500);
         }
 
         Mockito.verify(amazonDynamoDB, times(1)).close();

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/config/impl/ConfigProviderParametersStoreTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/config/impl/ConfigProviderParametersStoreTest.java
@@ -80,7 +80,7 @@ public class ConfigProviderParametersStoreTest {
 
         Map<String, String> unsortedEntries = source.getConfigEntries().stream().collect(Collectors.toMap(entry -> entry.key, entry -> entry.value));
         Map<String, String> sortedEntries = new TreeMap<>(unsortedEntries);
-        assertEquals("{\"01\":\"value-01\",\"02\":\"value-02\",\"11\":\"value-11\",\"12\":\"value-12\",\"21\":\"value-21\",\"22\":\"value-22\"}", Utils.jsonSerializeForLog(sortedEntries));
+        assertEquals(Utils.jsonSerializeForLog(sortedEntries), "{\"01\":\"value-01\",\"02\":\"value-02\",\"11\":\"value-11\",\"12\":\"value-12\",\"21\":\"value-21\",\"22\":\"value-22\"}");
     }
 
     private static Parameter buildParameter(String name, String value) {

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/creds/impl/TempCredsProviderTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/creds/impl/TempCredsProviderTest.java
@@ -49,44 +49,44 @@ public class TempCredsProviderTest {
 
         TempCredsProvider credsProvider = new TempCredsProvider();
         AssumeRoleRequest req = credsProvider.getAssumeRoleRequest("1234", "admin", null, null, "athenz.api");
-        assertEquals("arn:aws:iam::1234:role/admin", req.roleArn());
-        assertEquals("athenz.api", req.roleSessionName());
+        assertEquals(req.roleArn(), "arn:aws:iam::1234:role/admin");
+        assertEquals(req.roleSessionName(), "athenz.api");
         assertNull(req.durationSeconds());
         assertNull(req.externalId());
 
         req = credsProvider.getAssumeRoleRequest("12345", "adminuser", 101, "external", "athenz.api");
-        assertEquals("arn:aws:iam::12345:role/adminuser", req.roleArn());
-        assertEquals("athenz.api", req.roleSessionName());
-        assertEquals(Integer.valueOf(101), req.durationSeconds());
-        assertEquals("external", req.externalId());
+        assertEquals(req.roleArn(), "arn:aws:iam::12345:role/adminuser");
+        assertEquals(req.roleSessionName(), "athenz.api");
+        assertEquals(req.durationSeconds(), Integer.valueOf(101));
+        assertEquals(req.externalId(), "external");
 
         req = credsProvider.getAssumeRoleRequest("12345", "adminuser", 101, "external", "athenz.api-service");
-        assertEquals("arn:aws:iam::12345:role/adminuser", req.roleArn());
-        assertEquals("athenz.api-service", req.roleSessionName());
-        assertEquals(Integer.valueOf(101), req.durationSeconds());
-        assertEquals("external", req.externalId());
+        assertEquals(req.roleArn(), "arn:aws:iam::12345:role/adminuser");
+        assertEquals(req.roleSessionName(), "athenz.api-service");
+        assertEquals(req.durationSeconds(), Integer.valueOf(101));
+        assertEquals(req.externalId(), "external");
 
         req = credsProvider.getAssumeRoleRequest("12345", "adminuser", 101, "external", "athenz.api_service-test");
-        assertEquals("arn:aws:iam::12345:role/adminuser", req.roleArn());
-        assertEquals("athenz.api_service-test", req.roleSessionName());
-        assertEquals(Integer.valueOf(101), req.durationSeconds());
-        assertEquals("external", req.externalId());
+        assertEquals(req.roleArn(), "arn:aws:iam::12345:role/adminuser");
+        assertEquals(req.roleSessionName(), "athenz.api_service-test");
+        assertEquals(req.durationSeconds(), Integer.valueOf(101));
+        assertEquals(req.externalId(), "external");
 
         final String principalLongerThan64Chars = "athenz.environment.production.regions.us-west-2.services.zts-service";
         req = credsProvider.getAssumeRoleRequest("12345", "adminuser", 101, "external", principalLongerThan64Chars);
-        assertEquals("arn:aws:iam::12345:role/adminuser", req.roleArn());
-        assertEquals("athenz.environment.production....us-west-2.services.zts-service", req.roleSessionName());
-        assertEquals(Integer.valueOf(101), req.durationSeconds());
-        assertEquals("external", req.externalId());
+        assertEquals(req.roleArn(), "arn:aws:iam::12345:role/adminuser");
+        assertEquals(req.roleSessionName(), "athenz.environment.production....us-west-2.services.zts-service");
+        assertEquals(req.durationSeconds(), Integer.valueOf(101));
+        assertEquals(req.externalId(), "external");
         credsProvider.close();
 
         System.setProperty(ZTS_PROP_AWS_ROLE_SESSION_NAME, "athenz-zts-service");
         credsProvider = new TempCredsProvider();
         req = credsProvider.getAssumeRoleRequest("12345", "adminuser", 101, "external", "athenz.api-service");
-        assertEquals("arn:aws:iam::12345:role/adminuser", req.roleArn());
-        assertEquals("athenz-zts-service", req.roleSessionName());
-        assertEquals(Integer.valueOf(101), req.durationSeconds());
-        assertEquals("external", req.externalId());
+        assertEquals(req.roleArn(), "arn:aws:iam::12345:role/adminuser");
+        assertEquals(req.roleSessionName(), "athenz-zts-service");
+        assertEquals(req.durationSeconds(), Integer.valueOf(101));
+        assertEquals(req.externalId(), "external");
         credsProvider.close();
         System.clearProperty(ZTS_PROP_AWS_ROLE_SESSION_NAME);
     }

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/notification/impl/AWSZTSHealthNotificationTaskTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/notification/impl/AWSZTSHealthNotificationTaskTest.java
@@ -62,7 +62,7 @@ public class AWSZTSHealthNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = awsztsHealthNotificationTask.getNotifications();
-        assertEquals(0, notifications.size());
+        assertEquals(notifications.size(), 0);
     }
 
     @Test
@@ -104,13 +104,13 @@ public class AWSZTSHealthNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = awsztsHealthNotificationTask.getNotifications();
-        assertEquals(1, notifications.size());
+        assertEquals(notifications.size(), 1);
         assertTrue(notifications.get(0).getRecipients().contains("user.test1"));
         assertTrue(notifications.get(0).getRecipients().contains("user.test2"));
         Timestamp expiration = Timestamp.fromMillis(clientNotification.getExpiration() * 1000);
-        assertEquals("zts.url;testDomain;role;" + expiration + ";Fail to get token of type AWS. ",
-                notifications.get(0).getDetails().get("awsZtsHealth"));
-        assertEquals("testServer", notifications.get(0).getDetails().get("affectedZts"));
+        assertEquals(notifications.get(0).getDetails().get("awsZtsHealth"),
+                "zts.url;testDomain;role;" + expiration + ";Fail to get token of type AWS. ");
+        assertEquals(notifications.get(0).getDetails().get("affectedZts"), "testServer");
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_AWS_HEALTH_DOMAIN);
     }
@@ -125,7 +125,7 @@ public class AWSZTSHealthNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         String description = awsztsHealthNotificationTask.getDescription();
-        assertEquals("ZTS On AWS Health Notification", description);
+        assertEquals(description, "ZTS On AWS Health Notification");
     }
 
     @Test

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/DynamoDBAuthHistoryStoreConnectionTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/DynamoDBAuthHistoryStoreConnectionTest.java
@@ -74,9 +74,9 @@ public class DynamoDBAuthHistoryStoreConnectionTest {
         Mockito.when(principalDomainIndex.query(Mockito.any(Consumer.class))).thenReturn(Mockito.mock(PageIterable.class));
         DynamoDBAuthHistoryStoreConnection dynamoDBAuthHistoryStoreConnection = new DynamoDBAuthHistoryStoreConnection(table);
         AuthHistoryDependencies authHistoryDependencies = dynamoDBAuthHistoryStoreConnection.getAuthHistory("test.domain");
-        assertEquals(1, authHistoryDependencies.getIncomingDependencies().size());
-        assertEquals(0, authHistoryDependencies.getOutgoingDependencies().size());
-        assertEquals(authHistory, authHistoryDependencies.getIncomingDependencies().get(0));
+        assertEquals(authHistoryDependencies.getIncomingDependencies().size(), 1);
+        assertEquals(authHistoryDependencies.getOutgoingDependencies().size(), 0);
+        assertEquals(authHistoryDependencies.getIncomingDependencies().get(0), authHistory);
 
         dynamoDBAuthHistoryStoreConnection.setOperationTimeout(0);
         dynamoDBAuthHistoryStoreConnection.close();

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/utils/DynamoDBUtilsTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/utils/DynamoDBUtilsTest.java
@@ -34,10 +34,10 @@ public class DynamoDBUtilsTest {
         Date yesterday = new Date(epoch - TimeUnit.DAYS.toMillis(1));
         Date lastMonth = new Date(epoch - TimeUnit.DAYS.toMillis(30));
 
-        assertEquals("2020-06-09", DynamoDBUtils.getIso8601FromDate(now));
-        assertEquals("2020-06-09", DynamoDBUtils.getIso8601FromDate(anHourAgo));
-        assertEquals("2020-06-08", DynamoDBUtils.getIso8601FromDate(yesterday));
-        assertEquals("2020-05-10", DynamoDBUtils.getIso8601FromDate(lastMonth));
+        assertEquals(DynamoDBUtils.getIso8601FromDate(now), "2020-06-09");
+        assertEquals(DynamoDBUtils.getIso8601FromDate(anHourAgo), "2020-06-09");
+        assertEquals(DynamoDBUtils.getIso8601FromDate(yesterday), "2020-06-08");
+        assertEquals(DynamoDBUtils.getIso8601FromDate(lastMonth), "2020-05-10");
     }
 
     @Test
@@ -47,7 +47,7 @@ public class DynamoDBUtilsTest {
         long end = epoch - TimeUnit.HOURS.toMillis(72);
 
         List<String> unrefreshedCertDates = DynamoDBUtils.getISODatesByRange(beginning, end);
-        assertEquals(28, unrefreshedCertDates.size());
+        assertEquals(unrefreshedCertDates.size(), 28);
         assertTrue(unrefreshedCertDates.contains("2020-05-10"));
         assertTrue(unrefreshedCertDates.contains("2020-06-06"));
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/CertSignerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/CertSignerTest.java
@@ -60,10 +60,10 @@ public class CertSignerTest {
 
         CertSigner testSigner = factory.create();
         assertNotNull(testSigner);
-        assertEquals("cert2-keyid", testSigner.generateX509Certificate("aws", "us-west-2", "csr", "client", 100,
-                Priority.High, "keyid"));
-        assertEquals("ca-cert1-keyid", testSigner.getCACertificate("aws", "keyid"));
-        assertEquals(60, testSigner.getMaxCertExpiryTimeMins());
+        assertEquals(testSigner.generateX509Certificate("aws", "us-west-2", "csr", "client", 100,
+                Priority.High, "keyid"), "cert2-keyid");
+        assertEquals(testSigner.getCACertificate("aws", "keyid"), "ca-cert1-keyid");
+        assertEquals(testSigner.getMaxCertExpiryTimeMins(), 60);
 
         testSigner.close();
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreConnectionTest.java
@@ -389,15 +389,15 @@ public class JDBCCertRecordStoreConnectionTest {
 
         SQLException ex = new SQLException("sql-reason", "08S01", 9999);
         ServerResourceException rEx = jdbcConn.sqlError(ex, "sqlError");
-        Assert.assertEquals(ServerResourceException.INTERNAL_SERVER_ERROR, rEx.getCode());
+        Assert.assertEquals(rEx.getCode(), ServerResourceException.INTERNAL_SERVER_ERROR);
         
         ex = new SQLException("sql-reason", "40001", 9999);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        Assert.assertEquals(ServerResourceException.INTERNAL_SERVER_ERROR, rEx.getCode());
+        Assert.assertEquals(rEx.getCode(), ServerResourceException.INTERNAL_SERVER_ERROR);
 
         SQLTimeoutException tex = new SQLTimeoutException();
         rEx = jdbcConn.sqlError(tex, "sqlError");
-        Assert.assertEquals(ServerResourceException.SERVICE_UNAVAILABLE, rEx.getCode());
+        Assert.assertEquals(rEx.getCode(), ServerResourceException.SERVICE_UNAVAILABLE);
 
         jdbcConn.close();
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreStatusCheckerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreStatusCheckerTest.java
@@ -52,8 +52,8 @@ public class JDBCCertRecordStoreStatusCheckerTest {
             jdbcCertRecordStoreStatusChecker.check();
             fail();
         } catch (StatusCheckException ex) {
-            assertEquals(500, ex.getCode());
-            assertEquals("SERVICE_UNAVAILABLE", ex.getMsg());
+            assertEquals(ex.getCode(), 500);
+            assertEquals(ex.getMsg(), "SERVICE_UNAVAILABLE");
         }
 
         Mockito.verify(jdbcCertRecordStore, Mockito.times(1)).getConnection();

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCSSHRecordStoreConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCSSHRecordStoreConnectionTest.java
@@ -310,15 +310,15 @@ public class JDBCSSHRecordStoreConnectionTest {
 
         SQLException ex = new SQLException("sql-reason", "08S01", 9999);
         ServerResourceException rEx = jdbcConn.sqlError(ex, "sqlError");
-        Assert.assertEquals(ServerResourceException.INTERNAL_SERVER_ERROR, rEx.getCode());
+        Assert.assertEquals(rEx.getCode(), ServerResourceException.INTERNAL_SERVER_ERROR);
         
         ex = new SQLException("sql-reason", "40001", 9999);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        Assert.assertEquals(ServerResourceException.INTERNAL_SERVER_ERROR, rEx.getCode());
+        Assert.assertEquals(rEx.getCode(), ServerResourceException.INTERNAL_SERVER_ERROR);
 
         SQLTimeoutException tex = new SQLTimeoutException();
         rEx = jdbcConn.sqlError(tex, "sqlError");
-        Assert.assertEquals(ServerResourceException.SERVICE_UNAVAILABLE, rEx.getCode());
+        Assert.assertEquals(rEx.getCode(), ServerResourceException.SERVICE_UNAVAILABLE);
 
         jdbcConn.close();
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/key/PubKeysProviderTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/key/PubKeysProviderTest.java
@@ -38,7 +38,7 @@ public class PubKeysProviderTest {
         try {
             defaultPubKeysProvider.getPubKeysByService("sports", "api");
             fail();
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException ignored) {
         }
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
@@ -18,7 +18,6 @@ package com.yahoo.athenz.common.server.log.jetty;
 import com.yahoo.athenz.common.ServerCommonConsts;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.mockito.Mockito;

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/ExceptionCauseFetcherTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/ExceptionCauseFetcherTest.java
@@ -38,7 +38,7 @@ public class ExceptionCauseFetcherTest {
         }
 
         String cause = ExceptionCauseFetcher.getInnerCause(exception, "init message");
-        assertEquals("level97", cause);
+        assertEquals(cause, "level97");
     }
 
     @Test
@@ -55,6 +55,6 @@ public class ExceptionCauseFetcherTest {
 
         String cause = ExceptionCauseFetcher.getInnerCause(exception, "init message");
         // The max level is 100 so even though we created 500 levels, we'll get the cause from level 100
-        assertEquals("level100", cause);
+        assertEquals(cause, "level100");
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLoggerFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLoggerFactoryTest.java
@@ -38,7 +38,7 @@ public class JettyConnectionLoggerFactoryTest {
             jettyConnectionLoggerFactory.create();
             fail();
         } catch (Exception ex) {
-            assertEquals("Invalid SSLConnectionLogFactory", ex.getMessage());
+            assertEquals(ex.getMessage(), "Invalid SSLConnectionLogFactory");
         }
         System.clearProperty("athenz.ssl_logger_factory_class");
     }
@@ -51,7 +51,7 @@ public class JettyConnectionLoggerFactoryTest {
             jettyConnectionLoggerFactory.create();
             fail();
         } catch (Exception ex) {
-            assertEquals("Invalid metric class", ex.getMessage());
+            assertEquals(ex.getMessage(), "Invalid metric class");
         }
         System.clearProperty("athenz.jetty.container.metric_factory_class");
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLoggerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/JettyConnectionLoggerTest.java
@@ -71,16 +71,16 @@ public class JettyConnectionLoggerTest {
         
         Mockito.verify(connectionLog, Mockito.times(1)).log(connectionLogEntryArgumentCaptor.capture());
         Mockito.verify(metric, Mockito.times(1)).increment(Mockito.eq(CONNECTION_LOGGER_METRIC_DEFAULT_NAME), metricArgumentCaptor.capture());
-        assertEquals("no cipher suites in common", connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureMessage().get());
+        assertEquals(connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureMessage().get(), "no cipher suites in common");
         assertFalse(connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureCause().isPresent());
         List<String[]> allMetricValues = metricArgumentCaptor.getAllValues();
         assertEquals(allMetricValues.size(), 1);
         String[] testValue = allMetricValues.get(0);
         assertEquals(testValue.length, 4);
-        assertEquals("failureType", testValue[0]);
-        assertEquals("INCOMPATIBLE_CLIENT_CIPHER_SUITES", testValue[1]);
-        assertEquals("athenzPrincipal", testValue[2]);
-        assertEquals("unknown", testValue[3]);
+        assertEquals(testValue[0], "failureType");
+        assertEquals(testValue[1], "INCOMPATIBLE_CLIENT_CIPHER_SUITES");
+        assertEquals(testValue[2], "athenzPrincipal");
+        assertEquals(testValue[3], "unknown");
 
         athenzConnectionListener.onClosed(mockConnection2);
         athenzConnectionListener.shutdown();
@@ -118,8 +118,8 @@ public class JettyConnectionLoggerTest {
         jettyConnectionLogger.handshakeFailed(event, sslHandshakeException);
 
         Mockito.verify(connectionLog, Mockito.times(1)).log(connectionLogEntryArgumentCaptor.capture());
-        assertEquals(GENERAL_SSL_ERROR, connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureMessage().get());
-        assertEquals("Last cause (most specific reason)", connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureCause().get());
+        assertEquals(connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureMessage().get(), GENERAL_SSL_ERROR);
+        assertEquals(connectionLogEntryArgumentCaptor.getValue().sslHandshakeFailureCause().get(), "Last cause (most specific reason)");
 
         athenzConnectionListener.onClosed(mockConnection);
         athenzConnectionListener.shutdown();

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/net/InetComparatorTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/msd/net/InetComparatorTest.java
@@ -30,7 +30,7 @@ public class InetComparatorTest {
     @Test
     public void testCompare() throws UnknownHostException {
         assertTrue(InetComparator.compare(InetAddress.getByName("10.1.2.3"), InetAddress.getByName("10.0.2.3")) > 0);
-        assertEquals(0, InetComparator.compare(InetAddress.getByName("10.1.2.3"), InetAddress.getByName("10.1.2.3")));
+        assertEquals(InetComparator.compare(InetAddress.getByName("10.1.2.3"), InetAddress.getByName("10.1.2.3")), 0);
         assertTrue(InetComparator.compare(InetAddress.getByName("10.1.2.3"), InetAddress.getByName("10.1.2.4")) < 0);
         assertTrue(InetComparator.compare(InetAddress.getByName("10.255.2.3"), InetAddress.getByName("255.254.254.253")) < 0);
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/DomainRoleMembersFetcherCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/DomainRoleMembersFetcherCommonTest.java
@@ -58,19 +58,19 @@ public class DomainRoleMembersFetcherCommonTest {
         rolesList.add(role3);
 
         Set<String> receivedMembers = fetcherCommon.getDomainRoleMembers("role1", rolesList);
-        assertEquals(2, receivedMembers.size());
+        assertEquals(receivedMembers.size(), 2);
         assertTrue(receivedMembers.contains("user.unexpiredUser"));
         assertTrue(receivedMembers.contains("user.noExpiration"));
 
         receivedMembers = fetcherCommon.getDomainRoleMembers("role2", rolesList);
-        assertEquals(new HashSet<>(), receivedMembers);
+        assertEquals(receivedMembers, new HashSet<>());
 
         receivedMembers = fetcherCommon.getDomainRoleMembers("roleDoesntExist", rolesList);
-        assertEquals(new HashSet<>(), receivedMembers);
+        assertEquals(receivedMembers, new HashSet<>());
 
         // if the role list is empty we get an empty set
 
-        assertEquals(new HashSet<>(), fetcherCommon.getDomainRoleMembers("role1", null));
+        assertEquals(fetcherCommon.getDomainRoleMembers("role1", null), new HashSet<>());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class DomainRoleMembersFetcherCommonTest {
         role1.setRoleMembers(role1MemberList);
 
         Set<String> receivedMembers = fetcherCommon.getDomainRoleMembers(role1);
-        assertEquals(2, receivedMembers.size());
+        assertEquals(receivedMembers.size(), 2);
         assertTrue(receivedMembers.contains("user.unexpiredUser"));
         assertTrue(receivedMembers.contains("user.noExpiration"));
     }
@@ -99,7 +99,7 @@ public class DomainRoleMembersFetcherCommonTest {
     @Test
     public void testDomainRoleMembersFetcherNullProvider() {
         DomainRoleMembersFetcher fetcher = new DomainRoleMembersFetcher(null, USER_DOMAIN_PREFIX);
-        assertEquals(new HashSet<>(), fetcher.getDomainRoleMembers("domain", "role"));
+        assertEquals(fetcher.getDomainRoleMembers("domain", "role"), new HashSet<>());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class DomainRoleMembersFetcherCommonTest {
 
         DomainRoleMembersFetcher fetcher = new DomainRoleMembersFetcher(provider, USER_DOMAIN_PREFIX);
         Set<String> users = fetcher.getDomainRoleMembers("domain1", "role1");
-        assertEquals(1, users.size());
+        assertEquals(users.size(), 1);
         assertTrue(users.contains("user.user1"));
     }
 
@@ -142,11 +142,11 @@ public class DomainRoleMembersFetcherCommonTest {
 
         DomainRoleMembersFetcher fetcher = new DomainRoleMembersFetcher(provider, USER_DOMAIN_PREFIX);
         Set<String> users = fetcher.getDomainRoleMembers("domain1", "role1");
-        assertEquals(1, users.size());
+        assertEquals(users.size(), 1);
         assertTrue(users.contains("user.user1"));
 
         users = fetcher.getDomainRoleMembers("domain1", "domain1:role.role1");
-        assertEquals(1, users.size());
+        assertEquals(users.size(), 1);
         assertTrue(users.contains("user.user1"));
     }
 
@@ -173,6 +173,6 @@ public class DomainRoleMembersFetcherCommonTest {
         };
 
         DomainRoleMembersFetcher fetcher = new DomainRoleMembersFetcher(provider, USER_DOMAIN_PREFIX);
-        assertEquals(new HashSet<>(), fetcher.getDomainRoleMembers("domain1", "role1"));
+        assertEquals(fetcher.getDomainRoleMembers("domain1", "role1"), new HashSet<>());
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationEmailTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationEmailTest.java
@@ -33,9 +33,9 @@ public class NotificationEmailTest {
         NotificationEmail email2 = new NotificationEmail("subject", "body", emails);
 
         assertEquals(email1.hashCode(), email2.hashCode());
-        assertEquals("subject", email1.getSubject());
-        assertEquals("body", email1.getBody());
-        assertEquals(emails, email1.getFullyQualifiedRecipientsEmail());
+        assertEquals(email1.getSubject(), "subject");
+        assertEquals(email1.getBody(), "body");
+        assertEquals(email1.getFullyQualifiedRecipientsEmail(), emails);
 
         assertEquals(email1, email2);
         assertEquals(email1, email1);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationMetricTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationMetricTest.java
@@ -73,7 +73,7 @@ public class NotificationMetricTest {
                 "attributes=" +
                 "notif_type,domain_role_membership_review,domain,dom1,member,user.joe,role,role1,review_days,25;" +
                 "notif_type,domain_role_membership_review,domain,dom1,member,user.jane,role,role1,review_days,20;}";
-        assertEquals(expectedToString, notificationMetric.toString());
+        assertEquals(notificationMetric.toString(), expectedToString);
     }
 
     @Test
@@ -99,7 +99,7 @@ public class NotificationMetricTest {
         expectedAttributes.add(expectedRecord2);
 
         final NotificationMetric notificationMetric = new NotificationMetric(expectedAttributes);
-        assertEquals(-2000085904, notificationMetric.hashCode());
+        assertEquals(notificationMetric.hashCode(), -2000085904);
 
         final String[] expectedRecord3 = new String[] {
                 METRIC_NOTIFICATION_TYPE_KEY, "domain_role_membership_review",
@@ -122,7 +122,7 @@ public class NotificationMetricTest {
         expectedAttributes2.add(expectedRecord4);
 
         final NotificationMetric notificationMetric2 = new NotificationMetric(expectedAttributes2);
-        assertEquals(-2000085904, notificationMetric2.hashCode());
+        assertEquals(notificationMetric2.hashCode(), -2000085904);
 
         // Verify the objects are considered equal
         assertEquals(notificationMetric, notificationMetric2);
@@ -149,7 +149,7 @@ public class NotificationMetricTest {
         expectedAttributes3.add(expectedRecord6);
 
         final NotificationMetric notificationMetric3 = new NotificationMetric(expectedAttributes3);
-        assertEquals(-2000085903, notificationMetric3.hashCode());
+        assertEquals(notificationMetric3.hashCode(), -2000085903);
 
         // Verify the objects are considered not equal
         assertNotEquals(notificationMetric, notificationMetric3);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationToEmailConverterCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationToEmailConverterCommonTest.java
@@ -225,15 +225,15 @@ public class NotificationToEmailConverterCommonTest {
         assertNull(converter.getTableColumnName(3, 4, new String[]{"DOMAIN"}));
         assertNull(converter.getTableColumnName(2, 1, new String[]{"DOMAIN"}));
         assertNull(converter.getTableColumnName(1, 1, new String[]{"DOMAIN"}));
-        assertEquals("DOMAIN", converter.getTableColumnName(0, 1, new String[]{"DOMAIN"}));
-        assertEquals("ROLE", converter.getTableColumnName(1, 3, new String[]{"DOMAIN", "ROLE", "GROUP"}));
+        assertEquals(converter.getTableColumnName(0, 1, new String[]{"DOMAIN"}), "DOMAIN");
+        assertEquals(converter.getTableColumnName(1, 3, new String[]{"DOMAIN", "ROLE", "GROUP"}), "ROLE");
     }
 
     @Test
     public void testGetAthenzUIUrl() {
         System.setProperty("athenz.notification_athenz_ui_url", "https://athenz.io");
         NotificationToEmailConverterCommon converter = new NotificationToEmailConverterCommon(null);
-        assertEquals("https://athenz.io", converter.getAthenzUIUrl());
+        assertEquals(converter.getAthenzUIUrl(), "https://athenz.io");
         System.clearProperty("athenz.notification_athenz_ui_url");
     }
 
@@ -241,7 +241,7 @@ public class NotificationToEmailConverterCommonTest {
     public void testGetWorkflowUrl() {
         System.setProperty("athenz.notification_workflow_url", "https://athenz.io");
         NotificationToEmailConverterCommon converter = new NotificationToEmailConverterCommon(null);
-        assertEquals("https://athenz.io", converter.getWorkflowUrl());
+        assertEquals(converter.getWorkflowUrl(), "https://athenz.io");
         System.clearProperty("athenz.notification_workflow_url");
     }
 
@@ -315,8 +315,8 @@ public class NotificationToEmailConverterCommonTest {
     @Test
     public void testGetSubject() {
         NotificationToEmailConverterCommon converter = new NotificationToEmailConverterCommon(null);
-        assertEquals("Athenz Role Member Expiration Notification",
-                converter.getSubject("athenz.notification.email.role_member.expiry.subject"));
+        assertEquals(converter.getSubject("athenz.notification.email.role_member.expiry.subject"),
+                "Athenz Role Member Expiration Notification");
     }
 
     @Test

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationToMetricConverterCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/NotificationToMetricConverterCommonTest.java
@@ -33,10 +33,10 @@ public class NotificationToMetricConverterCommonTest {
         Timestamp yesterdayTimeStamp = Timestamp.fromMillis(1601828361000L);
         Timestamp monthFromNowTimeStamp = Timestamp.fromMillis(1604594993000L);
 
-        assertEquals("0", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), currentTimeStamp.toString()));
-        assertEquals("1", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), tomorrowTimeStamp.toString()));
-        assertEquals("-1", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), yesterdayTimeStamp.toString()));
-        assertEquals("31", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), monthFromNowTimeStamp.toString()));
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), currentTimeStamp.toString()), "0");
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), tomorrowTimeStamp.toString()), "1");
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), yesterdayTimeStamp.toString()), "-1");
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), monthFromNowTimeStamp.toString()), "31");
     }
 
     @Test
@@ -44,8 +44,8 @@ public class NotificationToMetricConverterCommonTest {
         Timestamp currentTimeStamp = Timestamp.fromMillis(1601914761000L);
         String badTimeStamp = "bad";
 
-        assertEquals("", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), badTimeStamp));
-        assertEquals("", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(badTimeStamp, currentTimeStamp.toString()));
-        assertEquals("", notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(badTimeStamp, badTimeStamp));
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(currentTimeStamp.toString(), badTimeStamp), "");
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(badTimeStamp, currentTimeStamp.toString()), "");
+        assertEquals(notificationToMetricConverterCommon.getNumberOfDaysBetweenTimestamps(badTimeStamp, badTimeStamp), "");
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/MetricNotificationServiceTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/MetricNotificationServiceTest.java
@@ -67,28 +67,28 @@ public class MetricNotificationServiceTest {
         Mockito.verify(metric, Mockito.times(2))
                 .increment(captorMetric.capture(), captorAttributes.capture());
 
-        assertEquals(2, captorMetric.getAllValues().size());
-        assertEquals("athenz_notification", captorMetric.getAllValues().get(0));
-        assertEquals("athenz_notification", captorMetric.getAllValues().get(1));
+        assertEquals(captorMetric.getAllValues().size(), 2);
+        assertEquals(captorMetric.getAllValues().get(0), "athenz_notification");
+        assertEquals(captorMetric.getAllValues().get(1), "athenz_notification");
 
         // Mockito captures all varargs arguments in a single array
 
-        assertEquals(2, captorAttributes.getAllValues().size());
+        assertEquals(captorAttributes.getAllValues().size(), 2);
 
         String[] collectedAttributes1 = captorAttributes.getAllValues().get(0);
-        assertEquals(6, collectedAttributes1.length);
+        assertEquals(collectedAttributes1.length, 6);
         List<String> expectedAttributes1 = Arrays.asList(
                 "key1", "attribute11",
                 "key2", "attribute12",
                 "key3", "attribute13");
-        assertEquals(expectedAttributes1, List.of(collectedAttributes1));
+        assertEquals(List.of(collectedAttributes1), expectedAttributes1);
 
         String[] collectedAttributes2 = captorAttributes.getAllValues().get(1);
-        assertEquals(6, collectedAttributes2.length);
+        assertEquals(collectedAttributes2.length, 6);
         List<String> expectedAttributes2 = Arrays.asList(
                 "key1", "attribute21",
                 "key2", "attribute22",
                 "key3", "attribute23");
-        assertEquals(expectedAttributes2, List.of(collectedAttributes2));
+        assertEquals(List.of(collectedAttributes2), expectedAttributes2);
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/rest/HttpTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/rest/HttpTest.java
@@ -233,7 +233,7 @@ public class HttpTest {
         Http.AuthorityList authorities = new Http.AuthorityList();
         authorities.add(authority);
 
-        assertEquals("athenz.api", Http.authorizedUser(httpServletRequest, authorities, authorizer, "action", "resource", null));
+        assertEquals(Http.authorizedUser(httpServletRequest, authorities, authorizer, "action", "resource", null), "athenz.api");
     }
 
     @Test

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHSignerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHSignerTest.java
@@ -63,8 +63,8 @@ public class SSHSignerTest {
         SSHSigner testSigner = factory.create();
         assertNotNull(testSigner);
 
-        assertEquals(certs, testSigner.generateCertificate(principal, certRequest, null, "user", "keyid"));
-        assertEquals("ssh-cert-keyid", testSigner.getSignerCertificate("user", "keyid"));
+        assertEquals(testSigner.generateCertificate(principal, certRequest, null, "user", "keyid"), certs);
+        assertEquals(testSigner.getSignerCertificate("user", "keyid"), "ssh-cert-keyid");
         testSigner.close();
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCConnectionTest.java
@@ -102,7 +102,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Domain domain = jdbcConn.getDomain("my-domain");
         assertNotNull(domain);
-        assertEquals("my-domain", domain.getName());
+        assertEquals(domain.getName(), "my-domain");
         assertTrue(domain.getEnabled());
         assertFalse(domain.getAuditEnabled());
         assertNull(domain.getDescription());
@@ -156,13 +156,13 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Domain domain = jdbcConn.getDomain("my-domain");
         assertNotNull(domain);
-        assertEquals("my-domain", domain.getName());
+        assertEquals(domain.getName(), "my-domain");
         assertTrue(domain.getEnabled());
         assertTrue(domain.getAuditEnabled());
         assertNull(domain.getDescription());
         assertNull(domain.getOrg());
         assertNull(domain.getId());
-        assertEquals("OnShore", domain.getUserAuthorityFilter());
+        assertEquals(domain.getUserAuthorityFilter(), "OnShore");
         assertNull(domain.getProductId());
         assertNull(domain.getFeatureFlags());
         assertEquals(domain.getTags(), Collections.singletonMap("tag-key", new TagValueList().setList(Collections.singletonList("tag-val"))));
@@ -193,8 +193,8 @@ public class JDBCConnectionTest {
         Mockito.doReturn(7).when(mockResultSet).getInt(1);
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(7, jdbcConn.getDomainId("my-domain"));
-        assertEquals(7, jdbcConn.getDomainId("my-domain"));
+        assertEquals(jdbcConn.getDomainId("my-domain"), 7);
+        assertEquals(jdbcConn.getDomainId("my-domain"), 7);
 
         jdbcConn.close();
     }
@@ -221,8 +221,8 @@ public class JDBCConnectionTest {
         Mockito.doReturn(9).when(mockResultSet).getInt(1);
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(9, jdbcConn.getRoleId(7, "role1"));
-        assertEquals(9, jdbcConn.getRoleId(7, "role1"));
+        assertEquals(jdbcConn.getRoleId(7, "role1"), 9);
+        assertEquals(jdbcConn.getRoleId(7, "role1"), 9);
 
         jdbcConn.close();
     }
@@ -249,8 +249,8 @@ public class JDBCConnectionTest {
         Mockito.doReturn(9).when(mockResultSet).getInt(1);
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(9, jdbcConn.getGroupId(7, "group1"));
-        assertEquals(9, jdbcConn.getGroupId(7, "group1"));
+        assertEquals(jdbcConn.getGroupId(7, "group1"), 9);
+        assertEquals(jdbcConn.getGroupId(7, "group1"), 9);
 
         jdbcConn.close();
     }
@@ -277,8 +277,8 @@ public class JDBCConnectionTest {
         Mockito.doReturn(7).when(mockResultSet).getInt(1);
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(7, jdbcConn.getPrincipalId("my-domain.user1"));
-        assertEquals(7, jdbcConn.getPrincipalId("my-domain.user1"));
+        assertEquals(jdbcConn.getPrincipalId("my-domain.user1"), 7);
+        assertEquals(jdbcConn.getPrincipalId("my-domain.user1"), 7);
 
         jdbcConn.close();
     }
@@ -301,7 +301,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Mockito.when(mockResultSet.next()).thenReturn(false);
 
-        assertEquals(0, jdbcConn.getLastInsertId());
+        assertEquals(jdbcConn.getLastInsertId(), 0);
         jdbcConn.close();
     }
 
@@ -367,8 +367,8 @@ public class JDBCConnectionTest {
         Mockito.doReturn(9).when(mockResultSet).getInt(1);
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(9, jdbcConn.getServiceId(7, "service1"));
-        assertEquals(9, jdbcConn.getServiceId(7, "service1"));
+        assertEquals(jdbcConn.getServiceId(7, "service1"), 9);
+        assertEquals(jdbcConn.getServiceId(7, "service1"), 9);
 
         jdbcConn.close();
     }
@@ -395,8 +395,8 @@ public class JDBCConnectionTest {
         Mockito.doReturn(9).when(mockResultSet).getInt(1);
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(9, jdbcConn.getHostId("host1"));
-        assertEquals(9, jdbcConn.getHostId("host1"));
+        assertEquals(jdbcConn.getHostId("host1"), 9);
+        assertEquals(jdbcConn.getHostId("host1"), 9);
 
         jdbcConn.close();
     }
@@ -448,12 +448,12 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Domain domain = jdbcConn.getDomain("my-domain");
         assertNotNull(domain);
-        assertEquals("my-domain", domain.getName());
+        assertEquals(domain.getName(), "my-domain");
         assertTrue(domain.getEnabled());
         assertTrue(domain.getAuditEnabled());
-        assertEquals("my own domain", domain.getDescription());
-        assertEquals("cloud_services", domain.getOrg());
-        assertEquals(UUID.fromString("e5e97240-e94e-11e4-8163-6d083f3f473f"), domain.getId());
+        assertEquals(domain.getDescription(), "my own domain");
+        assertEquals(domain.getOrg(), "cloud_services");
+        assertEquals(domain.getId(), UUID.fromString("e5e97240-e94e-11e4-8163-6d083f3f473f"));
         assertEquals(domain.getUserAuthorityFilter(), "OnShore");
         assertEquals(domain.getProductId(), "abcd-1234");
         assertEquals(domain.getTags(), Collections.singletonMap("tag-key", new TagValueList().setList(Collections.singletonList("tag-val"))));
@@ -884,10 +884,10 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, domains.size());
-        assertEquals("adomain", domains.get(0));
-        assertEquals("bdomain", domains.get(1));
-        assertEquals("zdomain", domains.get(2));
+        assertEquals(domains.size(), 3);
+        assertEquals(domains.get(0), "adomain");
+        assertEquals(domains.get(1), "bdomain");
+        assertEquals(domains.get(2), "zdomain");
         jdbcConn.close();
     }
 
@@ -941,7 +941,7 @@ public class JDBCConnectionTest {
                 .setCollectionName("role2")
                 .setPrincipalName("user.test2").setExpiration(Timestamp.fromMillis(654321));
 
-        assertEquals(2, expectedMembers.size());
+        assertEquals(expectedMembers.size(), 2);
         assertEquals(expectedMembers.get(0), expectedMember1);
         assertEquals(expectedMembers.get(1), expectedMember2);
         jdbcConn.close();
@@ -997,7 +997,7 @@ public class JDBCConnectionTest {
                 .setCollectionName("group2")
                 .setPrincipalName("user.test2").setExpiration(Timestamp.fromMillis(654321));
 
-        assertEquals(2, expectedMembers.size());
+        assertEquals(expectedMembers.size(), 2);
         assertEquals(expectedMembers.get(0), expectedMember1);
         assertEquals(expectedMembers.get(1), expectedMember2);
         jdbcConn.close();
@@ -1027,7 +1027,7 @@ public class JDBCConnectionTest {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         long modTime = jdbcConn.getDomainModTimestamp("my-domain");
-        assertEquals(1454358916, modTime);
+        assertEquals(modTime, 1454358916);
 
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "my-domain");
         jdbcConn.close();
@@ -1040,7 +1040,7 @@ public class JDBCConnectionTest {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         long modTime = jdbcConn.getDomainModTimestamp("my-domain");
-        assertEquals(0, modTime);
+        assertEquals(modTime, 0);
 
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "my-domain");
         jdbcConn.close();
@@ -1052,7 +1052,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Mockito.when(mockPrepStmt.executeQuery()).thenThrow(new SQLException("failed operation", "state", 1001));
 
-        assertEquals(0, jdbcConn.getDomainModTimestamp("my-domain"));
+        assertEquals(jdbcConn.getDomainModTimestamp("my-domain"), 0);
         jdbcConn.close();
     }
 
@@ -1080,7 +1080,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Role role = jdbcConn.getRole("my-domain", "role1");
         assertNotNull(role);
-        assertEquals("my-domain:role.role1", role.getName());
+        assertEquals(role.getName(), "my-domain:role.role1");
         assertTrue(role.getAuditEnabled());
         assertTrue(role.getSelfServe());
         assertNull(role.getMemberExpiryDays());
@@ -1134,7 +1134,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Role role = jdbcConn.getRole("my-domain", "role1");
         assertNotNull(role);
-        assertEquals("my-domain:role.role1", role.getName());
+        assertEquals(role.getName(), "my-domain:role.role1");
         assertTrue(role.getAuditEnabled());
         assertTrue(role.getSelfServe());
         assertTrue(role.getReviewEnabled());
@@ -1178,7 +1178,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Role role = jdbcConn.getRole("my-domain", "role1");
         assertNotNull(role);
-        assertEquals("my-domain:role.role1", role.getName());
+        assertEquals(role.getName(), "my-domain:role.role1");
         assertTrue(role.getAuditEnabled());
         assertNull(role.getSelfServe());
         assertNull(role.getUserAuthorityExpiration());
@@ -1226,8 +1226,8 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Role role = jdbcConn.getRole("my-domain", "role1");
         assertNotNull(role);
-        assertEquals("my-domain:role.role1", role.getName());
-        assertEquals("trust.domain", role.getTrust());
+        assertEquals(role.getName(), "my-domain:role.role1");
+        assertEquals(role.getTrust(), "trust.domain");
         assertNull(role.getUserAuthorityExpiration());
         assertNull(role.getUserAuthorityFilter());
         assertNull(role.getPrincipalDomainFilter());
@@ -1787,10 +1787,10 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, roles.size());
-        assertEquals("arole", roles.get(0));
-        assertEquals("brole", roles.get(1));
-        assertEquals("zrole", roles.get(2));
+        assertEquals(roles.size(), 3);
+        assertEquals(roles.get(0), "arole");
+        assertEquals(roles.get(1), "brole");
+        assertEquals(roles.get(2), "zrole");
         jdbcConn.close();
     }
 
@@ -2025,15 +2025,15 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, roleMembers.size());
+        assertEquals(roleMembers.size(), 3);
 
         assertNotNull(roleMembers.get(0).getExpiration());
         assertNull(roleMembers.get(1).getExpiration());
         assertNotNull(roleMembers.get(2).getExpiration());
 
-        assertEquals("adomain.storage", roleMembers.get(0).getMemberName());
-        assertEquals("bdomain.user2", roleMembers.get(1).getMemberName());
-        assertEquals("zdomain.user1", roleMembers.get(2).getMemberName());
+        assertEquals(roleMembers.get(0).getMemberName(), "adomain.storage");
+        assertEquals(roleMembers.get(1).getMemberName(), "bdomain.user2");
+        assertEquals(roleMembers.get(2).getMemberName(), "zdomain.user1");
         jdbcConn.close();
     }
 
@@ -2104,14 +2104,14 @@ public class JDBCConnectionTest {
         StringBuilder domain = new StringBuilder(512);
         StringBuilder name = new StringBuilder(512);
         assertTrue(jdbcConn.parsePrincipal("user.user", domain, name));
-        assertEquals("user", domain.toString());
-        assertEquals("user", name.toString());
+        assertEquals(domain.toString(), "user");
+        assertEquals(name.toString(), "user");
 
         domain.setLength(0);
         name.setLength(0);
         assertTrue(jdbcConn.parsePrincipal("coretech.storage.service", domain, name));
-        assertEquals("coretech.storage", domain.toString());
-        assertEquals("service", name.toString());
+        assertEquals(domain.toString(), "coretech.storage");
+        assertEquals(name.toString(), "service");
 
         assertFalse(jdbcConn.parsePrincipal(".coretech", domain, name));
         assertFalse(jdbcConn.parsePrincipal("coretech.storage.service.", domain, name));
@@ -3027,7 +3027,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Policy policy = jdbcConn.getPolicy("my-domain", "policy1", null);
         assertNotNull(policy);
-        assertEquals("my-domain:policy.policy1", policy.getName());
+        assertEquals(policy.getName(), "my-domain:policy.policy1");
 
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "my-domain");
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "policy1");
@@ -3115,7 +3115,7 @@ public class JDBCConnectionTest {
             jdbcConn.insertPolicy("my-domain", policy);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
         jdbcConn.close();
     }
@@ -3220,7 +3220,7 @@ public class JDBCConnectionTest {
             jdbcConn.updatePolicy("my-domain", policy);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
         jdbcConn.close();
     }
@@ -3317,10 +3317,10 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, policies.size());
-        assertEquals("apolicy", policies.get(0));
-        assertEquals("bpolicy", policies.get(1));
-        assertEquals("zpolicy", policies.get(2));
+        assertEquals(policies.size(), 3);
+        assertEquals(policies.get(0), "apolicy");
+        assertEquals(policies.get(1), "bpolicy");
+        assertEquals(policies.get(2), "zpolicy");
         jdbcConn.close();
     }
 
@@ -3689,7 +3689,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         ServiceIdentity service = jdbcConn.getServiceIdentity("my-domain", "service1");
         assertNotNull(service);
-        assertEquals("my-domain.service1", service.getName());
+        assertEquals(service.getName(), "my-domain.service1");
         assertNull(service.getExecutable());
         assertNull(service.getGroup());
         assertNull(service.getUser());
@@ -3728,11 +3728,11 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         ServiceIdentity service = jdbcConn.getServiceIdentity("my-domain", "service1");
         assertNotNull(service);
-        assertEquals("my-domain.service1", service.getName());
-        assertEquals("/usr/bin64/athenz", service.getExecutable());
-        assertEquals("users", service.getGroup());
-        assertEquals("root", service.getUser());
-        assertEquals("https://server.athenzcompany.com", service.getProviderEndpoint());
+        assertEquals(service.getName(), "my-domain.service1");
+        assertEquals(service.getExecutable(), "/usr/bin64/athenz");
+        assertEquals(service.getGroup(), "users");
+        assertEquals(service.getUser(), "root");
+        assertEquals(service.getProviderEndpoint(), "https://server.athenzcompany.com");
 
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "my-domain");
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "service1");
@@ -3813,7 +3813,7 @@ public class JDBCConnectionTest {
             jdbcConn.insertServiceIdentity("my-domain", service);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
         jdbcConn.close();
     }
@@ -3958,7 +3958,7 @@ public class JDBCConnectionTest {
             jdbcConn.updateServiceIdentity("my-domain", service);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
         jdbcConn.close();
     }
@@ -4092,10 +4092,10 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, services.size());
-        assertEquals("aservice", services.get(0));
-        assertEquals("bservice", services.get(1));
-        assertEquals("zservice", services.get(2));
+        assertEquals(services.size(), 3);
+        assertEquals(services.get(0), "aservice");
+        assertEquals(services.get(1), "bservice");
+        assertEquals(services.get(2), "zservice");
         jdbcConn.close();
     }
 
@@ -4266,7 +4266,7 @@ public class JDBCConnectionTest {
     @Test
     public void testSaveValue() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("test1", jdbcConn.saveValue("test1"));
+        assertEquals(jdbcConn.saveValue("test1"), "test1");
         assertNull(jdbcConn.saveValue(""));
         jdbcConn.close();
     }
@@ -4274,7 +4274,7 @@ public class JDBCConnectionTest {
     @Test
     public void testSaveUriValue() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("https://server.athenzcompany.com", jdbcConn.saveValue("https://server.athenzcompany.com"));
+        assertEquals(jdbcConn.saveValue("https://server.athenzcompany.com"), "https://server.athenzcompany.com");
         assertNull(jdbcConn.saveValue(""));
         jdbcConn.close();
     }
@@ -4282,16 +4282,16 @@ public class JDBCConnectionTest {
     @Test
     public void testProcessInsertValue() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("test1", jdbcConn.processInsertValue("test1"));
-        assertEquals("", jdbcConn.processInsertValue((String) null));
+        assertEquals(jdbcConn.processInsertValue("test1"), "test1");
+        assertEquals(jdbcConn.processInsertValue((String) null), "");
         jdbcConn.close();
     }
 
     @Test
     public void testProcessInsertIntValue() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals(1001, jdbcConn.processInsertValue(1001));
-        assertEquals(0, jdbcConn.processInsertValue((Integer) null));
+        assertEquals(jdbcConn.processInsertValue(1001), 1001);
+        assertEquals(jdbcConn.processInsertValue((Integer) null), 0);
         jdbcConn.close();
     }
 
@@ -4306,25 +4306,25 @@ public class JDBCConnectionTest {
     @Test
     public void testProcessInsertAssertionAffect() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("ALLOW", jdbcConn.processInsertValue(AssertionEffect.ALLOW));
-        assertEquals("DENY", jdbcConn.processInsertValue(AssertionEffect.DENY));
-        assertEquals("ALLOW", jdbcConn.processInsertValue((AssertionEffect) null));
+        assertEquals(jdbcConn.processInsertValue(AssertionEffect.ALLOW), "ALLOW");
+        assertEquals(jdbcConn.processInsertValue(AssertionEffect.DENY), "DENY");
+        assertEquals(jdbcConn.processInsertValue((AssertionEffect) null), "ALLOW");
         jdbcConn.close();
     }
 
     @Test
     public void testProcessInsertUriValue() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("https://server.athenzcompany.com", jdbcConn.processInsertValue("https://server.athenzcompany.com"));
-        assertEquals("", jdbcConn.processInsertValue((String) null));
+        assertEquals(jdbcConn.processInsertValue("https://server.athenzcompany.com"), "https://server.athenzcompany.com");
+        assertEquals(jdbcConn.processInsertValue((String) null), "");
         jdbcConn.close();
     }
 
     @Test
     public void testProcessInsertUuidValue() throws Exception {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("e5e97240-e94e-11e4-8163-6d083f3f473f", jdbcConn.processInsertUuidValue(UUID.fromString("e5e97240-e94e-11e4-8163-6d083f3f473f")));
-        assertEquals("", jdbcConn.processInsertUuidValue(null));
+        assertEquals(jdbcConn.processInsertUuidValue(UUID.fromString("e5e97240-e94e-11e4-8163-6d083f3f473f")), "e5e97240-e94e-11e4-8163-6d083f3f473f");
+        assertEquals(jdbcConn.processInsertUuidValue(null), "");
         jdbcConn.close();
     }
 
@@ -4354,13 +4354,13 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, publicKeys.size());
-        assertEquals("zms1.zone1", publicKeys.get(0).getId());
-        assertEquals("Value1", publicKeys.get(0).getKey());
-        assertEquals("zms2.zone1", publicKeys.get(1).getId());
-        assertEquals("Value2", publicKeys.get(1).getKey());
-        assertEquals("zms3.zone1", publicKeys.get(2).getId());
-        assertEquals("Value3", publicKeys.get(2).getKey());
+        assertEquals(publicKeys.size(), 3);
+        assertEquals(publicKeys.get(0).getId(), "zms1.zone1");
+        assertEquals(publicKeys.get(0).getKey(), "Value1");
+        assertEquals(publicKeys.get(1).getId(), "zms2.zone1");
+        assertEquals(publicKeys.get(1).getKey(), "Value2");
+        assertEquals(publicKeys.get(2).getId(), "zms3.zone1");
+        assertEquals(publicKeys.get(2).getKey(), "Value3");
         jdbcConn.close();
     }
 
@@ -4519,16 +4519,16 @@ public class JDBCConnectionTest {
 
         List<Assertion> assertions = jdbcConn.listAssertions("my-domain", "policy1", null);
 
-        assertEquals(2, assertions.size());
-        assertEquals("my-domain:role.role1", assertions.get(0).getRole());
-        assertEquals("my-domain:*", assertions.get(0).getResource());
-        assertEquals("*", assertions.get(0).getAction());
-        assertEquals("ALLOW", assertions.get(0).getEffect().toString());
+        assertEquals(assertions.size(), 2);
+        assertEquals(assertions.get(0).getRole(), "my-domain:role.role1");
+        assertEquals(assertions.get(0).getResource(), "my-domain:*");
+        assertEquals(assertions.get(0).getAction(), "*");
+        assertEquals(assertions.get(0).getEffect().toString(), "ALLOW");
 
-        assertEquals("my-domain:role.role2", assertions.get(1).getRole());
-        assertEquals("my-domain:service.*", assertions.get(1).getResource());
-        assertEquals("read", assertions.get(1).getAction());
-        assertEquals("DENY", assertions.get(1).getEffect().toString());
+        assertEquals(assertions.get(1).getRole(), "my-domain:role.role2");
+        assertEquals(assertions.get(1).getResource(), "my-domain:service.*");
+        assertEquals(assertions.get(1).getAction(), "read");
+        assertEquals(assertions.get(1).getEffect().toString(), "DENY");
         jdbcConn.close();
     }
 
@@ -4584,11 +4584,11 @@ public class JDBCConnectionTest {
 
         List<Assertion> assertions = jdbcConn.listAssertions("my-domain", "policy1", null);
 
-        assertEquals(2, assertions.size());
-        assertEquals("my-domain:role.role1", assertions.get(0).getRole());
-        assertEquals("my-domain:*", assertions.get(0).getResource());
-        assertEquals("*", assertions.get(0).getAction());
-        assertEquals("ALLOW", assertions.get(0).getEffect().toString());
+        assertEquals(assertions.size(), 2);
+        assertEquals(assertions.get(0).getRole(), "my-domain:role.role1");
+        assertEquals(assertions.get(0).getResource(), "my-domain:*");
+        assertEquals(assertions.get(0).getAction(), "*");
+        assertEquals(assertions.get(0).getEffect().toString(), "ALLOW");
 
         assertEquals(assertions.get(0).getConditions().getConditionsList().size(), 1);
         AssertionCondition ac1 = new AssertionCondition().setId(1);
@@ -4597,10 +4597,10 @@ public class JDBCConnectionTest {
         ac1.setConditionsMap(m1);
         assertEquals(assertions.get(0).getConditions().getConditionsList().get(0), ac1);
 
-        assertEquals("my-domain:role.role2", assertions.get(1).getRole());
-        assertEquals("my-domain:service.*", assertions.get(1).getResource());
-        assertEquals("read", assertions.get(1).getAction());
-        assertEquals("DENY", assertions.get(1).getEffect().toString());
+        assertEquals(assertions.get(1).getRole(), "my-domain:role.role2");
+        assertEquals(assertions.get(1).getResource(), "my-domain:service.*");
+        assertEquals(assertions.get(1).getAction(), "read");
+        assertEquals(assertions.get(1).getEffect().toString(), "DENY");
 
         assertEquals(assertions.get(1).getConditions().getConditionsList().size(), 1);
         AssertionCondition ac2 = new AssertionCondition().setId(2);
@@ -4813,8 +4813,8 @@ public class JDBCConnectionTest {
 
         PublicKeyEntry publicKey = jdbcConn.getPublicKeyEntry("my-domain", "service1", "zone1", false);
         assertNotNull(publicKey);
-        assertEquals("Value1", publicKey.getKey());
-        assertEquals("zone1", publicKey.getId());
+        assertEquals(publicKey.getKey(), "Value1");
+        assertEquals(publicKey.getId(), "zone1");
         jdbcConn.close();
     }
 
@@ -5623,10 +5623,10 @@ public class JDBCConnectionTest {
 
         List<String> serviceHosts = jdbcConn.listServiceHosts("my-domain", "service1");
 
-        assertEquals(3, serviceHosts.size());
-        assertEquals("host1", serviceHosts.get(0));
-        assertEquals("host3", serviceHosts.get(1));
-        assertEquals("host2", serviceHosts.get(2));
+        assertEquals(serviceHosts.size(), 3);
+        assertEquals(serviceHosts.get(0), "host1");
+        assertEquals(serviceHosts.get(1), "host3");
+        assertEquals(serviceHosts.get(2), "host2");
         jdbcConn.close();
     }
 
@@ -5898,10 +5898,10 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, templates.size());
-        assertEquals("platforms", templates.get(0));
-        assertEquals("user_understanding", templates.get(1));
-        assertEquals("vipng", templates.get(2));
+        assertEquals(templates.size(), 3);
+        assertEquals(templates.get(0), "platforms");
+        assertEquals(templates.get(1), "user_understanding");
+        assertEquals(templates.get(2), "vipng");
         jdbcConn.close();
     }
 
@@ -6071,10 +6071,10 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, entities.size());
-        assertEquals("a-entity", entities.get(0));
-        assertEquals("b-entity", entities.get(1));
-        assertEquals("z-entity", entities.get(2));
+        assertEquals(entities.size(), 3);
+        assertEquals(entities.get(0), "a-entity");
+        assertEquals(entities.get(1), "b-entity");
+        assertEquals(entities.get(2), "z-entity");
         jdbcConn.close();
     }
 
@@ -6168,8 +6168,8 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Entity entity = jdbcConn.getEntity("my-domain", "entity1");
         assertNotNull(entity);
-        assertEquals("my-domain:entity.entity1", entity.getName());
-        assertEquals("{\"value\":1}", JSON.string(entity.getValue()));
+        assertEquals(entity.getName(), "my-domain:entity.entity1");
+        assertEquals(JSON.string(entity.getValue()), "{\"value\":1}");
         Mockito.verify(mockPrepStmt, times(1)).setInt(1, 5);
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "entity1");
         jdbcConn.close();
@@ -6411,7 +6411,7 @@ public class JDBCConnectionTest {
         Mockito.doReturn(101).when(mockResultSet).getInt(1);
 
         int value = jdbcConn.insertPrincipal("domain.user1");
-        assertEquals(101, value);
+        assertEquals(value, 101);
         jdbcConn.close();
     }
 
@@ -6475,7 +6475,7 @@ public class JDBCConnectionTest {
         Mockito.when(mockResultSet.next()).thenReturn(true);
         Mockito.doReturn(101).when(mockResultSet).getInt(1);
 
-        assertEquals(101, jdbcConn.insertPrincipal("domain.user1"));
+        assertEquals(jdbcConn.insertPrincipal("domain.user1"), 101);
         jdbcConn.close();
     }
 
@@ -6501,7 +6501,7 @@ public class JDBCConnectionTest {
 
         Mockito.when(mockPrepStmt.executeUpdate()).thenReturn(0);
         int value = jdbcConn.insertHost("host1");
-        assertEquals(0, value);
+        assertEquals(value, 0);
         jdbcConn.close();
     }
 
@@ -6545,7 +6545,7 @@ public class JDBCConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(ArgumentMatchers.eq(1),
                 ArgumentMatchers.eq(new java.sql.Timestamp(1454358900)), ArgumentMatchers.isA(Calendar.class));
 
-        assertEquals(3, list.getDomains().size());
+        assertEquals(list.getDomains().size(), 3);
         boolean domain1Found = false;
         boolean domain2Found = false;
         boolean domain3Found = false;
@@ -6576,7 +6576,7 @@ public class JDBCConnectionTest {
         Mockito.when(mockResultSet.next()).thenReturn(false); // no entries
 
         DomainMetaList list = jdbcConn.listModifiedDomains(1454358900);
-        assertEquals(0, list.getDomains().size());
+        assertEquals(list.getDomains().size(), 0);
 
         jdbcConn.close();
     }
@@ -6707,26 +6707,26 @@ public class JDBCConnectionTest {
 
         AthenzDomain athenzDomain = jdbcConn.getAthenzDomain("my-domain");
         assertNotNull(athenzDomain);
-        assertEquals("my-domain", athenzDomain.getDomain().getName());
+        assertEquals(athenzDomain.getDomain().getName(), "my-domain");
         assertEquals(athenzDomain.getDomain().getSignAlgorithm(), "rsa");
         assertEquals(athenzDomain.getDomain().getContacts().size(), 1);
         assertEquals(athenzDomain.getDomain().getContacts().get("security-contact"), "user.joe");
         assertEquals(athenzDomain.getDomain().getSlackChannel(), "athenz");
-        assertEquals(2, athenzDomain.getRoles().size());
-        assertEquals(1, athenzDomain.getRoles().get(0).getRoleMembers().size());
-        assertEquals(1, athenzDomain.getRoles().get(1).getRoleMembers().size());
-        assertEquals(2, athenzDomain.getGroups().size());
-        assertEquals(1, athenzDomain.getGroups().get(0).getGroupMembers().size());
-        assertEquals(1, athenzDomain.getGroups().get(1).getGroupMembers().size());
-        assertEquals(2, athenzDomain.getPolicies().size());
-        assertEquals(1, athenzDomain.getPolicies().get(0).getAssertions().size());
-        assertEquals(1, athenzDomain.getPolicies().get(1).getAssertions().size());
-        assertEquals(1, athenzDomain.getServices().size());
-        assertEquals(1, athenzDomain.getServices().get(0).getPublicKeys().size());
-        assertEquals("zms1.zone1", athenzDomain.getServices().get(0).getPublicKeys().get(0).getId());
-        assertEquals("Value1", athenzDomain.getServices().get(0).getPublicKeys().get(0).getKey());
-        assertEquals(1, athenzDomain.getServices().get(0).getHosts().size());
-        assertEquals("host1", athenzDomain.getServices().get(0).getHosts().get(0));
+        assertEquals(athenzDomain.getRoles().size(), 2);
+        assertEquals(athenzDomain.getRoles().get(0).getRoleMembers().size(), 1);
+        assertEquals(athenzDomain.getRoles().get(1).getRoleMembers().size(), 1);
+        assertEquals(athenzDomain.getGroups().size(), 2);
+        assertEquals(athenzDomain.getGroups().get(0).getGroupMembers().size(), 1);
+        assertEquals(athenzDomain.getGroups().get(1).getGroupMembers().size(), 1);
+        assertEquals(athenzDomain.getPolicies().size(), 2);
+        assertEquals(athenzDomain.getPolicies().get(0).getAssertions().size(), 1);
+        assertEquals(athenzDomain.getPolicies().get(1).getAssertions().size(), 1);
+        assertEquals(athenzDomain.getServices().size(), 1);
+        assertEquals(athenzDomain.getServices().get(0).getPublicKeys().size(), 1);
+        assertEquals(athenzDomain.getServices().get(0).getPublicKeys().get(0).getId(), "zms1.zone1");
+        assertEquals(athenzDomain.getServices().get(0).getPublicKeys().get(0).getKey(), "Value1");
+        assertEquals(athenzDomain.getServices().get(0).getHosts().size(), 1);
+        assertEquals(athenzDomain.getServices().get(0).getHosts().get(0), "host1");
 
         assertEquals(athenzDomain.getRoles().get(0).getTags().get("role1-tag-key").getList().get(0), "role1-tag-val");
         assertEquals(athenzDomain.getRoles().get(1).getTags().get("role2-tag-key").getList().get(0), "role2-tag-val");
@@ -6894,7 +6894,7 @@ public class JDBCConnectionTest {
             jdbcConn.verifyDomainAzureSubscriptionUniqueness("iaas.athenz", "azure-123", "unitTest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("iaas.athenz.ci"));
         }
 
@@ -6934,7 +6934,7 @@ public class JDBCConnectionTest {
             jdbcConn.verifyDomainGcpProjectUniqueness("iaas.athenz", "gcp-123", "unitTest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("iaas.athenz.ci"));
         }
 
@@ -6995,7 +6995,7 @@ public class JDBCConnectionTest {
             jdbcConn.verifyDomainAwsAccountUniqueness("iaas.athenz", "12345", "unitTest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("iaas.athenz.ci"));
         }
 
@@ -7056,7 +7056,7 @@ public class JDBCConnectionTest {
             jdbcConn.verifyDomainProductIdUniqueness("iaas.athenz", 1001, "unitTest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("iaas.athenz.ci"));
         }
 
@@ -7117,7 +7117,7 @@ public class JDBCConnectionTest {
             jdbcConn.verifyDomainProductIdUniqueness("iaas.athenz", "abcd-1001", "unitTest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("iaas.athenz.ci"));
         }
         // turn off the check and verify it passes
@@ -7283,10 +7283,10 @@ public class JDBCConnectionTest {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         List<String> domains = jdbcConn.lookupDomainByRole("user.user", "admin");
-        assertEquals(3, domains.size());
-        assertEquals("adomain", domains.get(0));
-        assertEquals("bdomain", domains.get(1));
-        assertEquals("zdomain", domains.get(2));
+        assertEquals(domains.size(), 3);
+        assertEquals(domains.get(0), "adomain");
+        assertEquals(domains.get(1), "bdomain");
+        assertEquals(domains.get(2), "zdomain");
         jdbcConn.close();
     }
 
@@ -7323,9 +7323,9 @@ public class JDBCConnectionTest {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         List<String> domains = jdbcConn.lookupDomainByRole("user.user", "admin");
-        assertEquals(2, domains.size());
-        assertEquals("adomain", domains.get(0));
-        assertEquals("zdomain", domains.get(1));
+        assertEquals(domains.size(), 2);
+        assertEquals(domains.get(0), "adomain");
+        assertEquals(domains.get(1), "zdomain");
         jdbcConn.close();
     }
 
@@ -7421,22 +7421,22 @@ public class JDBCConnectionTest {
 
         List<RoleAuditLog> logs = jdbcConn.listRoleAuditLogs("my-domain", "role1");
         assertNotNull(logs);
-        assertEquals(2, logs.size());
-        assertEquals("ADD", logs.get(0).getAction());
-        assertEquals("user.admin1", logs.get(0).getAdmin());
-        assertEquals("user.member1", logs.get(0).getMember());
+        assertEquals(logs.size(), 2);
+        assertEquals(logs.get(0).getAction(), "ADD");
+        assertEquals(logs.get(0).getAdmin(), "user.admin1");
+        assertEquals(logs.get(0).getMember(), "user.member1");
         assertNull(logs.get(0).getAuditRef());
-        assertEquals("DELETE", logs.get(1).getAction());
-        assertEquals("user.admin2", logs.get(1).getAdmin());
-        assertEquals("user.member2", logs.get(1).getMember());
-        assertEquals("audit-ref", logs.get(1).getAuditRef());
+        assertEquals(logs.get(1).getAction(), "DELETE");
+        assertEquals(logs.get(1).getAdmin(), "user.admin2");
+        assertEquals(logs.get(1).getMember(), "user.member2");
+        assertEquals(logs.get(1).getAuditRef(), "audit-ref");
         jdbcConn.close();
     }
 
     @Test
     public void testRoleIndex() throws SQLException {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        assertEquals("101:role1", jdbcConn.roleIndex("101", "role1"));
+        assertEquals(jdbcConn.roleIndex("101", "role1"), "101:role1");
         jdbcConn.close();
     }
 
@@ -7491,28 +7491,28 @@ public class JDBCConnectionTest {
             .thenReturn("ALLOW");
 
         Map<String, List<Assertion>> roleAssertions = jdbcConn.getRoleAssertions("update", "getRoleAssertions");
-        assertEquals(2, roleAssertions.size());
+        assertEquals(roleAssertions.size(), 2);
 
         List<Assertion> assertions = roleAssertions.get("101:role1");
-        assertEquals(2, assertions.size());
+        assertEquals(assertions.size(), 2);
 
-        assertEquals("dom1:role.role1", assertions.get(0).getRole());
-        assertEquals("resource1", assertions.get(0).getResource());
-        assertEquals("update", assertions.get(0).getAction());
-        assertEquals("ALLOW", assertions.get(0).getEffect().toString());
+        assertEquals(assertions.get(0).getRole(), "dom1:role.role1");
+        assertEquals(assertions.get(0).getResource(), "resource1");
+        assertEquals(assertions.get(0).getAction(), "update");
+        assertEquals(assertions.get(0).getEffect().toString(), "ALLOW");
 
-        assertEquals("dom1:role.role1", assertions.get(1).getRole());
-        assertEquals("resource2", assertions.get(1).getResource());
-        assertEquals("update", assertions.get(1).getAction());
-        assertEquals("ALLOW", assertions.get(1).getEffect().toString());
+        assertEquals(assertions.get(1).getRole(), "dom1:role.role1");
+        assertEquals(assertions.get(1).getResource(), "resource2");
+        assertEquals(assertions.get(1).getAction(), "update");
+        assertEquals(assertions.get(1).getEffect().toString(), "ALLOW");
 
         assertions = roleAssertions.get("102:role3");
-        assertEquals(1, assertions.size());
+        assertEquals(assertions.size(), 1);
 
-        assertEquals("dom2:role.role3", assertions.get(0).getRole());
-        assertEquals("resource3", assertions.get(0).getResource());
-        assertEquals("update", assertions.get(0).getAction());
-        assertEquals("ALLOW", assertions.get(0).getEffect().toString());
+        assertEquals(assertions.get(0).getRole(), "dom2:role.role3");
+        assertEquals(assertions.get(0).getResource(), "resource3");
+        assertEquals(assertions.get(0).getAction(), "update");
+        assertEquals(assertions.get(0).getEffect().toString(), "ALLOW");
 
         jdbcConn.close();
     }
@@ -7541,7 +7541,7 @@ public class JDBCConnectionTest {
             .thenReturn("role3");
 
         Set<String> rolePrincipals = jdbcConn.getRolePrincipals("user.user1", "getRolePrincipals");
-        assertEquals(2, rolePrincipals.size());
+        assertEquals(rolePrincipals.size(), 2);
 
         assertTrue(rolePrincipals.contains("101:role1"));
         assertTrue(rolePrincipals.contains("102:role3"));
@@ -7585,26 +7585,26 @@ public class JDBCConnectionTest {
             .thenReturn(new java.sql.Timestamp(now + 30000));
 
         Map<String, List<String>> trustedRoles = jdbcConn.getTrustedRoles("getTrustedRoles");
-        assertEquals(2, trustedRoles.size());
+        assertEquals(trustedRoles.size(), 2);
 
         List<String> roles = trustedRoles.get("101:role1");
-        assertEquals(2, roles.size());
+        assertEquals(roles.size(), 2);
 
-        assertEquals("101:trole1", roles.get(0));
-        assertEquals("102:trole2", roles.get(1));
+        assertEquals(roles.get(0), "101:trole1");
+        assertEquals(roles.get(1), "102:trole2");
 
         roles = trustedRoles.get("103:role3");
-        assertEquals(1, roles.size());
+        assertEquals(roles.size(), 1);
 
-        assertEquals("103:trole3", roles.get(0));
+        assertEquals(roles.get(0), "103:trole3");
 
         trustedRoles = jdbcConn.getTrustedRoles("getTrustedRoles");
-        assertEquals(1, trustedRoles.size());
+        assertEquals(trustedRoles.size(), 1);
 
         roles = trustedRoles.get("103:role3");
-        assertEquals(1, roles.size());
+        assertEquals(roles.size(), 1);
 
-        assertEquals("103:trole3", roles.get(0));
+        assertEquals(roles.get(0), "103:trole3");
 
         // when we call the update trust map with timestamp in the past, it should return
         // right away without making any mysql calls
@@ -7644,11 +7644,11 @@ public class JDBCConnectionTest {
             .thenReturn("103");
 
         Map<String, String> awsDomains = jdbcConn.listDomainsByCloudProvider("aws");
-        assertEquals(3, awsDomains.size());
+        assertEquals(awsDomains.size(), 3);
 
-        assertEquals("101", awsDomains.get("dom1"));
-        assertEquals("102", awsDomains.get("dom2"));
-        assertEquals("103", awsDomains.get("dom3"));
+        assertEquals(awsDomains.get("dom1"), "101");
+        assertEquals(awsDomains.get("dom2"), "102");
+        assertEquals(awsDomains.get("dom3"), "103");
 
         jdbcConn.close();
     }
@@ -7673,11 +7673,11 @@ public class JDBCConnectionTest {
                 .thenReturn("103");
 
         Map<String, String> gcpDomains = jdbcConn.listDomainsByCloudProvider("gcp");
-        assertEquals(3, gcpDomains.size());
+        assertEquals(gcpDomains.size(), 3);
 
-        assertEquals("101", gcpDomains.get("dom1"));
-        assertEquals("102", gcpDomains.get("dom2"));
-        assertEquals("103", gcpDomains.get("dom3"));
+        assertEquals(gcpDomains.get("dom1"), "101");
+        assertEquals(gcpDomains.get("dom2"), "102");
+        assertEquals(gcpDomains.get("dom3"), "103");
 
         jdbcConn.close();
     }
@@ -7702,11 +7702,11 @@ public class JDBCConnectionTest {
                 .thenReturn("103");
 
         Map<String, String> azureDomains = jdbcConn.listDomainsByCloudProvider("azure");
-        assertEquals(3, azureDomains.size());
+        assertEquals(azureDomains.size(), 3);
 
-        assertEquals("101", azureDomains.get("dom1"));
-        assertEquals("102", azureDomains.get("dom2"));
-        assertEquals("103", azureDomains.get("dom3"));
+        assertEquals(azureDomains.get("dom1"), "101");
+        assertEquals(azureDomains.get("dom2"), "102");
+        assertEquals(azureDomains.get("dom3"), "103");
 
         jdbcConn.close();
     }
@@ -7741,10 +7741,10 @@ public class JDBCConnectionTest {
         List<Assertion> principalAssertions = new ArrayList<>();
 
         jdbcConn.addRoleAssertions(principalAssertions, null);
-        assertEquals(0, principalAssertions.size());
+        assertEquals(principalAssertions.size(), 0);
 
         jdbcConn.addRoleAssertions(principalAssertions, new ArrayList<>());
-        assertEquals(0, principalAssertions.size());
+        assertEquals(principalAssertions.size(), 0);
 
         jdbcConn.close();
     }
@@ -7766,10 +7766,10 @@ public class JDBCConnectionTest {
         roleAssertions.add(assertion);
 
         jdbcConn.addRoleAssertions(principalAssertions, roleAssertions);
-        assertEquals(3, principalAssertions.size());
-        assertEquals("dom1:resource", principalAssertions.get(0).getResource());
-        assertEquals("dom2:resource1", principalAssertions.get(1).getResource());
-        assertEquals("resource3", principalAssertions.get(2).getResource());
+        assertEquals(principalAssertions.size(), 3);
+        assertEquals(principalAssertions.get(0).getResource(), "dom1:resource");
+        assertEquals(principalAssertions.get(1).getResource(), "dom2:resource1");
+        assertEquals(principalAssertions.get(2).getResource(), "resource3");
 
         jdbcConn.close();
     }
@@ -7781,27 +7781,27 @@ public class JDBCConnectionTest {
 
         SQLException ex = new SQLException("sql-reason", "08S01", 9999);
         ServerResourceException rEx = jdbcConn.sqlError(ex, "sqlError");
-        assertEquals(ServerResourceException.CONFLICT, rEx.getCode());
+        assertEquals(rEx.getCode(), ServerResourceException.CONFLICT);
 
         ex = new SQLException("sql-reason", "40001", 9999);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        assertEquals(ServerResourceException.CONFLICT, rEx.getCode());
+        assertEquals(rEx.getCode(), ServerResourceException.CONFLICT);
 
         ex = new SQLException("sql-reason", "sql-state", 3101);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        assertEquals(ServerResourceException.CONFLICT, rEx.getCode());
+        assertEquals(rEx.getCode(), ServerResourceException.CONFLICT);
 
         ex = new SQLException("sql-reason", "sql-state", 1290);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        assertEquals(ServerResourceException.GONE, rEx.getCode());
+        assertEquals(rEx.getCode(), ServerResourceException.GONE);
 
         ex = new SQLException("sql-reason", "sql-state", 1062);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        assertEquals(ServerResourceException.BAD_REQUEST, rEx.getCode());
+        assertEquals(rEx.getCode(), ServerResourceException.BAD_REQUEST);
 
         ex = new SQLTimeoutException("sql-reason", "sql-state", 1001);
         rEx = jdbcConn.sqlError(ex, "sqlError");
-        assertEquals(ServerResourceException.SERVICE_UNAVAILABLE, rEx.getCode());
+        assertEquals(rEx.getCode(), ServerResourceException.SERVICE_UNAVAILABLE);
         jdbcConn.close();
     }
 
@@ -7822,7 +7822,7 @@ public class JDBCConnectionTest {
             jdbcConn.listResourceAccess("user.user1", "update", "user");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.NOT_FOUND);
         }
 
         jdbcConn.close();
@@ -7847,9 +7847,9 @@ public class JDBCConnectionTest {
         // we should get an empty assertion set for the principal
 
         List<ResourceAccess> resources = resourceAccessList.getResources();
-        assertEquals(1, resources.size());
+        assertEquals(resources.size(), 1);
         ResourceAccess rsrcAccess = resources.get(0);
-        assertEquals("user.user1", rsrcAccess.getPrincipal());
+        assertEquals(rsrcAccess.getPrincipal(), "user.user1");
         List<Assertion> assertions = rsrcAccess.getAssertions();
         assertTrue(assertions.isEmpty());
 
@@ -7886,9 +7886,9 @@ public class JDBCConnectionTest {
         // we should get an empty assertion set for the principal
 
         List<ResourceAccess> resources = resourceAccessList.getResources();
-        assertEquals(1, resources.size());
+        assertEquals(resources.size(), 1);
         ResourceAccess rsrcAccess = resources.get(0);
-        assertEquals("user.user1", rsrcAccess.getPrincipal());
+        assertEquals(rsrcAccess.getPrincipal(), "user.user1");
         List<Assertion> assertions = rsrcAccess.getAssertions();
         assertTrue(assertions.isEmpty());
 
@@ -7944,7 +7944,7 @@ public class JDBCConnectionTest {
 
         ResourceAccessList resourceAccessList = jdbcConn.listResourceAccess("user.user1", "update", "user");
         List<ResourceAccess> resources = resourceAccessList.getResources();
-        assertEquals(1, resources.size());
+        assertEquals(resources.size(), 1);
 
         ResourceAccess rsrcAccess = resources.get(0);
         assertEquals(rsrcAccess.getPrincipal(), "user.user1");
@@ -8036,21 +8036,21 @@ public class JDBCConnectionTest {
 
         ResourceAccessList resourceAccessList = jdbcConn.listResourceAccess("user.user1", "assume_aws_role", "user");
         List<ResourceAccess> resources = resourceAccessList.getResources();
-        assertEquals(1, resources.size());
+        assertEquals(resources.size(), 1);
 
         ResourceAccess rsrcAccess = resources.get(0);
         assertEquals(rsrcAccess.getPrincipal(), "user.user1");
 
         assertEquals(rsrcAccess.getAssertions().size(), 3);
 
-        assertEquals("resource3", rsrcAccess.getAssertions().get(0).getResource());
-        assertEquals("dom3:role.role3", rsrcAccess.getAssertions().get(0).getRole());
+        assertEquals(rsrcAccess.getAssertions().get(0).getResource(), "resource3");
+        assertEquals(rsrcAccess.getAssertions().get(0).getRole(), "dom3:role.role3");
 
-        assertEquals("dom1:role1", rsrcAccess.getAssertions().get(1).getResource());
-        assertEquals("dom1:role.role1", rsrcAccess.getAssertions().get(1).getRole());
+        assertEquals(rsrcAccess.getAssertions().get(1).getResource(), "dom1:role1");
+        assertEquals(rsrcAccess.getAssertions().get(1).getRole(), "dom1:role.role1");
 
-        assertEquals("dom2:role2", rsrcAccess.getAssertions().get(2).getResource());
-        assertEquals("dom2:role.role2", rsrcAccess.getAssertions().get(2).getRole());
+        assertEquals(rsrcAccess.getAssertions().get(2).getResource(), "dom2:role2");
+        assertEquals(rsrcAccess.getAssertions().get(2).getRole(), "dom2:role.role2");
 
         jdbcConn.close();
     }
@@ -8061,7 +8061,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
 
         ResourceAccess rsrcAccess = jdbcConn.getResourceAccessObject("user.user1", null);
-        assertEquals("user.user1", rsrcAccess.getPrincipal());
+        assertEquals(rsrcAccess.getPrincipal(), "user.user1");
         List<Assertion> assertions = rsrcAccess.getAssertions();
         assertTrue(assertions.isEmpty());
 
@@ -8070,13 +8070,13 @@ public class JDBCConnectionTest {
         roleAssertions.add(assertion);
 
         rsrcAccess = jdbcConn.getResourceAccessObject("user.user2", roleAssertions);
-        assertEquals("user.user2", rsrcAccess.getPrincipal());
+        assertEquals(rsrcAccess.getPrincipal(), "user.user2");
         assertions = rsrcAccess.getAssertions();
-        assertEquals(1, assertions.size());
+        assertEquals(assertions.size(), 1);
         Assertion testAssertion = assertions.get(0);
-        assertEquals("update", testAssertion.getAction());
-        assertEquals("role", testAssertion.getRole());
-        assertEquals("resource", testAssertion.getResource());
+        assertEquals(testAssertion.getAction(), "update");
+        assertEquals(testAssertion.getRole(), "role");
+        assertEquals(testAssertion.getResource(), "resource");
 
         jdbcConn.close();
     }
@@ -8183,10 +8183,10 @@ public class JDBCConnectionTest {
 
         Assertion assertion = jdbcConn.getAssertion("my-domain", "policy1", 101L);
 
-        assertEquals("my-domain:role.role1", assertion.getRole());
-        assertEquals("my-domain:*", assertion.getResource());
-        assertEquals("*", assertion.getAction());
-        assertEquals("ALLOW", assertion.getEffect().toString());
+        assertEquals(assertion.getRole(), "my-domain:role.role1");
+        assertEquals(assertion.getResource(), "my-domain:*");
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getEffect().toString(), "ALLOW");
 
         Mockito.verify(mockPrepStmt, times(1)).setInt(1, 101);
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "my-domain");
@@ -8266,7 +8266,7 @@ public class JDBCConnectionTest {
 
         List<String> principals = jdbcConn.listPrincipals("user");
 
-        assertEquals(4, principals.size());
+        assertEquals(principals.size(), 4);
         assertTrue(principals.contains("user.joe"));
         assertTrue(principals.contains("user.jane"));
         assertTrue(principals.contains("user.doe"));
@@ -8661,7 +8661,7 @@ public class JDBCConnectionTest {
             jdbcConn.insertQuota("athenz", quota);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
         jdbcConn.close();
     }
@@ -8744,7 +8744,7 @@ public class JDBCConnectionTest {
             jdbcConn.updateQuota("athenz", quota);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
         jdbcConn.close();
     }
@@ -8801,7 +8801,7 @@ public class JDBCConnectionTest {
             jdbcConn.deleteQuota("athenz");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
         jdbcConn.close();
     }
@@ -8999,7 +8999,7 @@ public class JDBCConnectionTest {
 
         DomainRoleMembers domainRoleMembers = jdbcConn.listDomainRoleMembers("athenz");
         List<DomainRoleMember> members = domainRoleMembers.getMembers();
-        assertEquals(2, members.size());
+        assertEquals(members.size(), 2);
 
         // get domain id
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "athenz");
@@ -9281,7 +9281,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Role role = jdbcConn.getRole("my-domain", "role1");
         assertNotNull(role);
-        assertEquals("my-domain:role.role1", role.getName());
+        assertEquals(role.getName(), "my-domain:role.role1");
         assertNull(role.getAuditEnabled());
         assertNull(role.getSignAlgorithm());
         assertNull(role.getReviewEnabled());
@@ -10255,7 +10255,7 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(4, roleMembers.size());
+        assertEquals(roleMembers.size(), 4);
 
         assertNotNull(roleMembers.get(0).getExpiration());
         assertNotNull(roleMembers.get(1).getExpiration());
@@ -10267,10 +10267,10 @@ public class JDBCConnectionTest {
         assertNull(roleMembers.get(2).getReviewReminder());
         assertNull(roleMembers.get(3).getReviewReminder());
 
-        assertEquals("a-domain.stduser1", roleMembers.get(0).getMemberName());
-        assertEquals("b-domain.pendinguser1", roleMembers.get(1).getMemberName());
-        assertEquals("c-domain.pendinguser2", roleMembers.get(2).getMemberName());
-        assertEquals("d-domain.pendinguser3", roleMembers.get(3).getMemberName());
+        assertEquals(roleMembers.get(0).getMemberName(), "a-domain.stduser1");
+        assertEquals(roleMembers.get(1).getMemberName(), "b-domain.pendinguser1");
+        assertEquals(roleMembers.get(2).getMemberName(), "c-domain.pendinguser2");
+        assertEquals(roleMembers.get(3).getMemberName(), "d-domain.pendinguser3");
 
         assertTrue(roleMembers.get(0).getApproved());
         assertFalse(roleMembers.get(1).getApproved());
@@ -10979,7 +10979,7 @@ public class JDBCConnectionTest {
         List<TemplateMetaData> templateDomainMappingList  = jdbcConn.getDomainTemplates("vipng");
         assertNotNull(templateDomainMappingList);
         for (TemplateMetaData meta:templateDomainMappingList) {
-            assertEquals(100,meta.getCurrentVersion().intValue());
+            assertEquals(meta.getCurrentVersion().intValue(), 100);
         }
         jdbcConn.close();
     }
@@ -11012,17 +11012,17 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, roles.size());
-        assertEquals("athenz", roles.get(0).getDomainName());
-        assertEquals("admin", roles.get(0).getRoleName());
-        assertEquals("OnShore-US", roles.get(0).getDomainUserAuthorityFilter());
+        assertEquals(roles.size(), 3);
+        assertEquals(roles.get(0).getDomainName(), "athenz");
+        assertEquals(roles.get(0).getRoleName(), "admin");
+        assertEquals(roles.get(0).getDomainUserAuthorityFilter(), "OnShore-US");
 
-        assertEquals("athenz.subdomain", roles.get(1).getDomainName());
-        assertEquals("readers", roles.get(1).getRoleName());
+        assertEquals(roles.get(1).getDomainName(), "athenz.subdomain");
+        assertEquals(roles.get(1).getRoleName(), "readers");
         assertTrue(roles.get(1).getDomainUserAuthorityFilter().isEmpty());
 
-        assertEquals("sports", roles.get(2).getDomainName());
-        assertEquals("readers", roles.get(2).getRoleName());
+        assertEquals(roles.get(2).getDomainName(), "sports");
+        assertEquals(roles.get(2).getRoleName(), "readers");
         assertTrue(roles.get(2).getDomainUserAuthorityFilter().isEmpty());
 
         jdbcConn.close();
@@ -13410,17 +13410,17 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, groups.size());
-        assertEquals("athenz", groups.get(0).getDomainName());
-        assertEquals("admin", groups.get(0).getGroupName());
-        assertEquals("OnShore-US", groups.get(0).getDomainUserAuthorityFilter());
+        assertEquals(groups.size(), 3);
+        assertEquals(groups.get(0).getDomainName(), "athenz");
+        assertEquals(groups.get(0).getGroupName(), "admin");
+        assertEquals(groups.get(0).getDomainUserAuthorityFilter(), "OnShore-US");
 
-        assertEquals("athenz.subdomain", groups.get(1).getDomainName());
-        assertEquals("readers", groups.get(1).getGroupName());
+        assertEquals(groups.get(1).getDomainName(), "athenz.subdomain");
+        assertEquals(groups.get(1).getGroupName(), "readers");
         assertTrue(groups.get(1).getDomainUserAuthorityFilter().isEmpty());
 
-        assertEquals("sports", groups.get(2).getDomainName());
-        assertEquals("readers", groups.get(2).getGroupName());
+        assertEquals(groups.get(2).getDomainName(), "sports");
+        assertEquals(groups.get(2).getGroupName(), "readers");
         assertTrue(groups.get(2).getDomainUserAuthorityFilter().isEmpty());
 
         jdbcConn.close();
@@ -16107,7 +16107,7 @@ public class JDBCConnectionTest {
 
         DomainGroupMembers domainGroupMembers = jdbcConn.listDomainGroupMembers("athenz");
         List<DomainGroupMember> members = domainGroupMembers.getMembers();
-        assertEquals(2, members.size());
+        assertEquals(members.size(), 2);
 
         // get domain id
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "athenz");
@@ -16546,7 +16546,7 @@ public class JDBCConnectionTest {
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
         Group group = jdbcConn.getGroup("my-domain", "group1");
         assertNotNull(group);
-        assertEquals("my-domain:group.group1", group.getName());
+        assertEquals(group.getName(), "my-domain:group.group1");
         assertTrue(group.getAuditEnabled());
         assertTrue(group.getSelfServe());
         assertNull(group.getMemberExpiryDays());
@@ -16775,15 +16775,15 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(3, groupMembers.size());
+        assertEquals(groupMembers.size(), 3);
 
         assertNotNull(groupMembers.get(0).getExpiration());
         assertNull(groupMembers.get(1).getExpiration());
         assertNotNull(groupMembers.get(2).getExpiration());
 
-        assertEquals("adomain.storage", groupMembers.get(0).getMemberName());
-        assertEquals("bdomain.user2", groupMembers.get(1).getMemberName());
-        assertEquals("zdomain.user1", groupMembers.get(2).getMemberName());
+        assertEquals(groupMembers.get(0).getMemberName(), "adomain.storage");
+        assertEquals(groupMembers.get(1).getMemberName(), "bdomain.user2");
+        assertEquals(groupMembers.get(2).getMemberName(), "zdomain.user1");
         jdbcConn.close();
     }
 
@@ -16844,17 +16844,17 @@ public class JDBCConnectionTest {
 
         // data back is sorted
 
-        assertEquals(4, groupMembers.size());
+        assertEquals(groupMembers.size(), 4);
 
         assertNotNull(groupMembers.get(0).getExpiration());
         assertNotNull(groupMembers.get(1).getExpiration());
         assertNull(groupMembers.get(2).getExpiration());
         assertNull(groupMembers.get(3).getExpiration());
 
-        assertEquals("a-domain.stduser1", groupMembers.get(0).getMemberName());
-        assertEquals("b-domain.pendinguser1", groupMembers.get(1).getMemberName());
-        assertEquals("c-domain.pendinguser2", groupMembers.get(2).getMemberName());
-        assertEquals("d-domain.pendinguser3", groupMembers.get(3).getMemberName());
+        assertEquals(groupMembers.get(0).getMemberName(), "a-domain.stduser1");
+        assertEquals(groupMembers.get(1).getMemberName(), "b-domain.pendinguser1");
+        assertEquals(groupMembers.get(2).getMemberName(), "c-domain.pendinguser2");
+        assertEquals(groupMembers.get(3).getMemberName(), "d-domain.pendinguser3");
 
         assertTrue(groupMembers.get(0).getApproved());
         assertFalse(groupMembers.get(1).getApproved());

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/ZMSFileChangeLogStoreCommonTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/ZMSFileChangeLogStoreCommonTest.java
@@ -439,9 +439,9 @@ public class ZMSFileChangeLogStoreCommonTest {
     public void testRandomSleepForRetry() {
 
         ZMSFileChangeLogStoreCommon fstore = new ZMSFileChangeLogStoreCommon(FSTORE_PATH);
-        assertEquals(1000, fstore.randomSleepForRetry(1));
-        assertEquals(2000, fstore.randomSleepForRetry(2));
-        assertEquals(3000, fstore.randomSleepForRetry(3));
+        assertEquals(fstore.randomSleepForRetry(1), 1000);
+        assertEquals(fstore.randomSleepForRetry(2), 2000);
+        assertEquals(fstore.randomSleepForRetry(3), 3000);
         long timeout = fstore.randomSleepForRetry(4);
         assertTrue(timeout >= 4000 && timeout <= 10000);
         timeout = fstore.randomSleepForRetry(5);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/AuthzHelperTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/AuthzHelperTest.java
@@ -385,11 +385,11 @@ public class AuthzHelperTest {
 
     @Test
     public void testRetrieveResourceDomainA() {
-        assertEquals("trustdomain", AuthzHelper.retrieveResourceDomain("resource", "assume_role", "trustdomain"));
-        assertEquals("domain1", AuthzHelper.retrieveResourceDomain("domain1:resource", "assume_role", null));
-        assertEquals("domain1", AuthzHelper.retrieveResourceDomain("domain1:resource", "read", null));
-        assertEquals("domain1", AuthzHelper.retrieveResourceDomain("domain1:resource", "read", "trustdomain"));
-        assertEquals("domain1", AuthzHelper.retrieveResourceDomain("domain1:a:b:c:d:e", "read", "trustdomain"));
+        assertEquals(AuthzHelper.retrieveResourceDomain("resource", "assume_role", "trustdomain"), "trustdomain");
+        assertEquals(AuthzHelper.retrieveResourceDomain("domain1:resource", "assume_role", null), "domain1");
+        assertEquals(AuthzHelper.retrieveResourceDomain("domain1:resource", "read", null), "domain1");
+        assertEquals(AuthzHelper.retrieveResourceDomain("domain1:resource", "read", "trustdomain"), "domain1");
+        assertEquals(AuthzHelper.retrieveResourceDomain("domain1:a:b:c:d:e", "read", "trustdomain"), "domain1");
         assertNull(AuthzHelper.retrieveResourceDomain("domain1-invalid", "read", null));
     }
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/ConfigManagerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/ConfigManagerTest.java
@@ -49,17 +49,17 @@ public class ConfigManagerTest {
                     throw new RuntimeException("Change callback throw");
                 })   // should be ignored
                 .registerChangeCallback(() -> changesCount++);
-        assertEquals(1, configManager.getConfigProviders().length);
+        assertEquals(configManager.getConfigProviders().length, 1);
 
         // Add a source - but no provider. Should fail.
         configManager.addConfigSource("mock://abc");
-        assertEquals(0, configManager.getConfigSources().length);
+        assertEquals(configManager.getConfigSources().length, 0);
 
         // Add provider.
         MockConfigProvider mockProvider = new MockConfigProvider();
         configManager.addProvider(mockProvider);
-        assertEquals(2, configManager.getConfigProviders().length);
-        assertEquals(mockProvider, configManager.getConfigProviders()[1]);
+        assertEquals(configManager.getConfigProviders().length, 2);
+        assertEquals(configManager.getConfigProviders()[1], mockProvider);
 
         // Verify not handling empty source-description.
         configManager.addConfigSource("    ");
@@ -68,25 +68,25 @@ public class ConfigManagerTest {
         // Add two sources.
         configManager.addConfigSource("mock://a1b2c3");
         configManager.addConfigSource(new MockConfigProvider.MockConfigSource("mock://aAb2d4", "aAb2d4".toCharArray()));
-        assertEquals(2, configManager.getConfigSources().length);
+        assertEquals(configManager.getConfigSources().length, 2);
         MockConfigProvider.MockConfigSource mockSource1 = (MockConfigProvider.MockConfigSource) configManager.getConfigSources()[0];
         MockConfigProvider.MockConfigSource mockSource2 = (MockConfigProvider.MockConfigSource) configManager.getConfigSources()[1];
-        assertEquals("mock://a1b2c3", mockSource1.sourceDescription);
-        assertEquals("mock://aAb2d4", mockSource2.sourceDescription);
+        assertEquals(mockSource1.sourceDescription, "mock://a1b2c3");
+        assertEquals(mockSource2.sourceDescription, "mock://aAb2d4");
 
-        assertEquals(2, changesCount);
+        assertEquals(changesCount, 2);
         assertConfigManagerState(configManager,
                 "config-test-a -> value-1\n" +
                 "config-test-b -> value-2\n" +
                 "config-test-c -> value-3\n" +
                 "config-test-d -> value-4");
-        assertEquals("value-1", configManager.getConfigValue("config-test-a"));
+        assertEquals(configManager.getConfigValue("config-test-a"), "value-1");
         assertNull(configManager.getConfigValue("config-test-X"));
 
         assertTrue(configManager.removeConfigSource("mock://a1b2c3"));
         assertFalse(configManager.removeConfigSource("mock://a1b2c3"));
 
-        assertEquals(3, changesCount);
+        assertEquals(changesCount, 3);
         assertConfigManagerState(configManager,
                 "config-test-a -> value-A\n" +
                 "config-test-b -> value-2\n" +
@@ -96,7 +96,7 @@ public class ConfigManagerTest {
         assertEquals(mockSource2, configManager.getConfigSources()[0]);
         mockSource1 = (MockConfigProvider.MockConfigSource) configManager.getConfigSources()[1];
 
-        assertEquals(4, changesCount);
+        assertEquals(changesCount, 4);
         assertConfigManagerState(configManager,
                 "config-test-a -> value-A\n" +
                 "config-test-b -> value-2\n" +
@@ -109,7 +109,7 @@ public class ConfigManagerTest {
         mockSource2.keysAndValues = "e5d4".toCharArray();
         mockSource1.keysAndValues = "a1c3eE".toCharArray();
         configManager.reloadAllConfigs();
-        assertEquals(5, changesCount);
+        assertEquals(changesCount, 5);
         assertConfigManagerState(configManager,
                 "config-test-a -> value-1\n" +
                 "config-test-c -> value-3\n" +
@@ -118,13 +118,13 @@ public class ConfigManagerTest {
 
         // Reload with no change - verify no change callback.
         configManager.reloadAllConfigs();
-        assertEquals(5, changesCount);
+        assertEquals(changesCount, 5);
 
         // Temporarily cause the higher-priority source (currently mockSource2) to throw -
         //  and verify that its' configs are not lost or overridden by lowe-priority sources.
         mockSource2.shouldThrow = true;
         configManager.reloadAllConfigs();
-        assertEquals(5, changesCount);
+        assertEquals(changesCount, 5);
         assertConfigManagerState(configManager,
                 "config-test-a -> value-1\n" +
                 "config-test-c -> value-3\n" +
@@ -132,21 +132,21 @@ public class ConfigManagerTest {
                 "config-test-e -> value-5");
 
         // Remove the provider - and verify can't add source.
-        assertEquals(2, configManager.getConfigSources().length);
+        assertEquals(configManager.getConfigSources().length, 2);
         assertTrue(configManager.removeProvider(mockProvider));
         assertFalse(configManager.removeProvider(mockProvider));
-        assertEquals(1, configManager.getConfigProviders().length);
+        assertEquals(configManager.getConfigProviders().length, 1);
         configManager.addConfigSource("mock://XXYYZZ");
-        assertEquals(2, configManager.getConfigSources().length);
-        assertEquals(5, changesCount);
+        assertEquals(configManager.getConfigSources().length, 2);
+        assertEquals(changesCount, 5);
 
         // Add a config-provider that will try to add an already added source.
         configManager.addProvider(new StupidConfigProvider(mockSource2));
         configManager.addConfigSource("mock://a1b2c3");   // source-description already added
         configManager.addConfigSource("something");       // mockSource2 already added
-        assertEquals(2, configManager.getConfigSources().length);
+        assertEquals(configManager.getConfigSources().length, 2);
         assertTrue(configManager.removeConfigSource(mockSource2));    // "mock://aAb2d4"
-        assertEquals(1, configManager.getConfigSources().length);
+        assertEquals(configManager.getConfigSources().length, 1);
         try {
             configManager.addConfigSource(mockSource2);       // add source that will throw an exception
             fail();

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/DynamicConfigTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/DynamicConfigTest.java
@@ -162,12 +162,12 @@ public class DynamicConfigTest {
             DynamicConfigCsv      dynamicConfigCsvMissing           = new DynamicConfigCsv(      configManager, "csv-key-missing",        "default-value-a,default-value-b");
             DynamicConfigCsv      dynamicConfigCsvFixed             = new DynamicConfigCsv(      "fixed-value-a,fixed-value-b");
 
-            assertEquals("string-value",  dynamicConfigStringOk.toString());
-            assertEquals("string-value",  dynamicConfigStringOk.get());
-            assertEquals("default-value", dynamicConfigStringMissing.get());
-            assertEquals("default-value", dynamicConfigStringFixed.get());
+            assertEquals(dynamicConfigStringOk.toString(), "string-value");
+            assertEquals(dynamicConfigStringOk.get(), "string-value");
+            assertEquals(dynamicConfigStringMissing.get(), "default-value");
+            assertEquals(dynamicConfigStringFixed.get(), "default-value");
 
-            assertEquals("100",            dynamicConfigIntegerOk.toString());
+            assertEquals(dynamicConfigIntegerOk.toString(), "100");
             assertEquals(Integer.valueOf(100),    dynamicConfigIntegerOk.get());
             assertEquals(Integer.valueOf(123456), dynamicConfigIntegerOverflow.get());
             assertEquals(Integer.valueOf(123456), dynamicConfigIntegerUnderflow.get());
@@ -177,7 +177,7 @@ public class DynamicConfigTest {
             assertEquals(Integer.valueOf(123456), dynamicConfigIntegerMissing.get());
             assertEquals(Integer.valueOf(123456), dynamicConfigIntegerFixed.get());
 
-            assertEquals("100",          dynamicConfigLongOk.toString());
+            assertEquals(dynamicConfigLongOk.toString(), "100");
             assertEquals(Long.valueOf(100L),    dynamicConfigLongOk.get());
             assertEquals(Long.valueOf(123456L), dynamicConfigLongOverflow.get());
             assertEquals(Long.valueOf(123456L), dynamicConfigLongUnderflow.get());
@@ -187,7 +187,7 @@ public class DynamicConfigTest {
             assertEquals(Long.valueOf(123456L), dynamicConfigLongMissing.get());
             assertEquals(Long.valueOf(123456L), dynamicConfigLongFixed.get());
 
-            assertEquals("12.34",        dynamicConfigFloatOk2.toString());
+            assertEquals(dynamicConfigFloatOk2.toString(), "12.34");
             assertEquals(Float.valueOf(100F),   dynamicConfigFloatOk1.get());
             assertEquals(Float.valueOf(12.34F), dynamicConfigFloatOk2.get());
             assertEquals(Float.valueOf(1.23F),  dynamicConfigFloatOverflow.get());
@@ -197,7 +197,7 @@ public class DynamicConfigTest {
             assertEquals(Float.valueOf(1.23F),  dynamicConfigFloatMissing.get());
             assertEquals(Float.valueOf(1.23F),  dynamicConfigFloatFixed.get());
 
-            assertEquals("12.34",          dynamicConfigDoubleOk2.toString());
+            assertEquals(dynamicConfigDoubleOk2.toString(), "12.34");
             assertEquals(Double.valueOf(100.0),   dynamicConfigDoubleOk1.get());
             assertEquals(Double.valueOf(12.34),   dynamicConfigDoubleOk2.get());
             assertEquals(Double.valueOf(123.456), dynamicConfigDoubleOverflow.get());
@@ -207,42 +207,42 @@ public class DynamicConfigTest {
             assertEquals(Double.valueOf(123.456), dynamicConfigDoubleMissing.get());
             assertEquals(Double.valueOf(123.456), dynamicConfigDoubleFixed.get());
 
-            assertEquals("true", dynamicConfigBooleanTrueTrue.toString());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanTrueTrue.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanTrueYes.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanTrueOn.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanTrueFalse.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanTrueNo.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanTrueOff.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanTrueInvalid.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanTrueMissing.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanTrueFixed.get());
+            assertEquals(dynamicConfigBooleanTrueTrue.toString(), "true");
+            assertEquals(dynamicConfigBooleanTrueTrue.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanTrueYes.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanTrueOn.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanTrueFalse.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanTrueNo.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanTrueOff.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanTrueInvalid.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanTrueMissing.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanTrueFixed.get(), Boolean.TRUE);
 
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanFalseTrue.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanFalseYes.get());
-            assertEquals(Boolean.TRUE,  dynamicConfigBooleanFalseOn.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanFalseFalse.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanFalseNo.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanFalseOff.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanFalseInvalid.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanFalseMissing.get());
-            assertEquals(Boolean.FALSE, dynamicConfigBooleanFalseFixed.get());
+            assertEquals(dynamicConfigBooleanFalseTrue.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanFalseYes.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanFalseOn.get(), Boolean.TRUE);
+            assertEquals(dynamicConfigBooleanFalseFalse.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanFalseNo.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanFalseOff.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanFalseInvalid.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanFalseMissing.get(), Boolean.FALSE);
+            assertEquals(dynamicConfigBooleanFalseFixed.get(), Boolean.FALSE);
 
-            assertEquals(100_000L,    dynamicConfigDurationShort.getMilliseconds());
-            assertEquals(100000_000L, dynamicConfigDurationLong.getMilliseconds());
-            assertEquals(123456_000L, dynamicConfigDurationTooBig.getMilliseconds());
-            assertEquals(123456_000L, dynamicConfigDurationInvalid1.getMilliseconds());
-            assertEquals(123456_000L, dynamicConfigDurationInvalid2.getMilliseconds());
-            assertEquals(123456_000L, dynamicConfigDurationMissing.getMilliseconds());
-            assertEquals(123456_000L, dynamicConfigDurationFixed.getMilliseconds());
+            assertEquals(dynamicConfigDurationShort.getMilliseconds(), 100_000L);
+            assertEquals(dynamicConfigDurationLong.getMilliseconds(), 100000_000L);
+            assertEquals(dynamicConfigDurationTooBig.getMilliseconds(), 123456_000L);
+            assertEquals(dynamicConfigDurationInvalid1.getMilliseconds(), 123456_000L);
+            assertEquals(dynamicConfigDurationInvalid2.getMilliseconds(), 123456_000L);
+            assertEquals(dynamicConfigDurationMissing.getMilliseconds(), 123456_000L);
+            assertEquals(dynamicConfigDurationFixed.getMilliseconds(), 123456_000L);
 
-            assertEquals("[\"aaa\",\"111\",\"1234567890123456789\",\"12.34\",\"bbb\"]", Utils.jsonSerializeForLog(dynamicConfigCsvOk.getStringsList()));
-            assertEquals("[111.0,1.23456789012345677E18,12.34]",                        Utils.jsonSerializeForLog(dynamicConfigCsvOk.getDoublesList()));
-            assertEquals("[111.0,1.23456794E18,12.34]",                                 Utils.jsonSerializeForLog(dynamicConfigCsvOk.getFloatsList()));
-            assertEquals("[111,1234567890123456789]",                                   Utils.jsonSerializeForLog(dynamicConfigCsvOk.getLongsList()));
-            assertEquals("[111]",                                                       Utils.jsonSerializeForLog(dynamicConfigCsvOk.getIntegersList()));
-            assertEquals("[\"default-value-a\",\"default-value-b\"]",                   Utils.jsonSerializeForLog(dynamicConfigCsvMissing.getStringsList()));
-            assertEquals("[\"fixed-value-a\",\"fixed-value-b\"]",                       Utils.jsonSerializeForLog(dynamicConfigCsvFixed.getStringsList()));
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvOk.getStringsList()), "[\"aaa\",\"111\",\"1234567890123456789\",\"12.34\",\"bbb\"]");
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvOk.getDoublesList()), "[111.0,1.23456789012345677E18,12.34]");
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvOk.getFloatsList()), "[111.0,1.23456794E18,12.34]");
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvOk.getLongsList()), "[111,1234567890123456789]");
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvOk.getIntegersList()), "[111]");
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvMissing.getStringsList()), "[\"default-value-a\",\"default-value-b\"]");
+            assertEquals(Utils.jsonSerializeForLog(dynamicConfigCsvFixed.getStringsList()), "[\"fixed-value-a\",\"fixed-value-b\"]");
             assertTrue(dynamicConfigCsvOk.hasItem("aaa"));
             assertFalse(dynamicConfigCsvOk.hasItem("ccc"));
             assertTrue(dynamicConfigCsvOk.hasItem(12.34));
@@ -263,7 +263,7 @@ public class DynamicConfigTest {
 
         File configFile = File.createTempFile("ConfigProviderFileTest.testDynamic", ".conf");
 
-        writeFile(configFile, "" +
+        writeFile(configFile,
                 "string-key: value-1\n" +
                 "duration-key-reload: 50\n");
 
@@ -291,16 +291,16 @@ public class DynamicConfigTest {
             // Add a "normal" change-callback.
             DynamicConfig.ChangeCallback<String> normalChangeCallback = (newValue, oldValue, _dynamicConfig) -> {
                 assertEquals(dynamicConfig, _dynamicConfig);
-                assertEquals("VALUE-1", oldValue);
-                assertEquals("VALUE-2", newValue);
+                assertEquals(oldValue, "VALUE-1");
+                assertEquals(newValue, "VALUE-2");
                 dynamicChangedCount++;
             };
             dynamicConfig.registerChangeCallback(normalChangeCallback);
 
-            assertEquals("VALUE-1",  dynamicConfig.get());
+            assertEquals(dynamicConfig.get(), "VALUE-1");
 
             // Make a config-change - that cause DynamicConfigTester to throw.
-            writeFile(configFile, "" +
+            writeFile(configFile,
                     "string-key: THROWING_VALUE\n" +
                     "duration-key-reload: 10\n");
 
@@ -313,7 +313,7 @@ public class DynamicConfigTest {
             }
 
             // Make a proper config-change.
-            writeFile(configFile, "" +
+            writeFile(configFile,
                     "string-key: value-2\n" +
                     "duration-key-reload: 10\n");
 
@@ -328,17 +328,17 @@ public class DynamicConfigTest {
             // No more updates
             configManager.close();
 
-            writeFile(configFile, "" +
+            writeFile(configFile,
                     "string-key: value-3\n" +
                     "duration-key-reload: 10\n");
 
             Thread.sleep(500);
 
-            assertEquals("VALUE-2",  dynamicConfig.get());
+            assertEquals(dynamicConfig.get(), "VALUE-2");
 
             assertTrue(dynamicConfig.unregisterChangeCallback(normalChangeCallback));
             assertFalse(dynamicConfig.unregisterChangeCallback(normalChangeCallback));
-            assertEquals(1, dynamicChangedCount);
+            assertEquals(dynamicChangedCount, 1);
         }
 
         @SuppressWarnings("unused") boolean deleted = configFile.delete();

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/providers/ConfigProviderFileTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/config/providers/ConfigProviderFileTest.java
@@ -49,16 +49,16 @@ public class ConfigProviderFileTest {
         assertEquals(configFile.getAbsolutePath(), source.file.getAbsolutePath());
 
         Collection<ConfigEntry> entries = source.getConfigEntries();
-        assertEquals(2, entries.size());
+        assertEquals(entries.size(), 2);
 
         ConfigEntry first = entries.stream().filter(entry -> entry.key.equals("ConfigProviderFileTest-1")).findFirst().orElse(null);
         assertNotNull(first);
-        assertEquals("value-1", first.value);
+        assertEquals(first.value, "value-1");
         assertEquals(source, first.sourceSource);
 
         ConfigEntry second = entries.stream().filter(entry -> entry.key.equals("ConfigProviderFileTest-2")).findFirst().orElse(null);
         assertNotNull(second);
-        assertEquals("value-2", second.value);
+        assertEquals(second.value, "value-2");
         assertEquals(source, second.sourceSource);
 
         @SuppressWarnings("unused") boolean deleted = configFile.delete();

--- a/libs/java/server_k8s_common/src/test/java/io/athenz/server/k8s/common/impl/KubernetesSecretPrivateKeyStoreTest.java
+++ b/libs/java/server_k8s_common/src/test/java/io/athenz/server/k8s/common/impl/KubernetesSecretPrivateKeyStoreTest.java
@@ -16,7 +16,6 @@
 package io.athenz.server.k8s.common.impl;
 
 import com.yahoo.athenz.auth.PrivateKeyStore;
-import com.yahoo.athenz.auth.ServerPrivateKey;
 import io.kubernetes.client.openapi.ApiClient;
 import okhttp3.HttpUrl;
 import okhttp3.mockwebserver.MockResponse;

--- a/libs/java/server_msg_pulsar/src/test/java/com/yahoo/athenz/common/messaging/pulsar/PulsarFactoryTest.java
+++ b/libs/java/server_msg_pulsar/src/test/java/com/yahoo/athenz/common/messaging/pulsar/PulsarFactoryTest.java
@@ -19,7 +19,6 @@
 package com.yahoo.athenz.common.messaging.pulsar;
 
 import com.yahoo.athenz.common.messaging.DomainChangeMessage;
-import com.yahoo.athenz.common.messaging.pulsar.client.AthenzPulsarClient;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -403,7 +403,7 @@ public class DBServiceTest {
             zms.dbService.checkDomainAuditEnabled(mockJdbcConn, domainName, auditCheck, caller, principal, DBService.AUDIT_TYPE_DOMAIN);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         }
     }
@@ -526,8 +526,8 @@ public class DBServiceTest {
     public void testUpdateTemplateRoleNoMembers() throws ServerResourceException {
         Role role = new Role().setName("_domain_:role.readers");
         Role newRole = zms.dbService.updateTemplateRole(null, role, "athenz", null);
-        assertEquals("athenz:role.readers", newRole.getName());
-        assertEquals(0, newRole.getRoleMembers().size());
+        assertEquals(newRole.getName(), "athenz:role.readers");
+        assertEquals(newRole.getRoleMembers().size(), 0);
     }
 
     @Test
@@ -538,9 +538,9 @@ public class DBServiceTest {
         when(con.getDomain("trustdomain")).thenReturn(domain);
 
         Role newRole = zms.dbService.updateTemplateRole(con, role, "athenz", null);
-        assertEquals("athenz:role.readers", newRole.getName());
-        assertEquals("trustdomain", newRole.getTrust());
-        assertEquals(0, newRole.getRoleMembers().size());
+        assertEquals(newRole.getName(), "athenz:role.readers");
+        assertEquals(newRole.getTrust(), "trustdomain");
+        assertEquals(newRole.getRoleMembers().size(), 0);
 
         // retry the operation with parameters
 
@@ -548,9 +548,9 @@ public class DBServiceTest {
         params.add(new TemplateParam().setName("service").setValue("storage"));
 
         newRole = zms.dbService.updateTemplateRole(con, role, "athenz", params);
-        assertEquals("athenz:role.readers", newRole.getName());
-        assertEquals("trustdomain", newRole.getTrust());
-        assertEquals(0, newRole.getRoleMembers().size());
+        assertEquals(newRole.getName(), "athenz:role.readers");
+        assertEquals(newRole.getTrust(), "trustdomain");
+        assertEquals(newRole.getRoleMembers().size(), 0);
 
         // empty and null trust values do not use the connection object
 
@@ -576,9 +576,9 @@ public class DBServiceTest {
         params.add(new TemplateParam().setName("trustdomain").setValue("sports"));
 
         Role newRole = zms.dbService.updateTemplateRole(con, role, "athenz", params);
-        assertEquals("athenz:role.readers", newRole.getName());
-        assertEquals("sports", newRole.getTrust());
-        assertEquals(0, newRole.getRoleMembers().size());
+        assertEquals(newRole.getName(), "athenz:role.readers");
+        assertEquals(newRole.getTrust(), "sports");
+        assertEquals(newRole.getRoleMembers().size(), 0);
 
         // domain does not exist with specified keyword
 
@@ -629,9 +629,9 @@ public class DBServiceTest {
         role.setRoleMembers(members);
 
         Role newRole = zms.dbService.updateTemplateRole(null, role, "athenz", null);
-        assertEquals("athenz:role.readers", newRole.getName());
+        assertEquals(newRole.getName(), "athenz:role.readers");
         List<RoleMember> newMembers = newRole.getRoleMembers();
-        assertEquals(3, newMembers.size());
+        assertEquals(newMembers.size(), 3);
 
         List<String> checkList = new ArrayList<>();
         checkList.add("user.user1");
@@ -654,9 +654,9 @@ public class DBServiceTest {
         params.add(new TemplateParam().setName("api").setValue("java"));
         params.add(new TemplateParam().setName("name").setValue("notfound"));
         Role newRole = zms.dbService.updateTemplateRole(null, role, "athenz", params);
-        assertEquals("athenz:role.storage_javareaders", newRole.getName());
+        assertEquals(newRole.getName(), "athenz:role.storage_javareaders");
         List<RoleMember> newMembers = newRole.getRoleMembers();
-        assertEquals(3, newMembers.size());
+        assertEquals(newMembers.size(), 3);
 
         List<String> checkList = new ArrayList<>();
         checkList.add("user.user1");
@@ -672,15 +672,15 @@ public class DBServiceTest {
 
         Policy newPolicy = zms.dbService.updateTemplatePolicy(policy, "athenz", null);
 
-        assertEquals("athenz:policy.policy1", newPolicy.getName());
+        assertEquals(newPolicy.getName(), "athenz:policy.policy1");
 
         List<Assertion> assertions = newPolicy.getAssertions();
-        assertEquals(1, assertions.size());
+        assertEquals(assertions.size(), 1);
         Assertion assertion = assertions.get(0);
-        assertEquals("athenz:role.role1", assertion.getRole());
-        assertEquals("athenz:*", assertion.getResource());
-        assertEquals("read", assertion.getAction());
-        assertEquals(AssertionEffect.ALLOW, assertion.getEffect());
+        assertEquals(assertion.getRole(), "athenz:role.role1");
+        assertEquals(assertion.getResource(), "athenz:*");
+        assertEquals(assertion.getAction(), "read");
+        assertEquals(assertion.getEffect(), AssertionEffect.ALLOW);
     }
 
     @Test
@@ -694,15 +694,15 @@ public class DBServiceTest {
         params.add(new TemplateParam().setName("name").setValue("notfound"));
         Policy newPolicy = zms.dbService.updateTemplatePolicy(policy, "athenz", params);
 
-        assertEquals("athenz:policy.storage_javapolicy1", newPolicy.getName());
+        assertEquals(newPolicy.getName(), "athenz:policy.storage_javapolicy1");
 
         List<Assertion> assertions = newPolicy.getAssertions();
-        assertEquals(1, assertions.size());
+        assertEquals(assertions.size(), 1);
         Assertion assertion = assertions.get(0);
-        assertEquals("athenz:role.java-role1", assertion.getRole());
-        assertEquals("athenz:java_storage_*", assertion.getResource());
-        assertEquals("read", assertion.getAction());
-        assertEquals(AssertionEffect.ALLOW, assertion.getEffect());
+        assertEquals(assertion.getRole(), "athenz:role.java-role1");
+        assertEquals(assertion.getResource(), "athenz:java_storage_*");
+        assertEquals(assertion.getAction(), "read");
+        assertEquals(assertion.getEffect(), AssertionEffect.ALLOW);
     }
 
     @Test
@@ -710,9 +710,9 @@ public class DBServiceTest {
         Policy policy = new Policy().setName("_domain_:policy.policy1");
         Policy newPolicy = zms.dbService.updateTemplatePolicy(policy, "athenz", null);
 
-        assertEquals("athenz:policy.policy1", newPolicy.getName());
+        assertEquals(newPolicy.getName(), "athenz:policy.policy1");
         List<Assertion> assertions = newPolicy.getAssertions();
-        assertEquals(0, assertions.size());
+        assertEquals(assertions.size(), 0);
     }
 
     @Test
@@ -722,15 +722,15 @@ public class DBServiceTest {
 
         Policy newPolicy = zms.dbService.updateTemplatePolicy(policy, "athenz", null);
 
-        assertEquals("athenz:policy.policy1", newPolicy.getName());
+        assertEquals(newPolicy.getName(), "athenz:policy.policy1");
 
         List<Assertion> assertions = newPolicy.getAssertions();
-        assertEquals(1, assertions.size());
+        assertEquals(assertions.size(), 1);
         Assertion assertion = assertions.get(0);
-        assertEquals("coretech:role.role1", assertion.getRole());
-        assertEquals("coretech:*", assertion.getResource());
-        assertEquals("read", assertion.getAction());
-        assertEquals(AssertionEffect.ALLOW, assertion.getEffect());
+        assertEquals(assertion.getRole(), "coretech:role.role1");
+        assertEquals(assertion.getResource(), "coretech:*");
+        assertEquals(assertion.getAction(), "read");
+        assertEquals(assertion.getEffect(), AssertionEffect.ALLOW);
     }
 
     @Test
@@ -748,7 +748,7 @@ public class DBServiceTest {
         ServiceIdentity newService = zms.dbService.updateTemplateServiceIdentity(service,
                 "athenz", params);
 
-        assertEquals("athenz.storage_java-backend", newService.getName());
+        assertEquals(newService.getName(), "athenz.storage_java-backend");
     }
 
     @Test
@@ -1244,7 +1244,7 @@ public class DBServiceTest {
                     null, null, "testExecutePutPolicyMissingAuditRef", false);
             fail("requesterror not thrown by replacePolicy.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zms.deleteTopLevelDomain(mockDomRsrcCtx, domain, auditRef, null);
@@ -1499,7 +1499,7 @@ public class DBServiceTest {
         assertEquals(entity2.getName(), ResourceUtils.entityResourceName(domainName, entityName));
 
         Struct value = entity2.getValue();
-        assertEquals("Value1", value.getString("Key1"));
+        assertEquals(value.getString("Key1"), "Value1");
 
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef, null);
     }
@@ -1529,7 +1529,7 @@ public class DBServiceTest {
         assertNotNull(entity2);
         assertEquals(entity2.getName(), ResourceUtils.entityResourceName(domainName, entityName));
         value = entity2.getValue();
-        assertEquals("Value2", value.getString("Key2"));
+        assertEquals(value.getString("Key2"), "Value2");
 
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef, null);
     }
@@ -1544,8 +1544,8 @@ public class DBServiceTest {
 
         Domain resDom1 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom1);
-        assertEquals("Test Domain1", resDom1.getDescription());
-        assertEquals("testorg", resDom1.getOrg());
+        assertEquals(resDom1.getDescription(), "Test Domain1");
+        assertEquals(resDom1.getOrg(), "testorg");
         assertTrue(resDom1.getEnabled());
         assertFalse(resDom1.getAuditEnabled());
         assertNull(resDom1.getTokenExpiryMins());
@@ -1576,12 +1576,12 @@ public class DBServiceTest {
 
         Domain resDom2 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom2);
-        assertEquals("Test2 Domain", resDom2.getDescription());
-        assertEquals("NewOrg", resDom2.getOrg());
+        assertEquals(resDom2.getDescription(), "Test2 Domain");
+        assertEquals(resDom2.getOrg(), "NewOrg");
         assertTrue(resDom2.getEnabled());
         assertFalse(resDom2.getAuditEnabled());
         assertEquals(Integer.valueOf(1001), resDom2.getYpmId());
-        assertEquals("12345", resDom2.getAccount());
+        assertEquals(resDom2.getAccount(), "12345");
         assertEquals(resDom2.getCertDnsDomain(), "athenz1.cloud");
         assertEquals(Integer.valueOf(20), resDom2.getTokenExpiryMins());
         assertEquals(Integer.valueOf(10), resDom2.getMemberExpiryDays());
@@ -1590,7 +1590,7 @@ public class DBServiceTest {
         assertEquals(Integer.valueOf(90), resDom2.getMemberPurgeExpiryDays());
         assertNull(resDom2.getRoleCertExpiryMins());
         assertNull(resDom2.getServiceCertExpiryMins());
-        assertEquals("service1", resDom2.getBusinessService());
+        assertEquals(resDom2.getBusinessService(), "service1");
 
         // now update without account and product ids
 
@@ -1606,12 +1606,12 @@ public class DBServiceTest {
 
         Domain resDom3 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom3);
-        assertEquals("Test2 Domain-New", resDom3.getDescription());
-        assertEquals("NewOrg-New", resDom3.getOrg());
+        assertEquals(resDom3.getDescription(), "Test2 Domain-New");
+        assertEquals(resDom3.getOrg(), "NewOrg-New");
         assertTrue(resDom3.getEnabled());
         assertFalse(resDom3.getAuditEnabled());
         assertEquals(Integer.valueOf(1001), resDom3.getYpmId());
-        assertEquals("12345", resDom3.getAccount());
+        assertEquals(resDom3.getAccount(), "12345");
         assertEquals(resDom3.getCertDnsDomain(), "athenz1.cloud");
         assertEquals(Integer.valueOf(20), resDom3.getTokenExpiryMins());
         assertEquals(Integer.valueOf(10), resDom3.getMemberExpiryDays());
@@ -1635,12 +1635,12 @@ public class DBServiceTest {
 
         Domain resDom4 = zms.getDomain(mockDomRsrcCtx, domainName);
         assertNotNull(resDom4);
-        assertEquals("Test2 Domain-New", resDom4.getDescription());
-        assertEquals("NewOrg-New", resDom4.getOrg());
+        assertEquals(resDom4.getDescription(), "Test2 Domain-New");
+        assertEquals(resDom4.getOrg(), "NewOrg-New");
         assertTrue(resDom4.getEnabled());
         assertFalse(resDom4.getAuditEnabled());
         assertEquals(Integer.valueOf(1001), resDom4.getYpmId());
-        assertEquals("12345", resDom4.getAccount());
+        assertEquals(resDom4.getAccount(), "12345");
         assertEquals(resDom4.getCertDnsDomain(), "athenz1.cloud");
         assertEquals(Integer.valueOf(500), resDom4.getTokenExpiryMins());
         assertEquals(Integer.valueOf(10), resDom4.getMemberExpiryDays());
@@ -1750,7 +1750,7 @@ public class DBServiceTest {
                     null, false, auditRef, "testExecutePutDomainMetaRetryException");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2033,7 +2033,7 @@ public class DBServiceTest {
                     auditRef, "deleteServiceIdentity");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -2060,7 +2060,7 @@ public class DBServiceTest {
                     auditRef, "deleteServiceIdentity");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2085,7 +2085,7 @@ public class DBServiceTest {
                     auditRef, "deleteEntity");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -2112,7 +2112,7 @@ public class DBServiceTest {
                     auditRef, "deleteEntity");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2137,7 +2137,7 @@ public class DBServiceTest {
                     auditRef, "deleteRole");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -2164,7 +2164,7 @@ public class DBServiceTest {
                     auditRef, "deleteRole");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2246,7 +2246,7 @@ public class DBServiceTest {
                     1001L, auditRef, "deleteAssertion");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2404,7 +2404,7 @@ public class DBServiceTest {
                     auditRef, "deletePolicy");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2434,7 +2434,7 @@ public class DBServiceTest {
                     keyEntry, auditRef, "putPublicKeyEntry");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2462,7 +2462,7 @@ public class DBServiceTest {
                     "0", auditRef, "deletePublicKeyEntry");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2489,7 +2489,7 @@ public class DBServiceTest {
                     keyEntry, auditRef, "putPublicKeyEntry");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.INTERNAL_SERVER_ERROR, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.INTERNAL_SERVER_ERROR);
         }
 
         zms.dbService.store = saveStore;
@@ -2788,7 +2788,7 @@ public class DBServiceTest {
                     service, null, auditRef, "putServiceIdentity", false);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2871,7 +2871,7 @@ public class DBServiceTest {
                     "providerendpoint", auditRef, "putServiceIdentitySystemMeta");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -2907,7 +2907,7 @@ public class DBServiceTest {
                 serviceName);
         assertNotNull(serviceRes2);
         assertEquals(serviceRes2.getName(), domainName + "." + serviceName);
-        assertEquals(2, service.getHosts().size());
+        assertEquals(service.getHosts().size(), 2);
         assertTrue(service.getHosts().contains("host2"));
         assertTrue(service.getHosts().contains("host3"));
 
@@ -2987,7 +2987,7 @@ public class DBServiceTest {
     private void verifyPolicies(String domainName) {
 
         List<String> names = zms.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -2999,16 +2999,16 @@ public class DBServiceTest {
         // The updated policy will have two assertions, one from the original, and the other from template application.
         // The original assertion is {    role: "solutiontemplate-withpolicy:role.role1",    action: "*",    effect: "ALLOW",    resource: "*"}
         // Newly added one is {    resource: "solutiontemplate-withpolicy:vip*",    role: "solutiontemplate-withpolicy:role.vip_admin",    action: "*"}
-        assertEquals(2, policy.getAssertions().size());
+        assertEquals(policy.getAssertions().size(), 2);
         Assertion assertion = policy.getAssertions().get(0); // this is the original assertion
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.admin", assertion.getRole());
-        assertEquals("solutiontemplate-withpolicy:*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.admin");
+        assertEquals(assertion.getResource(), "solutiontemplate-withpolicy:*");
 
         Assertion assertionAdded = policy.getAssertions().get(1); // this is the added assertion
-        assertEquals("*", assertionAdded.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertionAdded.getRole());
-        assertEquals("solutiontemplate-withpolicy:vip*", assertionAdded.getResource());
+        assertEquals(assertionAdded.getAction(), "*");
+        assertEquals(assertionAdded.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertionAdded.getResource(), "solutiontemplate-withpolicy:vip*");
     }
 
     @Test
@@ -3063,24 +3063,24 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         role = zms.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
@@ -3095,12 +3095,12 @@ public class DBServiceTest {
         // the rest should be identical what's in the template
 
         Policy policy = zms.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // remove the vipng template
 
@@ -3155,48 +3155,48 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the roles defined in template
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         role = zms.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Policy policy = zms.dbService.getPolicy(domainName, "vip_admin", null);
-        assertEquals(domainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         policy = zms.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // add another template
         templates = new ArrayList<>();
@@ -3205,17 +3205,17 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(2, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 2);
 
         names = zms.dbService.listRoles(domainName);
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deployer"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -3227,15 +3227,15 @@ public class DBServiceTest {
                 auditRef, caller);
 
         domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         names = zms.dbService.listRoles(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deployer"));
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deploy"));
 
@@ -3245,14 +3245,14 @@ public class DBServiceTest {
                 auditRef, caller);
 
         domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(0, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 0);
 
         names = zms.dbService.listRoles(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         zms.deleteSubDomain(mockDomRsrcCtx, "sys", "network", auditRef, null);
@@ -3277,38 +3277,38 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         //verify that our service collections includes the services defined in the template
 
         names = zms.dbService.listServiceIdentities(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("testService"));
         // Try applying the template again. This time, there should be no changes.
 
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
@@ -3352,31 +3352,31 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         //verify that our service collections includes the services defined in the template
 
         names = zms.dbService.listServiceIdentities(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("testService"));
         assertTrue(names.contains("testService2"));
         // Try applying the template again. This time, there should be no changes.
@@ -3384,7 +3384,7 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
@@ -3429,45 +3429,45 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         //verify that our service collections includes the services defined in the template
 
         names = zms.dbService.listServiceIdentities(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("testService3"));
         // Try applying the template again. This time, there should be no changes.
 
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         //trying to check for the keys
         ServiceIdentity serviceIdentity = zms.dbService.getServiceIdentity(domainName, "testService3", false);
-        assertEquals(1, serviceIdentity.getPublicKeys().size());
-        assertEquals("0", serviceIdentity.getPublicKeys().get(0).getId());
+        assertEquals(serviceIdentity.getPublicKeys().size(), 1);
+        assertEquals(serviceIdentity.getPublicKeys().get(0).getId(), "0");
 
         // remove the templateWithService template
 
@@ -3513,29 +3513,29 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         role = zms.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -3545,7 +3545,7 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -3553,12 +3553,12 @@ public class DBServiceTest {
         // the rest should be identical what's in the template
 
         Policy policy = zms.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // remove the vipng template
 
@@ -3617,48 +3617,48 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         role = zms.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Policy policy = zms.dbService.getPolicy(domainName, "vip_admin", null);
-        assertEquals(domainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         policy = zms.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // remove the vipng template
 
@@ -3710,12 +3710,12 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -3723,9 +3723,9 @@ public class DBServiceTest {
         // this should be our own role that we created previously
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
-        assertEquals(2, role.getRoleMembers().size());
+        assertEquals(role.getRoleMembers().size(), 2);
         List<String> checkList = new ArrayList<>();
         checkList.add("user.joe");
         checkList.add("user.jane");
@@ -3734,32 +3734,32 @@ public class DBServiceTest {
         // the rest should be whatever we had in the template
 
         role = zms.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // the rest should be whatever we had in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Policy policy = zms.dbService.getPolicy(domainName, "vip_admin", null);
-        assertEquals(domainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         policy = zms.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // remove the vipng template
 
@@ -3796,8 +3796,8 @@ public class DBServiceTest {
         DomainTemplateDetailsList domainTemplateDetailsList = zms.getDomainTemplateDetailsList(mockDomRsrcCtx, domainName);
         List<TemplateMetaData> metaData = domainTemplateDetailsList.getMetaData();
         for (TemplateMetaData meta : metaData) {
-            assertEquals(10, (meta.getLatestVersion().intValue()));
-            assertEquals("templateWithService", meta.getTemplateName());
+            assertEquals((meta.getLatestVersion().intValue()), 10);
+            assertEquals(meta.getTemplateName(), "templateWithService");
         }
 
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef, null);
@@ -3844,12 +3844,12 @@ public class DBServiceTest {
 
         List<Assertion> assertList = policy.getAssertions();
         assertNotNull(assertList);
-        assertEquals(3, assertList.size());
+        assertEquals(assertList.size(), 3);
         boolean domainAdminRoleCheck = false;
         boolean tenantAdminRoleCheck = false;
         boolean tenantUpdateCheck = false;
         for (Assertion obj : assertList) {
-            assertEquals(AssertionEffect.ALLOW, obj.getEffect());
+            assertEquals(obj.getEffect(), AssertionEffect.ALLOW);
             if (obj.getRole().equals("tenantadminpolicy:role.admin")) {
                 assertEquals(obj.getResource(), "coretech:role.storage.tenant.tenantadminpolicy.admin");
                 assertEquals(obj.getAction(), "assume_role");
@@ -3859,7 +3859,7 @@ public class DBServiceTest {
                     assertEquals(obj.getResource(), "coretech:role.storage.tenant.tenantadminpolicy.admin");
                     tenantAdminRoleCheck = true;
                 } else if (obj.getAction().equals("update")) {
-                    assertEquals("tenantadminpolicy:tenancy.coretech.storage", obj.getResource());
+                    assertEquals(obj.getResource(), "tenantadminpolicy:tenancy.coretech.storage");
                     tenantUpdateCheck = true;
                 }
             }
@@ -3882,9 +3882,9 @@ public class DBServiceTest {
         ZMSConfig zmsConfig = new ZMSConfig();
         zmsConfig.setUserDomain("user");
         DBService dbService = new DBService(null, null, zmsConfig, null, null);
-        assertEquals(120, dbService.defaultRetryCount);
-        assertEquals(250, dbService.retrySleepTime);
-        assertEquals(60, dbService.defaultOpTimeout);
+        assertEquals(dbService.defaultRetryCount, 120);
+        assertEquals(dbService.retrySleepTime, 250);
+        assertEquals(dbService.defaultOpTimeout, 60);
 
         System.clearProperty(ZMSConsts.ZMS_PROP_CONFLICT_RETRY_COUNT);
         System.clearProperty(ZMSConsts.ZMS_PROP_CONFLICT_RETRY_SLEEP_TIME);
@@ -4117,11 +4117,11 @@ public class DBServiceTest {
     public void testAuditLogPublicKeyEntry() throws ServerResourceException {
         StringBuilder auditDetails = new StringBuilder();
         assertFalse(zms.dbService.auditLogPublicKeyEntry(auditDetails, "keyId", true));
-        assertEquals("{\"id\": \"keyId\"}", auditDetails.toString());
+        assertEquals(auditDetails.toString(), "{\"id\": \"keyId\"}");
 
         auditDetails.setLength(0);
         assertFalse(zms.dbService.auditLogPublicKeyEntry(auditDetails, "keyId", false));
-        assertEquals(",{\"id\": \"keyId\"}", auditDetails.toString());
+        assertEquals(auditDetails.toString(), ",{\"id\": \"keyId\"}");
     }
 
     @Test
@@ -4129,11 +4129,11 @@ public class DBServiceTest {
         StringBuilder auditDetails = new StringBuilder();
         assertTrue(zms.dbService.addSolutionTemplate(mockDomRsrcCtx, null, null, "template1",
                 null, null, null, auditDetails));
-        assertEquals("{\"name\": \"template1\"}", auditDetails.toString());
+        assertEquals(auditDetails.toString(), "{\"name\": \"template1\"}");
 
         auditDetails.setLength(0);
         zms.dbService.deleteSolutionTemplate(mockDomRsrcCtx, null, null, "template1", null, auditDetails);
-        assertEquals("{\"name\": \"template1\"}", auditDetails.toString());
+        assertEquals(auditDetails.toString(), "{\"name\": \"template1\"}");
     }
 
     @Test
@@ -4221,7 +4221,7 @@ public class DBServiceTest {
         assertNotNull(role);
         assertEquals(role.getTrust(), domainName2);
         List<RoleMember> members = role.getRoleMembers();
-        assertEquals(3, members.size());
+        assertEquals(members.size(), 3);
 
         List<String> checkList = new ArrayList<>();
         checkList.add("user.joe");
@@ -4300,7 +4300,7 @@ public class DBServiceTest {
 
         ObjectStoreConnection conn = zms.dbService.store.getConnection(true, false);
         List<RoleMember> members = zms.dbService.getDelegatedRoleMembers(conn, domainName1, domainName2, roleName);
-        assertEquals(3, members.size());
+        assertEquals(members.size(), 3);
 
         List<String> checkList = new ArrayList<>();
         checkList.add("user.joe");
@@ -4740,11 +4740,11 @@ public class DBServiceTest {
         zms.putRole(mockDomRsrcCtx, domainName, "role5", auditRef, false, null, role5);
 
         DomainRoleMembers domainRoleMembers = zms.getDomainRoleMembers(mockDomRsrcCtx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
+        assertEquals(domainRoleMembers.getDomainName(), domainName);
 
         List<DomainRoleMember> members = domainRoleMembers.getMembers();
         assertNotNull(members);
-        assertEquals(5, members.size());
+        assertEquals(members.size(), 5);
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
@@ -4764,7 +4764,7 @@ public class DBServiceTest {
         domainRoleMembers = zms.getDomainRoleMembers(mockDomRsrcCtx, domainName);
         members = domainRoleMembers.getMembers();
         assertNotNull(members);
-        assertEquals(5, members.size());
+        assertEquals(members.size(), 5);
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
@@ -4777,11 +4777,11 @@ public class DBServiceTest {
                 "testExecuteDeleteDomainRoleMember");
 
         domainRoleMembers = zms.getDomainRoleMembers(mockDomRsrcCtx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
+        assertEquals(domainRoleMembers.getDomainName(), domainName);
 
         members = domainRoleMembers.getMembers();
         assertNotNull(members);
-        assertEquals(4, members.size());
+        assertEquals(members.size(), 4);
         ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
@@ -4805,7 +4805,7 @@ public class DBServiceTest {
             zms.dbService.executeDeleteDomainRoleMember(mockDomRsrcCtx, "dom1", "user.joe", adminUser, "unittest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(410, ex.getCode());
+            assertEquals(ex.getCode(), 410);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -4826,14 +4826,14 @@ public class DBServiceTest {
             zms.dbService.removePrincipalFromDomainRoles(null, conn, "dom1", "user.joe", adminUser, "unittest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zms.dbService.removePrincipalFromDomainRoles(null, conn, "dom1", "user.joe", adminUser, "unittest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(501, ex.getCode());
+            assertEquals(ex.getCode(), 501);
         }
     }
 
@@ -4881,7 +4881,7 @@ public class DBServiceTest {
             zms.dbService.removePrincipalFromAllRoles(mockDomRsrcCtx, conn, "user.joe", adminUser, "unittest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(501, ex.getCode());
+            assertEquals(ex.getCode(), 501);
         }
     }
 
@@ -4900,7 +4900,7 @@ public class DBServiceTest {
             zms.dbService.executeDeleteUser(mockDomRsrcCtx, "joe", "home.joe", adminUser, "unittest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(409, ex.getCode());
+            assertEquals(ex.getCode(), 409);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -4951,7 +4951,7 @@ public class DBServiceTest {
             zms.dbService.removePrincipalFromAllGroups(mockDomRsrcCtx, conn, "user.joe", adminUser, "unittest");
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(501, ex.getCode());
+            assertEquals(ex.getCode(), 501);
         }
     }
 
@@ -5000,7 +5000,7 @@ public class DBServiceTest {
                     auditRef, "putQuota");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -5025,14 +5025,14 @@ public class DBServiceTest {
             zms.dbService.executeDeleteQuota(mockDomRsrcCtx, domainName, auditRef, "deleteQuota");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         try {
             zms.dbService.executeDeleteQuota(mockDomRsrcCtx, domainName, auditRef, "deleteQuota");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -5133,7 +5133,7 @@ public class DBServiceTest {
 
         Quota quotaCheck = zms.getQuota(mockDomRsrcCtx, domainName);
         assertNotNull(quotaCheck);
-        assertEquals(domainName, quotaCheck.getName());
+        assertEquals(quotaCheck.getName(), domainName);
         assertEquals(quotaCheck.getAssertion(), 10);
         assertEquals(quotaCheck.getRole(), 14);
         assertEquals(quotaCheck.getPolicy(), 12);
@@ -5147,7 +5147,7 @@ public class DBServiceTest {
 
         quotaCheck = zms.getQuota(mockDomRsrcCtx, domainName);
 
-        assertEquals("server-default", quotaCheck.getName());
+        assertEquals(quotaCheck.getName(), "server-default");
         assertEquals(quotaCheck.getAssertion(), 100);
         assertEquals(quotaCheck.getRole(), 1000);
         assertEquals(quotaCheck.getPolicy(), 1000);
@@ -5787,7 +5787,7 @@ public class DBServiceTest {
         StringBuilder auditDetails = new StringBuilder();
         Role role = new Role().setName("dom1:role.role1").setAuditEnabled(true);
         zms.dbService.auditLogRoleSystemMeta(auditDetails, role, "role1");
-        assertEquals("{\"name\": \"role1\", \"auditEnabled\": \"true\"}", auditDetails.toString());
+        assertEquals(auditDetails.toString(), "{\"name\": \"role1\", \"auditEnabled\": \"true\"}");
     }
 
     @Test
@@ -6130,7 +6130,7 @@ public class DBServiceTest {
             zms.dbService.checkObjectAuditEnabled(mockJdbcConn, role.getAuditEnabled(), role.getName(), null, caller, principal);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         }
     }
@@ -6150,7 +6150,7 @@ public class DBServiceTest {
             zms.dbService.checkObjectAuditEnabled(mockJdbcConn, role.getAuditEnabled(), role.getName(), auditCheck, caller, principal);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         }
     }
@@ -6198,7 +6198,7 @@ public class DBServiceTest {
             zms.dbService.checkObjectAuditEnabled(mockJdbcConn, role.getAuditEnabled(), role.getName(), "auditref", caller, principal);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference validation failed "));
         }
         zms.dbService.auditReferenceValidator = null;
@@ -6582,8 +6582,8 @@ public class DBServiceTest {
 
         Domain resDom1 = zms.getDomain(mockDomRsrcCtx, "MetaDom1");
         assertNotNull(resDom1);
-        assertEquals("Test Domain1", resDom1.getDescription());
-        assertEquals("testorg", resDom1.getOrg());
+        assertEquals(resDom1.getDescription(), "Test Domain1");
+        assertEquals(resDom1.getOrg(), "testorg");
         assertTrue(resDom1.getEnabled());
         assertFalse(resDom1.getAuditEnabled());
 
@@ -7263,7 +7263,7 @@ public class DBServiceTest {
         assertNull(member.getSystemDisabled());
 
         member = getRoleMember(resRole1, "user.jane");
-        assertEquals(1, member.getSystemDisabled().intValue());
+        assertEquals(member.getSystemDisabled().intValue(), 1);
 
         member = getRoleMember(resRole1, "sys.auth.api");
         assertNull(member.getSystemDisabled());
@@ -7755,7 +7755,7 @@ public class DBServiceTest {
         zms.dbService.executePutRole(mockDomRsrcCtx, domainName1, "role1", role, null, null, "test", "putrole", false);
 
         DomainRoleMembers responseMembers = zms.dbService.listOverdueReviewRoleMembers(domainName1);
-        assertEquals("test-domain1", responseMembers.getDomainName());
+        assertEquals(responseMembers.getDomainName(), "test-domain1");
         List<DomainRoleMember> responseRoleMemberList = responseMembers.getMembers();
         assertEquals(responseRoleMemberList.size(), 2);
         assertEquals(responseRoleMemberList.get(0).getMemberName(), "user.overduereview1");
@@ -8716,7 +8716,7 @@ public class DBServiceTest {
                     memberName, auditRef, "deletePendingMember");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -8744,7 +8744,7 @@ public class DBServiceTest {
                     memberName, auditRef, "deleteMember");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -8773,7 +8773,7 @@ public class DBServiceTest {
                     memberName, auditRef, "deleteMember");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.defaultRetryCount = saveRetryCount;
@@ -9544,17 +9544,17 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
         assertNotNull(role.getNotifyRoles());
@@ -9579,7 +9579,7 @@ public class DBServiceTest {
         // verify that our policy collections includes the policies defined in the template
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
@@ -9588,7 +9588,7 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         names = zms.dbService.listPolicies(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
@@ -9627,17 +9627,17 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         // verify that our role collection includes the expected roles
 
         List<String> names = zms.dbService.listRoles(domainName);
-        assertEquals(2, names.size());
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
 
         Role role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
 
         //For the same role apply new role meta values to test whether it is overriding existing values.
         templates = new ArrayList<>();
@@ -9645,7 +9645,7 @@ public class DBServiceTest {
         domainTemplate = new DomainTemplate().setTemplateNames(templates);
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
         role = zms.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         //selfserve is overwritten so expect true
         assertTrue(role.getSelfServe()); //assert for updated Value
         assertEquals(role.getMemberExpiryDays().intValue(), 999); //Overwritten value. assert for updated Value
@@ -9822,8 +9822,8 @@ public class DBServiceTest {
         zms.dbService.store = mockObjStore;
 
         List<Role> rolesFetched = zms.dbService.getRolesByDomain("test1");
-        assertEquals(1, rolesFetched.size());
-        assertEquals("admin", rolesFetched.get(0).getName());
+        assertEquals(rolesFetched.size(), 1);
+        assertEquals(rolesFetched.get(0).getName(), "admin");
         zms.dbService.store = saveStore;
     }
 
@@ -9855,7 +9855,7 @@ public class DBServiceTest {
         zms.dbService.makeDomain(mockDomRsrcCtx, domain, admins, null, auditRef);
 
         ObjectStoreConnection conn = zms.dbService.store.getConnection(true, false);
-        assertEquals("employee", zms.dbService.getDomainUserAuthorityFilter(conn, domainName));
+        assertEquals(zms.dbService.getDomainUserAuthorityFilter(conn, domainName), "employee");
 
         zms.dbService.zmsConfig.setUserAuthority(savedAuthority);
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef, null);
@@ -9987,7 +9987,7 @@ public class DBServiceTest {
             zms.dbService.executePutGroupMembership(mockDomRsrcCtx, domainName, group, groupMember, auditRef, false);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
         }
 
         zms.dbService.store = saveStore;
@@ -10014,7 +10014,7 @@ public class DBServiceTest {
                     memberName, auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -10041,7 +10041,7 @@ public class DBServiceTest {
                     memberName, auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -10064,7 +10064,7 @@ public class DBServiceTest {
             zms.dbService.executeDeleteGroup(mockDomRsrcCtx, domainName, groupName, auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         zms.dbService.store = saveStore;
@@ -10302,7 +10302,7 @@ public class DBServiceTest {
             zms.dbService.executePutGroupMembershipDecision(mockDomRsrcCtx, domainName, group, groupMember, auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
         }
 
         // next we should get back our exception
@@ -10311,7 +10311,7 @@ public class DBServiceTest {
             zms.dbService.executePutGroupMembershipDecision(mockDomRsrcCtx, domainName, group, groupMember, auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         zms.dbService.store = saveStore;
@@ -10811,7 +10811,7 @@ public class DBServiceTest {
         Map<String, String> map = new HashMap<>();
         map.put("coretech", "OnShore-US");
 
-        assertEquals("OnShore-US", zms.dbService.getDomainUserAuthorityFilterFromMap(null, map, "coretech"));
+        assertEquals(zms.dbService.getDomainUserAuthorityFilterFromMap(null, map, "coretech"), "OnShore-US");
 
         // we have a domain that is null
 
@@ -10838,7 +10838,7 @@ public class DBServiceTest {
         Mockito.when(conn.getDomain("coretech")).thenReturn(domain);
 
         map.clear();
-        assertEquals("OnShore-US", zms.dbService.getDomainUserAuthorityFilterFromMap(conn, map, "coretech"));
+        assertEquals(zms.dbService.getDomainUserAuthorityFilterFromMap(conn, map, "coretech"), "OnShore-US");
     }
 
     @Test
@@ -11253,15 +11253,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteRoleTags(roleCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals("newRole", roleCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), "newRole");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().containsAll(expectedTagsToBeRemoved));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertRoleTags(roleCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newRole", roleCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), "newRole");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.keySet().containsAll(Arrays.asList("newTagKey", "newTagKey2")));
         assertTrue(resultInsertTags.values().stream()
@@ -11351,15 +11351,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteServiceTags(serviceCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals("newService", serviceCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(serviceCapture.getValue(), "newService");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().containsAll(expectedTagsToBeRemoved));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertServiceTags(serviceCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newService", serviceCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(serviceCapture.getValue(), "newService");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.keySet().containsAll(Arrays.asList("newTagKey", "newTagKey2")));
         assertTrue(resultInsertTags.values().stream()
@@ -11411,15 +11411,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteServiceTags(serviceCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals("newService", serviceCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(serviceCapture.getValue(), "newService");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().isEmpty());
 
         // assert tags to add should be empty
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertServiceTags(serviceCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newService", serviceCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(serviceCapture.getValue(), "newService");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.isEmpty());
 
@@ -11466,15 +11466,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteRoleTags(roleCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals("newRole", roleCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), "newRole");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().isEmpty());
 
         // assert tags to add should be empty
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertRoleTags(roleCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newRole", roleCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), "newRole");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.isEmpty());
 
@@ -11517,8 +11517,8 @@ public class DBServiceTest {
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
 
         Mockito.verify(conn, times(1)).insertRoleTags(roleCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals(roleName, roleCapture.getValue());
-        assertEquals(domainName, domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), roleName);
+        assertEquals(domainCapture.getValue(), domainName);
 
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(0);
         TagValueList tagValues = resultInsertTags.get(updateRoleMetaTag);
@@ -11564,15 +11564,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteRoleTags(roleCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals(roleName, roleCapture.getValue());
-        assertEquals(domainName, domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), roleName);
+        assertEquals(domainCapture.getValue(), domainName);
         assertTrue(tagCapture.getValue().contains(initialTagKey));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(1)).insertRoleTags(roleCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals(roleName, roleCapture.getValue());
-        assertEquals(domainName, domainCapture.getValue());
+        assertEquals(roleCapture.getValue(), roleName);
+        assertEquals(domainCapture.getValue(), domainName);
 
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(0);
         TagValueList tagValues = resultInsertTags.get(updateRoleMetaTag);
@@ -11654,13 +11654,13 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteDomainTags(domainCapture.capture(), tagCapture.capture());
-        assertEquals("newDomain", domainCapture.getValue());
+        assertEquals(domainCapture.getValue(), "newDomain");
         assertTrue(tagCapture.getValue().containsAll(expectedTagsToBeRemoved));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertDomainTags(domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newDomain", domainCapture.getValue());
+        assertEquals(domainCapture.getValue(), "newDomain");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.keySet().containsAll(Arrays.asList("newTagKey", "newTagKey2")));
         assertTrue(resultInsertTags.values().stream()
@@ -12154,15 +12154,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteGroupTags(groupCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals("newGroup", groupCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), "newGroup");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().containsAll(expectedTagsToBeRemoved));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertGroupTags(groupCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newGroup", groupCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), "newGroup");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.keySet().containsAll(Arrays.asList("newTagKey", "newTagKey2")));
         assertTrue(resultInsertTags.values().stream()
@@ -12212,15 +12212,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteGroupTags(groupCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals("newGroup", groupCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), "newGroup");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().isEmpty());
 
         // assert tags to add should be empty
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertGroupTags(groupCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals("newGroup", groupCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), "newGroup");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.isEmpty());
 
@@ -12265,8 +12265,8 @@ public class DBServiceTest {
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
 
         Mockito.verify(conn, times(1)).insertGroupTags(groupCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals(groupName, groupCapture.getValue());
-        assertEquals(domainName, domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), groupName);
+        assertEquals(domainCapture.getValue(), domainName);
 
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(0);
         TagValueList tagValues = resultInsertTags.get(updateGroupMetaTag);
@@ -12317,15 +12317,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> domainCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deleteGroupTags(groupCapture.capture(), domainCapture.capture(), tagCapture.capture());
-        assertEquals(groupName, groupCapture.getValue());
-        assertEquals(domainName, domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), groupName);
+        assertEquals(domainCapture.getValue(), domainName);
         assertTrue(tagCapture.getValue().contains(initialTagKey));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(1)).insertGroupTags(groupCapture.capture(), domainCapture.capture(), tagInsertCapture.capture());
-        assertEquals(groupName, groupCapture.getValue());
-        assertEquals(domainName, domainCapture.getValue());
+        assertEquals(groupCapture.getValue(), groupName);
+        assertEquals(domainCapture.getValue(), domainName);
 
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(0);
         TagValueList tagValues = resultInsertTags.get(updateGroupMetaTag);
@@ -12695,7 +12695,7 @@ public class DBServiceTest {
         assertNull(zms.dbService.assertionDomainCheck(":role.value", "athenz:resource.value"));
         assertNull(zms.dbService.assertionDomainCheck("ads:role.value", "athenz:resource.value"));
         assertNull(zms.dbService.assertionDomainCheck("sports:role.value", "athenz:resource.value"));
-        assertEquals("athenz", zms.dbService.assertionDomainCheck("athenz:role.value", "athenz:resource.value"));
+        assertEquals(zms.dbService.assertionDomainCheck("athenz:role.value", "athenz:resource.value"), "athenz");
     }
 
     @Test
@@ -12917,15 +12917,15 @@ public class DBServiceTest {
         ArgumentCaptor<String> versionCapture = ArgumentCaptor.forClass(String.class);
 
         Mockito.verify(conn, times(1)).deletePolicyTags(policyCapture.capture(), domainCapture.capture(), tagCapture.capture(), versionCapture.capture());
-        assertEquals("newPolicy", policyCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(policyCapture.getValue(), "newPolicy");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().containsAll(expectedTagsToBeRemoved));
 
         // assert tags to add
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertPolicyTags(policyCapture.capture(), domainCapture.capture(), tagInsertCapture.capture(), versionCapture.capture());
-        assertEquals("newPolicy", policyCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(policyCapture.getValue(), "newPolicy");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertTrue(resultInsertTags.keySet().containsAll(Arrays.asList("newTagKey", "newTagKey2")));
         assertTrue(resultInsertTags.values().stream()
@@ -12982,15 +12982,15 @@ public class DBServiceTest {
 
 
         Mockito.verify(conn, times(1)).deletePolicyTags(policyCapture.capture(), domainCapture.capture(), tagCapture.capture(), versionCapture.capture());
-        assertEquals("policy", policyCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(policyCapture.getValue(), "policy");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         assertTrue(tagCapture.getValue().contains("tagKey"));
 
         // assert tags to add should be empty
         ArgumentCaptor<Map<String, TagValueList>> tagInsertCapture = ArgumentCaptor.forClass(Map.class);
         Mockito.verify(conn, times(2)).insertPolicyTags(policyCapture.capture(), domainCapture.capture(), tagInsertCapture.capture(), versionCapture.capture());
-        assertEquals("policy", policyCapture.getValue());
-        assertEquals("sys.auth", domainCapture.getValue());
+        assertEquals(policyCapture.getValue(), "policy");
+        assertEquals(domainCapture.getValue(), "sys.auth");
         Map<String, TagValueList> resultInsertTags = tagInsertCapture.getAllValues().get(1);
         assertEquals(resultInsertTags, newPolicyTags);
 
@@ -13209,7 +13209,7 @@ public class DBServiceTest {
         zms.dbService.executePutDomainTemplate(mockDomRsrcCtx, domainName, domainTemplate, auditRef, caller);
 
         DomainTemplateList domainTemplateList = zms.dbService.listDomainTemplates(domainName);
-        assertEquals(1, domainTemplateList.getTemplateNames().size());
+        assertEquals(domainTemplateList.getTemplateNames().size(), 1);
 
         StringBuilder auditDetails = new StringBuilder(ZMSConsts.STRING_BLDR_SIZE_DEFAULT);
         auditDetails.append("{\"templates\": ");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ExceptionMapperTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ExceptionMapperTest.java
@@ -28,18 +28,18 @@ public class ExceptionMapperTest {
 
         JsonGeneralExceptionMapper mapper1 = new JsonGeneralExceptionMapper();
         Response response = mapper1.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
 
         JsonMappingExceptionMapper mapper2 = new JsonMappingExceptionMapper();
         response = mapper2.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
 
         JsonParseExceptionMapper mapper3 = new JsonParseExceptionMapper();
         response = mapper3.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
 
         JsonProcessingExceptionMapper mapper4 = new JsonProcessingExceptionMapper();
         response = mapper4.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalGroupTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/PrincipalGroupTest.java
@@ -55,9 +55,9 @@ public class PrincipalGroupTest {
         prGroup.setDomainName("domain");
         prGroup.setDomainUserAuthorityFilter("authority");
 
-        assertEquals("role", prGroup.getGroupName());
-        assertEquals("domain", prGroup.getDomainName());
-        assertEquals("authority", prGroup.getDomainUserAuthorityFilter());
+        assertEquals(prGroup.getGroupName(), "role");
+        assertEquals(prGroup.getDomainName(), "domain");
+        assertEquals(prGroup.getDomainUserAuthorityFilter(), "authority");
     }
 
     @Test
@@ -89,11 +89,11 @@ public class PrincipalGroupTest {
         zmsImpl.putGroup(ctx, domainName, "group5", auditRef, false, null, group5);
 
         DomainGroupMembers domainGroupMembers = zmsImpl.getDomainGroupMembers(ctx, domainName);
-        assertEquals(domainName, domainGroupMembers.getDomainName());
+        assertEquals(domainGroupMembers.getDomainName(), domainName);
 
         List<DomainGroupMember> members = domainGroupMembers.getMembers();
         assertNotNull(members);
-        assertEquals(4, members.size());
+        assertEquals(members.size(), 4);
         assertTrue(ZMSTestUtils.verifyDomainGroupMember(members, "user.jack", "group1", "group3", "group4"));
         assertTrue(ZMSTestUtils.verifyDomainGroupMember(members, "user.janie", "group1", "group2"));
         assertTrue(ZMSTestUtils.verifyDomainGroupMember(members, "user.jane", "group2", "group3", "group5"));

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceExceptionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceExceptionTest.java
@@ -23,33 +23,33 @@ public class ResourceExceptionTest {
 
     @Test
     public void testCodeToString() {
-        
-        assertEquals("OK", ResourceException.codeToString(200));
-        assertEquals("Created", ResourceException.codeToString(201));
-        assertEquals("Accepted", ResourceException.codeToString(202));
-        assertEquals("No Content", ResourceException.codeToString(204));
-        assertEquals("Moved Permanently", ResourceException.codeToString(301));
-        assertEquals("Found", ResourceException.codeToString(302));
-        assertEquals("See Other", ResourceException.codeToString(303));
-        assertEquals("Not Modified", ResourceException.codeToString(304));
-        assertEquals("Temporary Redirect", ResourceException.codeToString(307));
-        assertEquals("Bad Request", ResourceException.codeToString(400));
-        assertEquals("Unauthorized", ResourceException.codeToString(401));
-        assertEquals("Forbidden", ResourceException.codeToString(403));
-        assertEquals("Not Found", ResourceException.codeToString(404));
-        assertEquals("Conflict", ResourceException.codeToString(409));
-        assertEquals("Gone", ResourceException.codeToString(410));
-        assertEquals("Precondition Failed", ResourceException.codeToString(412));
-        assertEquals("Unsupported Media Type", ResourceException.codeToString(415));
-        assertEquals("Precondition Required", ResourceException.codeToString(428));
-        assertEquals("Too Many Requests", ResourceException.codeToString(429));
-        assertEquals("Request Header Fields Too Large", ResourceException.codeToString(431));
-        assertEquals("Internal Server Error", ResourceException.codeToString(500));
-        assertEquals("Not Implemented", ResourceException.codeToString(501));
-        assertEquals("Service Unavailable", ResourceException.codeToString(503));
-        assertEquals("Gateway Timeout", ResourceException.codeToString(504));
-        assertEquals("Network Authentication Required", ResourceException.codeToString(511));
-        assertEquals("1001", ResourceException.codeToString(1001));
+
+        assertEquals(ResourceException.codeToString(200), "OK");
+        assertEquals(ResourceException.codeToString(201), "Created");
+        assertEquals(ResourceException.codeToString(202), "Accepted");
+        assertEquals(ResourceException.codeToString(204), "No Content");
+        assertEquals(ResourceException.codeToString(301), "Moved Permanently");
+        assertEquals(ResourceException.codeToString(302), "Found");
+        assertEquals(ResourceException.codeToString(303), "See Other");
+        assertEquals(ResourceException.codeToString(304), "Not Modified");
+        assertEquals(ResourceException.codeToString(307), "Temporary Redirect");
+        assertEquals(ResourceException.codeToString(400), "Bad Request");
+        assertEquals(ResourceException.codeToString(401), "Unauthorized");
+        assertEquals(ResourceException.codeToString(403), "Forbidden");
+        assertEquals(ResourceException.codeToString(404), "Not Found");
+        assertEquals(ResourceException.codeToString(409), "Conflict");
+        assertEquals(ResourceException.codeToString(410), "Gone");
+        assertEquals(ResourceException.codeToString(412), "Precondition Failed");
+        assertEquals(ResourceException.codeToString(415), "Unsupported Media Type");
+        assertEquals(ResourceException.codeToString(428), "Precondition Required");
+        assertEquals(ResourceException.codeToString(429), "Too Many Requests");
+        assertEquals(ResourceException.codeToString(431), "Request Header Fields Too Large");
+        assertEquals(ResourceException.codeToString(500), "Internal Server Error");
+        assertEquals(ResourceException.codeToString(501), "Not Implemented");
+        assertEquals(ResourceException.codeToString(503), "Service Unavailable");
+        assertEquals(ResourceException.codeToString(504), "Gateway Timeout");
+        assertEquals(ResourceException.codeToString(511), "Network Authentication Required");
+        assertEquals(ResourceException.codeToString(1001), "1001");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceOwnershipTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ResourceOwnershipTest.java
@@ -245,7 +245,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceDomainOwnership(ctx, domainName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(410, ex.getCode());
+            assertEquals(ex.getCode(), 410);
         }
 
         zmsImpl.dbService.defaultRetryCount = saveRetryCount;
@@ -277,7 +277,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceDomainOwnership(ctx, domainName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("unable to put resource"));
         }
 
@@ -354,7 +354,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceRoleOwnership(ctx, domainName, roleName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(410, ex.getCode());
+            assertEquals(ex.getCode(), 410);
         }
 
         zmsImpl.dbService.defaultRetryCount = saveRetryCount;
@@ -387,7 +387,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceRoleOwnership(ctx, domainName, roleName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("unable to put resource"));
         }
 
@@ -464,7 +464,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceGroupOwnership(ctx, domainName, groupName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(410, ex.getCode());
+            assertEquals(ex.getCode(), 410);
         }
 
         zmsImpl.dbService.defaultRetryCount = saveRetryCount;
@@ -497,7 +497,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceGroupOwnership(ctx, domainName, groupName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("unable to put resource"));
         }
 
@@ -573,7 +573,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourcePolicyOwnership(ctx, domainName, policyName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(410, ex.getCode());
+            assertEquals(ex.getCode(), 410);
         }
 
         zmsImpl.dbService.defaultRetryCount = saveRetryCount;
@@ -606,7 +606,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourcePolicyOwnership(ctx, domainName, policyName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("unable to put resource"));
         }
 
@@ -683,7 +683,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceServiceIdentityOwnership(ctx, domainName, serviceName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("unable to put resource"));
         }
 
@@ -724,7 +724,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putResourceServiceIdentityOwnership(ctx, domainName, serviceName, auditRef, resourceOwnership);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(410, ex.getCode());
+            assertEquals(ex.getCode(), 410);
         }
 
         zmsImpl.dbService.defaultRetryCount = saveRetryCount;
@@ -765,7 +765,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, "TF2", role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // put the same role with the same ownership which should be processed
@@ -838,7 +838,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteRole(ctx, domainName, roleName4, auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with a different ownership should fail
@@ -847,7 +847,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteRole(ctx, domainName, roleName4, auditRef, "TF6");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with the correct ownership should work
@@ -923,7 +923,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putMembership(ctx, domainName, roleName, "user.user2a", auditRef, false, "TF3", mbr2);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to delete existing member with a different ownership
@@ -931,7 +931,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteMembership(ctx, domainName, roleName, "user.user2", auditRef, "TF3");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // now add a member with the same ownership and it should be ok
@@ -982,7 +982,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putMembership(ctx, domainName, roleName2, "user.user2b", auditRef, false, null, mbr3);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to delete a member without any owner and it should be rejected
@@ -991,7 +991,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteMembership(ctx, domainName, roleName2, "user.user2b", auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to add a member with the same ownership and it should work fine
@@ -1056,7 +1056,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, "TF2", roleMeta);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to set meta without any ownership which should be rejected
@@ -1065,7 +1065,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, roleMeta);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // setting the meta owner to the same value should be ok
@@ -1092,7 +1092,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, "", role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // put the same role with the meta owner's value which should be rejected
@@ -1101,7 +1101,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, "TF1", role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // put the same role with the member owner's value which should be rejected as well
@@ -1110,7 +1110,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, "TF2", role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // now update the role with the ignore ownership flag and make sure it's processed
@@ -1186,7 +1186,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, "TF2", group1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // put the same group with the same ownership which should be processed
@@ -1259,7 +1259,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteGroup(ctx, domainName, groupName4, auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with a different ownership should fail
@@ -1268,7 +1268,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteGroup(ctx, domainName, groupName4, auditRef, "TF6");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with the correct ownership should work
@@ -1343,7 +1343,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroupMembership(ctx, domainName, groupName, "user.user2a", auditRef, false, "TF3", mbr2);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to delete existing member with a different ownership
@@ -1351,7 +1351,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteGroupMembership(ctx, domainName, groupName, "user.user2", auditRef, "TF3");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // now add a member with the same ownership and it should be ok
@@ -1402,7 +1402,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroupMembership(ctx, domainName, groupName2, "user.user2b", auditRef, false, null, mbr3);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to delete a member without any owner and it should be rejected
@@ -1411,7 +1411,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteGroupMembership(ctx, domainName, groupName2, "user.user3", auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to add a member with the same ownership and it should work fine
@@ -1476,7 +1476,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, "TF2", groupMeta);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to set meta without any ownership which should be rejected
@@ -1485,7 +1485,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, groupMeta);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // setting the meta owner to the same value should be ok
@@ -1512,7 +1512,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, "", group1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // put the same group with the meta owner's value which should be rejected
@@ -1521,7 +1521,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, "TF1", group1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // put the same group with the member owner's value which should be rejected as well
@@ -1530,7 +1530,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, "TF2", group1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // now update the group with the ignore ownership flag and make sure it's processed
@@ -1648,7 +1648,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteUserDomain(ctx1, "john-doe", auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the domain with the wrong ownership should fail
@@ -1657,7 +1657,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteUserDomain(ctx1, "john-doe", auditRef, "TF2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the domain with the correct ownership should work
@@ -1672,7 +1672,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteSubDomain(ctx, domainName2, "sub2", auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the subdomain with the wrong ownership should fail
@@ -1681,7 +1681,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteSubDomain(ctx, domainName2, "sub2", auditRef, "TF3");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the subdomain with the ignore ownership should work
@@ -1694,7 +1694,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteTopLevelDomain(ctx, domainName2, auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the top level domain with the wrong ownership should fail
@@ -1703,7 +1703,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteTopLevelDomain(ctx, domainName2, auditRef, "TF2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the top level domain with the correct ownership should work
@@ -1756,7 +1756,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putDomainMeta(ctx, domainName, auditRef, null, domainMeta);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to update meta with a new ownership which should be rejected
@@ -1765,7 +1765,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putDomainMeta(ctx, domainName, auditRef, "TF2", domainMeta);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // try to update with the same ownership value which should be oik
@@ -1849,7 +1849,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putPolicy(ctx, domainName, policyName2, auditRef, false, null, policy2);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the policy with a different ownership which should be rejected
@@ -1858,7 +1858,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putPolicy(ctx, domainName, policyName2, auditRef, false, "TF2", policy2);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the policy with the same ownership which should be processed
@@ -1937,7 +1937,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putPolicy(ctx, domainName, policyName4, auditRef, false, "TF4", policy4);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object without any ownership should fail
@@ -1946,7 +1946,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deletePolicy(ctx, domainName, policyName3, auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with a different ownership should fail
@@ -1955,7 +1955,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deletePolicy(ctx, domainName, policyName3, auditRef, "TF3");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with the correct ownership should work
@@ -2015,7 +2015,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putAssertion(ctx, domainName, policyName, auditRef, "TF2", assertion);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // delete the assertion with different ownership and it should be rejected
@@ -2024,7 +2024,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteAssertion(ctx, domainName, policyName, assertion1.getId(), auditRef, "TF2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // delete the assertion with null ownership and it should be rejected
@@ -2033,7 +2033,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteAssertion(ctx, domainName, policyName, assertion1.getId(), auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // delete the assertion with same ownership and it should be ok
@@ -2057,7 +2057,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putAssertion(ctx, domainName, policyName, auditRef, null, assertion);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // apply the assertion with the ignore ownership flag which should be ok
@@ -2147,7 +2147,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putServiceIdentity(ctx, domainName, serviceName, auditRef, false, null, service1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the service with a different ownership which should be rejected
@@ -2156,7 +2156,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putServiceIdentity(ctx, domainName, serviceName, auditRef, false, "TF2", service1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the service with the same ownership which should be processed
@@ -2206,7 +2206,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putServiceIdentity(ctx, domainName, serviceName, auditRef, false, "TF3", service1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the object and make sure all ownership fields are set
@@ -2229,7 +2229,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putServiceIdentity(ctx, domainName, serviceName, auditRef, false, "TF5", service1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the object and make sure all ownership fields are set
@@ -2252,7 +2252,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putServiceIdentity(ctx, domainName, serviceName, auditRef, false, "TF7", service1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // update the object and make sure all ownership fields are set
@@ -2295,7 +2295,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteServiceIdentity(ctx, domainName, serviceName2, auditRef, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with a different ownership should fail
@@ -2304,7 +2304,7 @@ public class ResourceOwnershipTest {
             zmsImpl.deleteServiceIdentity(ctx, domainName, serviceName2, auditRef, "TF6");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // deleting the object with the correct ownership should work
@@ -2368,7 +2368,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putPublicKeyEntry(ctx, domainName, serviceName, "key3", auditRef, null, publicKey);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // add the same public key with a different ownership value which should be rejected
@@ -2377,7 +2377,7 @@ public class ResourceOwnershipTest {
             zmsImpl.putPublicKeyEntry(ctx, domainName, serviceName, "key3", auditRef, "TF2", publicKey);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.CONFLICT, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.CONFLICT);
         }
 
         // add the same public key with the ignore option which should be ok

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
@@ -107,7 +107,7 @@ public class RsrcCtxWrapperTest {
         try {
             wrapper.authenticate();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -245,7 +245,7 @@ public class RsrcCtxWrapperTest {
             wrapper.throwZmsException(restExc);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(503, ex.getCode());
+            assertEquals(ex.getCode(), 503);
         }
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSDeleteDomainTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSDeleteDomainTest.java
@@ -507,7 +507,7 @@ public class ZMSDeleteDomainTest {
             zmsImpl.deleteTopLevelDomain(ctx, "DelTopChildDom1", auditRef, null);
             fail("requesterror not thrown.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteSubDomain(ctx, "DelTopChildDom1", "DelSubDom2", auditRef, null);
@@ -559,7 +559,7 @@ public class ZMSDeleteDomainTest {
             fail("requesterror not thrown by deleteTopLevelDomain.");
         } catch (ResourceException ex) {
             System.out.println("*** " + ex.getMessage());
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, "TopDomainAuditRequired", auditRef, null);
@@ -664,7 +664,7 @@ public class ZMSDeleteDomainTest {
         try {
             zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1", "DelSubDom2", auditRef, null);
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteSubDomain(ctx, "DelSubChildDom1.DelSubDom2", "DelSubDom3", auditRef, null);
@@ -725,7 +725,7 @@ public class ZMSDeleteDomainTest {
             zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain2", "ExistantSubDom2", null, null);
             fail("requesterror not thrown by deleteSubDomain.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteSubDomain(ctx, "ExistantTopDomain2", "ExistantSubDom2", auditRef, null);
@@ -776,7 +776,7 @@ public class ZMSDeleteDomainTest {
             zmsImpl.deleteDomainRoleMember(ctx, "invalid-domain", "user.joe", auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -813,11 +813,11 @@ public class ZMSDeleteDomainTest {
         zmsImpl.putRole(ctx, domainName, "role5", auditRef, false, null, role5);
 
         DomainRoleMembers domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
+        assertEquals(domainRoleMembers.getDomainName(), domainName);
 
         List<DomainRoleMember> members = domainRoleMembers.getMembers();
         assertNotNull(members);
-        assertEquals(5, members.size());
+        assertEquals(members.size(), 5);
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
@@ -835,7 +835,7 @@ public class ZMSDeleteDomainTest {
 
         members = domainRoleMembers.getMembers();
         assertNotNull(members);
-        assertEquals(5, members.size());
+        assertEquals(members.size(), 5);
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jack", "role1", "role3", "role4");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
@@ -847,11 +847,11 @@ public class ZMSDeleteDomainTest {
         zmsImpl.deleteDomainRoleMember(ctx, domainName, "user.jack", auditRef);
 
         domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
+        assertEquals(domainRoleMembers.getDomainName(), domainName);
 
         members = domainRoleMembers.getMembers();
         assertNotNull(members);
-        assertEquals(4, members.size());
+        assertEquals(members.size(), 4);
         ZMSTestUtils.verifyDomainRoleMember(members, "user.janie", "role1", "role2");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jane", "role2", "role3", "role5");
         ZMSTestUtils.verifyDomainRoleMember(members, "user.jack-service", "role5");
@@ -877,7 +877,7 @@ public class ZMSDeleteDomainTest {
         zmsImpl.putRole(ctx, domainName, "admin", auditRef, false, null, adminRole);
 
         DomainRoleMembers domainRoleMembers = zmsImpl.getDomainRoleMembers(ctx, domainName);
-        assertEquals(domainName, domainRoleMembers.getDomainName());
+        assertEquals(domainRoleMembers.getDomainName(), domainName);
 
         List<DomainRoleMember> members = domainRoleMembers.getMembers();
         assertNotNull(members);
@@ -1128,7 +1128,7 @@ public class ZMSDeleteDomainTest {
             zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
             fail("request-error not thrown.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Domain has non-empty account attribute"));
         }
 
@@ -1141,7 +1141,7 @@ public class ZMSDeleteDomainTest {
             zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
             fail("request-error not thrown.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Domain has non-empty gcp-project attribute"));
         }
 
@@ -1155,7 +1155,7 @@ public class ZMSDeleteDomainTest {
             zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
             fail("request-error not thrown.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Domain has non-empty azure-subscription attribute"));
         }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -843,7 +843,7 @@ public class ZMSImplTest {
 
         DomainList domList = zmsImpl.getDomainList(ctx, 1, null, null,
                 null, null, null, null, null, null, null, null, null, null, null, null);
-        assertEquals(1, domList.getNames().size());
+        assertEquals(domList.getNames().size(), 1);
 
         zmsImpl.deleteTopLevelDomain(ctx, "LimitDom1", auditRef, null);
         zmsImpl.deleteTopLevelDomain(ctx, "LimitDom2", auditRef, null);
@@ -1120,7 +1120,7 @@ public class ZMSImplTest {
         try {
             zmsImpl.postUserDomain(ctx, "john-doe2", auditRef, null, dom1);
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -1330,7 +1330,7 @@ public class ZMSImplTest {
         try {
             zmsImpl.postSubDomain(ctx, "AddSubMismatchParentDom2", auditRef, null, dom2);
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "AddSubMismatchParentDom1", auditRef, null);
@@ -1819,7 +1819,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, domain, "Role1", null, false, null, role);
             fail("requesterror not thrown by putRole.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -1844,7 +1844,7 @@ public class ZMSImplTest {
                     "CreateMismatchRoleDom1.Role1", auditRef, false, null, role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "CreateMismatchRoleDom1", auditRef, null);
@@ -1868,7 +1868,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, "CreateRoleInvalidNameDom1", "Role111", auditRef, false, null, role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx,"CreateRoleInvalidNameDom1", auditRef, null);
@@ -1891,7 +1891,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, "CreateRoleInvalidStructDom1", "Role1", auditRef, false, null, role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx,"CreateRoleInvalidStructDom1", auditRef, null);
@@ -1914,7 +1914,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, domainName, "Role1", auditRef, false, null, role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         Role role2 = zmsTestInitializer.createRoleObject(domainName, "Role2", null, "joe", "user.jane");
@@ -1923,7 +1923,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, domainName, "Role2", auditRef, false, null, role2);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // invalid group member
@@ -1934,7 +1934,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, domainName, "Role3", auditRef, false, null, role3);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -1959,7 +1959,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, domainName, "Role1", auditRef, false, null, role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -1984,7 +1984,7 @@ public class ZMSImplTest {
             zmsImpl.putRole(ctx, domainName, "Role1", auditRef, false, null, role1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -2013,7 +2013,7 @@ public class ZMSImplTest {
         List<RoleMember> members = role.getRoleMembers();
         assertNotNull(members);
         assertEquals(members.size(), 1);
-        assertEquals("user.joe", members.get(0).getMemberName());
+        assertEquals(members.get(0).getMemberName(), "user.joe");
 
         zmsImpl.deleteTopLevelDomain(ctx,"CreateDuplicateMemberRoleDom1", auditRef, null);
     }
@@ -2296,7 +2296,7 @@ public class ZMSImplTest {
             zmsImpl.deleteRole(ctx, domain, "Role1", null, null);
             fail("requesterror not thrown by deleteRole.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -2368,7 +2368,7 @@ public class ZMSImplTest {
             zmsImpl.deleteRole(ctx, domain, role, auditRef, null);
             fail("should be fail");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("it cannot be deleted"));
         }
 
@@ -2400,7 +2400,7 @@ public class ZMSImplTest {
             zmsImpl.validateRoleNotAssociatedToPolicy(policies, relatedRole, domainName, caller);
             fail("should be fail");
         } catch (ResourceException ex){
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("it cannot be deleted"));
         }
 
@@ -2480,7 +2480,7 @@ public class ZMSImplTest {
         zmsImpl.putRole(ctx, "test-domain1", "Role1", auditRef, false, null, role1);
 
         DomainRoleMembers responseMembers = zmsImpl.getOverdueReview(ctx, "test-domain1");
-        assertEquals("test-domain1", responseMembers.getDomainName());
+        assertEquals(responseMembers.getDomainName(), "test-domain1");
         List<DomainRoleMember> responseRoleMemberList = responseMembers.getMembers();
         assertEquals(responseRoleMemberList.size(), 2);
         assertEquals(responseRoleMemberList.get(0).getMemberName(), "user.overduereview1");
@@ -2864,7 +2864,7 @@ public class ZMSImplTest {
         assertNotNull(members);
         assertEquals(members.size(), 1);
 
-        assertEquals("user.doe", members.get(0).getMemberName());
+        assertEquals(members.get(0).getMemberName(), "user.doe");
 
         zmsImpl.deleteTopLevelDomain(ctx,"MbrAddDom1EmptyRole", auditRef, null);
     }
@@ -2908,7 +2908,7 @@ public class ZMSImplTest {
         assertNotNull(members);
         assertEquals(members.size(), 1);
 
-        assertEquals(domainName + ":group.dev-team", members.get(0).getMemberName());
+        assertEquals(members.get(0).getMemberName(), domainName + ":group.dev-team");
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }
@@ -2936,7 +2936,7 @@ public class ZMSImplTest {
             zmsImpl.putMembership(ctx, domain, "Role1", "user.john", null, false, null, mbr);
             fail("requesterror not thrown by putMembership.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -3467,7 +3467,7 @@ public class ZMSImplTest {
             zmsImpl.deleteMembership(ctx, domainName, "Role1", "user.joe", null, null);
             fail("requesterror not thrown by deleteMembership.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         }
 
@@ -4911,7 +4911,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, domain, "Policy1", null, false, null, policy);
             fail("requesterror not thrown by putPolicy.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -5154,7 +5154,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, domain, "admin", auditRef, false, null, policy);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("admin policy cannot be modified"), ex.getMessage());
         }
         zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -5180,7 +5180,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, "testCreatePolicyNoAssertions", "Policy1", auditRef, false, null, policy1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "testCreatePolicyNoAssertions", auditRef, null);
@@ -5219,7 +5219,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, domainName, policyName, auditRef, false, null, policy);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with invalid domain name
@@ -5238,7 +5238,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, domainName, policyName, auditRef, false, null, policy);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -5264,7 +5264,7 @@ public class ZMSImplTest {
                     "PolicyAddMismatchNameDom1.Policy1", auditRef, false, null, policy1);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "PolicyAddMismatchNameDom1", auditRef, null);
@@ -5289,7 +5289,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, "PolicyAddInvalidNameDom1", "Policy1", auditRef, false, null, policy);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "PolicyAddInvalidNameDom1", auditRef, null);
@@ -5313,7 +5313,7 @@ public class ZMSImplTest {
             zmsImpl.putPolicy(ctx, "PolicyAddInvalidStructDom1", "Policy1", auditRef, false, null, policy);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "PolicyAddInvalidStructDom1", auditRef, null);
@@ -5633,7 +5633,7 @@ public class ZMSImplTest {
             zmsImpl.putServiceIdentity(ctx, "ServiceAddDom1NotSimpleName", "Service1.Test", auditRef, false, null, service);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceAddDom1NotSimpleName", auditRef, null);
@@ -5659,7 +5659,7 @@ public class ZMSImplTest {
             zmsImpl.putServiceIdentity(ctx, domain, "Service1", null, false, null, service);
             fail("requesterror not thrown by putServiceIdentity.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -5686,7 +5686,7 @@ public class ZMSImplTest {
                     "ServiceAddMismatchNameDom1.Service1", auditRef, false, null, service);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceAddMismatchNameDom1", auditRef, null);
@@ -5710,7 +5710,7 @@ public class ZMSImplTest {
             zmsImpl.putServiceIdentity(ctx, "ServiceAddInvalidNameDom1", "Service1", auditRef, false, null, service);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceAddInvalidNameDom1", auditRef, null);
@@ -5737,7 +5737,7 @@ public class ZMSImplTest {
             zmsImpl.putServiceIdentity(ctx, "ServiceAddInvalidCertDom1", "Service1", auditRef, false, null, service);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceAddInvalidCertDom1", auditRef, null);
@@ -5760,7 +5760,7 @@ public class ZMSImplTest {
             zmsImpl.putServiceIdentity(ctx, "ServiceAddInvalidStructDom1", "Service1", auditRef, false, null, service);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceAddInvalidStructDom1", auditRef, null);
@@ -5962,7 +5962,7 @@ public class ZMSImplTest {
             zmsImpl.getServiceIdentity(ctx, "ServiceGetDom1", "Service2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // this should throw a request error exception
@@ -5970,7 +5970,7 @@ public class ZMSImplTest {
             zmsImpl.getServiceIdentity(ctx, "ServiceGetDom1", "Service2.Service3");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceGetDom1", auditRef, null);
@@ -6123,7 +6123,7 @@ public class ZMSImplTest {
             zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1", "Service1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         serviceRes2 = zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1", "Service2");
@@ -6136,7 +6136,7 @@ public class ZMSImplTest {
             zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1", "Service1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // this should throw a not found exception
@@ -6144,7 +6144,7 @@ public class ZMSImplTest {
             zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1", "Service2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // this should throw an invalid exception
@@ -6152,7 +6152,7 @@ public class ZMSImplTest {
             zmsImpl.getServiceIdentity(ctx, "ServiceDelDom1", "Service2.Service3");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "ServiceDelDom1", auditRef, null);
@@ -6183,7 +6183,7 @@ public class ZMSImplTest {
             zmsImpl.deleteServiceIdentity(ctx, domain, "Service1", null, null);
             fail("requesterror not thrown by deleteServiceIdentity.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -6367,14 +6367,14 @@ public class ZMSImplTest {
 
         EntityList entityList = zmsImpl.getEntityList(ctx, domainName);
         assertNotNull(entityList);
-        assertEquals(0, entityList.getNames().size());
+        assertEquals(entityList.getNames().size(), 0);
 
         Entity entity1 = zmsTestInitializer.createEntityObject(domainName, "Entity1");
         zmsImpl.putEntity(ctx, domainName, "Entity1", auditRef, entity1);
 
         entityList = zmsImpl.getEntityList(ctx, domainName);
         assertNotNull(entityList);
-        assertEquals(1, entityList.getNames().size());
+        assertEquals(entityList.getNames().size(), 1);
         assertTrue(entityList.getNames().contains("entity1"));
 
         Entity entity2 = zmsTestInitializer.createEntityObject(domainName, "Entity2");
@@ -6382,7 +6382,7 @@ public class ZMSImplTest {
 
         entityList = zmsImpl.getEntityList(ctx, domainName);
         assertNotNull(entityList);
-        assertEquals(2, entityList.getNames().size());
+        assertEquals(entityList.getNames().size(), 2);
         assertTrue(entityList.getNames().contains("entity1"));
         assertTrue(entityList.getNames().contains("entity2"));
 
@@ -6390,14 +6390,14 @@ public class ZMSImplTest {
 
         entityList = zmsImpl.getEntityList(ctx, domainName);
         assertNotNull(entityList);
-        assertEquals(1, entityList.getNames().size());
+        assertEquals(entityList.getNames().size(), 1);
         assertTrue(entityList.getNames().contains("entity2"));
 
         zmsImpl.deleteEntity(ctx, domainName, "entity2", auditRef);
 
         entityList = zmsImpl.getEntityList(ctx, domainName);
         assertNotNull(entityList);
-        assertEquals(0, entityList.getNames().size());
+        assertEquals(entityList.getNames().size(), 0);
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }
@@ -6419,7 +6419,7 @@ public class ZMSImplTest {
             zmsImpl.putEntity(ctx, domainName, "Entity1", null, entity);
             fail("requesterror not thrown by putEntity.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -6502,7 +6502,7 @@ public class ZMSImplTest {
             zmsImpl.deleteEntity(ctx, domainName, "Entity1", null);
             fail("requesterror not thrown by deleteEntity.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -6999,7 +6999,7 @@ public class ZMSImplTest {
         assertEquals(serviceName.toLowerCase(), tRoles.getService());
         assertEquals(tenantDomain.toLowerCase(), tRoles.getTenant());
         assertEquals(resourceGroup.toLowerCase(), tRoles.getResourceGroup());
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
     }
@@ -7119,7 +7119,7 @@ public class ZMSImplTest {
             zmsImpl.putDefaultAdmins(ctx, domain, null, admins);
             fail("requesterror not thrown by putDefaultAdmins.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -7478,10 +7478,10 @@ public class ZMSImplTest {
             String publicKey = zmsImpl.getPublicKey("sys.auth", "zms", keyId);
             DomainData domainData = sDomain.getDomain();
             if (domainData.getName().equals("signeddom1")) {
-                assertEquals("12345", domainData.getAccount());
+                assertEquals(domainData.getAccount(), "12345");
                 dom1Found = true;
             } else if (domainData.getName().equals("signeddom2")) {
-                assertEquals("12346", domainData.getAccount());
+                assertEquals(domainData.getAccount(), "12346");
                 dom2Found = true;
             }
             assertTrue(Crypto.verify(SignUtils.asCanonicalString(sDomain.getDomain()),
@@ -7610,7 +7610,7 @@ public class ZMSImplTest {
         sdoms = (SignedDomains) response.getEntity();
         String eTag2 = response.getHeaderString("ETag");
         assertNotNull(eTag2);
-        assertNotEquals(eTag, eTag2);
+        assertNotEquals(eTag2, eTag);
         list = sdoms.getDomains();
         assertNotNull(list);
         assertEquals(list.size(), numDoms);
@@ -7627,10 +7627,10 @@ public class ZMSImplTest {
         assertNotEquals(eTag, eTag2);
         list = sdoms.getDomains();
         assertNotNull(list);
-        assertEquals(1, list.size());
+        assertEquals(list.size(), 1);
 
         response = zmsImpl.getSignedDomains(rsrcCtx, null, null, null, Boolean.TRUE, false, eTag);
-        assertEquals(304, response.getStatus());
+        assertEquals(response.getStatus(), 304);
         eTag2 = response.getHeaderString("ETag");
 
         assertNotNull(eTag2);
@@ -7708,14 +7708,14 @@ public class ZMSImplTest {
         assertNotNull(sdoms);
         List<SignedDomain> list = sdoms.getDomains();
         assertNotNull(list);
-        assertEquals(1, list.size());
+        assertEquals(list.size(), 1);
 
         SignedDomain sDomain = list.get(0);
         String signature = sDomain.getSignature();
         String keyId = sDomain.getKeyId();
         String publicKey = zmsImpl.getPublicKey("sys.auth", "zms", keyId);
         assertTrue(Crypto.verify(SignUtils.asCanonicalString(sDomain.getDomain()), Crypto.loadPublicKey(publicKey), signature));
-        assertEquals("signeddom1filtered", sDomain.getDomain().getName());
+        assertEquals(sDomain.getDomain().getName(), "signeddom1filtered");
 
         // use domain=signeddom1filtered and metaonly=true
         //
@@ -7726,7 +7726,7 @@ public class ZMSImplTest {
         assertNotNull(sdoms);
         list = sdoms.getDomains();
         assertNotNull(list);
-        assertEquals(1, list.size());
+        assertEquals(list.size(), 1);
 
         sDomain = list.get(0);
         signature = sDomain.getSignature();
@@ -7734,7 +7734,7 @@ public class ZMSImplTest {
         keyId = sDomain.getKeyId();
         assertTrue(keyId == null || keyId.isEmpty());
         DomainData ddata = sDomain.getDomain();
-        assertEquals("signeddom1filtered", ddata.getName());
+        assertEquals(ddata.getName(), "signeddom1filtered");
         assertNotNull(ddata.getModified());
         assertNull(ddata.getPolicies());
         assertNull(ddata.getRoles());
@@ -7750,14 +7750,14 @@ public class ZMSImplTest {
         assertNotNull(sdoms);
         list = sdoms.getDomains();
         assertNotNull(list);
-        assertEquals(1, list.size());
+        assertEquals(list.size(), 1);
 
         sDomain = list.get(0);
         signature = sDomain.getSignature();
         keyId = sDomain.getKeyId();
         publicKey = zmsImpl.getPublicKey("sys.auth", "zms", keyId);
         assertTrue(Crypto.verify(SignUtils.asCanonicalString(sDomain.getDomain()), Crypto.loadPublicKey(publicKey), signature));
-        assertEquals("signeddom1filtered", sDomain.getDomain().getName());
+        assertEquals(sDomain.getDomain().getName(), "signeddom1filtered");
 
         zmsImpl.deleteTopLevelDomain(ctx, "signeddom1filtered", auditRef, null);
         zmsImpl.deleteTopLevelDomain(ctx, "signeddom2filtered", auditRef, null);
@@ -7979,7 +7979,7 @@ public class ZMSImplTest {
         try {
             zmsImpl.access("READ", "AccessDom1:resource5", principal1, "AccessDom1");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "AccessDom1", auditRef, null);
@@ -8189,7 +8189,7 @@ public class ZMSImplTest {
         try {
             zmsImpl.access("READ", "AccessDom1:resource5", principal1, "AccessDom1");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "AccessDom1", auditRef, null);
@@ -8536,7 +8536,7 @@ public class ZMSImplTest {
         try {
             zmsImpl.access("READ", "AccessDom1:resource5", principal1, "AccessDom1");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, "AccessDom1", auditRef, null);
@@ -8780,21 +8780,21 @@ public class ZMSImplTest {
             zmsTest.getAccess(rsrcCtxJohn, "READ", "user.jane:Resource1", null, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsTest.getAccess(rsrcCtxJohn, "WRITE", "user.jane:Resource1", null, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsTest.getAccess(rsrcCtxJohn, "UPDATE", "user.jane:Resource1", null, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         System.clearProperty(ZMSConsts.ZMS_PROP_VIRTUAL_DOMAIN);
@@ -8816,21 +8816,21 @@ public class ZMSImplTest {
             zmsTest.getAccess(rsrcCtxJane, "READ", "user.jane:Resource1", null, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsTest.getAccess(rsrcCtxJane, "WRITE", "user.jane:Resource1", null, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsTest.getAccess(rsrcCtxJane, "UPDATE", "user.jane:Resource1", null, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         System.clearProperty(ZMSConsts.ZMS_PROP_VIRTUAL_DOMAIN);
@@ -10030,13 +10030,13 @@ public class ZMSImplTest {
         assertNotNull(policy);
 
         List<Assertion> assertList = policy.getAssertions();
-        assertEquals(3, assertList.size());
+        assertEquals(assertList.size(), 3);
 
         boolean domainAdminRoleCheck = false;
         boolean tenantAdminRoleCheck = false;
         boolean tenantUpdateCheck = false;
         for (Assertion obj : assertList) {
-            assertEquals(AssertionEffect.ALLOW, obj.getEffect());
+            assertEquals(obj.getEffect(), AssertionEffect.ALLOW);
             switch (obj.getRole()) {
                 case "addtenancydom1:role.admin":
                     assertEquals(obj.getAction(), "assume_role");
@@ -10321,19 +10321,19 @@ public class ZMSImplTest {
         String tenantRoleInProviderDomain = providerService + ".tenant." + tenantDomain + ".admin";
 
         List<Assertion> assertList = policy.getAssertions();
-        assertEquals(3, assertList.size());
+        assertEquals(assertList.size(), 3);
         boolean domainAdminRoleCheck = false;
         boolean tenantAdminRoleCheck = false;
         boolean tenantUpdateCheck = false;
         for (Assertion obj : assertList) {
-            assertEquals(AssertionEffect.ALLOW, obj.getEffect());
+            assertEquals(obj.getEffect(), AssertionEffect.ALLOW);
             if (obj.getRole().equals(tenantDomain + ":role.admin")) {
-                assertEquals("assume_role", obj.getAction());
-                assertEquals("coretech:role.storage.tenant.puttenancyauthorizedservice.admin", obj.getResource());
+                assertEquals(obj.getAction(), "assume_role");
+                assertEquals(obj.getResource(), "coretech:role.storage.tenant.puttenancyauthorizedservice.admin");
                 domainAdminRoleCheck = true;
             } else if (obj.getRole().equals(tenantDomain + ":role.tenancy." + provider + ".admin")) {
                 if (obj.getAction().equals("assume_role")) {
-                    assertEquals("coretech:role.storage.tenant.puttenancyauthorizedservice.admin", obj.getResource());
+                    assertEquals(obj.getResource(), "coretech:role.storage.tenant.puttenancyauthorizedservice.admin");
                     tenantAdminRoleCheck = true;
                 } else if (obj.getAction().equals("update")) {
                     assertEquals(tenantDomain + ":tenancy." + provider, obj.getResource());
@@ -10394,7 +10394,7 @@ public class ZMSImplTest {
             zmsImpl.putTenancy(rsrcCtx, tenantDomain, provider, auditRef, tenant);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // clean up our domains
@@ -10422,21 +10422,21 @@ public class ZMSImplTest {
             zmsImpl.getRole(ctx, "AddTenancyDom1", "coretech.storage.admin", false, false, false);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsImpl.getRole(ctx, "AddTenancyDom1", "coretech.storage.reader", false, false, false);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsImpl.getRole(ctx, "AddTenancyDom1", "coretech.storage.writer", false, false, false);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         // verify the admin policy has been successfully created
@@ -10450,14 +10450,14 @@ public class ZMSImplTest {
             zmsImpl.getPolicy(ctx, "AddTenancyDom1", "tenancy.coretech.storage.reader");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         try {
             zmsImpl.getPolicy(ctx, "AddTenancyDom1", "tenancy.coretech.storage.writer");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         zmsImpl.deleteTenancy(ctx, "AddTenancyDom1", "coretech.storage", auditRef);
@@ -10515,7 +10515,7 @@ public class ZMSImplTest {
             zmsImpl.putTenancy(ctx, tenantDomain, providerDomain + "." + providerService, null, tenant);
             fail("requesterror not thrown by putTenancy.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
@@ -10544,7 +10544,7 @@ public class ZMSImplTest {
             zmsImpl.putTenancy(ctx, tenantDomain, providerDomain + "." + providerService, auditRef, tenant);
             fail("request error not thrown by putTenancy.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
             zmsImpl.deleteTopLevelDomain(ctx, providerDomain, auditRef, null);
@@ -10674,7 +10674,7 @@ public class ZMSImplTest {
             zmsImpl.deleteTenancy(ctx, tenantDomain, provService, auditRef);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
             assertTrue(ex.getMessage().contains("Unable to retrieve service"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
@@ -10715,7 +10715,7 @@ public class ZMSImplTest {
             zmsImpl.deleteTenancy(ctx, tenantDomain,  providerDomain + "." + providerService, null);
             fail("requesterror not thrown by deleteTenancy.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
@@ -10869,8 +10869,8 @@ public class ZMSImplTest {
         // test valid setup domain
         DomainDataCheck ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(3, ddc.getPolicyCount());
-        assertEquals(3, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 3);
+        assertEquals(ddc.getAssertionCount(), 3);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
@@ -10891,8 +10891,8 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(3, ddc.getPolicyCount());
-        assertEquals(4, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 3);
+        assertEquals(ddc.getAssertionCount(), 4);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
@@ -10920,10 +10920,10 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(3, ddc.getPolicyCount());
-        assertEquals(5, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 3);
+        assertEquals(ddc.getAssertionCount(), 5);
         assertNull(ddc.getDanglingRoles());
-        assertEquals(1, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getDanglingPolicies().size(), 1);
         assertNull(ddc.getProvidersWithoutTrust());
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
@@ -10933,10 +10933,10 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(3, ddc.getPolicyCount());
-        assertEquals(5, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(1, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 3);
+        assertEquals(ddc.getAssertionCount(), 5);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 1);
         assertNull(ddc.getProvidersWithoutTrust());
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
@@ -10963,10 +10963,10 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(3, ddc.getPolicyCount());
-        assertEquals(6, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 3);
+        assertEquals(ddc.getAssertionCount(), 6);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
         assertNull(ddc.getProvidersWithoutTrust());
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
@@ -10997,10 +10997,10 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(4, ddc.getPolicyCount());
-        assertEquals(9, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 4);
+        assertEquals(ddc.getAssertionCount(), 9);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
         assertTrue(ddc.getDanglingRoles().contains("role3"));
         boolean danglingPolicy1Found = false;
         boolean danglingPolicy2Found = false;
@@ -11013,7 +11013,7 @@ public class ZMSImplTest {
         }
         assertTrue(danglingPolicy1Found);
         assertTrue(danglingPolicy2Found);
-        assertEquals(1, ddc.getProvidersWithoutTrust().size());
+        assertEquals(ddc.getProvidersWithoutTrust().size(), 1);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         // test that now all is hunky-dory between the tenant and provider.
@@ -11032,16 +11032,16 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(4, ddc.getPolicyCount());
-        assertEquals(9, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 4);
+        assertEquals(ddc.getAssertionCount(), 9);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         ddc = zmsImpl.getDomainDataCheck(ctx, provDomainSub);
         assertNotNull(ddc);
-        assertEquals(5, ddc.getPolicyCount());
-        assertEquals(5, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 5);
+        assertEquals(ddc.getAssertionCount(), 5);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
@@ -11053,19 +11053,19 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, provDomainSub);
         assertNotNull(ddc);
-        assertEquals(5, ddc.getPolicyCount());
-        assertEquals(5, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 5);
+        assertEquals(ddc.getAssertionCount(), 5);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
-        assertEquals(1, ddc.getTenantsWithoutAssumeRole().size());
+        assertEquals(ddc.getTenantsWithoutAssumeRole().size(), 1);
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(3, ddc.getPolicyCount());
-        assertEquals(6, ddc.getAssertionCount());
-        assertEquals(2, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 3);
+        assertEquals(ddc.getAssertionCount(), 6);
+        assertEquals(ddc.getDanglingRoles().size(), 2);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
         assertNull(ddc.getProvidersWithoutTrust());
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
@@ -11089,12 +11089,12 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, provDomainTop);
         assertNotNull(ddc);
-        assertEquals(5, ddc.getPolicyCount());
-        assertEquals(5, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 5);
+        assertEquals(ddc.getAssertionCount(), 5);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
-        assertEquals(1, ddc.getTenantsWithoutAssumeRole().size());
+        assertEquals(ddc.getTenantsWithoutAssumeRole().size(), 1);
 
         // now set up the tenant for the subdomain provider
         ProviderResourceGroupRoles providerRoles = new ProviderResourceGroupRoles()
@@ -11110,11 +11110,11 @@ public class ZMSImplTest {
         // for the resource group: testgetdomaindatacheckprovider.sub.storage.ravers
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc, ddc.toString());
-        assertEquals(7, ddc.getPolicyCount());
-        assertEquals(12, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
-        assertEquals(1, ddc.getProvidersWithoutTrust().size());
+        assertEquals(ddc.getPolicyCount(), 7);
+        assertEquals(ddc.getAssertionCount(), 12);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
+        assertEquals(ddc.getProvidersWithoutTrust().size(), 1);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         // setup tenancy in the tenant domain for the provider subdomain
@@ -11123,8 +11123,8 @@ public class ZMSImplTest {
         // the subdomain provider believes it is in sync with tenant
         ddc = zmsImpl.getDomainDataCheck(ctx, provDomainSub);
         assertNotNull(ddc);
-        assertEquals(5, ddc.getPolicyCount());
-        assertEquals(5, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 5);
+        assertEquals(ddc.getAssertionCount(), 5);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
@@ -11133,11 +11133,11 @@ public class ZMSImplTest {
         // but the tenant sees the sub provider is not setup
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(7, ddc.getPolicyCount());
-        assertEquals(12, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
-        assertEquals(1, ddc.getProvidersWithoutTrust().size());
+        assertEquals(ddc.getPolicyCount(), 7);
+        assertEquals(ddc.getAssertionCount(), 12);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
+        assertEquals(ddc.getProvidersWithoutTrust().size(), 1);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         // now set up the subdomain provider for the tenant with resource groups
@@ -11154,10 +11154,10 @@ public class ZMSImplTest {
         // now tenant sees the subdomain has provisioned it
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(7, ddc.getPolicyCount());
-        assertEquals(12, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 7);
+        assertEquals(ddc.getAssertionCount(), 12);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
         assertNull(ddc.getProvidersWithoutTrust());
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
@@ -11173,10 +11173,10 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(11, ddc.getPolicyCount());
-        assertEquals(18, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
+        assertEquals(ddc.getPolicyCount(), 11);
+        assertEquals(ddc.getAssertionCount(), 18);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
         assertNull(ddc.getProvidersWithoutTrust());
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
@@ -11188,11 +11188,11 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(11, ddc.getPolicyCount());
-        assertEquals(18, ddc.getAssertionCount());
-        assertEquals(1, ddc.getDanglingRoles().size());
-        assertEquals(2, ddc.getDanglingPolicies().size());
-        assertEquals(1, ddc.getProvidersWithoutTrust().size());
+        assertEquals(ddc.getPolicyCount(), 11);
+        assertEquals(ddc.getAssertionCount(), 18);
+        assertEquals(ddc.getDanglingRoles().size(), 1);
+        assertEquals(ddc.getDanglingPolicies().size(), 2);
+        assertEquals(ddc.getProvidersWithoutTrust().size(), 1);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         // delete the dangling policies and dangling role
@@ -11202,11 +11202,11 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(10, ddc.getPolicyCount());
-        assertEquals(14, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 10);
+        assertEquals(ddc.getAssertionCount(), 14);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
-        assertEquals(1, ddc.getProvidersWithoutTrust().size());
+        assertEquals(ddc.getProvidersWithoutTrust().size(), 1);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         // add the tenancy support for top domain
@@ -11220,11 +11220,11 @@ public class ZMSImplTest {
 
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(10, ddc.getPolicyCount());
-        assertEquals(14, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 10);
+        assertEquals(ddc.getAssertionCount(), 14);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
-        assertEquals(1, ddc.getProvidersWithoutTrust().size());
+        assertEquals(ddc.getProvidersWithoutTrust().size(), 1);
         assertNull(ddc.getTenantsWithoutAssumeRole());
 
         // delete the provider resource group roles for the subdomain provider
@@ -11233,8 +11233,8 @@ public class ZMSImplTest {
                 "ravers", auditRef);
         ddc = zmsImpl.getDomainDataCheck(ctx, tenantDomainName);
         assertNotNull(ddc);
-        assertEquals(7, ddc.getPolicyCount());
-        assertEquals(11, ddc.getAssertionCount());
+        assertEquals(ddc.getPolicyCount(), 7);
+        assertEquals(ddc.getAssertionCount(), 11);
         assertNull(ddc.getDanglingRoles());
         assertNull(ddc.getDanglingPolicies());
         assertNull(ddc.getProvidersWithoutTrust());
@@ -11259,8 +11259,8 @@ public class ZMSImplTest {
         ResourceContext rsrcCtxTest = zmsTestInitializer.createResourceContext(testPrincipal);
         ServicePrincipal principal = zmsImpl.getServicePrincipal(rsrcCtxTest);
         assertNotNull(principal);
-        assertEquals("storage", principal.getService());
-        assertEquals("coretech", principal.getDomain());
+        assertEquals(principal.getService(), "storage");
+        assertEquals(principal.getDomain(), "coretech");
     }
 
     @Test
@@ -11278,8 +11278,8 @@ public class ZMSImplTest {
         ResourceContext rsrcCtxTest = zmsTestInitializer.createResourceContext(testPrincipal);
         ServicePrincipal principal = zmsImpl.getServicePrincipal(rsrcCtxTest);
         assertNotNull(principal);
-        assertEquals("test1", principal.getService());
-        assertEquals("user", principal.getDomain());
+        assertEquals(principal.getService(), "test1");
+        assertEquals(principal.getDomain(), "user");
     }
 
     @Test
@@ -11867,7 +11867,7 @@ public class ZMSImplTest {
 
         // our response is going to get the admin role
 
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("role1"));
         assertTrue(names.contains("role2"));
@@ -11934,8 +11934,8 @@ public class ZMSImplTest {
 
         List<String> names = new ArrayList<>(zmsImpl.dbService.listRoles(domainName));
         String next = zmsImpl.processListRequest(2, null, names);
-        assertEquals("role1", next);
-        assertEquals(2, names.size());
+        assertEquals(next, "role1");
+        assertEquals(names.size(), 2);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("role1"));
         zmsImpl.dbService.executeDeleteDomain(ctx, domainName, auditRef, "unittest");
@@ -11971,7 +11971,7 @@ public class ZMSImplTest {
 
         // make sure to account for the admin role
 
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("role1"));
         assertTrue(names.contains("role2"));
@@ -12169,8 +12169,8 @@ public class ZMSImplTest {
         // case so we need to handle the test case accordingly.
 
         AthenzDomain domain = zmsImpl.retrieveAccessDomain("hasaccessdom2", principal2);
-        assertEquals(AccessStatus.DENIED, zmsImpl.hasAccess(domain, "update",
-                "hasaccessdom2:resource1", principal2, null));
+        assertEquals(zmsImpl.hasAccess(domain, "update",
+                "hasaccessdom2:resource1", principal2, null), AccessStatus.DENIED);
         zmsImpl.deleteTopLevelDomain(ctx, "HasAccessDom2", auditRef, null);
     }
 
@@ -12649,7 +12649,7 @@ public class ZMSImplTest {
         zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom2);
 
         DomainList domList = zmsImpl.listDomains(1, null, null, null, 0, false);
-        assertEquals(1, domList.getNames().size());
+        assertEquals(domList.getNames().size(), 1);
 
         zmsImpl.deleteTopLevelDomain(ctx, "LimitDom1", auditRef, null);
         zmsImpl.deleteTopLevelDomain(ctx, "LimitDom2", auditRef, null);
@@ -12820,7 +12820,7 @@ public class ZMSImplTest {
         timestamp += 10000; // add 10 seconds
         domModList = zmsImpl.dbService.listModifiedDomains(timestamp, true);
         assertNotNull(domModList);
-        assertEquals(0, domModList.getDomains().size());
+        assertEquals(domModList.getDomains().size(), 0);
 
         zmsImpl.deleteTopLevelDomain(ctx, "ListDomMod1", auditRef, null);
         zmsImpl.deleteTopLevelDomain(ctx, "ListDomMod2", auditRef, null);
@@ -12960,7 +12960,7 @@ public class ZMSImplTest {
             zmsImpl.deletePublicKeyEntry(ctx, domain, "Service1", "1", null, null);
             fail("requesterror not thrown by deletePublicKeyEntry.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -13348,7 +13348,7 @@ public class ZMSImplTest {
             zmsImpl.putPublicKeyEntry(ctx, domain, "Service1", "zone1", null, null, keyEntry);
             fail("requesterror not thrown by putPublicKeyEntry.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
@@ -13381,7 +13381,7 @@ public class ZMSImplTest {
             zmsImpl.putPublicKeyEntry(ctx, domain, "Service1.Service2", "zone1", null, null, keyEntry);
             fail("requesterror not thrown by putPublicKeyEntry.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domain, auditRef, null);
         }
@@ -13617,7 +13617,7 @@ public class ZMSImplTest {
         assertTrue(dom2.getAdminUsers().contains("user.user3b"));
         templates = dom2.getTemplates();
         list = templates.getTemplateNames();
-        assertEquals(3, list.size());
+        assertEquals(list.size(), 3);
         assertTrue(list.contains("platforms"));
         assertTrue(list.contains("vipng"));
         assertTrue(list.contains("athenz"));
@@ -13648,7 +13648,7 @@ public class ZMSImplTest {
         assertTrue(dom2.getAdminUsers().contains("user.user3b"));
         templates = dom2.getTemplates();
         list = templates.getTemplateNames();
-        assertEquals(3, list.size());
+        assertEquals(list.size(), 3);
         assertTrue(list.contains("platforms"));
         assertTrue(list.contains("vipng"));
         assertTrue(list.contains("athenz"));
@@ -13678,7 +13678,7 @@ public class ZMSImplTest {
         assertEquals(dom2.getName(), "user3b");
         templates = dom2.getTemplates();
         list = templates.getTemplateNames();
-        assertEquals(3, list.size());
+        assertEquals(list.size(), 3);
         assertTrue(list.contains("platforms"));
         assertTrue(list.contains("vipng"));
         assertTrue(list.contains("athenz"));
@@ -14035,7 +14035,7 @@ public class ZMSImplTest {
         AthenzObject.DOMAIN_TEMPLATE_LIST.convertToLowerCase(templates);
 
         list = templates.getTemplateNames();
-        assertEquals(3, list.size());
+        assertEquals(list.size(), 3);
         assertTrue(list.contains("platforms"));
         assertTrue(list.contains("vipng"));
         assertTrue(list.contains("athenz"));
@@ -14492,7 +14492,7 @@ public class ZMSImplTest {
         assertEquals(providerService.toLowerCase(), tRoles.getService());
         assertEquals(tenantDomain.toLowerCase(), tRoles.getTenant());
         assertEquals(resourceGroup.toLowerCase(), tRoles.getResourceGroup());
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
     }
@@ -14551,7 +14551,7 @@ public class ZMSImplTest {
         assertEquals(providerService.toLowerCase(), tRoles.getService());
         assertEquals(tenantDomain.toLowerCase(), tRoles.getTenant());
         assertEquals(resourceGroup1.toLowerCase(), tRoles.getResourceGroup());
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         // verify group 2 roles with valid size of roles
 
@@ -14576,13 +14576,13 @@ public class ZMSImplTest {
                 tenantDomain, providerDomain, providerService, resourceGroup1);
 
         assertNotNull(tRoles);
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         tRoles = zmsImpl.getProviderResourceGroupRoles(ctx,
                 tenantDomain, providerDomain, providerService, resourceGroup2);
 
         assertNotNull(tRoles);
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
     }
@@ -14652,7 +14652,7 @@ public class ZMSImplTest {
                 tenantDomain, "test1", "invalid", "hockey");
 
         assertNotNull(tRoles);
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         zmsImpl.deleteTopLevelDomain(ctx, tenantDomain, auditRef, null);
     }
@@ -14761,14 +14761,14 @@ public class ZMSImplTest {
                 tenantDomain, providerDomain, providerService, resourceGroup);
 
         assertNotNull(pRoles);
-        assertEquals(0, pRoles.getRoles().size());
+        assertEquals(pRoles.getRoles().size(), 0);
 
         // but for provider we're still going to get full set of roles
 
         TenantResourceGroupRoles tRoles = zmsImpl.getTenantResourceGroupRoles(rsrcCtx, providerDomain,
                 providerService, tenantDomain, resourceGroup);
         assertNotNull(tRoles);
-        assertEquals(2, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 2);
 
         // now this time we're going to delete with the principal with the
         // authorized service token
@@ -14782,14 +14782,14 @@ public class ZMSImplTest {
                 tenantDomain, providerDomain, providerService, resourceGroup);
 
         assertNotNull(pRoles);
-        assertEquals(0, pRoles.getRoles().size());
+        assertEquals(pRoles.getRoles().size(), 0);
 
         // and for provider we're now going to get 0 tenant roles as well
 
         tRoles = zmsImpl.getTenantResourceGroupRoles(ctx, providerDomain,
                 providerService, tenantDomain, resourceGroup);
         assertNotNull(tRoles);
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         // clean up our domains
 
@@ -14882,14 +14882,14 @@ public class ZMSImplTest {
                 tenantDomain, providerDomain, providerService, resourceGroup);
 
         assertNotNull(pRoles);
-        assertEquals(0, pRoles.getRoles().size());
+        assertEquals(pRoles.getRoles().size(), 0);
 
         // but for provider we're still going to get full set of roles
 
         TenantResourceGroupRoles tRoles = zms.getTenantResourceGroupRoles(ctx, providerDomain,
                 providerService, tenantDomain, resourceGroup);
         assertNotNull(tRoles);
-        assertEquals(2, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 2);
 
         // Also, domain dependency remains until the resources are removed from the provider
 
@@ -14909,14 +14909,14 @@ public class ZMSImplTest {
                 tenantDomain, providerDomain, providerService, resourceGroup);
 
         assertNotNull(pRoles);
-        assertEquals(0, pRoles.getRoles().size());
+        assertEquals(pRoles.getRoles().size(), 0);
 
         // and for provider we're now going to get 0 tenant roles as well
 
         tRoles = zms.getTenantResourceGroupRoles(ctx, providerDomain,
                 providerService, tenantDomain, resourceGroup);
         assertNotNull(tRoles);
-        assertEquals(0, tRoles.getRoles().size());
+        assertEquals(tRoles.getRoles().size(), 0);
 
         // Domain dependency will be removed
 
@@ -15035,7 +15035,7 @@ public class ZMSImplTest {
                     resourceGroup, auditRef, providerRoles);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
 
         // clean up our domains
@@ -15089,7 +15089,7 @@ public class ZMSImplTest {
             zmsImpl.optionsUserToken(ctx, "user1", null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // empty service must return 400
@@ -15098,7 +15098,7 @@ public class ZMSImplTest {
             zmsImpl.optionsUserToken(ctx, "user1", "");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // unknown registered service must return 400
@@ -15106,7 +15106,7 @@ public class ZMSImplTest {
             zmsImpl.optionsUserToken(ctx, "user1", "unknown_service_name");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // in a list all services must be valid - any invalid must return 400
@@ -15115,7 +15115,7 @@ public class ZMSImplTest {
             zmsImpl.optionsUserToken(ctx, "user1", "coretech.storage,unknown_service_name");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -15130,9 +15130,9 @@ public class ZMSImplTest {
                 null, new Object(), "apiName", false);
 
         zmsImpl.optionsUserToken(ctx, "user", "coretech.storage");
-        assertEquals("GET", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_METHODS));
-        assertEquals("2592000", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_MAX_AGE));
-        assertEquals("true", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_METHODS), "GET");
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_MAX_AGE), "2592000");
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
 
         // using default values where we'll get back null for origin and no allow headers
 
@@ -15158,10 +15158,10 @@ public class ZMSImplTest {
         // this time we're going to try with multiple services
 
         zmsImpl.optionsUserToken(ctx, "user", "coretech.storage,coretech.index");
-        assertEquals("GET", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_METHODS));
-        assertEquals("2592000", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_MAX_AGE));
-        assertEquals("true", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS));
-        assertEquals(origin, servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_METHODS), "GET");
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_MAX_AGE), "2592000");
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_ORIGIN), origin);
 
         // because X-Forwarded-For is not in the request header list,
         // our header list will be null
@@ -15174,7 +15174,7 @@ public class ZMSImplTest {
         zmsImpl.corsRequestHeaderList.add("x-forwarded-for");
         zmsImpl.optionsUserToken(ctx, "user", "coretech.storage,coretech.index");
 
-        assertEquals(requestHeaders, servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_HEADERS), requestHeaders);
         zmsImpl.corsRequestHeaderList.remove("x-forwarded-for");
     }
 
@@ -15189,7 +15189,7 @@ public class ZMSImplTest {
                 null, new Object(), "apiName", false);
 
         zmsImpl.setStandardCORSHeaders(ctx);
-        assertEquals("true", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
 
         // using default values where we'll get back null for origin and no allow headers
 
@@ -15213,10 +15213,10 @@ public class ZMSImplTest {
 
         zmsImpl.corsRequestHeaderList.add("x-forwarded-for");
         zmsImpl.setStandardCORSHeaders(ctx);
-        assertEquals("true", servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
 
-        assertEquals(origin, servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_ORIGIN));
-        assertEquals(requestHeaders, servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_HEADERS));
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_ORIGIN), origin);
+        assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_HEADERS), requestHeaders);
         zmsImpl.corsRequestHeaderList.remove("x-forwarded-for");
     }
 
@@ -15284,14 +15284,14 @@ public class ZMSImplTest {
             zmsImpl.getTemplate(ctx, "platforms test");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             zmsImpl.getTemplate(ctx, "invalid");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -15305,7 +15305,7 @@ public class ZMSImplTest {
 
         List<Role> roles = template.getRoles();
         assertNotNull(roles);
-        assertEquals(3, roles.size());
+        assertEquals(roles.size(), 3);
 
         Role userRole = null;
         Role superuserRole = null;
@@ -15330,7 +15330,7 @@ public class ZMSImplTest {
 
         // openstack_readers role has 2 members
 
-        assertEquals(2, openstackReadersRole.getRoleMembers().size());
+        assertEquals(openstackReadersRole.getRoleMembers().size(), 2);
         List<String> checkList = new ArrayList<>();
         checkList.add("sys.builder");
         checkList.add("sys.openstack");
@@ -15343,7 +15343,7 @@ public class ZMSImplTest {
 
         List<Policy> policies = template.getPolicies();
         assertNotNull(policies);
-        assertEquals(3, policies.size());
+        assertEquals(policies.size(), 3);
 
         Policy userPolicy = null;
         Policy superuserPolicy = null;
@@ -15366,9 +15366,9 @@ public class ZMSImplTest {
         assertNotNull(superuserPolicy);
         assertNotNull(openstackReadersPolicy);
 
-        assertEquals(1, userPolicy.getAssertions().size());
-        assertEquals(1, superuserPolicy.getAssertions().size());
-        assertEquals(2, openstackReadersPolicy.getAssertions().size());
+        assertEquals(userPolicy.getAssertions().size(), 1);
+        assertEquals(superuserPolicy.getAssertions().size(), 1);
+        assertEquals(openstackReadersPolicy.getAssertions().size(), 2);
 
         template = zmsImpl.getTemplate(ctx, "vipng");
         assertNotNull(template);
@@ -15379,10 +15379,10 @@ public class ZMSImplTest {
         template = zmsImpl.getTemplate(ctx, "VipNg");
         assertNotNull(template);
 
-        assertEquals(10, template.getMetadata().getLatestVersion().intValue());
-        assertEquals("2020-04-28T00:00:00.000Z", template.getMetadata().timestamp.toString());
-        assertEquals("Vipng template", template.getMetadata().description);
-        assertEquals("", template.getMetadata().keywordsToReplace);
+        assertEquals(template.getMetadata().getLatestVersion().intValue(), 10);
+        assertEquals(template.getMetadata().timestamp.toString(), "2020-04-28T00:00:00.000Z");
+        assertEquals(template.getMetadata().description, "Vipng template");
+        assertEquals(template.getMetadata().keywordsToReplace, "");
         assertFalse(template.getMetadata().getAutoUpdate());
     }
 
@@ -15403,7 +15403,7 @@ public class ZMSImplTest {
             zmsImpl.validateSolutionTemplates(templateNames, caller);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
             assertTrue(ex.getMessage().contains("athenz"));
         }
     }
@@ -16139,7 +16139,7 @@ public class ZMSImplTest {
             ctx.throwZmsException(restExc);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
             assertEquals( ((ResourceError) ex.data).message, "failed struct");
         }
     }
@@ -16295,7 +16295,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertions(assertList, "domain1", "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with empty domain name
@@ -16313,7 +16313,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertions(assertList, "domain1", "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with invalid domain name
@@ -16331,7 +16331,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertions(assertList, "domain1", "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -16352,7 +16352,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with empty domain name
@@ -16367,7 +16367,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with invalid domain name
@@ -16382,7 +16382,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with invalid resource name
@@ -16397,7 +16397,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with null action
@@ -16412,7 +16412,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with empty action
@@ -16427,7 +16427,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         // assertion with action containing control characters
@@ -16442,7 +16442,7 @@ public class ZMSImplTest {
             zmsImpl.validatePolicyAssertion(assertion, "domain1", new HashSet<>(), "unitTest");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -16644,7 +16644,7 @@ public class ZMSImplTest {
 
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<Role> roles = zmsImpl.setupRoleList(domain, Boolean.TRUE, null, null);
-        assertEquals(4, roles.size()); // need to account for admin role
+        assertEquals(roles.size(), 4); // need to account for admin role
 
         boolean role1Check = false;
         boolean role2Check = false;
@@ -16732,7 +16732,7 @@ public class ZMSImplTest {
 
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<Role> roles = zmsImpl.setupRoleList(domain, Boolean.FALSE, null, null);
-        assertEquals(5, roles.size()); // need to account for admin role
+        assertEquals(roles.size(), 5); // need to account for admin role
 
         boolean role1Check = false;
         boolean role2Check = false;
@@ -16792,7 +16792,7 @@ public class ZMSImplTest {
         // for the boolean flag instead of false
 
         roles = zmsImpl.setupRoleList(domain, null, null, null);
-        assertEquals(5, roles.size()); // need to account for admin role
+        assertEquals(roles.size(), 5); // need to account for admin role
 
         role1Check = false;
         role2Check = false;
@@ -16874,7 +16874,7 @@ public class ZMSImplTest {
 
         Roles roleList = zmsImpl.getRoles(ctx, domainName, Boolean.TRUE, null, null);
         List<Role> roles = roleList.getList();
-        assertEquals(4, roles.size()); // need to account for admin role
+        assertEquals(roles.size(), 4); // need to account for admin role
 
         boolean role1Check = false;
         boolean role2Check = false;
@@ -16953,7 +16953,7 @@ public class ZMSImplTest {
 
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<Policy> policies = zmsImpl.setupPolicyList(domain, Boolean.TRUE, Boolean.FALSE, null, null);
-        assertEquals(3, policies.size()); // need to account for admin policy
+        assertEquals(policies.size(), 3); // need to account for admin policy
 
         boolean policy1Check = false;
         boolean policy2Check = false;
@@ -16997,7 +16997,7 @@ public class ZMSImplTest {
         domain.setPolicies(policyList);
 
         List<Policy> policies = zmsImpl.setupPolicyList(domain, Boolean.TRUE, Boolean.FALSE, null, null);
-        assertEquals(1, policies.size());
+        assertEquals(policies.size(), 1);
         assertEquals(policies.get(0).getName(), "setup-policy-with-assert-active-only:policy.policy1");
     }
 
@@ -17018,7 +17018,7 @@ public class ZMSImplTest {
         domain.setPolicies(policyList);
 
         List<Policy> policies = zmsImpl.setupPolicyList(domain, Boolean.TRUE, Boolean.TRUE, null, null);
-        assertEquals(2, policies.size());
+        assertEquals(policies.size(), 2);
         assertEquals(policies.get(0).getName(), "setup-policy-with-assert-all-versions:policy.policy1");
         assertEquals(policies.get(0).getVersion(), "ver1");
         assertTrue(policies.get(0).getActive());
@@ -17027,7 +17027,7 @@ public class ZMSImplTest {
         assertFalse(policies.get(1).getActive());
 
         policies = zmsImpl.setupPolicyList(domain, Boolean.FALSE, Boolean.TRUE, null, null);
-        assertEquals(2, policies.size());
+        assertEquals(policies.size(), 2);
         assertEquals(policies.get(0).getName(), "setup-policy-with-assert-all-versions:policy.policy1");
         assertEquals(policies.get(0).getVersion(), "ver1");
         assertTrue(policies.get(0).getActive());
@@ -17056,7 +17056,7 @@ public class ZMSImplTest {
 
         Policies policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.FALSE, null, null);
         List<Policy> policies = policyList.getList();
-        assertEquals(3, policies.size()); // need to account for admin policy
+        assertEquals(policies.size(), 3); // need to account for admin policy
 
         boolean policy1Check = false;
         boolean policy2Check = false;
@@ -17105,7 +17105,7 @@ public class ZMSImplTest {
 
         Policies policyList = zmsImpl.getPolicies(ctx, domainName, Boolean.TRUE, Boolean.TRUE, null, null);
         List<Policy> policies = policyList.getList();
-        assertEquals(5, policies.size()); // need to account for admin policy
+        assertEquals(policies.size(), 5); // need to account for admin policy
         // set our default versions for our policy objects
         policy1.setVersion("0");
         policy2.setVersion("0");
@@ -17164,7 +17164,7 @@ public class ZMSImplTest {
 
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<Policy> policies = zmsImpl.setupPolicyList(domain, Boolean.FALSE, Boolean.FALSE, null, null);
-        assertEquals(3, policies.size()); // need to account for admin policy
+        assertEquals(policies.size(), 3); // need to account for admin policy
 
         boolean policy1Check = false;
         boolean policy2Check = false;
@@ -17216,7 +17216,7 @@ public class ZMSImplTest {
         ServiceIdentities serviceList = zmsImpl.getServiceIdentities(ctx,
                 domainName, Boolean.TRUE, Boolean.TRUE, null, null);
         List<ServiceIdentity> services = serviceList.getList();
-        assertEquals(2, services.size());
+        assertEquals(services.size(), 2);
 
         boolean service1Check = false;
         boolean service2Check = false;
@@ -17290,7 +17290,7 @@ public class ZMSImplTest {
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<ServiceIdentity> services = zmsImpl.setupServiceIdentityList(domain,
                 Boolean.TRUE, Boolean.TRUE, null, null);
-        assertEquals(2, services.size());
+        assertEquals(services.size(), 2);
 
         boolean service1Check = false;
         boolean service2Check = false;
@@ -17347,7 +17347,7 @@ public class ZMSImplTest {
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<ServiceIdentity> services = zmsImpl.setupServiceIdentityList(domain,
                 Boolean.FALSE, Boolean.FALSE, null, null);
-        assertEquals(2, services.size());
+        assertEquals(services.size(), 2);
 
         boolean service1Check = false;
         boolean service2Check = false;
@@ -17402,7 +17402,7 @@ public class ZMSImplTest {
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<ServiceIdentity> services = zmsImpl.setupServiceIdentityList(domain,
                 Boolean.TRUE, Boolean.FALSE, null, null);
-        assertEquals(2, services.size());
+        assertEquals(services.size(), 2);
 
         boolean service1Check = false;
         boolean service2Check = false;
@@ -17457,7 +17457,7 @@ public class ZMSImplTest {
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<ServiceIdentity> services = zmsImpl.setupServiceIdentityList(domain,
                 Boolean.FALSE, Boolean.TRUE, null, null);
-        assertEquals(2, services.size());
+        assertEquals(services.size(), 2);
 
         boolean service1Check = false;
         boolean service2Check = false;
@@ -19059,7 +19059,7 @@ public class ZMSImplTest {
             zmsImpl.getDomainRoleMembers(ctx, "invalid-domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -19073,7 +19073,7 @@ public class ZMSImplTest {
             zmsImpl.getDomainGroupMembers(ctx, "invalid-domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -19160,7 +19160,7 @@ public class ZMSImplTest {
 
         Quota quotaCheck = zmsImpl.getQuota(ctx, domainName);
         assertNotNull(quotaCheck);
-        assertEquals(domainName, quotaCheck.getName());
+        assertEquals(quotaCheck.getName(), domainName);
         assertEquals(quotaCheck.getAssertion(), 10);
         assertEquals(quotaCheck.getRole(), 14);
         assertEquals(quotaCheck.getPolicy(), 12);
@@ -19173,7 +19173,7 @@ public class ZMSImplTest {
 
         quotaCheck = zmsImpl.getQuota(ctx, domainName);
 
-        assertEquals("server-default", quotaCheck.getName());
+        assertEquals(quotaCheck.getName(), "server-default");
         assertEquals(quotaCheck.getAssertion(), 100);
         assertEquals(quotaCheck.getRole(), 1000);
         assertEquals(quotaCheck.getPolicy(), 1000);
@@ -19496,14 +19496,14 @@ public class ZMSImplTest {
             zmsImpl.getStatus(ctx);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         // create the status file
 
         new FileOutputStream(healthCheckFile).close();
         Status status = zmsImpl.getStatus(ctx);
-        assertEquals(ResourceException.OK, status.getCode());
+        assertEquals(status.getCode(), ResourceException.OK);
 
         // delete the status file
 
@@ -19512,7 +19512,7 @@ public class ZMSImplTest {
             zmsImpl.getStatus(ctx);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         System.clearProperty(ZMSConsts.ZMS_PROP_HEALTH_CHECK_PATH);
@@ -19532,7 +19532,7 @@ public class ZMSImplTest {
         zmsImpl.statusPort = 0;
 
         Status status = zmsImpl.getStatus(ctx);
-        assertEquals(ResourceException.OK, status.getCode());
+        assertEquals(status.getCode(), ResourceException.OK);
 
         // if the MockStatusCheckerThrowException is set
         // the MockStatusCheckerThrowException determines that there is a problem with the server
@@ -19965,7 +19965,7 @@ public class ZMSImplTest {
 
         assertNotNull(sdoms);
         List<SignedDomain> list = sdoms.getDomains();
-        assertEquals(0, list.size());
+        assertEquals(list.size(), 0);
 
         zmsImpl.objectStore.clearConnections();
     }
@@ -20146,7 +20146,7 @@ public class ZMSImplTest {
 
         assertNotNull(sdoms);
         List<SignedDomain> list = sdoms.getDomains();
-        assertEquals(0, list.size());
+        assertEquals(list.size(), 0);
 
         zmsImpl.objectStore.clearConnections();
     }
@@ -20224,10 +20224,10 @@ public class ZMSImplTest {
         assertEquals(Integer.valueOf(10), signedDomain.getDomain().getTokenExpiryMins());
         assertEquals(Integer.valueOf(20), signedDomain.getDomain().getRoleCertExpiryMins());
         assertEquals(Integer.valueOf(30), signedDomain.getDomain().getServiceCertExpiryMins());
-        assertEquals("test description", signedDomain.getDomain().getDescription());
-        assertEquals("test dns domain", signedDomain.getDomain().getCertDnsDomain());
-        assertEquals("org", signedDomain.getDomain().getOrg());
-        assertEquals("OnShore-US", signedDomain.getDomain().getUserAuthorityFilter());
+        assertEquals(signedDomain.getDomain().getDescription(), "test description");
+        assertEquals(signedDomain.getDomain().getCertDnsDomain(), "test dns domain");
+        assertEquals(signedDomain.getDomain().getOrg(), "org");
+        assertEquals(signedDomain.getDomain().getUserAuthorityFilter(), "OnShore-US");
         assertEquals(Integer.valueOf(40), signedDomain.getDomain().getMemberExpiryDays());
         assertEquals(Integer.valueOf(50), signedDomain.getDomain().getGroupExpiryDays());
         assertEquals(Integer.valueOf(60), signedDomain.getDomain().getServiceExpiryDays());
@@ -20795,7 +20795,7 @@ public class ZMSImplTest {
             zmsImpl.putRoleSystemMeta(ctx, "rolesystemmetadom1", "role1", "auditenabled", null, rsm);
             fail("notfounderror not thrown.");
         } catch (ResourceException e) {
-            assertEquals(404, e.getCode());
+            assertEquals(e.getCode(), 404);
         }
     }
 
@@ -21061,7 +21061,7 @@ public class ZMSImplTest {
             zmsImpl.putRoleMeta(ctx, "rolemetadom1", "role1", auditRef, null, rm);
             fail("notfounderror not thrown.");
         } catch (ResourceException e) {
-            assertEquals(404, e.getCode());
+            assertEquals(e.getCode(), 404);
         }
     }
 
@@ -23749,7 +23749,7 @@ public class ZMSImplTest {
             zmsImpl.getJWSDomain(ctx, "unknown", Boolean.TRUE, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         // null data causing exception which is caught
@@ -24154,12 +24154,12 @@ public class ZMSImplTest {
 
         // valid filter
 
-        assertEquals("validFilter", zmsImpl.enforcedUserAuthorityFilter("validFilter", null));
-        assertEquals("validFilter", zmsImpl.enforcedUserAuthorityFilter(null, "validFilter"));
-        assertEquals("validFilter", zmsImpl.enforcedUserAuthorityFilter("validFilter", ""));
-        assertEquals("validFilter", zmsImpl.enforcedUserAuthorityFilter("", "validFilter"));
-        assertEquals("validFilter1,validFilter2", zmsImpl.enforcedUserAuthorityFilter("validFilter1", "validFilter2"));
-        assertEquals("validFilter,validFilter", zmsImpl.enforcedUserAuthorityFilter("validFilter", "validFilter"));
+        assertEquals(zmsImpl.enforcedUserAuthorityFilter("validFilter", null), "validFilter");
+        assertEquals(zmsImpl.enforcedUserAuthorityFilter(null, "validFilter"), "validFilter");
+        assertEquals(zmsImpl.enforcedUserAuthorityFilter("validFilter", ""), "validFilter");
+        assertEquals(zmsImpl.enforcedUserAuthorityFilter("", "validFilter"), "validFilter");
+        assertEquals(zmsImpl.enforcedUserAuthorityFilter("validFilter1", "validFilter2"), "validFilter1,validFilter2");
+        assertEquals(zmsImpl.enforcedUserAuthorityFilter("validFilter", "validFilter"), "validFilter,validFilter");
 
         zmsImpl.userAuthority = savedAuthority;
     }
@@ -24179,7 +24179,7 @@ public class ZMSImplTest {
 
         zmsImpl.userAuthority = Mockito.mock(Authority.class);
 
-        assertEquals("elevated-clearance", zmsImpl.getUserAuthorityExpiryAttr(role.getUserAuthorityExpiration()));
+        assertEquals(zmsImpl.getUserAuthorityExpiryAttr(role.getUserAuthorityExpiration()), "elevated-clearance");
 
         role.setUserAuthorityExpiration("");
         assertNull(zmsImpl.getUserAuthorityExpiryAttr(role.getUserAuthorityExpiration()));
@@ -24964,7 +24964,7 @@ public class ZMSImplTest {
         List<GroupMember> members = group.getGroupMembers();
         assertNotNull(members);
         assertEquals(members.size(), 1);
-        assertEquals("user.joe", members.get(0).getMemberName());
+        assertEquals(members.get(0).getMemberName(), "user.joe");
 
         zmsImpl.deleteTopLevelDomain(ctx,domainName, auditRef, null);
     }
@@ -25508,7 +25508,7 @@ public class ZMSImplTest {
             zmsImpl.deleteGroup(ctx, domainName, groupName, null, null);
             fail("requesterror not thrown by deleteGroup.");
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Audit reference required"));
         } finally {
             zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -28766,8 +28766,8 @@ public class ZMSImplTest {
                     break;
             }
         }
-        assertEquals(2, joeCount);
-        assertEquals(2, joeyCount);
+        assertEquals(joeCount, 2);
+        assertEquals(joeyCount, 2);
 
         // now let's create a role member where the group has an expiry
 
@@ -28798,8 +28798,8 @@ public class ZMSImplTest {
                 }
             }
         }
-        assertEquals(1, joeCount);
-        assertEquals(1, joeCountWithExpiry);
+        assertEquals(joeCount, 1);
+        assertEquals(joeCountWithExpiry, 1);
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSMetaAttributeTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSMetaAttributeTest.java
@@ -608,12 +608,12 @@ public class ZMSMetaAttributeTest {
         List<String> productIdList = Collections.singletonList("product");
         when(mockDomainMetaStore.getValidProductIds(isNull())).thenReturn(productIdList);
         zmsImpl.domainMetaStore = mockDomainMetaStore;
-        assertEquals("bservice", zmsImpl.getDomainMetaStoreValidValuesList(ctx, "businessService", null).getValidValues().get(0));
-        assertEquals("awsAcc", zmsImpl.getDomainMetaStoreValidValuesList(ctx, "awsAccount", null).getValidValues().get(0));
-        assertEquals("azureSub", zmsImpl.getDomainMetaStoreValidValuesList(ctx, "azureSubscription", null).getValidValues().get(0));
-        assertEquals("gcpProject", zmsImpl.getDomainMetaStoreValidValuesList(ctx, "gcpProject", null).getValidValues().get(0));
-        assertEquals("product", zmsImpl.getDomainMetaStoreValidValuesList(ctx, "productId", null).getValidValues().get(0));
-        assertEquals("product", zmsImpl.getDomainMetaStoreValidValuesList(ctx, "productNumber", null).getValidValues().get(0));
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "businessService", null).getValidValues().get(0), "bservice");
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "awsAccount", null).getValidValues().get(0), "awsAcc");
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "azureSubscription", null).getValidValues().get(0), "azureSub");
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "gcpProject", null).getValidValues().get(0), "gcpProject");
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "productId", null).getValidValues().get(0), "product");
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "productNumber", null).getValidValues().get(0), "product");
         zmsImpl.domainMetaStore = savedMetaStore;
     }
 
@@ -626,11 +626,11 @@ public class ZMSMetaAttributeTest {
         zmsImpl.domainMetaStore = new TestDomainMetaStore();
         DomainMetaStoreValidValuesList emptyValidValuesList = new DomainMetaStoreValidValuesList();
         emptyValidValuesList.setValidValues(new ArrayList<>());
-        assertEquals(emptyValidValuesList, zmsImpl.getDomainMetaStoreValidValuesList(ctx, "businessService", null));
-        assertEquals(emptyValidValuesList, zmsImpl.getDomainMetaStoreValidValuesList(ctx, "awsAccount", null));
-        assertEquals(emptyValidValuesList, zmsImpl.getDomainMetaStoreValidValuesList(ctx, "azureSubscription", null));
-        assertEquals(emptyValidValuesList, zmsImpl.getDomainMetaStoreValidValuesList(ctx, "gcpProject", null));
-        assertEquals(emptyValidValuesList, zmsImpl.getDomainMetaStoreValidValuesList(ctx, "productId", null));
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "businessService", null), emptyValidValuesList);
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "awsAccount", null), emptyValidValuesList);
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "azureSubscription", null), emptyValidValuesList);
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "gcpProject", null), emptyValidValuesList);
+        assertEquals(zmsImpl.getDomainMetaStoreValidValuesList(ctx, "productId", null), emptyValidValuesList);
         zmsImpl.domainMetaStore = savedMetaStore;
     }
 
@@ -705,7 +705,7 @@ public class ZMSMetaAttributeTest {
             zmsImpl.putDomainMeta(ctx, domName, auditRef, null, meta);
             fail("notfounderror not thrown.");
         } catch (ResourceException e) {
-            assertEquals(404, e.getCode());
+            assertEquals(e.getCode(), 404);
         }
     }
 
@@ -948,7 +948,7 @@ public class ZMSMetaAttributeTest {
             zmsImpl.putDomainSystemMeta(ctx, domainName, "productid", auditRef, meta);
             fail("bad request exc not thrown");
         } catch (ResourceException exc) {
-            assertEquals(400, exc.getCode());
+            assertEquals(exc.getCode(), 400);
             assertTrue(exc.getMessage().contains("Unique Product Id must be specified for top level domain"));
         }
 
@@ -967,7 +967,7 @@ public class ZMSMetaAttributeTest {
             zmsImpl.putDomainSystemMeta(ctx, domainName, "productid", auditRef, meta);
             fail("bad request exc not thrown");
         } catch (ResourceException exc) {
-            assertEquals(400, exc.getCode());
+            assertEquals(exc.getCode(), 400);
             assertTrue(exc.getMessage().contains("is already assigned to domain"));
         }
 
@@ -1160,7 +1160,7 @@ public class ZMSMetaAttributeTest {
                     "Test Domain", "testOrg", zmsTestInitializer.getAdminUser(), ctx.principal().getFullName());
             zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom);
         } catch (ResourceException rexc) {
-            assertEquals(400, rexc.getCode());
+            assertEquals(rexc.getCode(), 400);
         }
 
         SubDomain subDom = zmsTestInitializer.createSubDomainObject("metaSubDom", "MetaDomProductid",

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSObjectReviewTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSObjectReviewTest.java
@@ -133,7 +133,7 @@ public class ZMSObjectReviewTest {
             zmsImpl.getRolesForReview(rsrcCtx1, zmsTestInitializer.getAdminUser());
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.FORBIDDEN);
         }
     }
 
@@ -246,7 +246,7 @@ public class ZMSObjectReviewTest {
             zmsImpl.getGroupsForReview(rsrcCtx1, zmsTestInitializer.getAdminUser());
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.FORBIDDEN);
         }
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSPrincipalRolesTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSPrincipalRolesTest.java
@@ -666,7 +666,7 @@ public class ZMSPrincipalRolesTest {
             zmsImpl.getPrincipalRoles(rsrcCtx1, null, null, Boolean.TRUE);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.INTERNAL_SERVER_ERROR, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.INTERNAL_SERVER_ERROR);
         }
 
         zmsImpl.dbService.store = saveStore;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTagTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTagTest.java
@@ -350,7 +350,7 @@ public class ZMSTagTest {
 
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<Policy> policies = zmsImpl.setupPolicyList(domain, Boolean.FALSE, Boolean.FALSE, "tag-key", "val3");
-        assertEquals(1, policies.size()); // need to account for admin policy
+        assertEquals(policies.size(), 1); // need to account for admin policy
 
         assertEquals(policies.get(0).getName(), "setup-policy-with-tags:policy.policy1");
         assertEquals(policies.get(0).getVersion(), "0");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTemplateTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTemplateTest.java
@@ -84,7 +84,7 @@ public class ZMSTemplateTest {
             zmsImpl.putDomainTemplate(ctx, domainName, auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -110,7 +110,7 @@ public class ZMSTemplateTest {
             zmsImpl.putDomainTemplate(ctx, domainName, auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -143,43 +143,43 @@ public class ZMSTemplateTest {
         // verify that our role collection includes the roles defined in template
 
         List<String> names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Role role = zmsImpl.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         role = zmsImpl.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Policy policy = zmsImpl.dbService.getPolicy(domainName, "vip_admin", null);
-        assertEquals(domainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         policy = zmsImpl.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // delete an applied service template
         //
@@ -189,11 +189,11 @@ public class ZMSTemplateTest {
         // verify that our role collection does NOT include the roles defined in template
 
         names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         zmsImpl.deleteSubDomain(ctx, "sys", "network", auditRef, null);
@@ -229,7 +229,7 @@ public class ZMSTemplateTest {
         // verify that our role collection includes the roles defined in template
 
         List<String> names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(7, names.size());
+        assertEquals(names.size(), 7);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -239,9 +239,9 @@ public class ZMSTemplateTest {
         assertTrue(names.contains("openstack_readers"));
 
         Role role = zmsImpl.dbService.getRole(domainName, "openstack_readers", false, false, false);
-        assertEquals(domainName + ":role.openstack_readers", role.getName());
+        assertEquals(role.getName(), domainName + ":role.openstack_readers");
         assertNull(role.getTrust());
-        assertEquals(2, role.getRoleMembers().size());
+        assertEquals(role.getRoleMembers().size(), 2);
 
         List<String> checkList = new ArrayList<>();
         checkList.add("sys.builder");
@@ -249,13 +249,13 @@ public class ZMSTemplateTest {
         zmsTestInitializer.checkRoleMember(checkList, role.getRoleMembers());
 
         role = zmsImpl.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(7, names.size());
+        assertEquals(names.size(), 7);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -265,20 +265,20 @@ public class ZMSTemplateTest {
         assertTrue(names.contains("openstack_readers"));
 
         Policy policy = zmsImpl.dbService.getPolicy(domainName, "vip_admin", null);
-        assertEquals(domainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         policy = zmsImpl.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // delete applied service template
         //
@@ -288,7 +288,7 @@ public class ZMSTemplateTest {
         // verify that our role collection does NOT include the vipng roles defined in template
 
         names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(5, names.size());
+        assertEquals(names.size(), 5);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deployer"));
         assertTrue(names.contains("user"));
@@ -296,7 +296,7 @@ public class ZMSTemplateTest {
         assertTrue(names.contains("openstack_readers"));
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(5, names.size());
+        assertEquals(names.size(), 5);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deploy"));
         assertTrue(names.contains("user"));
@@ -311,14 +311,14 @@ public class ZMSTemplateTest {
         // verify that our role collection does NOT include the platforms roles defined in template
 
         names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("user"));
         assertTrue(names.contains("superuser"));
         assertTrue(names.contains("openstack_readers"));
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("user"));
         assertTrue(names.contains("superuser"));
@@ -332,11 +332,11 @@ public class ZMSTemplateTest {
         // verify that our role collection does NOT include the user_provisioning roles defined in template
 
         names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         zmsImpl.deleteSubDomain(ctx, "sys", "network", auditRef, null);
@@ -377,7 +377,7 @@ public class ZMSTemplateTest {
                     auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -405,7 +405,7 @@ public class ZMSTemplateTest {
                     auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -429,7 +429,7 @@ public class ZMSTemplateTest {
                     auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         templateList.setTemplateNames(Collections.emptyList());
@@ -438,7 +438,7 @@ public class ZMSTemplateTest {
                     auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -466,7 +466,7 @@ public class ZMSTemplateTest {
                     auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
@@ -500,43 +500,43 @@ public class ZMSTemplateTest {
         // verify that our role collection includes the roles defined in template
 
         List<String> names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Role role = zmsImpl.dbService.getRole(domainName, "vip_admin", false, false, false);
-        assertEquals(domainName + ":role.vip_admin", role.getName());
+        assertEquals(role.getName(), domainName + ":role.vip_admin");
         assertNull(role.getTrust());
         assertTrue(role.getRoleMembers().isEmpty());
 
         role = zmsImpl.dbService.getRole(domainName, "sys_network_super_vip_admin", false, false, false);
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getName(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(3, names.size());
+        assertEquals(names.size(), 3);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
 
         Policy policy = zmsImpl.dbService.getPolicy(domainName, "vip_admin", null);
-        assertEquals(domainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         policy = zmsImpl.dbService.getPolicy(domainName, "sys_network_super_vip_admin", null);
-        assertEquals(domainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getName(), domainName + ":policy.sys_network_super_vip_admin");
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
-        assertEquals(domainName + ":role.sys_network_super_vip_admin", assertion.getRole());
-        assertEquals(domainName + ":vip*", assertion.getResource());
+        assertEquals(assertion.getAction(), "*");
+        assertEquals(assertion.getRole(), domainName + ":role.sys_network_super_vip_admin");
+        assertEquals(assertion.getResource(), domainName + ":vip*");
 
         // delete an applied service template
         //
@@ -545,11 +545,11 @@ public class ZMSTemplateTest {
         // verify that our role collection does NOT include the roles defined in template
 
         names = zmsImpl.dbService.listRoles(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         names = zmsImpl.dbService.listPolicies(domainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         zmsImpl.deleteSubDomain(ctx, "sys", "network", auditRef, null);
@@ -565,14 +565,14 @@ public class ZMSTemplateTest {
             zmsImpl.getDomainTemplateList(ctx, "invalid_domain name");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             zmsImpl.getDomainTemplateList(ctx, "not_found_domain_name");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -592,7 +592,7 @@ public class ZMSTemplateTest {
 
         DomainTemplateList domaintemplateList = zmsImpl.getDomainTemplateList(ctx, domainName);
         List<String> templates = domaintemplateList.getTemplateNames();
-        assertEquals(0, templates.size());
+        assertEquals(templates.size(), 0);
 
         // add a single template
 
@@ -605,7 +605,7 @@ public class ZMSTemplateTest {
 
         domaintemplateList = zmsImpl.getDomainTemplateList(ctx, domainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(1, templates.size());
+        assertEquals(templates.size(), 1);
         assertTrue(templates.contains("user_provisioning"));
 
         // add 2 templates
@@ -620,7 +620,7 @@ public class ZMSTemplateTest {
 
         domaintemplateList = zmsImpl.getDomainTemplateList(ctx, domainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(2, templates.size());
+        assertEquals(templates.size(), 2);
         assertTrue(templates.contains("user_provisioning"));
         assertTrue(templates.contains("platforms"));
 
@@ -632,7 +632,7 @@ public class ZMSTemplateTest {
 
         domaintemplateList = zmsImpl.getDomainTemplateList(ctx, domainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(2, templates.size());
+        assertEquals(templates.size(), 2);
         assertTrue(templates.contains("user_provisioning"));
         assertTrue(templates.contains("platforms"));
 
@@ -643,7 +643,7 @@ public class ZMSTemplateTest {
 
         domaintemplateList = zmsImpl.getDomainTemplateList(ctx, domainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(1, templates.size());
+        assertEquals(templates.size(), 1);
         assertTrue(templates.contains("platforms"));
 
         // delete last applied service template
@@ -694,7 +694,7 @@ public class ZMSTemplateTest {
         // verify that our role collection includes the roles defined in template
 
         List<String> names = zmsImpl.dbService.listRoles(subDomainName);
-        assertEquals(7, names.size());
+        assertEquals(names.size(), 7);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -706,7 +706,7 @@ public class ZMSTemplateTest {
         Role role = zmsImpl.dbService.getRole(subDomainName, "openstack_readers", false, false, false);
         assertEquals(subDomainName + ":role.openstack_readers", role.getName());
         assertNull(role.getTrust());
-        assertEquals(2, role.getRoleMembers().size());
+        assertEquals(role.getRoleMembers().size(), 2);
 
         List<String> checkList = new ArrayList<>();
         checkList.add("sys.builder");
@@ -715,12 +715,12 @@ public class ZMSTemplateTest {
 
         role = zmsImpl.dbService.getRole(subDomainName, "sys_network_super_vip_admin", false, false, false);
         assertEquals(subDomainName + ":role.sys_network_super_vip_admin", role.getName());
-        assertEquals("sys.network", role.getTrust());
+        assertEquals(role.getTrust(), "sys.network");
 
         // verify that our policy collections includes the policies defined in the template
 
         names = zmsImpl.dbService.listPolicies(subDomainName);
-        assertEquals(7, names.size());
+        assertEquals(names.size(), 7);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("vip_admin"));
         assertTrue(names.contains("sys_network_super_vip_admin"));
@@ -731,17 +731,17 @@ public class ZMSTemplateTest {
 
         Policy policy = zmsImpl.dbService.getPolicy(subDomainName, "vip_admin", null);
         assertEquals(subDomainName + ":policy.vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getAssertions().size(), 1);
         Assertion assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
+        assertEquals(assertion.getAction(), "*");
         assertEquals(subDomainName + ":role.vip_admin", assertion.getRole());
         assertEquals(subDomainName + ":vip*", assertion.getResource());
 
         policy = zmsImpl.dbService.getPolicy(subDomainName, "sys_network_super_vip_admin", null);
         assertEquals(subDomainName + ":policy.sys_network_super_vip_admin", policy.getName());
-        assertEquals(1, policy.getAssertions().size());
+        assertEquals(policy.getAssertions().size(), 1);
         assertion = policy.getAssertions().get(0);
-        assertEquals("*", assertion.getAction());
+        assertEquals(assertion.getAction(), "*");
         assertEquals(subDomainName + ":role.sys_network_super_vip_admin", assertion.getRole());
         assertEquals(subDomainName + ":vip*", assertion.getResource());
 
@@ -749,7 +749,7 @@ public class ZMSTemplateTest {
 
         DomainTemplateList domaintemplateList = zmsImpl.getDomainTemplateList(ctx, subDomainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(3, templates.size());
+        assertEquals(templates.size(), 3);
         assertTrue(templates.contains("vipng"));
         assertTrue(templates.contains("platforms"));
         assertTrue(templates.contains("user_provisioning"));
@@ -761,12 +761,12 @@ public class ZMSTemplateTest {
 
         domaintemplateList = zmsImpl.getDomainTemplateList(ctx, subDomainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(2, templates.size());
+        assertEquals(templates.size(), 2);
         assertTrue(templates.contains("platforms"));
         assertTrue(templates.contains("user_provisioning"));
 
         names = zmsImpl.dbService.listRoles(subDomainName);
-        assertEquals(5, names.size());
+        assertEquals(names.size(), 5);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deployer"));
         assertTrue(names.contains("user"));
@@ -774,7 +774,7 @@ public class ZMSTemplateTest {
         assertTrue(names.contains("openstack_readers"));
 
         names = zmsImpl.dbService.listPolicies(subDomainName);
-        assertEquals(5, names.size());
+        assertEquals(names.size(), 5);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("platforms_deploy"));
         assertTrue(names.contains("user"));
@@ -788,18 +788,18 @@ public class ZMSTemplateTest {
 
         domaintemplateList = zmsImpl.getDomainTemplateList(ctx, subDomainName);
         templates = domaintemplateList.getTemplateNames();
-        assertEquals(1, templates.size());
+        assertEquals(templates.size(), 1);
         assertTrue(templates.contains("user_provisioning"));
 
         names = zmsImpl.dbService.listRoles(subDomainName);
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("user"));
         assertTrue(names.contains("superuser"));
         assertTrue(names.contains("openstack_readers"));
 
         names = zmsImpl.dbService.listPolicies(subDomainName);
-        assertEquals(4, names.size());
+        assertEquals(names.size(), 4);
         assertTrue(names.contains("admin"));
         assertTrue(names.contains("user"));
         assertTrue(names.contains("superuser"));
@@ -815,11 +815,11 @@ public class ZMSTemplateTest {
         assertTrue(templates.isEmpty());
 
         names = zmsImpl.dbService.listRoles(subDomainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         names = zmsImpl.dbService.listPolicies(subDomainName);
-        assertEquals(1, names.size());
+        assertEquals(names.size(), 1);
         assertTrue(names.contains("admin"));
 
         zmsImpl.deleteSubDomain(ctx, "sys", "network", auditRef, null);
@@ -863,7 +863,7 @@ public class ZMSTemplateTest {
             zmsImpl.putDomainTemplateExt(ctx, domainName, templateName, auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid Role error: String pattern mismatch"));
         }
 
@@ -906,7 +906,7 @@ public class ZMSTemplateTest {
             zmsImpl.putDomainTemplateExt(ctx, domainName, templateName, auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid Role error: String pattern mismatch"));
         }
 
@@ -949,7 +949,7 @@ public class ZMSTemplateTest {
             zmsImpl.putDomainTemplateExt(ctx, domainName, templateName, auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid ServiceIdentity error: String pattern mismatch"));
         }
 
@@ -992,7 +992,7 @@ public class ZMSTemplateTest {
             zmsImpl.putDomainTemplateExt(ctx, domainName, templateName, auditRef, templateList);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid ResourceName error: String pattern mismatch"));
         }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/DomainRoleMembersFetcherTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/DomainRoleMembersFetcherTest.java
@@ -61,7 +61,7 @@ public class DomainRoleMembersFetcherTest {
                 "domain1",
                 "domain1:role.admin");
 
-        assertEquals(2, domainRoleMembers.size());
+        assertEquals(domainRoleMembers.size(), 2);
         assertTrue(domainRoleMembers.contains("user.domain1rolemember1"));
         assertTrue(domainRoleMembers.contains("user.domain1rolemember2"));
     }
@@ -76,7 +76,7 @@ public class DomainRoleMembersFetcherTest {
                 "domain1",
                 "domain1:role.admin");
 
-        assertEquals(new HashSet<>(), domainRoleMembers);
+        assertEquals(domainRoleMembers, new HashSet<>());
     }
 
     @Test
@@ -90,6 +90,6 @@ public class DomainRoleMembersFetcherTest {
                 "domain1",
                 "domain1:role.admin");
 
-        assertEquals(new HashSet<>(), domainRoleMembers);
+        assertEquals(domainRoleMembers, new HashSet<>());
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/GroupMemberExpiryNotificationTaskTest.java
@@ -630,7 +630,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         members.put("weather.api", domainGroupMember);
 
         Map<String, DomainGroupMember> consolidatedMembers = task.consolidateGroupMembers(members);
-        assertEquals(1, consolidatedMembers.size());
+        assertEquals(consolidatedMembers.size(), 1);
         assertNotNull(consolidatedMembers.get("user.joe"));
     }
 
@@ -684,7 +684,7 @@ public class GroupMemberExpiryNotificationTaskTest {
         domainGroupMembers.put("weather", groupMembers);
 
         Map<String, DomainGroupMember> consolidatedMembers = task.consolidateDomainAdmins(domainGroupMembers);
-        assertEquals(1, consolidatedMembers.size());
+        assertEquals(consolidatedMembers.size(), 1);
         assertNotNull(consolidatedMembers.get("user.joe"));
 
         // empty list should give us empty map
@@ -763,16 +763,16 @@ public class GroupMemberExpiryNotificationTaskTest {
         domainGroupMembers.put("weather", groupMembers);
 
         Map<String, DomainGroupMember> consolidatedMembers = task.consolidateDomainAdmins(domainGroupMembers);
-        Assert.assertEquals(3, consolidatedMembers.size());
+        Assert.assertEquals(consolidatedMembers.size(), 3);
 
         DomainGroupMember domainGroupMember = consolidatedMembers.get("user.joe");
         assertNotNull(domainGroupMember);
-        Assert.assertEquals(1, domainGroupMember.getMemberGroups().size());
-        Assert.assertEquals("user.user1", domainGroupMember.getMemberGroups().get(0).getMemberName());
+        Assert.assertEquals(domainGroupMember.getMemberGroups().size(), 1);
+        Assert.assertEquals(domainGroupMember.getMemberGroups().get(0).getMemberName(), "user.user1");
 
         domainGroupMember = consolidatedMembers.get("user.dave");
         assertNotNull(domainGroupMember);
-        Assert.assertEquals(2, domainGroupMember.getMemberGroups().size());
+        Assert.assertEquals(domainGroupMember.getMemberGroups().size(), 2);
         List<String> expectedValues = Arrays.asList("user.user2", "user.user3");
         List<String> actualValues = domainGroupMember.getMemberGroups().stream().map(GroupMember::getMemberName)
                 .collect(Collectors.toList());
@@ -780,8 +780,8 @@ public class GroupMemberExpiryNotificationTaskTest {
 
         domainGroupMember = consolidatedMembers.get("user.jane");
         assertNotNull(domainGroupMember);
-        Assert.assertEquals(1, domainGroupMember.getMemberGroups().size());
-        Assert.assertEquals("user.user4", domainGroupMember.getMemberGroups().get(0).getMemberName());
+        Assert.assertEquals(domainGroupMember.getMemberGroups().size(), 1);
+        Assert.assertEquals(domainGroupMember.getMemberGroups().get(0).getMemberName(), "user.user4");
     }
 
     @Test
@@ -809,7 +809,7 @@ public class GroupMemberExpiryNotificationTaskTest {
 
         GroupMember groupMember = new GroupMember().setDomainName("athenz").setGroupName("dev-team");
         EnumSet<DisableNotificationEnum> enumSet = task.getDisabledNotificationState(groupMember);
-        assertEquals(1, enumSet.size());
+        assertEquals(enumSet.size(), 1);
 
         groupMember = new GroupMember().setDomainName("athenz").setGroupName("qa-team");
         enumSet = task.getDisabledNotificationState(groupMember);
@@ -894,44 +894,47 @@ public class GroupMemberExpiryNotificationTaskTest {
         // owner of the principals, one for user.joe as the domain admin and another
         // for user.jane as domain admin
 
-        assertEquals(3, notifications.size());
+        assertEquals(notifications.size(), 3);
 
         // get the notification for user.joe as the admin of the domains
 
         Notification notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_ROLES_LIST);
         assertNotNull(notification);
 
-        assertEquals(1, notification.getRecipients().size());
-        assertEquals(2, notification.getDetails().size());
-        assertEquals("user.joe", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
-        assertEquals("home.joe;deployment;athenz.api;" + currentTime + ";notify+details" +
+        assertEquals(notification.getRecipients().size(), 1);
+        assertEquals(notification.getDetails().size(), 2);
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER), "user.joe");
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
+                "home.joe;deployment;athenz.api;" + currentTime + ";notify+details" +
                         "|home.joe;deployment;home.joe.openhouse;" + currentTime + ";" +
-                        "|home.joe;deployment;athenz.backend;" + currentTime + ";",
-                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+                        "|home.joe;deployment;athenz.backend;" + currentTime + ";"
+                );
 
         // get the notification for user.jane as the admin of the domains
 
         notification = getNotification(notifications, "user.jane", NOTIFICATION_DETAILS_ROLES_LIST);
         assertNotNull(notification);
 
-        assertEquals(1, notification.getRecipients().size());
-        assertEquals(2, notification.getDetails().size());
-        assertEquals("user.jane", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
-        assertEquals("home.joe;deployment;athenz.api;" + currentTime + ";notify+details" +
-                        "|home.joe;deployment;athenz.backend;" + currentTime + ";",
-                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+        assertEquals(notification.getRecipients().size(), 1);
+        assertEquals(notification.getDetails().size(), 2);
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER), "user.jane");
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
+                "home.joe;deployment;athenz.api;" + currentTime + ";notify+details" +
+                        "|home.joe;deployment;athenz.backend;" + currentTime + ";"
+                );
 
         // get the notification for user.joe as the owner of the principals
 
         notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_MEMBERS_LIST);
         assertNotNull(notification);
 
-        assertEquals(1, notification.getRecipients().size());
-        assertEquals(1, notification.getDetails().size());
-        assertEquals("home.joe;deployment;athenz.api;" + currentTime + ";notify+details" +
+        assertEquals(notification.getRecipients().size(), 1);
+        assertEquals(notification.getDetails().size(), 1);
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST),
+                "home.joe;deployment;athenz.api;" + currentTime + ";notify+details" +
                         "|home.joe;deployment;home.joe.openhouse;" + currentTime + ";" +
-                        "|home.joe;deployment;athenz.backend;" + currentTime + ";",
-                notification.getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST));
+                        "|home.joe;deployment;athenz.backend;" + currentTime + ";"
+                );
     }
 
     private Notification getNotification(List<Notification> notifications, String recipient, String detailsKey) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/MembershipDecisionNotificationCommonTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/MembershipDecisionNotificationCommonTest.java
@@ -47,7 +47,7 @@ public class MembershipDecisionNotificationCommonTest {
         members.add("user.jane");
         Set<String> recipients = membershipDecisionNotificationCommon.getRecipients(members);
 
-        assertEquals(2, recipients.size());
+        assertEquals(recipients.size(), 2);
         assertTrue(recipients.contains("user.joe"));
         assertTrue(recipients.contains("user.jane"));
     }
@@ -79,7 +79,7 @@ public class MembershipDecisionNotificationCommonTest {
         members.add("dom2.svc1");
         Set<String> recipients = membershipDecisionNotificationCommon.getRecipients(members);
 
-        assertEquals(3, recipients.size());
+        assertEquals(recipients.size(), 3);
         assertTrue(recipients.contains("user.joe"));
         assertTrue(recipients.contains("user.approver1"));
         assertTrue(recipients.contains("user.approver2"));
@@ -113,7 +113,7 @@ public class MembershipDecisionNotificationCommonTest {
         members.add("dom1:group.group1");
         Set<String> recipients = membershipDecisionNotificationCommon.getRecipients(members);
 
-        assertEquals(3, recipients.size());
+        assertEquals(recipients.size(), 3);
         assertTrue(recipients.contains("user.jane"));
         assertTrue(recipients.contains("user.approver1"));
         assertTrue(recipients.contains("user.approver2"));
@@ -157,7 +157,7 @@ public class MembershipDecisionNotificationCommonTest {
         members.add("dom1:group.group1");
         Set<String> recipients = membershipDecisionNotificationCommon.getRecipients(members);
 
-        assertEquals(5, recipients.size());
+        assertEquals(recipients.size(), 5);
         assertTrue(recipients.contains("user.jane"));
         assertTrue(recipients.contains("user.notifier1"));
         assertTrue(recipients.contains("user.notifier2"));
@@ -188,7 +188,7 @@ public class MembershipDecisionNotificationCommonTest {
         members.add("dom1:group.group1");
         Set<String> recipients = membershipDecisionNotificationCommon.getRecipients(members);
 
-        assertEquals(1, recipients.size());
+        assertEquals(recipients.size(), 1);
         assertTrue(recipients.contains("user.jane"));
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipDecisionNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipDecisionNotificationTaskTest.java
@@ -189,7 +189,7 @@ public class PutGroupMembershipDecisionNotificationTaskTest {
                         notificationToEmailConverterCommon);
 
         String description = putgroupMembershipDecisionNotificationTask.getDescription();
-        assertEquals("Pending Group Membership Decision Notification", description);
+        assertEquals(description, "Pending Group Membership Decision Notification");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutGroupMembershipNotificationTaskTest.java
@@ -434,7 +434,7 @@ public class PutGroupMembershipNotificationTaskTest {
                         new HashMap<>(), dbsvc, USER_DOMAIN_PREFIX, notificationToEmailConverterCommon);
 
         String description = putGroupMembershipNotificationTask.getDescription();
-        assertEquals("Group Membership Approval Notification", description);
+        assertEquals(description, "Group Membership Approval Notification");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipDecisionNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipDecisionNotificationTaskTest.java
@@ -321,7 +321,7 @@ public class PutRoleMembershipDecisionNotificationTaskTest {
                         notificationToEmailConverterCommon);
 
         String description = putRoleMembershipDecisionNotificationTask.getDescription();
-        assertEquals("Pending Membership Decision Notification", description);
+        assertEquals(description, "Pending Membership Decision Notification");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutRoleMembershipNotificationTaskTest.java
@@ -425,7 +425,7 @@ public class PutRoleMembershipNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         String description = putMembershipNotificationTask.getDescription();
-        assertEquals("Membership Approval Notification", description);
+        assertEquals(description, "Membership Approval Notification");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
@@ -564,15 +564,15 @@ public class RoleMemberExpiryNotificationTaskTest {
         assertTrue(disabledNotificationState.isEmpty());
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleDisabledUserNotif);
-        assertEquals(1, disabledNotificationState.size());
+        assertEquals(disabledNotificationState.size(), 1);
         assertTrue(disabledNotificationState.contains(DisableNotificationEnum.USER));
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleDisabledAdminNotif);
-        assertEquals(1, disabledNotificationState.size());
+        assertEquals(disabledNotificationState.size(), 1);
         assertTrue(disabledNotificationState.contains(DisableNotificationEnum.ADMIN));
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleDisabledNotifs);
-        assertEquals(2, disabledNotificationState.size());
+        assertEquals(disabledNotificationState.size(), 2);
         assertTrue(disabledNotificationState.containsAll(Arrays.asList(DisableNotificationEnum.ADMIN,
                 DisableNotificationEnum.USER)));
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommonTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberNotificationCommonTest.java
@@ -76,7 +76,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(0, notifications.size());
+        assertEquals(notifications.size(), 0);
 
         // Verify the same result when setting the memberRoles to an empty collection
         roleMember.setMemberRoles(Collections.emptyList());
@@ -90,7 +90,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(0, notifications.size());
+        assertEquals(notifications.size(), 0);
 
         final Timestamp expirationTs = Timestamp.fromMillis(100);
         final Timestamp reviewTs = Timestamp.fromMillis(50);
@@ -113,9 +113,9 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(2, notifications.size());
-        assertEquals(2, notifications.get(0).getDetails().size());
-        assertEquals(1, notifications.get(1).getDetails().size());
+        assertEquals(notifications.size(), 2);
+        assertEquals(notifications.get(0).getDetails().size(), 2);
+        assertEquals(notifications.get(1).getDetails().size(), 1);
 
         assertEquals(notifications.get(0).getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
                 "athenz1;role1;user.joe;" + expirationTs + ";notify+details");
@@ -137,9 +137,9 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(2, notifications.size());
-        assertEquals(2, notifications.get(0).getDetails().size());
-        assertEquals(1, notifications.get(1).getDetails().size());
+        assertEquals(notifications.size(), 2);
+        assertEquals(notifications.get(0).getDetails().size(), 2);
+        assertEquals(notifications.get(1).getDetails().size(), 1);
         assertEquals(notifications.get(0).getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
                 "athenz1;role1;user.joe;" + expirationTs + ";notify+details|athenz2;role1;user.joe;" + expirationTs
                         + ";|athenz2;role2;user.joe;" + expirationTs + ";");
@@ -214,7 +214,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(4, notifications.size());
+        assertEquals(notifications.size(), 4);
         for (Notification notification : notifications) {
             assertEquals(notification.getRecipients().size(), 1);
             final String principal = notification.getRecipients().iterator().next();
@@ -276,7 +276,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(0, notification.size());
+        assertEquals(notification.size(), 0);
 
         // Verify the same result when setting the memberRoles to an empty collection
         roleMember.setMemberRoles(Collections.emptyList());
@@ -288,7 +288,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewPrincipalNotificationToMetricConverter(),
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
-        assertEquals(0, notification.size());
+        assertEquals(notification.size(), 0);
 
         final Timestamp expirationTs = Timestamp.fromMillis(100);
         final Timestamp reviewTs = Timestamp.fromMillis(50);
@@ -307,9 +307,9 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(2, notification.size());
-        assertEquals(2, notification.get(0).getDetails().size());
-        assertEquals(1, notification.get(1).getDetails().size());
+        assertEquals(notification.size(), 2);
+        assertEquals(notification.get(0).getDetails().size(), 2);
+        assertEquals(notification.get(1).getDetails().size(), 1);
 
         assertEquals(notification.get(0).getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
                 "athenz1;role1;user.joe;" + reviewTs + ";");
@@ -332,8 +332,8 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(2, notification.size());
-        assertEquals(2, notification.get(0).getDetails().size());
+        assertEquals(notification.size(), 2);
+        assertEquals(notification.get(0).getDetails().size(), 2);
         String expectedRolesList = "athenz1;role1;user.joe;" + reviewTs +
                 ";|athenz2;role1;user.joe;" + reviewTs +
                 ";|athenz2;role2;user.joe;" + reviewTs + ";";
@@ -384,8 +384,8 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(1));
 
-        assertEquals(1, notification.size());
-        assertEquals(1, notification.get(0).getDetails().size());
+        assertEquals(notification.size(), 1);
+        assertEquals(notification.get(0).getDetails().size(), 1);
 
         assertEquals(notification.get(0).getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST),
                 "athenz1;role1;user.joe;" + reviewTs + ";");
@@ -400,8 +400,8 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(2));
 
-        assertEquals(1, notification.size());
-        assertEquals(2, notification.get(0).getDetails().size());
+        assertEquals(notification.size(), 1);
+        assertEquals(notification.get(0).getDetails().size(), 2);
 
         assertEquals(notification.get(0).getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
                 "athenz1;role1;user.joe;" + reviewTs + ";");
@@ -417,7 +417,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberReviewNotificationTask.RoleReviewDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(3));
 
-        assertEquals(0, notification.size());
+        assertEquals(notification.size(), 0);
     }
 
     @Test
@@ -456,7 +456,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(0, notification.size());
+        assertEquals(notification.size(), 0);
 
         // Verify the same result when setting the memberRoles to an empty collection
         roleMember.setMemberRoles(Collections.emptyList());
@@ -470,7 +470,7 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(0, notification.size());
+        assertEquals(notification.size(), 0);
 
         final Timestamp expirationTs = Timestamp.fromMillis(100);
         final Timestamp reviewTs = Timestamp.fromMillis(50);
@@ -497,9 +497,9 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(2, notification.size());
-        assertEquals(2, notification.get(0).getDetails().size());
-        assertEquals(1, notification.get(1).getDetails().size());
+        assertEquals(notification.size(), 2);
+        assertEquals(notification.get(0).getDetails().size(), 2);
+        assertEquals(notification.get(1).getDetails().size(), 1);
 
         assertEquals(notification.get(0).getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
                 "athenz1;role1;user.joe;" + expirationTs + ";notify+details|groupdomain1;grouprole1;user.joe;" + expirationTs + ";");
@@ -522,8 +522,8 @@ public class RoleMemberNotificationCommonTest {
                 new RoleMemberExpiryNotificationTask.RoleExpiryDomainNotificationToMetricConverter(),
                 memberRole -> DisableNotificationEnum.getEnumSet(0));
 
-        assertEquals(2, notification.size());
-        assertEquals(2, notification.get(0).getDetails().size());
+        assertEquals(notification.size(), 2);
+        assertEquals(notification.get(0).getDetails().size(), 2);
         assertEquals(notification.get(0).getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
                 "athenz1;role1;user.joe;" + expirationTs + ";notify+details|groupdomain1;grouprole1;user.joe;" + expirationTs
                     + ";|athenz2;role1;user.joe;" + expirationTs + ";|athenz2;role2;user.joe;" + expirationTs + ";");
@@ -596,7 +596,7 @@ public class RoleMemberNotificationCommonTest {
         members.put("weather.api", domainRoleMember);
 
         Map<String, DomainRoleMember> consolidatedMembers = task.consolidateRoleMembers(members);
-        assertEquals(1, consolidatedMembers.size());
+        assertEquals(consolidatedMembers.size(), 1);
         assertNotNull(consolidatedMembers.get("user.joe"));
     }
 
@@ -649,7 +649,7 @@ public class RoleMemberNotificationCommonTest {
         domainRoleMembers.put("weather", memberRoles);
 
         Map<String, DomainRoleMember> consolidatedMembers = task.consolidateDomainAdmins(domainRoleMembers);
-        assertEquals(1, consolidatedMembers.size());
+        assertEquals(consolidatedMembers.size(), 1);
         assertNotNull(consolidatedMembers.get("user.joe"));
 
         // empty list should give us empty map
@@ -727,16 +727,16 @@ public class RoleMemberNotificationCommonTest {
         domainRoleMembers.put("weather", memberRoles);
 
         Map<String, DomainRoleMember> consolidatedMembers = task.consolidateDomainAdmins(domainRoleMembers);
-        Assert.assertEquals(3, consolidatedMembers.size());
+        Assert.assertEquals(consolidatedMembers.size(), 3);
 
         DomainRoleMember domainRoleMember = consolidatedMembers.get("user.joe");
         assertNotNull(domainRoleMember);
-        Assert.assertEquals(1, domainRoleMember.getMemberRoles().size());
-        Assert.assertEquals("user.user1", domainRoleMember.getMemberRoles().get(0).getMemberName());
+        Assert.assertEquals(domainRoleMember.getMemberRoles().size(), 1);
+        Assert.assertEquals(domainRoleMember.getMemberRoles().get(0).getMemberName(), "user.user1");
 
         domainRoleMember = consolidatedMembers.get("user.dave");
         assertNotNull(domainRoleMember);
-        Assert.assertEquals(2, domainRoleMember.getMemberRoles().size());
+        Assert.assertEquals(domainRoleMember.getMemberRoles().size(), 2);
         List<String> expectedValues = Arrays.asList("user.user2", "user.user3");
         List<String> actualValues = domainRoleMember.getMemberRoles().stream().map(MemberRole::getMemberName)
                 .collect(Collectors.toList());
@@ -744,8 +744,8 @@ public class RoleMemberNotificationCommonTest {
 
         domainRoleMember = consolidatedMembers.get("user.jane");
         assertNotNull(domainRoleMember);
-        Assert.assertEquals(1, domainRoleMember.getMemberRoles().size());
-        Assert.assertEquals("user.user4", domainRoleMember.getMemberRoles().get(0).getMemberName());
+        Assert.assertEquals(domainRoleMember.getMemberRoles().size(), 1);
+        Assert.assertEquals(domainRoleMember.getMemberRoles().get(0).getMemberName(), "user.user4");
     }
 
     @Test
@@ -823,44 +823,47 @@ public class RoleMemberNotificationCommonTest {
         // owner of the principals, one for user.joe as the domain admin and another
         // for user.jane as domain admin
 
-        assertEquals(3, notifications.size());
+        assertEquals(notifications.size(), 3);
 
         // get the notification for user.joe as the admin of the domains
 
         Notification notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_ROLES_LIST);
         assertNotNull(notification);
 
-        assertEquals(1, notification.getRecipients().size());
-        assertEquals(2, notification.getDetails().size());
-        assertEquals("user.joe", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
-        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+        assertEquals(notification.getRecipients().size(), 1);
+        assertEquals(notification.getDetails().size(), 2);
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER), "user.joe");
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
+                "home.joe;deployment;athenz.api;" + currentTime +
                         ";|home.joe;deployment;home.joe.openhouse;" + currentTime +
-                        ";|home.joe;deployment;athenz.backend;" + currentTime + ";",
-                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+                        ";|home.joe;deployment;athenz.backend;" + currentTime + ";"
+                );
 
         // get the notification for user.jane as the admin of the domains
 
         notification = getNotification(notifications, "user.jane", NOTIFICATION_DETAILS_ROLES_LIST);
         assertNotNull(notification);
 
-        assertEquals(1, notification.getRecipients().size());
-        assertEquals(2, notification.getDetails().size());
-        assertEquals("user.jane", notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER));
-        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
-                        ";|home.joe;deployment;athenz.backend;" + currentTime + ";",
-                notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST));
+        assertEquals(notification.getRecipients().size(), 1);
+        assertEquals(notification.getDetails().size(), 2);
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_MEMBER), "user.jane");
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_ROLES_LIST),
+                "home.joe;deployment;athenz.api;" + currentTime +
+                        ";|home.joe;deployment;athenz.backend;" + currentTime + ";"
+                );
 
         // get the notification for user.joe as the owner of the principals
 
         notification = getNotification(notifications, "user.joe", NOTIFICATION_DETAILS_MEMBERS_LIST);
         assertNotNull(notification);
 
-        assertEquals(1, notification.getRecipients().size());
-        assertEquals(1, notification.getDetails().size());
-        assertEquals("home.joe;deployment;athenz.api;" + currentTime +
+        assertEquals(notification.getRecipients().size(), 1);
+        assertEquals(notification.getDetails().size(), 1);
+        assertEquals(notification.getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST),
+                "home.joe;deployment;athenz.api;" + currentTime +
                         ";|home.joe;deployment;home.joe.openhouse;" + currentTime +
-                        ";|home.joe;deployment;athenz.backend;" + currentTime + ";",
-                notification.getDetails().get(NOTIFICATION_DETAILS_MEMBERS_LIST));
+                        ";|home.joe;deployment;athenz.backend;" + currentTime + ";"
+                );
     }
 
     private Notification getNotification(List<Notification> notifications, String recipient, String detailsKey) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberReviewNotificationTaskTest.java
@@ -484,15 +484,15 @@ public class RoleMemberReviewNotificationTaskTest {
         assertTrue(disabledNotificationState.isEmpty());
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleDisabledUserNotif);
-        assertEquals(1, disabledNotificationState.size());
+        assertEquals(disabledNotificationState.size(), 1);
         assertTrue(disabledNotificationState.contains(DisableNotificationEnum.USER));
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleDisabledAdminNotif);
-        assertEquals(1, disabledNotificationState.size());
+        assertEquals(disabledNotificationState.size(), 1);
         assertTrue(disabledNotificationState.contains(DisableNotificationEnum.ADMIN));
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleDisabledNotifs);
-        assertEquals(2, disabledNotificationState.size());
+        assertEquals(disabledNotificationState.size(), 2);
         assertTrue(disabledNotificationState.containsAll(Arrays.asList(DisableNotificationEnum.ADMIN, DisableNotificationEnum.USER)));
 
         disabledNotificationState = notificationFilter.getDisabledNotificationState(memberRoleInvalid);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationTaskFactoryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationTaskFactoryTest.java
@@ -35,7 +35,7 @@ public class ZMSNotificationTaskFactoryTest {
         ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc,
                 USER_DOMAIN_PREFIX, new NotificationToEmailConverterCommon(null));
         List<NotificationTask> notificationTasks = zmsNotificationTaskFactory.getNotificationTasks();
-        assertEquals(5, notificationTasks.size());
+        assertEquals(notificationTasks.size(), 5);
         assertEquals(notificationTasks.get(0).getDescription(), "pending role membership approvals reminders");
         assertEquals(notificationTasks.get(1).getDescription(), "pending group membership approvals reminders");
         assertEquals(notificationTasks.get(2).getDescription(), "membership expiration reminders");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/PrincipalDomainFilterTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/PrincipalDomainFilterTest.java
@@ -21,7 +21,6 @@ import com.yahoo.athenz.zms.*;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.*;
 
-import java.lang.reflect.Member;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -45,42 +45,42 @@ public class ZMSUtilsTest {
 
     @Test
     public void testRemoveDomainPrefix() {
-        assertEquals("role1", ZMSUtils.removeDomainPrefix("role1", "domain1", "role."));
-        assertEquals("role1", ZMSUtils.removeDomainPrefix("domain1:role.role1", "domain1", "role."));
-        assertEquals("domain1:role.role1", ZMSUtils.removeDomainPrefix("domain1:role.role1", "domain2", "role."));
-        assertEquals("domain1:role.role1", ZMSUtils.removeDomainPrefix("domain1:role.role1", "domain1", "policy."));
-        assertEquals("policy1", ZMSUtils.removeDomainPrefix("domain1:policy.policy1", "domain1", "policy."));
+        assertEquals(ZMSUtils.removeDomainPrefix("role1", "domain1", "role."), "role1");
+        assertEquals(ZMSUtils.removeDomainPrefix("domain1:role.role1", "domain1", "role."), "role1");
+        assertEquals(ZMSUtils.removeDomainPrefix("domain1:role.role1", "domain2", "role."), "domain1:role.role1");
+        assertEquals(ZMSUtils.removeDomainPrefix("domain1:role.role1", "domain1", "policy."), "domain1:role.role1");
+        assertEquals(ZMSUtils.removeDomainPrefix("domain1:policy.policy1", "domain1", "policy."), "policy1");
     }
 
     @Test
     public void testGetTenantResourceGroupRolePrefix() {
 
-        assertEquals("storage.tenant.sports.api.",
-                ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", null));
-        assertEquals("storage.tenant.sports.api.res_group.",
-                ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", ""));
-        assertEquals("storage.tenant.sports.api.res_group.Group1.",
-                ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", "Group1"));
+        assertEquals(ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", null),
+                "storage.tenant.sports.api.");
+        assertEquals(ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", ""),
+                "storage.tenant.sports.api.res_group.");
+        assertEquals(ZMSUtils.getTenantResourceGroupRolePrefix("storage", "sports.api", "Group1"),
+                "storage.tenant.sports.api.res_group.Group1.");
     }
 
     @Test
     public void testGetTrustedResourceGroupRolePrefix() {
-        assertEquals("coretech:role.storage.tenant.sports.api.",
-                ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", null));
-        assertEquals("coretech:role.storage.tenant.sports.api.",
-                ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", ""));
-        assertEquals("coretech:role.storage.tenant.sports.api.res_group.group1.",
-                ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", "group1"));
+        assertEquals(ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", null),
+                "coretech:role.storage.tenant.sports.api.");
+        assertEquals(ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", ""),
+                "coretech:role.storage.tenant.sports.api.");
+        assertEquals(ZMSUtils.getTrustedResourceGroupRolePrefix("coretech", "storage", "sports.api", "group1"),
+                "coretech:role.storage.tenant.sports.api.res_group.group1.");
     }
 
     @Test
     public void testGetProviderResourceGroupRolePrefix() {
-        assertEquals("sports.hosted.res_group.hockey.",
-                ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", "hockey"));
-        assertEquals("sports.hosted.",
-                ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", null));
-        assertEquals("sports.hosted.",
-                ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", ""));
+        assertEquals(ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", "hockey"),
+                "sports.hosted.res_group.hockey.");
+        assertEquals(ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", null),
+                "sports.hosted.");
+        assertEquals(ZMSUtils.getProviderResourceGroupRolePrefix("sports", "hosted", ""),
+                "sports.hosted.");
     }
 
     @Test
@@ -141,8 +141,8 @@ public class ZMSUtilsTest {
     @Test
     public void testExtractRoleName() {
 
-        assertEquals("role1", ZMSUtils.extractRoleName("my-domain1", "my-domain1:role.role1"));
-        assertEquals("role1.role2", ZMSUtils.extractRoleName("my-domain1", "my-domain1:role.role1.role2"));
+        assertEquals(ZMSUtils.extractRoleName("my-domain1", "my-domain1:role.role1"), "role1");
+        assertEquals(ZMSUtils.extractRoleName("my-domain1", "my-domain1:role.role1.role2"), "role1.role2");
 
         // invalid roles names
         assertNull(ZMSUtils.extractRoleName("my-domain1", "my-domain1:role1"));
@@ -156,8 +156,8 @@ public class ZMSUtilsTest {
     @Test
     public void testExtractEntityName() {
 
-        assertEquals("entity1", ZMSUtils.extractEntityName("my-domain1", "my-domain1:entity.entity1"));
-        assertEquals("entity1.entity2", ZMSUtils.extractEntityName("my-domain1", "my-domain1:entity.entity1.entity2"));
+        assertEquals(ZMSUtils.extractEntityName("my-domain1", "my-domain1:entity.entity1"), "entity1");
+        assertEquals(ZMSUtils.extractEntityName("my-domain1", "my-domain1:entity.entity1.entity2"), "entity1.entity2");
 
         // invalid entity names
         assertNull(ZMSUtils.extractEntityName("my-domain1", "my-domain1:entity1"));
@@ -171,8 +171,8 @@ public class ZMSUtilsTest {
     @Test
     public void testExtractServiceName() {
 
-        assertEquals("service1", ZMSUtils.extractServiceName("my-domain1", "my-domain1.service1"));
-        assertEquals("service1", ZMSUtils.extractServiceName("my-domain1.domain2", "my-domain1.domain2.service1"));
+        assertEquals(ZMSUtils.extractServiceName("my-domain1", "my-domain1.service1"), "service1");
+        assertEquals(ZMSUtils.extractServiceName("my-domain1.domain2", "my-domain1.domain2.service1"), "service1");
 
         // invalid service names
         assertNull(ZMSUtils.extractServiceName("my-domain1", "my-domain1:service1"));
@@ -186,8 +186,8 @@ public class ZMSUtilsTest {
     @Test
     public void testExtractPolicyName() {
 
-        assertEquals("policy1", ZMSUtils.extractPolicyName("my-domain1", "my-domain1:policy.policy1"));
-        assertEquals("policy1.policy2", ZMSUtils.extractPolicyName("my-domain1", "my-domain1:policy.policy1.policy2"));
+        assertEquals(ZMSUtils.extractPolicyName("my-domain1", "my-domain1:policy.policy1"), "policy1");
+        assertEquals(ZMSUtils.extractPolicyName("my-domain1", "my-domain1:policy.policy1.policy2"), "policy1.policy2");
 
         // invalid policies names
         assertNull(ZMSUtils.extractPolicyName("my-domain1", "my-domain1:policy1"));
@@ -271,14 +271,14 @@ public class ZMSUtilsTest {
         assertNull(ZMSUtils.combineUserAuthorityFilters("", null));
         assertNull(ZMSUtils.combineUserAuthorityFilters("", ""));
 
-        assertEquals("role", ZMSUtils.combineUserAuthorityFilters("role", null));
-        assertEquals("role", ZMSUtils.combineUserAuthorityFilters("role", ""));
+        assertEquals(ZMSUtils.combineUserAuthorityFilters("role", null), "role");
+        assertEquals(ZMSUtils.combineUserAuthorityFilters("role", ""), "role");
 
-        assertEquals("domain", ZMSUtils.combineUserAuthorityFilters(null, "domain"));
-        assertEquals("domain", ZMSUtils.combineUserAuthorityFilters("", "domain"));
+        assertEquals(ZMSUtils.combineUserAuthorityFilters(null, "domain"), "domain");
+        assertEquals(ZMSUtils.combineUserAuthorityFilters("", "domain"), "domain");
 
-        assertEquals("role,domain", ZMSUtils.combineUserAuthorityFilters("role", "domain"));
-        assertEquals("same,same", ZMSUtils.combineUserAuthorityFilters("same", "same"));
+        assertEquals(ZMSUtils.combineUserAuthorityFilters("role", "domain"), "role,domain");
+        assertEquals(ZMSUtils.combineUserAuthorityFilters("same", "same"), "same,same");
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ExceptionMapperTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ExceptionMapperTest.java
@@ -28,18 +28,18 @@ public class ExceptionMapperTest {
 
         JsonGeneralExceptionMapper mapper1 = new JsonGeneralExceptionMapper();
         Response response = mapper1.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
 
         JsonMappingExceptionMapper mapper2 = new JsonMappingExceptionMapper();
         response = mapper2.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
 
         JsonParseExceptionMapper mapper3 = new JsonParseExceptionMapper();
         response = mapper3.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
 
         JsonProcessingExceptionMapper mapper4 = new JsonProcessingExceptionMapper();
         response = mapper4.toResponse(null);
-        assertEquals(400, response.getStatus());
+        assertEquals(response.getStatus(), 400);
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ResourceExceptionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ResourceExceptionTest.java
@@ -23,33 +23,33 @@ public class ResourceExceptionTest {
 
     @Test
     public void testCodeToString() {
-        
-        assertEquals("OK", ResourceException.codeToString(200));
-        assertEquals("Created", ResourceException.codeToString(201));
-        assertEquals("Accepted", ResourceException.codeToString(202));
-        assertEquals("No Content", ResourceException.codeToString(204));
-        assertEquals("Moved Permanently", ResourceException.codeToString(301));
-        assertEquals("Found", ResourceException.codeToString(302));
-        assertEquals("See Other", ResourceException.codeToString(303));
-        assertEquals("Not Modified", ResourceException.codeToString(304));
-        assertEquals("Temporary Redirect", ResourceException.codeToString(307));
-        assertEquals("Bad Request", ResourceException.codeToString(400));
-        assertEquals("Unauthorized", ResourceException.codeToString(401));
-        assertEquals("Forbidden", ResourceException.codeToString(403));
-        assertEquals("Not Found", ResourceException.codeToString(404));
-        assertEquals("Conflict", ResourceException.codeToString(409));
-        assertEquals("Gone", ResourceException.codeToString(410));
-        assertEquals("Precondition Failed", ResourceException.codeToString(412));
-        assertEquals("Unsupported Media Type", ResourceException.codeToString(415));
-        assertEquals("Precondition Required", ResourceException.codeToString(428));
-        assertEquals("Too Many Requests", ResourceException.codeToString(429));
-        assertEquals("Request Header Fields Too Large", ResourceException.codeToString(431));
-        assertEquals("Internal Server Error", ResourceException.codeToString(500));
-        assertEquals("Not Implemented", ResourceException.codeToString(501));
-        assertEquals("Service Unavailable", ResourceException.codeToString(503));
-        assertEquals("Gateway Timeout", ResourceException.codeToString(504));
-        assertEquals("Network Authentication Required", ResourceException.codeToString(511));
-        assertEquals("1001", ResourceException.codeToString(1001));
+
+        assertEquals(ResourceException.codeToString(200), "OK");
+        assertEquals(ResourceException.codeToString(201), "Created");
+        assertEquals(ResourceException.codeToString(202), "Accepted");
+        assertEquals(ResourceException.codeToString(204), "No Content");
+        assertEquals(ResourceException.codeToString(301), "Moved Permanently");
+        assertEquals(ResourceException.codeToString(302), "Found");
+        assertEquals(ResourceException.codeToString(303), "See Other");
+        assertEquals(ResourceException.codeToString(304), "Not Modified");
+        assertEquals(ResourceException.codeToString(307), "Temporary Redirect");
+        assertEquals(ResourceException.codeToString(400), "Bad Request");
+        assertEquals(ResourceException.codeToString(401), "Unauthorized");
+        assertEquals(ResourceException.codeToString(403), "Forbidden");
+        assertEquals(ResourceException.codeToString(404), "Not Found");
+        assertEquals(ResourceException.codeToString(409), "Conflict");
+        assertEquals(ResourceException.codeToString(410), "Gone");
+        assertEquals(ResourceException.codeToString(412), "Precondition Failed");
+        assertEquals(ResourceException.codeToString(415), "Unsupported Media Type");
+        assertEquals(ResourceException.codeToString(428), "Precondition Required");
+        assertEquals(ResourceException.codeToString(429), "Too Many Requests");
+        assertEquals(ResourceException.codeToString(431), "Request Header Fields Too Large");
+        assertEquals(ResourceException.codeToString(500), "Internal Server Error");
+        assertEquals(ResourceException.codeToString(501), "Not Implemented");
+        assertEquals(ResourceException.codeToString(503), "Service Unavailable");
+        assertEquals(ResourceException.codeToString(504), "Gateway Timeout");
+        assertEquals(ResourceException.codeToString(511), "Network Authentication Required");
+        assertEquals(ResourceException.codeToString(1001), "1001");
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
@@ -156,7 +156,7 @@ public class RsrcCtxWrapperTest {
         try {
             wrapper.authenticate();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -351,8 +351,8 @@ public class RsrcCtxWrapperTest {
                 authorizerMock, metricMock, timerMetricMock, "apiName");
 
         wrapper.authenticate();
-        assertEquals("athenz.role", wrapper.logPrincipal());
-        assertEquals("hockey", wrapper.getPrincipalDomain());
+        assertEquals(wrapper.logPrincipal(), "athenz.role");
+        assertEquals(wrapper.getPrincipalDomain(), "hockey");
     }
 
     @Test
@@ -377,7 +377,7 @@ public class RsrcCtxWrapperTest {
             wrapper.throwZtsException(restExc);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(503, ex.getCode());
+            assertEquals(ex.getCode(), 503);
         }
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -1209,16 +1209,16 @@ public class ZTSImplTest {
         ResourceContext context = createResourceContext(principal);
 
         HostServices hosts = zts.getHostServices(context, "host1");
-        assertEquals(1, hosts.getNames().size());
+        assertEquals(hosts.getNames().size(), 1);
         assertTrue(hosts.getNames().contains("coretech.storage"));
 
         hosts = zts.getHostServices(context, "host2");
-        assertEquals(2, hosts.getNames().size());
+        assertEquals(hosts.getNames().size(), 2);
         assertTrue(hosts.getNames().contains("coretech.storage"));
         assertTrue(hosts.getNames().contains("coretech.backup"));
 
         hosts = zts.getHostServices(context, "host3");
-        assertEquals(1, hosts.getNames().size());
+        assertEquals(hosts.getNames().size(), 1);
         assertTrue(hosts.getNames().contains("coretech.backup"));
     }
 
@@ -1683,7 +1683,7 @@ public class ZTSImplTest {
             zts.getRoleToken(context, "coretech", null, 600, 1200, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
 
         // now include the role and verify valid response
@@ -2959,8 +2959,8 @@ public class ZTSImplTest {
         SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
         store.processSignedDomain(signedDomain, false);
 
-        assertEquals("coretech", zts.retrieveTenantDomainName("storage.tenant.coretech.admin", "storage"));
-        assertEquals("coretech", zts.retrieveTenantDomainName("storage.tenant.coretech.admin", null));
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.admin", "storage"), "coretech");
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.admin", null), "coretech");
     }
 
     @Test
@@ -2976,14 +2976,14 @@ public class ZTSImplTest {
         SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
         store.processSignedDomain(signedDomain, false);
 
-        assertEquals("coretech", zts.retrieveTenantDomainName("storage.tenant.coretech.resource_group.admin", "storage"));
-        assertEquals("coretech", zts.retrieveTenantDomainName("storage.tenant.coretech.resource_group.admin", null));
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.resource_group.admin", "storage"), "coretech");
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.resource_group.admin", null), "coretech");
 
         signedDomain = createSignedDomain("coretech.office.burbank", "weather", "storage", true);
         store.processSignedDomain(signedDomain, false);
 
-        assertEquals("coretech.office.burbank", zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.resource_group.admin", "storage"));
-        assertEquals("coretech.office.burbank", zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.resource_group.admin", null));
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.resource_group.admin", "storage"), "coretech.office.burbank");
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.resource_group.admin", null), "coretech.office.burbank");
     }
 
     @Test
@@ -2992,8 +2992,8 @@ public class ZTSImplTest {
         SignedDomain signedDomain = createSignedDomain("coretech.office.burbank", "weather", "storage", true);
         store.processSignedDomain(signedDomain, false);
 
-        assertEquals("coretech.office.burbank", zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.admin", "storage"));
-        assertEquals("coretech.office.burbank", zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.admin", null));
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.admin", "storage"), "coretech.office.burbank");
+        assertEquals(zts.retrieveTenantDomainName("storage.tenant.coretech.office.burbank.admin", null), "coretech.office.burbank");
     }
 
     @Test
@@ -3128,7 +3128,7 @@ public class ZTSImplTest {
             ctx.throwZtsException(restExc);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(401, ex.getCode());
+            assertEquals(ex.getCode(), 401);
             assertEquals( ((ResourceError) ex.getData()).message, "failed message");
         }
     }
@@ -3467,7 +3467,7 @@ public class ZTSImplTest {
             authorizer.access("update", "coretechtrust:table1:test3", principal1, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -3480,7 +3480,7 @@ public class ZTSImplTest {
             authorizer.access("update", "unknowndoamin:table1", principal1, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -4452,7 +4452,7 @@ public class ZTSImplTest {
             zts.processRoleCertificateRequest(context, principal, "user_domain", certReq, null, req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         zts.verifyCertSubjectOU = verifyCertSubjectOU;
@@ -4512,7 +4512,7 @@ public class ZTSImplTest {
             zts.postRoleCertificateRequest(context, "coretech", "readers", req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("is not included in the requested role(s)"));
         }
     }
@@ -4536,7 +4536,7 @@ public class ZTSImplTest {
             zts.postRoleCertificateRequest(context, "coretech", "readers", req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
             assertTrue(ex.getMessage().contains("No such domain: coretech"));
         }
     }
@@ -4593,7 +4593,7 @@ public class ZTSImplTest {
             zts.postRoleCertificateRequest(context, "coretech", "readers", req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Unable to parse PKCS10 CSR"));
         }
 
@@ -4604,7 +4604,7 @@ public class ZTSImplTest {
             zts.postRoleCertificateRequest(context, "coretech", "readers", req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Unable to parse PKCS10 CSR"));
         }
     }
@@ -4876,8 +4876,8 @@ public class ZTSImplTest {
         list.add("service");
 
         AthenzObject.LIST.convertToLowerCase(list);
-        assertEquals("domain", list.get(0));
-        assertEquals("service", list.get(1));
+        assertEquals(list.get(0), "domain");
+        assertEquals(list.get(1), "service");
 
         // should not cause any exceptions
         AthenzObject.LIST.convertToLowerCase(null);
@@ -5563,7 +5563,7 @@ public class ZTSImplTest {
             ztsImpl.postInstanceRegisterInformation(context, info);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         orgUnitValues.add("Testing Domain");
@@ -6533,7 +6533,7 @@ public class ZTSImplTest {
                     "localhost");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -8591,14 +8591,14 @@ public class ZTSImplTest {
             ztsImpl.getStatus(context);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         // create the status file
 
         new FileOutputStream(healthCheckFile).close();
         Status status = ztsImpl.getStatus(context);
-        assertEquals(ResourceException.OK, status.getCode());
+        assertEquals(status.getCode(), ResourceException.OK);
 
         // delete the status file
 
@@ -8607,7 +8607,7 @@ public class ZTSImplTest {
             ztsImpl.getStatus(context);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
         }
 
         System.clearProperty(ZTSConsts.ZTS_PROP_HEALTH_CHECK_PATH);
@@ -8633,7 +8633,7 @@ public class ZTSImplTest {
         ztsImpl.statusPort = 0;
 
         Status status = ztsImpl.getStatus(context);
-        assertEquals(ResourceException.OK, status.getCode());
+        assertEquals(status.getCode(), ResourceException.OK);
 
         // if the MockStatusCheckerThrowException is set
         // the MockStatusCheckerThrowException determines that there is a problem with the server
@@ -9307,7 +9307,7 @@ public class ZTSImplTest {
             ztsImpl.postInstanceRefreshRequest(context, "athenz", "syncer", req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -9596,7 +9596,7 @@ public class ZTSImplTest {
             ztsImpl.postSSHCertRequest(context, certRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Failed to get ssh certs"));
         }
     }
@@ -9610,7 +9610,7 @@ public class ZTSImplTest {
         assertEquals(serverHostName, ZTSImpl.getServerHostName());
 
         System.setProperty(ZTSConsts.ZTS_PROP_HOSTNAME, "server1.athenz");
-        assertEquals("server1.athenz", ZTSImpl.getServerHostName());
+        assertEquals(ZTSImpl.getServerHostName(), "server1.athenz");
         System.clearProperty(ZTSConsts.ZTS_PROP_HOSTNAME);
     }
 
@@ -9782,7 +9782,7 @@ public class ZTSImplTest {
         domainPolicies.setPolicies(zmsPolicies);
 
         policies = zts.getPolicyList(domainData, null);
-        assertEquals(1, policies.size());
+        assertEquals(policies.size(), 1);
         assertNull(policies.get(0).getAssertions());
     }
 
@@ -9862,7 +9862,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=" + scope);
         assertNotNull(resp);
-        assertEquals("coretech:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -9880,14 +9880,14 @@ public class ZTSImplTest {
         try {
             assertNotNull(claimSet);
             assertNotNull(claimSet.getJWTID());
-            assertEquals("user_domain.user", claimSet.getSubject());
-            assertEquals("coretech", claimSet.getAudience().get(0));
-            assertEquals("writers", claimSet.getStringClaim("scope"));
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "coretech");
+            assertEquals(claimSet.getStringClaim("scope"), "writers");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -9899,7 +9899,7 @@ public class ZTSImplTest {
         resp = ztsImpl.postAccessTokenRequest(context1,
                 "grant_type=client_credentials&scope=coretech:domain&expires_in=100");
         assertNotNull(resp);
-        assertEquals("coretech:role.readers coretech:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.readers coretech:role.writers");
 
         accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -9914,10 +9914,10 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("user_domain.user1", claimSet.getSubject());
-            assertEquals("coretech", claimSet.getAudience().get(0));
-            assertEquals(100 * 1000, claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime());
-            assertEquals("readers writers", claimSet.getStringClaim("scope"));
+            assertEquals(claimSet.getSubject(), "user_domain.user1");
+            assertEquals(claimSet.getAudience().get(0), "coretech");
+            assertEquals(claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime(), 100 * 1000);
+            assertEquals(claimSet.getStringClaim("scope"), "readers writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -9953,7 +9953,7 @@ public class ZTSImplTest {
             ztsImpl.postAccessTokenRequest(context, "grant_type=client_credentials&scope=coretech:domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
 
         // now add the second role as well
@@ -9963,7 +9963,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=coretech:domain&expires_in=100");
         assertNotNull(resp);
-        assertEquals("coretech:role.readers coretech:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.readers coretech:role.writers");
     }
 
     @Test
@@ -9994,7 +9994,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=coretech:domain");
         assertNotNull(resp);
-        assertEquals("coretech:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10012,17 +10012,17 @@ public class ZTSImplTest {
         try {
             assertNotNull(claimSet);
             assertNotNull(claimSet.getJWTID());
-            assertEquals("user_domain.user", claimSet.getSubject());
-            assertEquals("coretech", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "coretech");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
-            assertEquals("writers", claimSet.getStringClaim("scope"));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
+            assertEquals(claimSet.getStringClaim("scope"), "writers");
 
             Map<String, Object> cnf = (Map<String, Object>) claimSet.getClaim("cnf");
-            assertEquals("A4DtL2JmUMhAsvJj5tKyn64SqzmuXbMrJa0n761y5v0", cnf.get("x5t#S256"));
+            assertEquals(cnf.get("x5t#S256"), "A4DtL2JmUMhAsvJj5tKyn64SqzmuXbMrJa0n761y5v0");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10049,7 +10049,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=coretech:domain");
         assertNotNull(resp);
-        assertEquals("coretech:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10067,14 +10067,14 @@ public class ZTSImplTest {
         try {
             assertNotNull(claimSet);
             assertNotNull(claimSet.getJWTID());
-            assertEquals("user_domain.user", claimSet.getSubject());
-            assertEquals("coretech", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "coretech");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
-            assertEquals("writers", claimSet.getStringClaim("scope"));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
+            assertEquals(claimSet.getStringClaim("scope"), "writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10126,7 +10126,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=" + scope + "&expires_in=240");
         assertNotNull(resp);
-        assertEquals("coretech:role.writers openid", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers openid");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10146,8 +10146,8 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("writers", claimSet.getStringClaim("scope"));
-            assertEquals(240 * 1000, claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime());
+            assertEquals(claimSet.getStringClaim("scope"), "writers");
+            assertEquals(claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime(), 240 * 1000);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10198,7 +10198,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=" + scope + "&expires_in=240" + reqComp);
         assertNotNull(resp);
-        assertEquals("coretech:role.writers openid", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers openid");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10216,8 +10216,8 @@ public class ZTSImplTest {
         try {
             assertNotNull(claimSet);
             assertEquals(issuer, claimSet.getIssuer());
-            assertEquals("writers", claimSet.getStringClaim("scope"));
-            assertEquals(240 * 1000, claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime());
+            assertEquals(claimSet.getStringClaim("scope"), "writers");
+            assertEquals(claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime(), 240 * 1000);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10261,7 +10261,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=" + scope + "&expires_in=57600");
         assertNotNull(resp);
-        assertEquals("coretech:role.writers openid", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers openid");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10282,7 +10282,7 @@ public class ZTSImplTest {
 
         // the value should be 12 hours - the default max
 
-        assertEquals(12 * 60 * 60 * 1000, claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime());
+        assertEquals(claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime(), 12 * 60 * 60 * 1000);
     }
 
     @Test
@@ -10302,7 +10302,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type=client_credentials&scope=" + scope);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -10332,13 +10332,13 @@ public class ZTSImplTest {
             ztsImpl.postAccessTokenRequest(context, "grant_type=client_credentials&scope=" + scope);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
 
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=coretech:domain openid coretech:service.api");
         assertNotNull(resp);
-        assertEquals("coretech:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech:role.writers");
 
         assertNotNull(resp.getAccess_token());
         assertNull(resp.getId_token());
@@ -10358,7 +10358,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type=client_credentials&scope=sportstest:domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
         }
     }
 
@@ -10376,7 +10376,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type=client_credentials&scope=coretech:role.testrole");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -10394,21 +10394,21 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, null);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             zts.postAccessTokenRequest(context, "");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             zts.postAccessTokenRequest(context, "grant_type=unknown_type&scope=openid");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid grant request"));
         }
 
@@ -10416,7 +10416,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type%=client_credentials");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid grant request"));
         }
 
@@ -10424,7 +10424,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type=client_credentials%");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid grant request"));
         }
 
@@ -10432,7 +10432,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid grant request"));
         }
 
@@ -10440,7 +10440,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type=client_credentials");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("no scope provided"));
         }
 
@@ -10448,7 +10448,7 @@ public class ZTSImplTest {
             zts.postAccessTokenRequest(context, "grant_type=client_credentials&scope=");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("no scope provided"));
         }
     }
@@ -10483,7 +10483,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=coretech-proxy2:domain&proxy_for_principal=user_domain.joe");
         assertNotNull(resp);
-        assertEquals("coretech-proxy2:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech-proxy2:role.writers");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10499,14 +10499,14 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("user_domain.joe", claimSet.getSubject());
-            assertEquals("user_domain.proxy-user1", claimSet.getStringClaim("proxy"));
-            assertEquals("coretech-proxy2", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getSubject(), "user_domain.joe");
+            assertEquals(claimSet.getStringClaim("proxy"), "user_domain.proxy-user1");
+            assertEquals(claimSet.getAudience().get(0), "coretech-proxy2");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10543,7 +10543,7 @@ public class ZTSImplTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=client_credentials&scope=coretech-proxy3:domain&proxy_for_principal=user_domain.joe");
         assertNotNull(resp);
-        assertEquals("coretech-proxy3:role.writers", resp.getScope());
+        assertEquals(resp.getScope(), "coretech-proxy3:role.writers");
 
         String accessTokenStr = resp.getAccess_token();
         assertNotNull(accessTokenStr);
@@ -10560,14 +10560,14 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("user_domain.joe", claimSet.getSubject());
-            assertEquals("user_domain.proxy-user1", claimSet.getStringClaim("proxy"));
-            assertEquals("coretech-proxy3", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getSubject(), "user_domain.joe");
+            assertEquals(claimSet.getStringClaim("proxy"), "user_domain.proxy-user1");
+            assertEquals(claimSet.getAudience().get(0), "coretech-proxy3");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10679,14 +10679,14 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("user_domain.joe", claimSet.getSubject());
-            assertEquals("user_domain.proxy-user1", claimSet.getStringClaim("proxy"));
-            assertEquals("coretech-proxy4", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getSubject(), "user_domain.joe");
+            assertEquals(claimSet.getStringClaim("proxy"), "user_domain.proxy-user1");
+            assertEquals(claimSet.getAudience().get(0), "coretech-proxy4");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -10733,7 +10733,7 @@ public class ZTSImplTest {
             zts.postRoleCertificateRequestExt(context, req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(404, ex.getCode());
+            assertEquals(ex.getCode(), 404);
             assertTrue(ex.getMessage().contains("No such domain: coretech"));
         }
     }
@@ -10762,7 +10762,7 @@ public class ZTSImplTest {
             zts.postRoleCertificateRequestExt(context, req);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("is not included in the requested role(s)"));
         }
     }
@@ -11055,7 +11055,7 @@ public class ZTSImplTest {
             zts.validatePrincipalNotRoleIdentity(principal, "testCaller");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
         }
     }
 
@@ -11130,8 +11130,8 @@ public class ZTSImplTest {
 
         // valid authorized user should return the proxy user
 
-        assertEquals("user_domain.proxy", zts.getProxyForPrincipalValue("user_domain.proxy",
-                "user_domain.proxy-user1", "user_domain", "getAccessToken"));
+        assertEquals(zts.getProxyForPrincipalValue("user_domain.proxy",
+                "user_domain.proxy-user1", "user_domain", "getAccessToken"), "user_domain.proxy");
 
         // invalid authorized proxy user should return 403
 
@@ -11510,7 +11510,7 @@ public class ZTSImplTest {
         assertEquals(zts.privateECKey, zts.getServerPrivateKey("UNKNOWN"));
 
         List<String> algValues = zts.getSupportedSigningAlgValues();
-        assertEquals(1, algValues.size());
+        assertEquals(algValues.size(), 1);
         assertTrue(algValues.contains("ES256"));
 
         // now let's try the rsa key
@@ -11529,7 +11529,7 @@ public class ZTSImplTest {
         assertEquals(zts.privateRSAKey, zts.getServerPrivateKey("UNKNOWN"));
 
         algValues = zts.getSupportedSigningAlgValues();
-        assertEquals(1, algValues.size());
+        assertEquals(algValues.size(), 1);
         assertTrue(algValues.contains("RS256"));
 
         // now let's try both keys
@@ -11548,7 +11548,7 @@ public class ZTSImplTest {
         assertEquals(zts.privateECKey, zts.getServerPrivateKey("UNKNOWN"));
 
         algValues = zts.getSupportedSigningAlgValues();
-        assertEquals(2, algValues.size());
+        assertEquals(algValues.size(), 2);
         assertTrue(algValues.contains("ES256"));
         assertTrue(algValues.contains("RS256"));
 
@@ -11571,12 +11571,12 @@ public class ZTSImplTest {
     @Test
     public void testGetInstanceRegisterQueryLog() {
 
-        assertEquals("provider=aws&certReqInstanceId=id001&hostname=athenz.io",
-                zts.getInstanceRegisterQueryLog("aws", "id001", "athenz.io"));
-        assertEquals("provider=aws&certReqInstanceId=id001", zts.getInstanceRegisterQueryLog("aws", "id001", null));
-        assertEquals("provider=aws&hostname=athenz.io", zts.getInstanceRegisterQueryLog("aws", null, "athenz.io"));
-        assertEquals("provider=aws", zts.getInstanceRegisterQueryLog("aws", null, null));
-        assertEquals("provider=aws", zts.getInstanceRegisterQueryLog("aws", null, null));
+        assertEquals(zts.getInstanceRegisterQueryLog("aws", "id001", "athenz.io"),
+                "provider=aws&certReqInstanceId=id001&hostname=athenz.io");
+        assertEquals(zts.getInstanceRegisterQueryLog("aws", "id001", null), "provider=aws&certReqInstanceId=id001");
+        assertEquals(zts.getInstanceRegisterQueryLog("aws", null, "athenz.io"), "provider=aws&hostname=athenz.io");
+        assertEquals(zts.getInstanceRegisterQueryLog("aws", null, null), "provider=aws");
+        assertEquals(zts.getInstanceRegisterQueryLog("aws", null, null), "provider=aws");
 
         // our max length is 1024 so we'll use the following check
         // 46 chars + hostname so we'll get create a string with
@@ -11586,7 +11586,7 @@ public class ZTSImplTest {
         hostnameBuilder.append("123456".repeat(163));
 
         final String check = "provider=aws&certReqInstanceId=id001&hostname=" + hostnameBuilder;
-        assertEquals(check, zts.getInstanceRegisterQueryLog("aws", "id001", hostnameBuilder + "01234"));
+        assertEquals(zts.getInstanceRegisterQueryLog("aws", "id001", hostnameBuilder + "01234"), check);
     }
 
     @Test
@@ -12230,13 +12230,13 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("coretech", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getAudience().get(0), "coretech");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
-            assertEquals(authzDetails, claimSet.getStringClaim("authorization_details"));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
+            assertEquals(claimSet.getStringClaim("authorization_details"), authzDetails);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -12286,13 +12286,13 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("coretech", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getAudience().get(0), "coretech");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
-            assertEquals(authzDetails, claimSet.getStringClaim("authorization_details"));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
+            assertEquals(claimSet.getStringClaim("authorization_details"), authzDetails);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -12315,9 +12315,9 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("coretech", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getAudience().get(0), "coretech");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
-            assertEquals(authzDetails, claimSet.getStringClaim("authorization_details"));
+            assertEquals(claimSet.getStringClaim("authorization_details"), authzDetails);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -12342,9 +12342,9 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("coretech", claimSet.getAudience().get(0));
+            assertEquals(claimSet.getAudience().get(0), "coretech");
             assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
-            assertEquals(authzDetails, claimSet.getStringClaim("authorization_details"));
+            assertEquals(claimSet.getStringClaim("authorization_details"), authzDetails);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -12592,12 +12592,12 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimSet);
-            assertEquals("coretech", claimSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOAuthIssuer, claimSet.getIssuer());
+            assertEquals(claimSet.getAudience().get(0), "coretech");
+            assertEquals(claimSet.getIssuer(), ztsImpl.ztsOAuthIssuer);
             List<String> scopes = claimSet.getStringListClaim("scp");
             assertNotNull(scopes);
-            assertEquals(1, scopes.size());
-            assertEquals("writers", scopes.get(0));
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
 
             Map<String, Object> cnf = (Map<String, Object>) claimSet.getClaim("cnf");
             assertNotNull(cnf);
@@ -12623,7 +12623,7 @@ public class ZTSImplTest {
             zts.getTransportRules(context, "transportrules", "api");
             fail();
         } catch (ResourceException re) {
-            assertEquals(ResourceException.BAD_REQUEST, re.getCode());
+            assertEquals(re.getCode(), ResourceException.BAD_REQUEST);
         }
         zts.readOnlyMode = dynamicConfigBoolean;
     }
@@ -12640,7 +12640,7 @@ public class ZTSImplTest {
             zts.getWorkloadsByIP(context, "10.0.0.1");
             fail();
         } catch (ResourceException re) {
-            assertEquals(ResourceException.BAD_REQUEST, re.getCode());
+            assertEquals(re.getCode(), ResourceException.BAD_REQUEST);
         }
         zts.readOnlyMode = dynamicConfigBoolean;
     }
@@ -12657,7 +12657,7 @@ public class ZTSImplTest {
             zts.getWorkloadsByService(context, "transportrules", "api");
             fail();
         } catch (ResourceException re) {
-            assertEquals(ResourceException.BAD_REQUEST, re.getCode());
+            assertEquals(re.getCode(), ResourceException.BAD_REQUEST);
         }
         zts.readOnlyMode = dynamicConfigBoolean;
     }
@@ -12854,7 +12854,7 @@ public class ZTSImplTest {
             zts.getWorkloadsByService(context, domainName, serviceName);
             fail();
         } catch (ResourceException re) {
-            assertEquals(ResourceException.BAD_REQUEST, re.getCode());
+            assertEquals(re.getCode(), ResourceException.BAD_REQUEST);
         }
 
         DataCache domain = new DataCache();
@@ -13564,9 +13564,9 @@ public class ZTSImplTest {
         OpenIDConfig openIDConfig = zts.getOpenIDConfig(ctx);
         assertNotNull(openIDConfig);
 
-        assertEquals("https://athenz.cloud:4443/zts/v1", openIDConfig.getIssuer());
-        assertEquals("https://athenz.cloud:4443/zts/v1/oauth2/keys?rfc=true", openIDConfig.getJwks_uri());
-        assertEquals("https://athenz.cloud:4443/zts/v1/oauth2/auth", openIDConfig.getAuthorization_endpoint());
+        assertEquals(openIDConfig.getIssuer(), "https://athenz.cloud:4443/zts/v1");
+        assertEquals(openIDConfig.getJwks_uri(), "https://athenz.cloud:4443/zts/v1/oauth2/keys?rfc=true");
+        assertEquals(openIDConfig.getAuthorization_endpoint(), "https://athenz.cloud:4443/zts/v1/oauth2/auth");
 
         assertEquals(Collections.singletonList("RS256"), openIDConfig.getId_token_signing_alg_values_supported());
         assertEquals(Collections.singletonList("id_token"), openIDConfig.getResponse_types_supported());
@@ -13595,9 +13595,9 @@ public class ZTSImplTest {
         OpenIDConfig openIDConfig = ztsImpl.getOpenIDConfig(ctx);
         assertNotNull(openIDConfig);
 
-        assertEquals("https://athenz.io/zts/v1", openIDConfig.getIssuer());
-        assertEquals("https://athenz.io/zts/v1/oauth2/keys?rfc=true", openIDConfig.getJwks_uri());
-        assertEquals("https://athenz.io/zts/v1/oauth2/auth", openIDConfig.getAuthorization_endpoint());
+        assertEquals(openIDConfig.getIssuer(), "https://athenz.io/zts/v1");
+        assertEquals(openIDConfig.getJwks_uri(), "https://athenz.io/zts/v1/oauth2/keys?rfc=true");
+        assertEquals(openIDConfig.getAuthorization_endpoint(), "https://athenz.io/zts/v1/oauth2/auth");
 
         assertEquals(Collections.singletonList("RS256"), openIDConfig.getId_token_signing_alg_values_supported());
         assertEquals(Collections.singletonList("id_token"), openIDConfig.getResponse_types_supported());
@@ -13615,10 +13615,10 @@ public class ZTSImplTest {
         OAuthConfig oauthConfig = zts.getOAuthConfig(ctx);
         assertNotNull(oauthConfig);
 
-        assertEquals("https://athenz.cloud:4443/zts/v1", oauthConfig.getIssuer());
-        assertEquals("https://athenz.cloud:4443/zts/v1/oauth2/keys?rfc=true", oauthConfig.getJwks_uri());
-        assertEquals("https://athenz.cloud:4443/zts/v1/oauth2/auth", oauthConfig.getAuthorization_endpoint());
-        assertEquals("https://athenz.cloud:4443/zts/v1/oauth2/token", oauthConfig.getToken_endpoint());
+        assertEquals(oauthConfig.getIssuer(), "https://athenz.cloud:4443/zts/v1");
+        assertEquals(oauthConfig.getJwks_uri(), "https://athenz.cloud:4443/zts/v1/oauth2/keys?rfc=true");
+        assertEquals(oauthConfig.getAuthorization_endpoint(), "https://athenz.cloud:4443/zts/v1/oauth2/auth");
+        assertEquals(oauthConfig.getToken_endpoint(), "https://athenz.cloud:4443/zts/v1/oauth2/token");
 
         assertEquals(Collections.singletonList("RS256"), oauthConfig.getToken_endpoint_auth_signing_alg_values_supported());
 
@@ -13806,9 +13806,9 @@ public class ZTSImplTest {
         JWTClaimsSet claimsSet = getClaimsFromResponse(response, privateKey.getKey(), null);
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("https://athenz.io", claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getIssuer(), "https://athenz.io");
             List<String> groups = claimsSet.getStringListClaim("groups");
             assertNull(groups);
         } catch (ParseException ex) {
@@ -13850,10 +13850,10 @@ public class ZTSImplTest {
         List<String> userGroups;
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("nonce", claimsSet.getStringClaim("nonce"));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getStringClaim("nonce"), "nonce");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userGroups = claimsSet.getStringListClaim("groups");
             assertNotNull(userGroups);
             assertEquals(userGroups.size(), 2);
@@ -13885,9 +13885,9 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userGroups = claimsSet.getStringListClaim("groups");
             assertNotNull(userGroups);
             assertEquals(userGroups.size(), 1);
@@ -13973,10 +13973,10 @@ public class ZTSImplTest {
         JWTClaimsSet claimsSet = getClaimsFromResponse(response, privateKey.getKey(), null);
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("nonce", claimsSet.getStringClaim("nonce"));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getStringClaim("nonce"), "nonce");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             List<String> userGroups = claimsSet.getStringListClaim("groups");
             assertNotNull(userGroups);
             assertEquals(userGroups.size(), 2);
@@ -14082,10 +14082,10 @@ public class ZTSImplTest {
         List<String> userGroups;
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("nonce", claimsSet.getStringClaim("nonce"));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getStringClaim("nonce"), "nonce");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userGroups = claimsSet.getStringListClaim("groups");
             assertNotNull(userGroups);
             assertEquals(userGroups.size(), 4);
@@ -14119,9 +14119,9 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userGroups = claimsSet.getStringListClaim("groups");
             assertNotNull(userGroups);
             assertEquals(userGroups.size(), 2);
@@ -14177,9 +14177,9 @@ public class ZTSImplTest {
         }
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userGroups = claimsSet.getStringListClaim("groups");
             assertNull(userGroups);
         } catch (ParseException ex) {
@@ -14231,10 +14231,10 @@ public class ZTSImplTest {
         List<String> userRoles;
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals((roleInAudClaim == Boolean.TRUE) ? "coretech.api:writers" : "coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("nonce", claimsSet.getStringClaim("nonce"));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), (roleInAudClaim == Boolean.TRUE) ? "coretech.api:writers" : "coretech.api");
+            assertEquals(claimsSet.getStringClaim("nonce"), "nonce");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userRoles = claimsSet.getStringListClaim("groups");
             assertNotNull(userRoles);
             assertEquals(userRoles.size(), 1);
@@ -14252,9 +14252,9 @@ public class ZTSImplTest {
         claimsSet = getClaimsFromResponse(response, privateKey.getKey(), output);
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals((roleInAudClaim == Boolean.TRUE) ? "coretech.api:writers" : "coretech.api", claimsSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals( claimsSet.getAudience().get(0), (roleInAudClaim == Boolean.TRUE) ? "coretech.api:writers" : "coretech.api");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userRoles = claimsSet.getStringListClaim("groups");
             assertNotNull(userRoles);
             assertEquals(userRoles.size(), 1);
@@ -14397,10 +14397,10 @@ public class ZTSImplTest {
 
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("nonce", claimsSet.getStringClaim("nonce"));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getStringClaim("nonce"), "nonce");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             List<String> userRoles = claimsSet.getStringListClaim("groups");
             assertNotNull(userRoles);
             assertEquals(userRoles.size(), 1);
@@ -14459,10 +14459,10 @@ public class ZTSImplTest {
         List<String> userRoles;
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals("nonce", claimsSet.getStringClaim("nonce"));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getStringClaim("nonce"), "nonce");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userRoles = claimsSet.getStringListClaim("groups");
             assertNotNull(userRoles);
             assertEquals(userRoles.size(), 2);
@@ -14482,9 +14482,9 @@ public class ZTSImplTest {
 
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userRoles = claimsSet.getStringListClaim("groups");
             assertNotNull(userRoles);
             assertEquals(userRoles.size(), 2);
@@ -14526,9 +14526,9 @@ public class ZTSImplTest {
 
         try {
             assertNotNull(claimsSet);
-            assertEquals("user_domain.user", claimsSet.getSubject());
-            assertEquals("coretech.api", claimsSet.getAudience().get(0));
-            assertEquals(ztsImpl.ztsOpenIDIssuer, claimsSet.getIssuer());
+            assertEquals(claimsSet.getSubject(), "user_domain.user");
+            assertEquals(claimsSet.getAudience().get(0), "coretech.api");
+            assertEquals(claimsSet.getIssuer(), ztsImpl.ztsOpenIDIssuer);
             userRoles = claimsSet.getStringListClaim("groups");
             assertNull(userRoles);
         } catch (ParseException ex) {
@@ -14546,7 +14546,7 @@ public class ZTSImplTest {
         assertEquals(zts.privateOrigKey, zts.getSignPrivateKey("unknown"));
 
         List<String> algValues = zts.getSupportedSigningAlgValues();
-        assertEquals(1, algValues.size());
+        assertEquals(algValues.size(), 1);
         assertTrue(algValues.contains("RS256"));
 
         // load our ec and rsa private keys
@@ -14558,7 +14558,7 @@ public class ZTSImplTest {
         zts.loadServicePrivateKey();
 
         algValues = zts.getSupportedSigningAlgValues();
-        assertEquals(2, algValues.size());
+        assertEquals(algValues.size(), 2);
         assertTrue(algValues.contains("RS256"));
         assertTrue(algValues.contains("ES256"));
 
@@ -14909,7 +14909,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "gcp", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid external credentials provider"));
         }
         ztsImpl.externalCredentialsManager.enableProvider("gcp");
@@ -14924,7 +14924,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "gcp", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("gcp exchange token error"));
         }
     }
@@ -15044,7 +15044,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "azure", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("principal not included in requested roles"));
         }
 
@@ -15055,7 +15055,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "azure", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("principal not included in requested roles"));
         }
 
@@ -15109,7 +15109,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "aws", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
             assertTrue(ex.getMessage().contains("Invalid external credentials provider"));
         }
 
@@ -15119,7 +15119,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "gcp", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
             assertTrue(ex.getMessage().contains("Missing credentials attributes"));
         }
 
@@ -15132,7 +15132,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "gcp", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
             assertTrue(ex.getMessage().contains("Either athenzRoleName or athenzScope must be specified"));
         }
 
@@ -15146,7 +15146,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "gcp", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
             assertTrue(ex.getMessage().contains("Invalid client id"));
         }
 
@@ -15161,7 +15161,7 @@ public class ZTSImplTest {
             ztsImpl.postExternalCredentialsRequest(context, "gcp", "coretech", extCredsRequest);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(ResourceException.NOT_FOUND, ex.getCode());
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
             assertTrue(ex.getMessage().contains("No such domain"));
         }
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cache/DataCacheTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cache/DataCacheTest.java
@@ -1016,13 +1016,13 @@ public class DataCacheTest {
 
         cache.processAWSAssumeRoleAssertion(assertion);
         Set<String> set = cache.getAWSResourceRoleSet("role");
-        assertEquals(1, set.size());
+        assertEquals(set.size(), 1);
 
         // calling with same assertion - no changes
 
         cache.processAWSAssumeRoleAssertion(assertion);
         set = cache.getAWSResourceRoleSet("role");
-        assertEquals(1, set.size());
+        assertEquals(set.size(), 1);
 
         // calling an assertion with deny should be no changes
 
@@ -1034,7 +1034,7 @@ public class DataCacheTest {
 
         cache.processAWSAssumeRoleAssertion(assertion2);
         set = cache.getAWSResourceRoleSet("role");
-        assertEquals(1, set.size());
+        assertEquals(set.size(), 1);
 
         // now another assertion with explicitly
         // specifying the effect
@@ -1047,7 +1047,7 @@ public class DataCacheTest {
 
         cache.processAWSAssumeRoleAssertion(assertion3);
         set = cache.getAWSResourceRoleSet("role");
-        assertEquals(2, set.size());
+        assertEquals(set.size(), 2);
         assertTrue(set.contains("resource"));
         assertTrue(set.contains("resource3"));
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cache/MemberRoleTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cache/MemberRoleTest.java
@@ -26,14 +26,14 @@ public class MemberRoleTest {
     public void testMemberRole() {
 
         MemberRole mr = new MemberRole("role", 100);
-        assertEquals("role", mr.getRole());
-        assertEquals(100, mr.getExpiration());
-        assertEquals(3510355, mr.hashCode());
+        assertEquals(mr.getRole(), "role");
+        assertEquals(mr.getExpiration(), 100);
+        assertEquals(mr.hashCode(), 3510355);
 
         mr = new MemberRole(null, 200);
         assertNull(mr.getRole());
-        assertEquals(200, mr.getExpiration());
-        assertEquals(7161, mr.hashCode());
+        assertEquals(mr.getExpiration(), 200);
+        assertEquals(mr.hashCode(), 7161);
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -90,10 +90,10 @@ public class InstanceCertManagerTest {
 
         // first time our signer was null and we should get back the cert
         instanceManager.resetX509CertificateSigner();
-        assertEquals("caCert", instanceManager.getX509CertificateSigner("aws", null));
+        assertEquals(instanceManager.getX509CertificateSigner("aws", null), "caCert");
 
         // second time it should be a no-op
-        assertEquals("caCert", instanceManager.getX509CertificateSigner("aws", null));
+        assertEquals(instanceManager.getX509CertificateSigner("aws", null), "caCert");
 
         instanceManager.shutdown();
     }
@@ -1294,7 +1294,7 @@ public class InstanceCertManagerTest {
             instance.loadCertificateBundle(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME);
             fail();
         } catch (ResourceException ex) {
-            assertEquals(500, ex.getCode());
+            assertEquals(ex.getCode(), 500);
         }
 
         System.setProperty(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME, "src/test/resources/valid_cn_x509.cert");
@@ -1421,7 +1421,7 @@ public class InstanceCertManagerTest {
             new InstanceCertManager(null, null, null, new DynamicConfigBoolean(false));
             fail();
         } catch (ResourceException ex) {
-            assertEquals(500, ex.getCode());
+            assertEquals(ex.getCode(), 500);
             assertTrue(ex.getMessage().contains("Unable to load Certificate bundle from: invalid-file"));
         }
         System.clearProperty(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/X509RoleCertRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/X509RoleCertRequestTest.java
@@ -37,16 +37,16 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr);
         assertNotNull(certReq);
 
-        assertEquals("coretech", certReq.getReqRoleDomain());
-        assertEquals("api", certReq.getReqRoleName());
+        assertEquals(certReq.getReqRoleDomain(), "coretech");
+        assertEquals(certReq.getReqRoleName(), "api");
 
         // override the values
 
         certReq.setReqRoleDomain("athenz");
         certReq.setReqRoleName("backend");
 
-        assertEquals("athenz", certReq.getReqRoleDomain());
-        assertEquals("backend", certReq.getReqRoleName());
+        assertEquals(certReq.getReqRoleDomain(), "athenz");
+        assertEquals(certReq.getReqRoleName(), "backend");
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileSSHRecordStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileSSHRecordStoreTest.java
@@ -19,7 +19,6 @@ import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.auth.impl.SimplePrincipal;
 import com.yahoo.athenz.common.server.ssh.SSHRecordStore;
 import com.yahoo.athenz.zts.ZTSConsts;
-import com.yahoo.athenz.zts.ZTSImpl;
 import org.testng.annotations.Test;
 
 import java.io.File;

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/HttpCertSignerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/HttpCertSignerTest.java
@@ -417,45 +417,45 @@ public class HttpCertSignerTest {
         HttpCertSignerFactory certFactory = new HttpCertSignerFactory();
         HttpCertSigner certSigner = (HttpCertSigner) certFactory.create();
 
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("unknown", null));
-        assertEquals("x509-key-data", certSigner.getProviderKeyId(null, null));
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("", null));
+        assertEquals(certSigner.getProviderKeyId("unknown", null), "x509-key-data");
+        assertEquals(certSigner.getProviderKeyId(null, null), "x509-key-data");
+        assertEquals(certSigner.getProviderKeyId("", null), "x509-key-data");
 
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("unknown", ""));
-        assertEquals("x509-key-data", certSigner.getProviderKeyId(null, ""));
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("", ""));
+        assertEquals(certSigner.getProviderKeyId("unknown", ""), "x509-key-data");
+        assertEquals(certSigner.getProviderKeyId(null, ""), "x509-key-data");
+        assertEquals(certSigner.getProviderKeyId("", ""), "x509-key-data");
 
         // using null for the key-id argument
 
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-east-1", null));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-east-2", null));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-west-1", null));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-west-2", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-1", null), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-2", null), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-1", null), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-2", null), "x509-aws-key");
 
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("athenz.aws.us-west-3", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-3", null), "x509-key-data");
 
-        assertEquals("x509-azure-key", certSigner.getProviderKeyId("athenz.azure.eastus", null));
-        assertEquals("x509-azure-key", certSigner.getProviderKeyId("athenz.azure.westus", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus", null), "x509-azure-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.westus", null), "x509-azure-key");
 
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("athenz.azure.eastus2", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus2", null), "x509-key-data");
 
-        assertEquals("x509-key-data-id", certSigner.getProviderKeyId("athenz.azure.eastus2", "x509-key-data-id"));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus2", "x509-key-data-id"), "x509-key-data-id");
 
         // using empty string for key-id argument
 
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-east-1", ""));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-east-2", ""));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-west-1", ""));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-west-2", ""));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-1", ""), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-2", ""), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-1", ""), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-2", ""), "x509-aws-key");
 
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("athenz.aws.us-west-3", ""));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-3", ""), "x509-key-data");
 
-        assertEquals("x509-azure-key", certSigner.getProviderKeyId("athenz.azure.eastus", ""));
-        assertEquals("x509-azure-key", certSigner.getProviderKeyId("athenz.azure.westus", ""));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus", ""), "x509-azure-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.westus", ""), "x509-azure-key");
 
-        assertEquals("x509-key-data", certSigner.getProviderKeyId("athenz.azure.eastus2", ""));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus2", ""), "x509-key-data");
 
-        assertEquals("x509-key-data-id2", certSigner.getProviderKeyId("athenz.azure.eastus2", "x509-key-data-id2"));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus2", "x509-key-data-id2"), "x509-key-data-id2");
 
         certSigner.close();
         System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_PROVIDER_KEYS_FNAME);
@@ -468,16 +468,16 @@ public class HttpCertSignerTest {
         HttpCertSignerFactory certFactory = new HttpCertSignerFactory();
         HttpCertSigner certSigner = (HttpCertSigner) certFactory.create();
 
-        assertEquals("x509-key", certSigner.getProviderKeyId("unknown", null));
-        assertEquals("x509-key", certSigner.getProviderKeyId(null, ""));
-        assertEquals("x509-key", certSigner.getProviderKeyId("", null));
+        assertEquals(certSigner.getProviderKeyId("unknown", null), "x509-key");
+        assertEquals(certSigner.getProviderKeyId(null, ""), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("", null), "x509-key");
 
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.aws.us-east-1", null));
-        assertEquals("x509-key-id", certSigner.getProviderKeyId("athenz.aws.us-east-1", "x509-key-id"));
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.aws.us-east-2", ""));
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.azure.eastus", null));
-        assertEquals("x509-key-id2", certSigner.getProviderKeyId("athenz.azure.eastus", "x509-key-id2"));
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.azure.westus", ""));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-1", null), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-1", "x509-key-id"), "x509-key-id");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-2", ""), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus", null), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus", "x509-key-id2"), "x509-key-id2");
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.westus", ""), "x509-key");
         certSigner.close();
     }
 
@@ -487,21 +487,21 @@ public class HttpCertSignerTest {
         HttpCertSignerFactory certFactory = new HttpCertSignerFactory();
         HttpCertSigner certSigner = (HttpCertSigner) certFactory.create();
 
-        assertEquals("x509-key", certSigner.getProviderKeyId("unknown", null));
-        assertEquals("x509-key", certSigner.getProviderKeyId(null, null));
-        assertEquals("x509-key", certSigner.getProviderKeyId("", ""));
+        assertEquals(certSigner.getProviderKeyId("unknown", null), "x509-key");
+        assertEquals(certSigner.getProviderKeyId(null, null), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("", ""), "x509-key");
 
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-west-1", ""));
-        assertEquals("x509-aws-key", certSigner.getProviderKeyId("athenz.aws.us-west-2", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-1", ""), "x509-aws-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-2", null), "x509-aws-key");
 
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.aws.us-east-1", null));
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.aws.us-east-2", ""));
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.aws.us-west-3", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-1", null), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-east-2", ""), "x509-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.aws.us-west-3", null), "x509-key");
 
-        assertEquals("x509-azure-key", certSigner.getProviderKeyId("athenz.azure.eastus", null));
-        assertEquals("x509-azure-key", certSigner.getProviderKeyId("athenz.azure.westus", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus", null), "x509-azure-key");
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.westus", null), "x509-azure-key");
 
-        assertEquals("x509-key", certSigner.getProviderKeyId("athenz.azure.eastus2", null));
+        assertEquals(certSigner.getProviderKeyId("athenz.azure.eastus2", null), "x509-key");
 
         certSigner.close();
         System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_PROVIDER_KEYS_FNAME);
@@ -517,7 +517,7 @@ public class HttpCertSignerTest {
             certFactory.create();
             fail();
         } catch (ResourceException ex) {
-            assertEquals(500, ex.getCode());
+            assertEquals(ex.getCode(), 500);
         }
 
         System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_PROVIDER_KEYS_FNAME);
@@ -533,7 +533,7 @@ public class HttpCertSignerTest {
             certFactory.create();
             fail();
         } catch (ResourceException ex) {
-            assertEquals(500, ex.getCode());
+            assertEquals(ex.getCode(), 500);
         }
 
         System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_PROVIDER_KEYS_FNAME);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/azure/AzureAccessTokenProviderTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/azure/AzureAccessTokenProviderTest.java
@@ -163,7 +163,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("assertion audience 'my.audience'"));
         }
 
@@ -175,7 +175,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, systemIdTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("assertion audience 'my.audience'"));
         }
         Mockito.when(httpDriver.doPostHttpResponse(any())).thenReturn(new HttpDriverResponse(200, ACCESS_TOKEN_RESPONSE_STR, null));
@@ -199,7 +199,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("Unable to retrieve Azure client ID"));
         }
 
@@ -210,7 +210,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("Unable to retrieve Azure client ID"));
         }
         Mockito.when(httpDriver.doGet(any(), any())).thenReturn(USER_MANAGED_IDENTITY_RESPONSE_STR);
@@ -222,7 +222,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("Principal not authorized for configured scope"));
         }
         Mockito.when(authorizer.access(any(), any(), any(), any())).thenReturn(true);
@@ -235,7 +235,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("assertion audience 'my.audience'"));
         }
 
@@ -246,7 +246,7 @@ public class AzureAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("my http-failure"));
         }
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenErrorTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenErrorTest.java
@@ -48,13 +48,13 @@ public class GcpAccessTokenErrorTest {
         ObjectMapper mapper = new ObjectMapper();
         GcpAccessTokenError response = mapper.readValue(responseStr, GcpAccessTokenError.class);
         assertNotNull(response);
-        assertEquals("Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).", response.getErrorMessage());
+        assertEquals(response.getErrorMessage(), "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).");
 
         GcpAccessTokenError.Error error = response.getError();
         assertNotNull(error);
-        assertEquals(403, error.getCode());
-        assertEquals("Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).", error.getMessage());
-        assertEquals("PERMISSION_DENIED", error.getStatus());
+        assertEquals(error.getCode(), 403);
+        assertEquals(error.getMessage(), "Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist).");
+        assertEquals(error.getStatus(), "PERMISSION_DENIED");
     }
 
     @Test
@@ -69,7 +69,7 @@ public class GcpAccessTokenErrorTest {
         ObjectMapper mapper = new ObjectMapper();
         GcpAccessTokenError response = mapper.readValue(responseStr, GcpAccessTokenError.class);
         assertNotNull(response);
-        assertEquals("", response.getErrorMessage());
+        assertEquals(response.getErrorMessage(), "");
         assertNull(response.getError());
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenProviderTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenProviderTest.java
@@ -92,7 +92,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("ZTS authorizer not configured"));
         }
 
@@ -105,7 +105,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("gcp project id not configured"));
         }
 
@@ -117,7 +117,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.BAD_REQUEST, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.BAD_REQUEST);
             assertTrue(ex.getMessage().contains("missing gcp service account"));
         }
 
@@ -130,7 +130,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("Principal not authorized for configured scope"));
         }
 
@@ -145,7 +145,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, idTokenGroups, new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(ServerResourceException.FORBIDDEN, ex.getCode());
+            assertEquals(ex.getCode(), ServerResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("http-failure"));
         }
     }
@@ -222,7 +222,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, new ArrayList<>(), new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("gcp exchange token error"));
         }
     }
@@ -257,7 +257,7 @@ public class GcpAccessTokenProviderTest {
             provider.getCredentials(principal, domainDetails, new ArrayList<>(), new IdToken(), signer, request);
             fail();
         } catch (ServerResourceException ex) {
-            assertEquals(403, ex.getCode());
+            assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("Permission 'iam.serviceAccounts.getAccessToken' denied on resource (or it may not exist)."));
         }
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenRequestTest.java
@@ -41,7 +41,7 @@ public class GcpAccessTokenRequestTest {
 
         request.setScopeList("scope1 scope2   scope3");
         List<String> scopes = request.getScope();
-        assertEquals(3, scopes.size());
+        assertEquals(scopes.size(), 3);
         assertTrue(scopes.contains("scope1"));
         assertTrue(scopes.contains("scope2"));
         assertTrue(scopes.contains("scope3"));

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenResponseTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpAccessTokenResponseTest.java
@@ -36,7 +36,7 @@ public class GcpAccessTokenResponseTest {
         ObjectMapper mapper = new ObjectMapper();
         GcpAccessTokenResponse response = mapper.readValue(responseStr, GcpAccessTokenResponse.class);
         assertNotNull(response);
-        assertEquals("access-token", response.getAccessToken());
-        assertEquals("2014-10-02T15:01:23Z", response.getExpireTime());
+        assertEquals(response.getAccessToken(), "access-token");
+        assertEquals(response.getExpireTime(), "2014-10-02T15:01:23Z");
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpExchangeTokenErrorTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpExchangeTokenErrorTest.java
@@ -37,7 +37,7 @@ public class GcpExchangeTokenErrorTest {
         ObjectMapper mapper = new ObjectMapper();
         GcpExchangeTokenError response = mapper.readValue(responseStr, GcpExchangeTokenError.class);
         assertNotNull(response);
-        assertEquals("failure", response.getError());
-        assertEquals("error message", response.getErrorDescription());
+        assertEquals(response.getError(), "failure");
+        assertEquals(response.getErrorDescription(), "error message");
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpExchangeTokenResponseTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/external/gcp/GcpExchangeTokenResponseTest.java
@@ -38,9 +38,9 @@ public class GcpExchangeTokenResponseTest {
         ObjectMapper mapper = new ObjectMapper();
         GcpExchangeTokenResponse response = mapper.readValue(responseStr, GcpExchangeTokenResponse.class);
         assertNotNull(response);
-        assertEquals("Bearer", response.getTokenType());
-        assertEquals("access-token", response.getAccessToken());
-        assertEquals("jwt", response.getIssuedTokenType());
-        assertEquals(300, response.getExpiresIn());
+        assertEquals(response.getTokenType(), "Bearer");
+        assertEquals(response.getAccessToken(), "access-token");
+        assertEquals(response.getIssuedTokenType(), "jwt");
+        assertEquals(response.getExpiresIn(), 300);
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTaskTest.java
@@ -184,7 +184,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(0, notifications.size());
+        assertEquals(notifications.size(), 0);
     }
 
     @Test
@@ -234,7 +234,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(6, notifications.size());
+        assertEquals(notifications.size(), 6);
         notifications.sort(Comparator.comparing(notif -> notif.getDetails().get(NOTIFICATION_DETAILS_UNREFRESHED_CERTS)));
         // Assert one records for provider1:
         String expectedDetail = "service0;provider1;instanceID0;" + Timestamp.fromMillis(currentDate.getTime()) + ";;hostName0";
@@ -294,10 +294,10 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(3, notifications.size());
-        assertEquals("domain4", notifications.get(0).getDetails().get("domain"));
-        assertEquals("domain2", notifications.get(1).getDetails().get("domain"));
-        assertEquals("domain0", notifications.get(2).getDetails().get("domain"));
+        assertEquals(notifications.size(), 3);
+        assertEquals(notifications.get(0).getDetails().get("domain"), "domain4");
+        assertEquals(notifications.get(1).getDetails().get("domain"), "domain2");
+        assertEquals(notifications.get(2).getDetails().get("domain"), "domain0");
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
     }
@@ -328,7 +328,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(new ArrayList<>(), notifications);
+        assertEquals(notifications, new ArrayList<>());
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
     }
@@ -357,7 +357,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(new ArrayList<>(), notifications);
+        assertEquals(notifications, new ArrayList<>());
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
     }
@@ -393,10 +393,10 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(3, notifications.size());
-        assertEquals("domain5", notifications.get(0).getDetails().get("domain"));
-        assertEquals("domain2", notifications.get(1).getDetails().get("domain"));
-        assertEquals("domain3", notifications.get(2).getDetails().get("domain"));
+        assertEquals(notifications.size(), 3);
+        assertEquals(notifications.get(0).getDetails().get("domain"), "domain5");
+        assertEquals(notifications.get(1).getDetails().get("domain"), "domain2");
+        assertEquals(notifications.get(2).getDetails().get("domain"), "domain3");
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_IGNORED_SERVICES_LIST);
@@ -430,8 +430,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(new ArrayList<>(), notifications);
-
+        assertEquals(notifications, new ArrayList<>());
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_IGNORED_SERVICES_LIST);
@@ -494,12 +493,12 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(5, notifications.size());
-        assertEquals("domain8", notifications.get(0).getDetails().get("domain"));
-        assertEquals("domain7", notifications.get(1).getDetails().get("domain"));
-        assertEquals("domain5", notifications.get(2).getDetails().get("domain"));
-        assertEquals("domain3", notifications.get(3).getDetails().get("domain"));
-        assertEquals("domain1", notifications.get(4).getDetails().get("domain"));
+        assertEquals(notifications.size(), 5);
+        assertEquals(notifications.get(0).getDetails().get("domain"), "domain8");
+        assertEquals(notifications.get(1).getDetails().get("domain"), "domain7");
+        assertEquals(notifications.get(2).getDetails().get("domain"), "domain5");
+        assertEquals(notifications.get(3).getDetails().get("domain"), "domain3");
+        assertEquals(notifications.get(4).getDetails().get("domain"), "domain1");
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
     }
@@ -538,7 +537,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(new ArrayList<>(), notifications);
+        assertEquals(notifications, new ArrayList<>());
 
         System.clearProperty(ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST);
     }
@@ -557,7 +556,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 httpsPort,
                 notificationToEmailConverterCommon);
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(new ArrayList<>(), notifications);
+        assertEquals(notifications, new ArrayList<>());
     }
 
     @Test
@@ -593,7 +592,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         List<Notification> notifications = certFailedRefreshNotificationTask.getNotifications();
-        assertEquals(6, notifications.size());
+        assertEquals(notifications.size(), 6);
         // Assert 2 records for domain5 and domain0:
         String twoRecordsDomain5 = "service5;provider;instanceID5;" + Timestamp.fromMillis(currentDate.getTime()) + ";;hostName5|" +
                 "service5;provider;instanceID5;" + Timestamp.fromMillis(currentDate.getTime()) + ";;secondHostName5";
@@ -631,7 +630,7 @@ public class CertFailedRefreshNotificationTaskTest {
                 notificationToEmailConverterCommon);
 
         String description = certFailedRefreshNotificationTask.getDescription();
-        assertEquals("certificate failed refresh notification", description);
+        assertEquals(description, "certificate failed refresh notification");
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/DomainRoleMembersFetcherTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/notification/DomainRoleMembersFetcherTest.java
@@ -41,7 +41,7 @@ public class DomainRoleMembersFetcherTest {
                 "domain1",
                 "domain1:role.admin");
 
-        assertEquals(2, domainRoleMembers.size());
+        assertEquals(domainRoleMembers.size(), 2);
         assertTrue(domainRoleMembers.contains("user.domain1rolemember1"));
         assertTrue(domainRoleMembers.contains("user.domain1rolemember2"));
     }
@@ -56,7 +56,7 @@ public class DomainRoleMembersFetcherTest {
                 "domain1",
                 "domain1:role.admin");
 
-        assertEquals(new HashSet<>(), domainRoleMembers);
+        assertEquals(domainRoleMembers, new HashSet<>());
     }
 
     @Test
@@ -70,6 +70,6 @@ public class DomainRoleMembersFetcherTest {
                 "domain1",
                 "domain1:role.admin");
 
-        assertEquals(new HashSet<>(), domainRoleMembers);
+        assertEquals(domainRoleMembers, new HashSet<>());
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -39,12 +39,12 @@ public class CloudStoreTest {
         // set the account to 1234
 
         store.updateAwsAccount("iaas", "1234");
-        assertEquals("1234", store.getAwsAccount("iaas"));
+        assertEquals(store.getAwsAccount("iaas"), "1234");
 
         // update the account value
 
         store.updateAwsAccount("iaas", "1235");
-        assertEquals("1235", store.getAwsAccount("iaas"));
+        assertEquals(store.getAwsAccount("iaas"), "1235");
         store.close();
     }
 
@@ -56,7 +56,7 @@ public class CloudStoreTest {
         // set the account to 1234
 
         store.updateAwsAccount("iaas", "1234");
-        assertEquals("1234", store.getAwsAccount("iaas"));
+        assertEquals(store.getAwsAccount("iaas"), "1234");
 
         // delete the account with null
 
@@ -66,7 +66,7 @@ public class CloudStoreTest {
         // update the account value
 
         store.updateAwsAccount("iaas", "1235");
-        assertEquals("1235", store.getAwsAccount("iaas"));
+        assertEquals(store.getAwsAccount("iaas"), "1235");
 
         // delete the account with empty string
 
@@ -352,9 +352,9 @@ public class CloudStoreTest {
         assertNull(cloudStore.getAzureSubscription("athenz"));
 
         cloudStore.updateAzureSubscription("athenz", "12345", "321", "999");
-        assertEquals("12345", cloudStore.getAzureSubscription("athenz"));
-        assertEquals("321", cloudStore.getAzureTenant("athenz"));
-        assertEquals("999", cloudStore.getAzureClient("athenz"));
+        assertEquals(cloudStore.getAzureSubscription("athenz"), "12345");
+        assertEquals(cloudStore.getAzureTenant("athenz"), "321");
+        assertEquals(cloudStore.getAzureClient("athenz"), "999");
 
         cloudStore.updateAzureSubscription("athenz", "", "", "");
         assertNull(cloudStore.getAzureSubscription("athenz"));
@@ -362,14 +362,14 @@ public class CloudStoreTest {
         assertNull(cloudStore.getAzureClient("athenz"));
 
         cloudStore.updateAzureSubscription("athenz", "12345", null, "888");
-        assertEquals("12345", cloudStore.getAzureSubscription("athenz"));
+        assertEquals(cloudStore.getAzureSubscription("athenz"), "12345");
         assertNull(cloudStore.getAzureTenant("athenz"));
-        assertEquals("888", cloudStore.getAzureClient("athenz"));
+        assertEquals(cloudStore.getAzureClient("athenz"), "888");
 
         cloudStore.updateAzureSubscription("athenz", "12345", "777", null);
-        assertEquals("12345", cloudStore.getAzureSubscription("athenz"));
-        assertEquals("777", cloudStore.getAzureTenant("athenz"));
-        assertEquals("888", cloudStore.getAzureClient("athenz"));
+        assertEquals(cloudStore.getAzureSubscription("athenz"), "12345");
+        assertEquals(cloudStore.getAzureTenant("athenz"), "777");
+        assertEquals(cloudStore.getAzureClient("athenz"), "888");
 
         cloudStore.close();
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
@@ -2117,7 +2117,7 @@ public class DataStoreTest {
             store.init();
             fail();
         } catch (ResourceException ex) {
-            assertEquals(500, ex.getCode());
+            assertEquals(ex.getCode(), 500);
         }
     }
     
@@ -5459,8 +5459,8 @@ public class DataStoreTest {
 
         domainMap.put("domain2", new DomainAttributes().setFetchTime(now - store.domainFetchRefreshTime - 1));
         List<String> domains = store.getDomainRefreshList();
-        assertEquals(1, domains.size());
-        assertEquals("domain2", domains.get(0));
+        assertEquals(domains.size(), 1);
+        assertEquals(domains.get(0), "domain2");
 
         // now let's add domains more than the configured limit
 
@@ -5469,6 +5469,6 @@ public class DataStoreTest {
         }
 
         domains = store.getDomainRefreshList();
-        assertEquals(store.domainFetchCount, domains.size());
+        assertEquals(domains.size(), store.domainFetchCount);
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/token/AccessTokenRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/token/AccessTokenRequestTest.java
@@ -33,14 +33,14 @@ public class AccessTokenRequestTest {
 
         AccessTokenRequest req1 = new AccessTokenRequest("sports:domain");
         assertNotNull(req1);
-        assertEquals("sports", req1.getDomainName());
+        assertEquals(req1.getDomainName(), "sports");
         assertNull(req1.getRoleNames("sports"));
         assertTrue(req1.sendScopeResponse());
         assertFalse(req1.isOpenIdScope());
 
         AccessTokenRequest req2 = new AccessTokenRequest("openid sports:service.api sports:domain");
         assertNotNull(req2);
-        assertEquals("sports", req2.getDomainName());
+        assertEquals(req2.getDomainName(), "sports");
         assertNull(req2.getRoleNames("sports"));
         assertTrue(req2.sendScopeResponse());
         assertTrue(req2.isOpenIdScope());
@@ -49,36 +49,36 @@ public class AccessTokenRequestTest {
 
         AccessTokenRequest req3 = new AccessTokenRequest("openid sports:service.api sports:domain sports:role.role1");
         assertNotNull(req3);
-        assertEquals("sports", req3.getDomainName());
+        assertEquals(req3.getDomainName(), "sports");
         assertNull(req3.getRoleNames("sports"));
         assertTrue(req3.sendScopeResponse());
         assertTrue(req3.isOpenIdScope());
 
         AccessTokenRequest req4 = new AccessTokenRequest("sports:role.role1");
         assertNotNull(req4);
-        assertEquals("sports", req4.getDomainName());
+        assertEquals(req4.getDomainName(), "sports");
         assertNotNull(req4.getRoleNames("sports"));
-        assertEquals(1, req4.getRoleNames("sports").length);
-        assertEquals("role1", req4.getRoleNames("sports")[0]);
+        assertEquals(req4.getRoleNames("sports").length, 1);
+        assertEquals(req4.getRoleNames("sports")[0], "role1");
         assertFalse(req4.sendScopeResponse());
         assertFalse(req4.isOpenIdScope());
 
         AccessTokenRequest req5 = new AccessTokenRequest("sports:role.role1 unknown-scope");
         assertNotNull(req5);
-        assertEquals("sports", req5.getDomainName());
+        assertEquals(req5.getDomainName(), "sports");
         assertNotNull(req5.getRoleNames("sports"));
-        assertEquals(1, req5.getRoleNames("sports").length);
-        assertEquals("role1", req5.getRoleNames("sports")[0]);
+        assertEquals(req5.getRoleNames("sports").length, 1);
+        assertEquals(req5.getRoleNames("sports")[0], "role1");
         assertFalse(req5.sendScopeResponse());
         assertFalse(req5.isOpenIdScope());
 
         AccessTokenRequest req6 = new AccessTokenRequest("sports:role.role1 sports:role.role2");
         assertNotNull(req6);
-        assertEquals("sports", req6.getDomainName());
+        assertEquals(req6.getDomainName(), "sports");
         assertNotNull(req6.getRoleNames("sports"));
-        assertEquals(2, req6.getRoleNames("sports").length);
-        assertEquals("role1", req6.getRoleNames("sports")[0]);
-        assertEquals("role2", req6.getRoleNames("sports")[1]);
+        assertEquals(req6.getRoleNames("sports").length, 2);
+        assertEquals(req6.getRoleNames("sports")[0], "role1");
+        assertEquals(req6.getRoleNames("sports")[1], "role2");
         assertFalse(req6.sendScopeResponse());
         assertFalse(req6.isOpenIdScope());
     }
@@ -90,7 +90,7 @@ public class AccessTokenRequestTest {
 
         AccessTokenRequest req1 = new AccessTokenRequest("openid sports:service.api sports:domain");
         assertNotNull(req1);
-        assertEquals("sports", req1.getDomainName());
+        assertEquals(req1.getDomainName(), "sports");
         assertNull(req1.getRoleNames("sports"));
         assertTrue(req1.sendScopeResponse());
         assertFalse(req1.isOpenIdScope());
@@ -103,42 +103,42 @@ public class AccessTokenRequestTest {
             new AccessTokenRequest("openid");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("unknown-scope");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest(":role.role1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("sports:role.role1 :role.role2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("sports:role.role1 openid weather:service.api");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("sports:role.role1 openid sports:service.api sports:service.backend");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -149,28 +149,28 @@ public class AccessTokenRequestTest {
             new AccessTokenRequest("sports:domain openid");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("openid :domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("sports:domain openid sports:service.");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("sports:domain openid :service.api");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -184,21 +184,21 @@ public class AccessTokenRequestTest {
             new AccessTokenRequest("sports:domain weather:domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("sports:domain weather:role.role1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new AccessTokenRequest("weather:role.role2 sports:domain weather:role.role1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/token/IdTokenRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/token/IdTokenRequestTest.java
@@ -61,9 +61,9 @@ public class IdTokenRequestTest {
 
         IdTokenRequest req4 = new IdTokenRequest("openid sports:group.dev-team");
         assertNotNull(req4);
-        assertEquals("sports", req4.getDomainName());
+        assertEquals(req4.getDomainName(), "sports");
         assertNull(req4.getRoleNames("sports"));
-        assertEquals(1, req4.getGroupNames("sports").size());
+        assertEquals(req4.getGroupNames("sports").size(), 1);
         assertTrue(req4.getGroupNames("sports").contains("dev-team"));
         assertTrue(req4.isOpenIdScope());
         assertTrue(req4.isGroupsScope());
@@ -71,9 +71,9 @@ public class IdTokenRequestTest {
 
         IdTokenRequest req5 = new IdTokenRequest("openid sports:role.dev-role");
         assertNotNull(req5);
-        assertEquals("sports", req5.getDomainName());
-        assertEquals(1, req5.getRoleNames("sports").length);
-        assertEquals("dev-role", req5.getRoleNames("sports")[0]);
+        assertEquals(req5.getDomainName(), "sports");
+        assertEquals(req5.getRoleNames("sports").length, 1);
+        assertEquals(req5.getRoleNames("sports")[0], "dev-role");
         assertNull(req5.getGroupNames("sports"));
         assertTrue(req5.isOpenIdScope());
         assertFalse(req5.isGroupsScope());
@@ -81,7 +81,7 @@ public class IdTokenRequestTest {
 
         IdTokenRequest req6 = new IdTokenRequest("openid sports:service.api sports:domain sports:group.dev-team");
         assertNotNull(req6);
-        assertEquals("sports", req6.getDomainName());
+        assertEquals(req6.getDomainName(), "sports");
         assertNull(req6.getRoleNames("sports"));
         assertNull(req6.getGroupNames("sports"));
         assertTrue(req6.sendScopeResponse());
@@ -91,10 +91,10 @@ public class IdTokenRequestTest {
 
         IdTokenRequest req7 = new IdTokenRequest("openid sports:service.api sports:role.reader sports:group.dev-team");
         assertNotNull(req7);
-        assertEquals("sports", req7.getDomainName());
-        assertEquals(1, req7.getRoleNames("sports").length);
-        assertEquals("reader", req7.getRoleNames("sports")[0]);
-        assertEquals(1, req7.getGroupNames("sports").size());
+        assertEquals(req7.getDomainName(), "sports");
+        assertEquals(req7.getRoleNames("sports").length, 1);
+        assertEquals(req7.getRoleNames("sports")[0], "reader");
+        assertEquals(req7.getGroupNames("sports").size(), 1);
         assertTrue(req7.getGroupNames("sports").contains("dev-team"));
         assertFalse(req7.sendScopeResponse());
         assertTrue(req7.isOpenIdScope());
@@ -121,63 +121,63 @@ public class IdTokenRequestTest {
             new IdTokenRequest("groups");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("unknown-scope");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest(":role.role1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("sports:role.role1 :role.role2");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("openid sports:group.dev-team :group.prod-team");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("openid :group.prod-team");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("sports:role.role1 openid weather:service.api");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("sports:group.dev-team openid weather:group.dev-team");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("sports:role.role1 openid sports:service.api sports:service.backend");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 
@@ -193,21 +193,21 @@ public class IdTokenRequestTest {
             new IdTokenRequest("openid sports:domain weather:domain");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("openid sports:domain weather:role.role1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
 
         try {
             new IdTokenRequest("openid weather:role.role2 sports:domain weather:role.role1");
             fail();
         } catch (ResourceException ex) {
-            assertEquals(400, ex.getCode());
+            assertEquals(ex.getCode(), 400);
         }
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -74,17 +74,17 @@ public class ZTSUtilsTest {
     public void testRetrieveConfigSetting() {
         
         System.setProperty("prop1", "1001");
-        assertEquals(1001, ConfigProperties.retrieveConfigSetting("prop1", 99));
-        assertEquals(99, ConfigProperties.retrieveConfigSetting("prop2", 99));
+        assertEquals(ConfigProperties.retrieveConfigSetting("prop1", 99), 1001);
+        assertEquals(ConfigProperties.retrieveConfigSetting("prop2", 99), 99);
 
         System.setProperty("prop1", "-101");
-        assertEquals(99, ConfigProperties.retrieveConfigSetting("prop1", 99));
+        assertEquals(ConfigProperties.retrieveConfigSetting("prop1", 99), 99);
 
         System.setProperty("prop1", "0");
-        assertEquals(99, ConfigProperties.retrieveConfigSetting("prop1", 99));
+        assertEquals(ConfigProperties.retrieveConfigSetting("prop1", 99), 99);
         
         System.setProperty("prop1", "abc");
-        assertEquals(99, ConfigProperties.retrieveConfigSetting("prop1", 99));
+        assertEquals(ConfigProperties.retrieveConfigSetting("prop1", 99), 99);
     }
     
     @Test
@@ -585,10 +585,10 @@ public class ZTSUtilsTest {
 
     @Test
     public void testParseInt() {
-        assertEquals(0, ZTSUtils.parseInt(null, 0));
-        assertEquals(-1, ZTSUtils.parseInt("", -1));
-        assertEquals(100, ZTSUtils.parseInt("100", 1));
-        assertEquals(0, ZTSUtils.parseInt("abc", 0));
+        assertEquals(ZTSUtils.parseInt(null, 0), 0);
+        assertEquals(ZTSUtils.parseInt("", -1), -1);
+        assertEquals(ZTSUtils.parseInt("100", 1), 100);
+        assertEquals(ZTSUtils.parseInt("abc", 0), 0);
     }
 
     @Test

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/AwsAuthHistoryFetcherTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/AwsAuthHistoryFetcherTest.java
@@ -125,7 +125,7 @@ public class AwsAuthHistoryFetcherTest {
         Set<AuthHistoryDynamoDBRecord> logRecords = awsAuthHistoryFetcher.getLogs(startTime, endTime, true);
 
         // Assert we get the expected four records
-        assertEquals(4, logRecords.size());
+        assertEquals(logRecords.size(), 4);
         assertTrue(logRecords.contains(LogsParserUtils.getRecordFromLogEvent(message1)));
         assertTrue(logRecords.contains(LogsParserUtils.getRecordFromLogEvent(message3)));
         assertTrue(logRecords.contains(LogsParserUtils.getRecordFromLogEvent(message4)));

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/LogsParserUtilsTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/LogsParserUtilsTest.java
@@ -38,66 +38,66 @@ public class LogsParserUtilsTest {
         String message = "98.136.200.210 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zms/v1/domain/home.testuser/token HTTP/1.1\" 200 16 \"-\" \"Jersey/2.18 (HttpUrlConnection 1.8.0_302)\" - 2 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         AuthHistoryDynamoDBRecord recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zms/v1/domain/home.testuser/token", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zms/v1/domain/home.testuser/token");
 
         // Test /domain/{domainName}/token?role={roleName}
         message = ".211.22.37 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zts/v1/domain/home.testuser/token?role=test-role HTTP/1.1\" 200 288 \"-\" \"ZTS-POST-DEPLOY-CHECK\" 0 7 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zts/v1/domain/home.testuser/token?role=test-role", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zts/v1/domain/home.testuser/token?role=test-role");
 
         // Test /oauth2/token
         message = "77.238.175.59 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"POST /zts/v1/oauth2/token?authorization_details=%5B%7B%22type%22%3A%22message_access%22%2C%22uuid%22%3A%221001%22%2C%22mbox-id%22%3A%22mbx-001%22%7D%5D&expires_in=7200&grant_type=client_credentials&scope=home.testuser%3Arole.test-role HTTP/1.1\" 400 69 \"-\" \"Go-http-client/1.1\" 207 2 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("POST /zts/v1/oauth2/token?authorization_details=%5B%7B%22type%22%3A%22message_access%22%2C%22uuid%22%3A%221001%22%2C%22mbox-id%22%3A%22mbx-001%22%7D%5D&expires_in=7200&grant_type=client_credentials&scope=home.testuser%3Arole.test-role", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "POST /zts/v1/oauth2/token?authorization_details=%5B%7B%22type%22%3A%22message_access%22%2C%22uuid%22%3A%221001%22%2C%22mbox-id%22%3A%22mbx-001%22%7D%5D&expires_in=7200&grant_type=client_credentials&scope=home.testuser%3Arole.test-role");
 
         // Test /domain/{domainName}/role/{roleName}/token
         message = "77.238.175.59 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"POST /zts/v1/domain/home.testuser/role/test-role/token HTTP/1.1\" 200 1792 \"-\" \"Go-http-client/1.1\" 1141 158 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("POST /zts/v1/domain/home.testuser/role/test-role/token", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "POST /zts/v1/domain/home.testuser/role/test-role/token");
 
         // Test /access/domain/{domainName}/role/{roleName}/principal/{principal}
         message = "69.147.100.8 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zts/v1/access/domain/home.testuser/role/some.role/principal/some.other.principal HTTP/1.1\" 200 380 \"-\" \"Jersey/2.35 (Apache HttpClient 4.5.13)\" - 1 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zts/v1/access/domain/home.testuser/role/some.role/principal/some.other.principal", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zts/v1/access/domain/home.testuser/role/some.role/principal/some.other.principal");
 
         // Test /access/domain/{domainName}/principal/{principal}
         message = "69.147.100.8 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zts/v1/access/domain/home.testuser/principal/some.other.principal HTTP/1.1\" 200 380 \"-\" \"Jersey/2.35 (Apache HttpClient 4.5.13)\" - 1 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zts/v1/access/domain/home.testuser/principal/some.other.principal", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zts/v1/access/domain/home.testuser/principal/some.other.principal");
 
         // Test /rolecert
         message = "52.6.160.123 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"POST /zts/v1/rolecert?roleName=home.testuser:role.test-role HTTP/1.1\" 200 2220 \"-\" \"SIA-AWS 2.60.0\" 1549 50 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("POST /zts/v1/rolecert?roleName=home.testuser:role.test-role", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "POST /zts/v1/rolecert?roleName=home.testuser:role.test-role");
 
         // Test /access/{action}/{resource}
         message = "98.136.200.210 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zms/v1/access/create/home.testuser:testsource?principal=some.principal HTTP/1.1\" 200 16 \"-\" \"Jersey/2.18 (HttpUrlConnection 1.8.0_302)\" - 2 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zms/v1/access/create/home.testuser:testsource?principal=some.principal", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zms/v1/access/create/home.testuser:testsource?principal=some.principal");
 
         // Test /access/{action}/{resource}?domain={trustDomain}
         message = "98.136.200.210 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zms/v1/access/create/home.origdomain:testsource?principal=some.principal&domain=home.testuser HTTP/1.1\" 200 16 \"-\" \"Jersey/2.18 (HttpUrlConnection 1.8.0_302)\" - 2 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zms/v1/access/create/home.origdomain:testsource?principal=some.principal&domain=home.testuser", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zms/v1/access/create/home.origdomain:testsource?principal=some.principal&domain=home.testuser");
 
         // Test /access/{action}?resource={resource}&domain={trustDomain}
         message = "98.136.200.210 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zms/v1/access/create?principal=some.principal&domain=home.testuser&resource=home.origdomain:testsource HTTP/1.1\" 200 16 \"-\" \"Jersey/2.18 (HttpUrlConnection 1.8.0_302)\" - 2 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zms/v1/access/create?principal=some.principal&domain=home.testuser&resource=home.origdomain:testsource", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zms/v1/access/create?principal=some.principal&domain=home.testuser&resource=home.origdomain:testsource");
 
         message="87.248.108.86 - user.testprincipal [19/Apr/2022:08:00:45 +0000] \"GET /zms/v1/access/sudo_test?resource=home.testuser:testsource&principal=user.testprincipal HTTP/1.1\" 200 16 \"-\" \"Go-http-client/1.1\" 0 22 Auth-X509 TLSv1.2 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         recordFromLogEvent = LogsParserUtils.getRecordFromLogEvent(message);
         TestUtils.assertRecordMatch(recordFromLogEvent, message);
-        assertEquals("GET /zms/v1/access/sudo_test?resource=home.testuser:testsource&principal=user.testprincipal", recordFromLogEvent.getEndpoint());
+        assertEquals(recordFromLogEvent.getEndpoint(), "GET /zms/v1/access/sudo_test?resource=home.testuser:testsource&principal=user.testprincipal");
     }
 
     @Test
@@ -107,7 +107,7 @@ public class LogsParserUtilsTest {
             LogsParserUtils.getRecordFromLogEvent(message);
             fail();
         } catch (MalformedURLException e) {
-            assertEquals("Failed to locate domain at endpoint: /zms/v1/access/create?principal=some.principal", e.getMessage());
+            assertEquals(e.getMessage(), "Failed to locate domain at endpoint: /zms/v1/access/create?principal=some.principal");
         }
     }
 }

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/TestUtils.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/TestUtils.java
@@ -22,10 +22,10 @@ import static org.testng.Assert.assertEquals;
 
 public class TestUtils {
     public static void assertRecordMatch(AuthHistoryDynamoDBRecord recordFromLogEvent, String message) {
-        assertEquals("home.testuser:user:testprincipal", recordFromLogEvent.getPrimaryKey());
-        assertEquals("home.testuser", recordFromLogEvent.getUriDomain());
-        assertEquals("user", recordFromLogEvent.getPrincipalDomain());
-        assertEquals("testprincipal", recordFromLogEvent.getPrincipalName());
-        assertEquals("19/Apr/2022:08:00:45", recordFromLogEvent.getTimestamp());
+        assertEquals(recordFromLogEvent.getPrimaryKey(), "home.testuser:user:testprincipal");
+        assertEquals(recordFromLogEvent.getUriDomain(), "home.testuser");
+        assertEquals(recordFromLogEvent.getPrincipalDomain(), "user");
+        assertEquals(recordFromLogEvent.getPrincipalName(), "testprincipal");
+        assertEquals(recordFromLogEvent.getTimestamp(), "19/Apr/2022:08:00:45");
     }
 }

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/impl/DynamoDBAuthHistorySenderTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/impl/DynamoDBAuthHistorySenderTest.java
@@ -111,7 +111,7 @@ public class DynamoDBAuthHistorySenderTest {
                 item.getUriDomain(), item.getPrincipalDomain(), item.getPrincipalName(), item.getEndpoint(),
                 item.getTimestamp(), "access-token", item.getTtl()))).get();
 
-        assertEquals(0, records.size());
+        assertEquals(records.size(), 0);
         localDynamoDbAsyncClientFactory.terminate();
 
         System.clearProperty("software.amazon.awssdk.http.service.impl");
@@ -167,7 +167,7 @@ public class DynamoDBAuthHistorySenderTest {
 
             List<AuthHistoryDynamoDBRecord> records = table.query(r -> r.queryConditional(queryConditional))
                     .items().stream().collect(Collectors.toList());
-            assertEquals(1, records.size());
+            assertEquals(records.size(), 1);
             AuthHistoryDynamoDBRecord record = records.get(0);
             assertEquals(record.getPrimaryKey(), getPrimaryKeyForTest(i));
         }

--- a/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/impl/LocalAuthHistoryFetcherTest.java
+++ b/syncers/auth_history_syncer/src/test/java/com/yahoo/athenz/syncer/auth/history/impl/LocalAuthHistoryFetcherTest.java
@@ -74,7 +74,7 @@ public class LocalAuthHistoryFetcherTest {
         Long endTime = 1654819201000L; // 10/Jun/2022:00:00:01
         Set<AuthHistoryDynamoDBRecord> logs = localAuthHistoryFetcher.getLogs(startTime, endTime, true);
         List<String> justPrincipals = logs.stream().map(record -> record.getPrimaryKey()).collect(Collectors.toList());
-        assertEquals(7, justPrincipals.size());
+        assertEquals(justPrincipals.size(), 7);
         assertTrue(justPrincipals.contains("home.testuser:user:testprincipal4"));
         assertTrue(justPrincipals.contains("home.testuser:user:testprincipal5"));
         assertTrue(justPrincipals.contains("home.testuser2:user:testprincipal1"));

--- a/syncers/zms_aws_domain_syncer/src/test/java/com/yahoo/athenz/zms_aws_domain_syncer/ZmsSyncerTest.java
+++ b/syncers/zms_aws_domain_syncer/src/test/java/com/yahoo/athenz/zms_aws_domain_syncer/ZmsSyncerTest.java
@@ -84,7 +84,7 @@ public class ZmsSyncerTest {
         StateFileBuilder stateFileBuilder = new StateFileBuilder(s3Client, validator);
 
         ZmsSyncer zmsSyncer = new ZmsSyncer(awsSyncer, zmsReader, stateFileBuilder);
-        assertEquals(new HashMap<>(), zmsSyncer.loadState());
+        assertEquals(zmsSyncer.loadState(), new HashMap<>());
         assertFalse(zmsSyncer.getLoadState());
         assertFalse(zmsSyncer.saveDomainsState());
     }


### PR DESCRIPTION
# Description
there are no code changes in the PR - only test files are updated

The assertEquals method has the following signature:

    public static void assertEquals(actual, expected)

In quite a few places the order of action and expected was switched. The test case still works but they're being reported as a problem due to incorrect order in IDE. So the correct order was established.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

