### PR TITLE
Resource ownership override support using a special keyword

### DIFF
--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -152,6 +152,9 @@ type AssertionConditionValuePattern string
 // AssertionConditionValue -
 type AssertionConditionValue string
 
+// ResourceOwnerName -
+type ResourceOwnerName string
+
 // ResourceDomainOwnership - The representation of the domain ownership object
 type ResourceDomainOwnership struct {
 

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -139,6 +139,10 @@ func init() {
 	tAssertionConditionValue.Pattern("([a-zA-Z0-9\\*][a-zA-Z0-9_\\.\\*-]*,)*[a-zA-Z0-9\\*][a-zA-Z0-9_\\.\\*-]*")
 	sb.AddType(tAssertionConditionValue.Build())
 
+	tResourceOwnerName := rdl.NewStringTypeBuilder("ResourceOwnerName")
+	tResourceOwnerName.Pattern("[a-zA-Z0-9_][a-zA-Z0-9_:-]*")
+	sb.AddType(tResourceOwnerName.Build())
+
 	tResourceDomainOwnership := rdl.NewStructTypeBuilder("Struct", "ResourceDomainOwnership")
 	tResourceDomainOwnership.Comment("The representation of the domain ownership object")
 	tResourceDomainOwnership.Field("metaOwner", "SimpleName", true, nil, "owner of the object's meta attribute")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -115,6 +115,9 @@ public class ZMSSchema {
         sb.stringType("AssertionConditionValue")
             .pattern("([a-zA-Z0-9\\*][a-zA-Z0-9_\\.\\*-]*,)*[a-zA-Z0-9\\*][a-zA-Z0-9_\\.\\*-]*");
 
+        sb.stringType("ResourceOwnerName")
+            .pattern("[a-zA-Z0-9_][a-zA-Z0-9_:-]*");
+
         sb.structType("ResourceDomainOwnership")
             .comment("The representation of the domain ownership object")
             .field("metaOwner", "SimpleName", true, "owner of the object's meta attribute")

--- a/core/zms/src/main/rdl/Names.tdl
+++ b/core/zms/src/main/rdl/Names.tdl
@@ -87,3 +87,5 @@ type AssertionConditionKey String (pattern="({AssertionConditionKeyPattern}\\.)*
 
 type AssertionConditionValuePattern String (pattern="[a-zA-Z0-9\\*][a-zA-Z0-9_\\.\\*-]*");
 type AssertionConditionValue String (pattern="({AssertionConditionValuePattern},)*{AssertionConditionValuePattern}");
+
+type ResourceOwnerName String (pattern="[a-zA-Z0-9_][a-zA-Z0-9_:-]*");

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
@@ -24,6 +24,7 @@ import com.yahoo.rdl.Validator.Result;
 import org.testng.annotations.Test;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static org.testng.Assert.*;
 
@@ -2969,5 +2970,13 @@ public class ZMSCoreTest {
         authHistory2.setTtl(1655282257L);
         assertEquals(a, a2);
         assertEquals(authHistory.getTtl(), authHistory2.getTtl());
+    }
+
+    @Test
+    public void testResourceOwnerType() {
+        Schema schema = ZMSSchema.instance();
+        Validator validator = new Validator(schema);
+        Result result = validator.validate("abc:force", "ResourceOwnerName");
+        assertTrue(result.valid);
     }
 }

--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9159</code.coverage.min>
+    <code.coverage.min>0.94</code.coverage.min>
   </properties>
 
   <dependencyManagement>

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/ResourceOwnershipTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/ResourceOwnershipTest.java
@@ -371,4 +371,703 @@ public class ResourceOwnershipTest {
             fail();
         }
     }
+
+    @Test
+    public void testIsResourceOwnershipOverrideAllowed() {
+        assertFalse(ResourceOwnership.isResourceOwnershipOverrideAllowed(null, "TF2"));
+        assertFalse(ResourceOwnership.isResourceOwnershipOverrideAllowed("TF1", "TF2"));
+        assertFalse(ResourceOwnership.isResourceOwnershipOverrideAllowed("TF1:abc", "TF2"));
+        assertFalse(ResourceOwnership.isResourceOwnershipOverrideAllowed("TF2:force", "TF2"));
+        assertTrue(ResourceOwnership.isResourceOwnershipOverrideAllowed("TF1:force", "TF2"));
+    }
+
+    @Test
+    public void testVerifyServicePublicKeysResourceOwnership() {
+        ResourceServiceIdentityOwnership ownership;
+        // no changes needed when resource ownership is same
+        ServiceIdentity service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setPublicKeysOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setPublicKeysOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        service = new ServiceIdentity().setName("service1");
+        try {
+            ownership = ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        service = new ServiceIdentity().setName("service1");
+        try {
+            ownership = ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getPublicKeysOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setPublicKeysOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getPublicKeysOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setPublicKeysOwner("TF1"));
+        try {
+            ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setPublicKeysOwner("TF1"));
+        try {
+            ResourceOwnership.verifyServicePublicKeysResourceOwnership(service, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyServiceResourceOwnership() {
+        ResourceServiceIdentityOwnership ownership;
+        // no changes needed when resource ownership is same
+        ServiceIdentity service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setObjectOwner("TF1").setPublicKeysOwner("TF1").setHostsOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyServiceResourceOwnership(service, true, true,"TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setObjectOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyServiceResourceOwnership(service, false, false,null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        service = new ServiceIdentity().setName("service1");
+        try {
+            ownership = ResourceOwnership.verifyServiceResourceOwnership(service, false, false,"ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        service = new ServiceIdentity().setName("service1");
+        try {
+            ownership = ResourceOwnership.verifyServiceResourceOwnership(service, false, false,"TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getObjectOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setObjectOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyServiceResourceOwnership(service, false, false,"TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getObjectOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyServiceResourceOwnership(service, false, false,"TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        service = new ServiceIdentity().setName("service1").setResourceOwnership(new ResourceServiceIdentityOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyServiceResourceOwnership(service, false, false,null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyPolicyAssertionsResourceOwnership() {
+        ResourcePolicyOwnership ownership;
+        // no changes needed when resource ownership is same
+        Policy policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setAssertionsOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setAssertionsOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        policy = new Policy().setName("policy1");
+        try {
+            ownership = ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        policy = new Policy().setName("policy1");
+        try {
+            ownership = ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getAssertionsOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setAssertionsOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getAssertionsOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setAssertionsOwner("TF1"));
+        try {
+            ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setAssertionsOwner("TF1"));
+        try {
+            ResourceOwnership.verifyPolicyAssertionsResourceOwnership(policy, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyPolicyResourceOwnership() {
+        ResourcePolicyOwnership ownership;
+        // no changes needed when resource ownership is same
+        Policy policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setObjectOwner("TF1").setAssertionsOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyPolicyResourceOwnership(policy, true, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setObjectOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyPolicyResourceOwnership(policy, true, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        policy = new Policy().setName("policy1");
+        try {
+            ownership = ResourceOwnership.verifyPolicyResourceOwnership(policy, true, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        policy = new Policy().setName("policy1");
+        try {
+            ownership = ResourceOwnership.verifyPolicyResourceOwnership(policy, true, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getAssertionsOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setObjectOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyPolicyResourceOwnership(policy, true, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getAssertionsOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyPolicyResourceOwnership(policy, true, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        policy = new Policy().setName("policy1").setResourceOwnership(new ResourcePolicyOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyPolicyResourceOwnership(policy, true, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyGroupMembersResourceOwnership() {
+        ResourceGroupOwnership ownership;
+        // no changes needed when resource ownership is same
+        Group group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMembersOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupMembersResourceOwnership(group, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMembersOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyGroupMembersResourceOwnership(group, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        group = new Group().setName("group1");
+        try {
+            ownership = ResourceOwnership.verifyGroupMembersResourceOwnership(group, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        group = new Group().setName("group1");
+        try {
+            ownership = ResourceOwnership.verifyGroupMembersResourceOwnership(group, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMembersOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMembersOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupMembersResourceOwnership(group, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMembersOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMembersOwner("TF1"));
+        try {
+            ResourceOwnership.verifyGroupMembersResourceOwnership(group, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMembersOwner("TF1"));
+        try {
+            ResourceOwnership.verifyGroupMembersResourceOwnership(group, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyGroupMetaResourceOwnership() {
+        ResourceGroupOwnership ownership;
+        // no changes needed when resource ownership is same
+        Group group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMetaOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupMetaResourceOwnership(group, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMetaOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyGroupMetaResourceOwnership(group, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        group = new Group().setName("group1");
+        try {
+            ownership = ResourceOwnership.verifyGroupMetaResourceOwnership(group, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        group = new Group().setName("group1");
+        try {
+            ownership = ResourceOwnership.verifyGroupMetaResourceOwnership(group, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMetaOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMetaOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupMetaResourceOwnership(group, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMetaOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMetaOwner("TF1"));
+        try {
+            ResourceOwnership.verifyGroupMetaResourceOwnership(group, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMetaOwner("TF1"));
+        try {
+            ResourceOwnership.verifyGroupMetaResourceOwnership(group, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyGroupResourceOwnership() {
+        ResourceGroupOwnership ownership;
+        // no changes needed when resource ownership is same
+        Group group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setObjectOwner("TF1").setMembersOwner("TF1").setMetaOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupResourceOwnership(group, true, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMetaOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyGroupResourceOwnership(group, true, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        group = new Group().setName("group1");
+        try {
+            ownership = ResourceOwnership.verifyGroupResourceOwnership(group, true, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        group = new Group().setName("group1");
+        try {
+            ownership = ResourceOwnership.verifyGroupResourceOwnership(group, true, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getObjectOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setObjectOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupResourceOwnership(group, true, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getObjectOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyGroupResourceOwnership(group, true, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyGroupResourceOwnership(group, true, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyRoleResourceOwnership() {
+        ResourceRoleOwnership ownership;
+        // no changes needed when resource ownership is same
+        Role role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setObjectOwner("TF1").setMembersOwner("TF1").setMetaOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleResourceOwnership(role, true, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setObjectOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyRoleResourceOwnership(role, true, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        role = new Role().setName("role1");
+        try {
+            ownership = ResourceOwnership.verifyRoleResourceOwnership(role, true, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        role = new Role().setName("role1");
+        try {
+            ownership = ResourceOwnership.verifyRoleResourceOwnership(role, true, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getObjectOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setObjectOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleResourceOwnership(role, true, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getObjectOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyRoleResourceOwnership(role, true, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setObjectOwner("TF1"));
+        try {
+            ResourceOwnership.verifyRoleResourceOwnership(role, true, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyRoleMemberResourceOwnership() {
+        ResourceRoleOwnership ownership;
+        // no changes needed when resource ownership is same
+        Role role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMembersOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMembersOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        role = new Role().setName("role1");
+        try {
+            ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        role = new Role().setName("role1");
+        try {
+            ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMembersOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMembersOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMembersOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMembersOwner("TF1"));
+        try {
+            ResourceOwnership.verifyRoleMembersResourceOwnership(role, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMembersOwner("TF1"));
+        try {
+            ResourceOwnership.verifyRoleMembersResourceOwnership(role, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
+
+    @Test
+    public void testVerifyRoleMetaResourceOwnership() {
+        ResourceRoleOwnership ownership;
+        // no changes needed when resource ownership is same
+        Role role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMetaOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleMetaResourceOwnership(role, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is not set and no owner specified
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMetaOwner(""));
+        try {
+            ownership = ResourceOwnership.verifyRoleMetaResourceOwnership(role, null, "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // no changes needed when resource ownership is set and request owner is set to ignore
+        role = new Role().setName("role1");
+        try {
+            ownership = ResourceOwnership.verifyRoleMetaResourceOwnership(role, "ignore", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException sre) {
+            fail();
+        }
+
+        // changes needed when resource ownership is not set and request owner is specified
+        role = new Role().setName("role1");
+        try {
+            ownership = ResourceOwnership.verifyRoleMetaResourceOwnership(role, "TF1", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMetaOwner(), "TF1");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // changes needed when resource ownership is force overridden
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMetaOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleMetaResourceOwnership(role, "TF2:force", "unit-test");
+            assertNotNull(ownership);
+            assertEquals(ownership.getMetaOwner(), "TF2");
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // exception is thrown when resource ownership is different and not force overridden
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMetaOwner("TF1"));
+        try {
+            ResourceOwnership.verifyRoleMetaResourceOwnership(role, "TF2", "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+
+        // exception is thrown when resource ownership is set and no owner specified
+        role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMetaOwner("TF1"));
+        try {
+            ResourceOwnership.verifyRoleMetaResourceOwnership(role, null, "unit-test");
+            fail();
+        } catch (ServerResourceException sre) {
+            assertEquals(sre.getCode(), 409);
+        }
+    }
 }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -152,6 +152,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     private static final String TYPE_POLICY_OPTIONS = "PolicyOptions";
     private static final String TYPE_TAG_KEY = "TagKey";
     private static final String TYPE_TAG_COMPOUND_VALUE = "TagCompoundValue";
+    private static final String TYPE_RESOURCE_OWNER_NAME = "ResourceOwnerName";
 
     private static final String SERVER_READ_ONLY_MESSAGE = "Server in Maintenance Read-Only mode. Please try your request later";
 
@@ -9028,7 +9029,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
     void validateResourceOwner(final String resourceOwner, final String caller) {
         if (!StringUtil.isEmpty(resourceOwner)) {
-            validate(resourceOwner, TYPE_SIMPLE_NAME, caller);
+            validate(resourceOwner, TYPE_RESOURCE_OWNER_NAME, caller);
             if (resourceOwner.length() > 32) {
                 throw ZMSUtils.requestError("Invalid resource owner: " + resourceOwner +
                         " : name length cannot exceed 32 characters", caller);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -30924,7 +30924,7 @@ public class ZMSImplTest {
         zmsImpl.validateResourceOwner("ZTS_Server", "unit-test");
         // invalid values
         try {
-            zmsImpl.validateResourceOwner("ZTS:Server", "unit-test");
+            zmsImpl.validateResourceOwner("ZTS@Server", "unit-test");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);


### PR DESCRIPTION
# Description
To promote better interoperability between various resource ownership mechanisms, this pr introduces a special suffix ( defaulted to ":force" ). Similar to how setting "ignore" works in the resource ownership use cases, ":force" allows users to override the resource ownership. e.g. if current resource ownership is set to "TF1", users can modify the resource ownership from "TF1" to "TF2" by sending "TF2:force" as the resource owner in mutate calls.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

