### PR TITLE
Changed to allow setting the maximum number of records to be deleted and the interval between deletions

### DIFF
--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/DynamoDBCertRecordStoreConnection.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/DynamoDBCertRecordStoreConnection.java
@@ -282,7 +282,7 @@ public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnect
     }
     
     @Override
-    public int deleteExpiredX509CertRecords(int expiryTimeMins) {
+    public int deleteExpiredX509CertRecords(int expiryTimeMins, int limit) {
 
         // with dynamo db there is no need to manually expunge expired
         // record since we have the TTL option enabled for our table,

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/DynamoDBSSHRecordStoreConnection.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/DynamoDBSSHRecordStoreConnection.java
@@ -178,7 +178,7 @@ public class DynamoDBSSHRecordStoreConnection implements SSHRecordStoreConnectio
     }
     
     @Override
-    public int deleteExpiredSSHCertRecords(int expiryTimeMins) {
+    public int deleteExpiredSSHCertRecords(int expiryTimeMins, int limit) {
 
         // with dynamo db there is no need to manually expunge expired
         // record since we have the TTL option enabled for our table,

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -482,8 +482,8 @@ public class DynamoDBCertRecordStoreConnectionTest {
     @Test
     public void testdeleteExpiredX509CertRecords() {
         DynamoDBCertRecordStoreConnection dbConn = getDBConnection();
-        assertEquals(dbConn.deleteExpiredX509CertRecords(100), 0);
-        assertEquals(dbConn.deleteExpiredX509CertRecords(100000), 0);
+        assertEquals(dbConn.deleteExpiredX509CertRecords(100, 0), 0);
+        assertEquals(dbConn.deleteExpiredX509CertRecords(100000, 0), 0);
         dbConn.close();
     }
 

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBSSHRecordStoreConnectionTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/DynamoDBSSHRecordStoreConnectionTest.java
@@ -258,8 +258,8 @@ public class DynamoDBSSHRecordStoreConnectionTest {
     @Test
     public void testDeleteExpiredSSHCertRecords() {
         DynamoDBSSHRecordStoreConnection dbConn = new DynamoDBSSHRecordStoreConnection(dynamoDB, tableName);
-        assertEquals(dbConn.deleteExpiredSSHCertRecords(100), 0);
-        assertEquals(dbConn.deleteExpiredSSHCertRecords(100000), 0);
+        assertEquals(dbConn.deleteExpiredSSHCertRecords(100, 0), 0);
+        assertEquals(dbConn.deleteExpiredSSHCertRecords(100000, 0), 0);
         dbConn.close();
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertRecordStoreConnection.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertRecordStoreConnection.java
@@ -70,9 +70,10 @@ public interface CertRecordStoreConnection extends Closeable {
      * considered expired if it hasn't been updated within the
      * specified number of minutes
      * @param expiryTimeMins expiry time in minutes
+     * @param limit delete limit
      * @return number of records deleted
      */
-    int deleteExpiredX509CertRecords(int expiryTimeMins) throws ServerResourceException;
+    int deleteExpiredX509CertRecords(int expiryTimeMins, int limit) throws ServerResourceException;
 
     /**
      * Return all certificate records that failed to refresh after updating them with the current notification time and server.

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/ssh/SSHRecordStoreConnection.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/ssh/SSHRecordStoreConnection.java
@@ -67,7 +67,8 @@ public interface SSHRecordStoreConnection extends Closeable {
      * considered expired if it hasn't been updated within the
      * specified number of minutes
      * @param expiryTimeMins expiry time in minutes
+     * @param limit maximum number of records to delete
      * @return number of records deleted
      */
-    int deleteExpiredSSHCertRecords(int expiryTimeMins) throws ServerResourceException;
+    int deleteExpiredSSHCertRecords(int expiryTimeMins, int limit) throws ServerResourceException;
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCSSHRecordStoreConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCSSHRecordStoreConnectionTest.java
@@ -339,13 +339,33 @@ public class JDBCSSHRecordStoreConnectionTest {
 
     @Test
     public void testdeleteExpiredSSHCertRecords() throws Exception {
+        final String SQL_NO_LIMIT = "DELETE FROM ssh_certificates " +
+                "WHERE issueTime < ADDDATE(NOW(), INTERVAL -? MINUTE);";
         
         JDBCSSHRecordStoreConnection jdbcConn = new JDBCSSHRecordStoreConnection(mockConn);
 
         Mockito.doReturn(1).when(mockPrepStmt).executeUpdate();
-        jdbcConn.deleteExpiredSSHCertRecords(360);
+        jdbcConn.deleteExpiredSSHCertRecords(360, 0);
         
+        Mockito.verify(mockConn, times(1)).prepareStatement(SQL_NO_LIMIT);
         Mockito.verify(mockPrepStmt, times(1)).setInt(1, 360);
+        jdbcConn.close();
+    }
+
+    @Test
+    public void testdeleteExpiredSSHCertRecordsWithLimit() throws Exception {
+
+        final String SQL_WITH_LIMIT = "DELETE FROM ssh_certificates " +
+                "WHERE issueTime < ADDDATE(NOW(), INTERVAL -? MINUTE) LIMIT ?;";
+
+        JDBCSSHRecordStoreConnection jdbcConn = new JDBCSSHRecordStoreConnection(mockConn);
+
+        Mockito.doReturn(1).when(mockPrepStmt).executeUpdate();
+        jdbcConn.deleteExpiredSSHCertRecords(360, 1000);
+
+        Mockito.verify(mockConn, times(1)).prepareStatement(SQL_WITH_LIMIT);
+        Mockito.verify(mockPrepStmt, times(1)).setInt(1, 360);
+        Mockito.verify(mockPrepStmt, times(1)).setInt(2, 1000);
         jdbcConn.close();
     }
     
@@ -355,7 +375,7 @@ public class JDBCSSHRecordStoreConnectionTest {
         JDBCSSHRecordStoreConnection jdbcConn = new JDBCSSHRecordStoreConnection(mockConn);
 
         Mockito.doReturn(1).when(mockPrepStmt).executeUpdate();
-        jdbcConn.deleteExpiredSSHCertRecords(0);
+        jdbcConn.deleteExpiredSSHCertRecords(0, 0);
         
         Mockito.verify(mockPrepStmt, times(0)).setInt(1, 0);
         jdbcConn.close();
@@ -368,7 +388,7 @@ public class JDBCSSHRecordStoreConnectionTest {
 
         Mockito.when(mockPrepStmt.executeUpdate()).thenThrow(new SQLException("exc", "exc", 101));
         try {
-            jdbcConn.deleteExpiredSSHCertRecords(360);
+            jdbcConn.deleteExpiredSSHCertRecords(360, 0);
             fail();
         } catch (ServerResourceException ex) {
             Assert.assertEquals(ex.getCode(), ServerResourceException.INTERNAL_SERVER_ERROR);

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -797,3 +797,16 @@ athenz.zts.k8s_provider_distribution_validator_factory_class=com.yahoo.athenz.in
 # the server allows the certificate signer module to impose the limit. The certificate
 # signer will either honor that value or lower it based on its own configuration.
 #athenz.zts.service_cert_default_expiry_mins=0
+
+# This property specifies the maximum number of records that the CertRecordCleaner
+# can delete in a single execution. If set to 0, there is no limit on the number of records
+# that can be deleted.
+#athenz.zts.cert_record_cleaner_limit=0
+
+# These properties define the interval at which the CertRecordCleaner is executed.
+# The cert_record_cleaner_duration property specifies the duration as an integer value,
+# and the cert_record_cleaner_timeunit property determines the unit of time.
+# The supported time units are: second, minute, hour, or day. The interval is calculated
+# as duration * timeunit, and the CertRecordCleaner will run at this defined interval.
+#athenz.zts.cert_record_cleaner_duration=1
+#athenz.zts.cert_record_cleaner_timeunit=day

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -137,6 +137,9 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_SSH_USER_CA_CERT_KEYID_FNAME = "athenz.zts.ssh_user_ca_cert_keyid_fname";
     public static final String ZTS_PROP_RESP_X509_SIGNER_CERTS       = "athenz.zts.resp_x509_signer_certs";
     public static final String ZTS_PROP_RESP_SSH_SIGNER_CERTS        = "athenz.zts.resp_ssh_signer_certs";
+    public static final String ZTS_PROP_CERT_RECORD_CLEANER_LIMIT    = "athenz.zts.cert_record_cleaner_limit";
+    public static final String ZTS_PROP_CERT_RECORD_CLEANER_DURATION = "athenz.zts.cert_record_cleaner_duration";
+    public static final String ZTS_PROP_CERT_RECORD_CLEANER_TIMEUNIT = "athenz.zts.cert_record_cleaner_timeunit";
 
     public static final String DB_PROP_USER               = "user";
     public static final String DB_PROP_PASSWORD           = "password";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
@@ -79,7 +79,7 @@ public class FileCertRecordStoreConnection implements CertRecordStoreConnection 
     }
     
     @Override
-    public int deleteExpiredX509CertRecords(int expiryTimeMins) {
+    public int deleteExpiredX509CertRecords(int expiryTimeMins, int limit) {
         String[] fnames = rootDir.list();
         if (fnames == null) {
             return 0;
@@ -98,6 +98,9 @@ public class FileCertRecordStoreConnection implements CertRecordStoreConnection 
             //noinspection ResultOfMethodCallIgnored
             file.delete();
             count += 1;
+            if (limit == count) {
+                break;
+            }
         }
         return count;
     }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileSSHRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileSSHRecordStoreConnection.java
@@ -77,7 +77,7 @@ public class FileSSHRecordStoreConnection implements SSHRecordStoreConnection {
     }
     
     @Override
-    public int deleteExpiredSSHCertRecords(int expiryTimeMins) {
+    public int deleteExpiredSSHCertRecords(int expiryTimeMins, int limit) {
         String[] fnames = rootDir.list();
         if (fnames == null) {
             return 0;
@@ -96,6 +96,9 @@ public class FileSSHRecordStoreConnection implements SSHRecordStoreConnection {
             //noinspection ResultOfMethodCallIgnored
             file.delete();
             count += 1;
+            if (count == limit) {
+                break;
+            }
         }
         return count;
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1464,7 +1465,7 @@ public class InstanceCertManagerTest {
         when(store.getConnection()).thenThrow(new RuntimeException("invalid connection"));
 
         InstanceCertManager.ExpiredX509CertRecordCleaner cleaner =
-                new InstanceCertManager.ExpiredX509CertRecordCleaner(store, 100, new DynamicConfigBoolean(false));
+                new InstanceCertManager.ExpiredX509CertRecordCleaner(store, 100, 0, new DynamicConfigBoolean(false));
 
         // make sure no exceptions are thrown
 
@@ -1479,7 +1480,7 @@ public class InstanceCertManagerTest {
         assertNotNull(store);
 
         InstanceCertManager.ExpiredSSHCertRecordCleaner cleaner =
-                new InstanceCertManager.ExpiredSSHCertRecordCleaner(store, 100, new DynamicConfigBoolean(false));
+                new InstanceCertManager.ExpiredSSHCertRecordCleaner(store, 100, 0, new DynamicConfigBoolean(false));
 
         // make sure no exceptions are thrown
 
@@ -1493,7 +1494,7 @@ public class InstanceCertManagerTest {
         when(store.getConnection()).thenThrow(new RuntimeException("invalid connection"));
 
         InstanceCertManager.ExpiredSSHCertRecordCleaner cleaner =
-                new InstanceCertManager.ExpiredSSHCertRecordCleaner(store, 100, new DynamicConfigBoolean(false));
+                new InstanceCertManager.ExpiredSSHCertRecordCleaner(store, 100, 0, new DynamicConfigBoolean(false));
 
         // make sure no exceptions are thrown
 
@@ -2358,14 +2359,14 @@ public class InstanceCertManagerTest {
                 .thenThrow(new ServerResourceException(400, "Invalid delete request"));
         when(certConnection.updateUnrefreshedCertificatesNotificationTimestamp(anyString(), anyLong(), anyString()))
                 .thenThrow(new ServerResourceException(400, "Invalid update unrefreshed cert request"));
-        when(certConnection.deleteExpiredX509CertRecords(anyInt()))
+        when(certConnection.deleteExpiredX509CertRecords(anyInt(), anyInt()))
                 .thenThrow(new ServerResourceException(400, "Invalid delete expired certs request"));
         instance.setCertStore(certStore);
 
         // verify cleaner runs without any exceptions
 
         InstanceCertManager.ExpiredX509CertRecordCleaner cleaner =
-                new InstanceCertManager.ExpiredX509CertRecordCleaner(certStore, 100, new DynamicConfigBoolean(false));
+                new InstanceCertManager.ExpiredX509CertRecordCleaner(certStore, 100, 0, new DynamicConfigBoolean(false));
         cleaner.run();
 
         try {
@@ -2432,14 +2433,14 @@ public class InstanceCertManagerTest {
                 .thenThrow(new ServerResourceException(400, "Invalid get request"));
         when(sshRecordStoreConnection.updateSSHCertRecord(any()))
                 .thenThrow(new ServerResourceException(400, "Invalid update request"));
-        when(sshRecordStoreConnection.deleteExpiredSSHCertRecords(anyInt()))
+        when(sshRecordStoreConnection.deleteExpiredSSHCertRecords(anyInt(), anyInt()))
                 .thenThrow(new ServerResourceException(400, "Invalid delete expired certs request"));
         instance.setSSHStore(sshRecordStore);
 
         // verify cleaner runs without any exceptions
 
         InstanceCertManager.ExpiredSSHCertRecordCleaner cleaner =
-                new InstanceCertManager.ExpiredSSHCertRecordCleaner(sshRecordStore, 100, new DynamicConfigBoolean(false));
+                new InstanceCertManager.ExpiredSSHCertRecordCleaner(sshRecordStore, 100, 0, new DynamicConfigBoolean(false));
         cleaner.run();
 
         try {
@@ -2494,4 +2495,14 @@ public class InstanceCertManagerTest {
 
         instance.shutdown();
     }
+
+    @Test
+    public void testParseTimeUnit() {
+        assertEquals(InstanceCertManager.parseTimeUnit("second"), TimeUnit.SECONDS);
+        assertEquals(InstanceCertManager.parseTimeUnit("minute"), TimeUnit.MINUTES);
+        assertEquals(InstanceCertManager.parseTimeUnit("hour"), TimeUnit.HOURS);
+        assertEquals(InstanceCertManager.parseTimeUnit("days"), TimeUnit.DAYS);
+        assertEquals(InstanceCertManager.parseTimeUnit("invalidstring"), TimeUnit.DAYS);
+    }
+
 }


### PR DESCRIPTION
# Description
Two new features have been added to CertRecordCleaner.  
1. A limit on the number of records that can be deleted in a single execution of CertRecordCleaner.  
2. The ability to freely configure the execution interval for CertRecordCleaner.  

These changes can be effectively utilized in environments where multiple instances of ZTS are running for redundancy.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

