### PR TITLE
functional test - fix slack channel test

### DIFF
--- a/ui/src/__tests__/spec/tests/domain.spec.js
+++ b/ui/src/__tests__/spec/tests/domain.spec.js
@@ -77,7 +77,7 @@ describe('Domain', () => {
         );
         await expand.click();
 
-        // click add business service
+        // click add slack channel
         let addSlackChannel = await $('a[data-testid="add-slack-channel"]');
         await browser.waitUntil(
             async () => await addSlackChannel.isClickable()
@@ -87,6 +87,7 @@ describe('Domain', () => {
         let randomInt = Math.floor(Math.random() * 100); // random number to append to slack channel name
         let slackChannelName = 'slack-channel-' + randomInt;
         let slackChannelInput = await $('input[name="slack-channel-input"]');
+        await slackChannelInput.clearValue();
         await slackChannelInput.addValue(slackChannelName);
         let submitButton = await $('button*=Submit');
         await submitButton.click();


### PR DESCRIPTION
# Description
- fix ui functional test when adding user for domain slack channel
- temporarily disable func test covering athenz-guide link from static instances page - due to msd call error

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

