### PR TITLE
Prevent null values in CSV export for adminFullName and memberFullName

### DIFF
--- a/ui/src/components/history/CollectionHistoryList.js
+++ b/ui/src/components/history/CollectionHistoryList.js
@@ -143,11 +143,11 @@ class CollectionHistoryList extends React.Component {
             result +=
                 item.action +
                 columnDelimiter +
-                item.adminFullName +
+                (item.adminFullName ? item.adminFullName : item.admin) +
                 columnDelimiter +
                 item.created +
                 columnDelimiter +
-                item.memberFullName +
+                (item.memberFullName ? item.memberFullName : item.member) +
                 columnDelimiter +
                 item.auditRef;
             result += lineDelimiter;


### PR DESCRIPTION
# Description
Ensure that the CSV export function handles cases where adminFullName or memberFullName is null by defaulting to the admin or member field, respectively. This prevents null values from being written to the CSV file, improving data integrity and readability.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

