### PR TITLE
Resolved the issue where a NullPointer occurs when the admin role is a trust role

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -2233,8 +2233,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         if (adminRole == null) {
             throw ZMSUtils.notFoundError("Invalid domain name specified", caller);
         }
-        if (StringUtils.isEmpty(adminRole.trust)) {
-            List<RoleMember> members = adminRole.getRoleMembers();
+        List<RoleMember> members = adminRole.getRoleMembers();
+        // If adminRole is a Trust Role, the member will be null.
+        if (members != null) {
             if (members.size() == 1 && members.get(0).getMemberName().equals(memberName)) {
                 throw ZMSUtils.forbiddenError("deleteDomainRoleMember: Cannot delete last member of 'admin' role", caller);
             }
@@ -5331,6 +5332,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         if (ZMSConsts.ADMIN_ROLE_NAME.equals(roleName)) {
             List<RoleMember> members = role.getRoleMembers();
+            // If adminRole is a Trust Role, the member will be null.
+            if (members == null) {
+                throw ZMSUtils.forbiddenError("deleteMembership: Cannot delete because the admin role member is null", caller);
+            }
             if (members.size() == 1 && members.get(0).getMemberName().equals(normalizedMember)) {
                 throw ZMSUtils.forbiddenError("deleteMembership: Cannot delete last member of 'admin' role", caller);
             }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -2233,9 +2233,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         if (adminRole == null) {
             throw ZMSUtils.notFoundError("Invalid domain name specified", caller);
         }
-        List<RoleMember> members = adminRole.getRoleMembers();
-        if (members.size() == 1 && members.get(0).getMemberName().equals(memberName)) {
-            throw ZMSUtils.forbiddenError("deleteDomainRoleMember: Cannot delete last member of 'admin' role", caller);
+        if (StringUtils.isEmpty(adminRole.trust)) {
+            List<RoleMember> members = adminRole.getRoleMembers();
+            if (members.size() == 1 && members.get(0).getMemberName().equals(memberName)) {
+                throw ZMSUtils.forbiddenError("deleteDomainRoleMember: Cannot delete last member of 'admin' role", caller);
+            }
         }
 
         // verify that request is properly authenticated for this request

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -3503,6 +3503,39 @@ public class ZMSImplTest {
     }
 
     @Test
+    public void testDeleteMembershipTrustAdminRole() {
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        final String domainName = "mbr-del-dom";
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        final String trustedDomainName = "trusted-domain";
+        TopLevelDomain trustedDomain = zmsTestInitializer.createTopLevelDomainObject(trustedDomainName,
+                "Test Domain1", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, trustedDomain);
+
+        Role role1 = zmsTestInitializer.createRoleObject(domainName, "admin", trustedDomainName,
+                null, null);
+        zmsImpl.putRole(ctx, domainName, "admin", auditRef, false, null, role1);
+        Role role = zmsImpl.getRole(ctx, domainName, "admin", false, false, false);
+        assertNotNull(role);
+
+        try {
+            zmsImpl.deleteMembership(ctx, domainName, "admin", "user.joe", auditRef, null);
+            fail();
+        } catch (ResourceException e){
+            assertEquals(e.getCode(), 403);
+        }
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+        zmsImpl.deleteTopLevelDomain(ctx, trustedDomainName, auditRef, null);
+    }
+
+    @Test
     public void testDeleteMembershipInvalidRoleCollection() {
         String domainName = "MbrGetRoleDom1";
         String roleName = "Role1";


### PR DESCRIPTION
# Description
It might be a rare case, but when the trust of the admin role is set, the admin role member cannot be retrieved, resulting in a NullPointerException. 
I have modified it so that member checks are not performed when it is a role with trust set.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

