### PR TITLE
fix minor typos and Go imports order

### DIFF
--- a/libs/go/athenzutils/privkey.go
+++ b/libs/go/athenzutils/privkey.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 )
 
-// ExtractSignerInfo extract crypto.Signer and x509.SignatureAlgorithm from the given private key (ECDSA or RSA).
+// ExtractSignerInfo extracts crypto.Signer and x509.SignatureAlgorithm from the given private key (ECDSA or RSA).
 func ExtractSignerInfo(privateKeyPEM []byte) (crypto.Signer, x509.SignatureAlgorithm, error) {
 	block, _ := pem.Decode(privateKeyPEM)
 	if block == nil {

--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/google/shlex"
 	"log"
 	"net"
 	"net/http"
@@ -39,11 +38,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ardielle/ardielle-go/rdl"
-
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/athenz/libs/go/sia/futil"
 	"github.com/AthenZ/athenz/libs/go/tls/config"
+	"github.com/ardielle/ardielle-go/rdl"
+	"github.com/google/shlex"
 )
 
 // CertReqDetails - struct with details to generate a certificate CSR


### PR DESCRIPTION
# Description
PR fixes a few minor typos and corrects the Go imports order to be sorted and `goimports`-compatible (a block of stdlib imports followed by a blank line followed by the third-party imports).

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

