### PR TITLE
Go client supports prefetching of role tokens

### DIFF
--- a/libs/go/ztsroletoken/role-token.go
+++ b/libs/go/ztsroletoken/role-token.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -162,7 +161,6 @@ func (r *roleToken) updateRoleToken() (string, error) {
 	}
 	r.zToken = rt.Token
 	r.expireTime = time.Unix(rt.ExpiryTime, 0)
-	log.Printf("[%s] Role token cache has been refreshed (expiration time: %s)", r.domain, r.expireTime.Format(time.RFC3339))
 	return r.zToken, nil
 }
 
@@ -173,7 +171,6 @@ func (r *roleToken) RoleTokenValue() (string, error) {
 	r.l.RUnlock()
 
 	if time.Now().Add(expirationDrift).After(e) {
-		log.Printf("[%s] Valid role token is not cached so new one will be fetched (expiration time: %s)", r.domain, e.Format(time.RFC3339))
 		return r.updateRoleToken()
 	}
 	return ztok, nil
@@ -198,10 +195,7 @@ func (r *roleToken) StartPrefetcher() error {
 			case <-r.stopCh:
 				return
 			case <-r.ticker.C:
-				_, err := r.updateRoleToken()
-				if err != nil {
-					log.Printf("[%s] Failed to prefetch new role token: %v", r.domain, err)
-				}
+				r.updateRoleToken()
 			}
 		}
 	}()

--- a/libs/go/ztsroletoken/role-token.go
+++ b/libs/go/ztsroletoken/role-token.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,35 +24,43 @@ const (
 )
 
 var expirationDrift = 10 * time.Minute
+var defaultPrefetchInterval = 10 * time.Minute
 
 // RoleToken is a mechanism to get a role token (ztoken)
 // as a string. It guarantees that the returned token has
 // not expired.
 type RoleToken interface {
 	RoleTokenValue() (string, error)
+	StartPrefetcher() error
+	StopPrefetcher() error
 }
 
 // RoleTokenOptions allows the caller to supply additional options
 // for getting a role token. The zero-value is a valid configuration.
 type RoleTokenOptions struct {
-	BaseZTSURL string        // the base ZTS URL to use
-	ProxyURL   string        // the proxy URL for accessing ZTS
-	Role       string        // the single role for which a token is required
-	MinExpire  time.Duration // the minimum expiry of the token in (server default if zero)
-	MaxExpire  time.Duration // the maximum expiry of the token (server default if zero)
-	AuthHeader string        // Auth Header to use while making ZMS calls
-	CACert     []byte        // Optional CA certpem to validate the ZTS server
+	BaseZTSURL       string        // the base ZTS URL to use
+	ProxyURL         string        // the proxy URL for accessing ZTS
+	Role             string        // the single role for which a token is required
+	MinExpire        time.Duration // the minimum expiry of the token in (server default if zero)
+	MaxExpire        time.Duration // the maximum expiry of the token (server default if zero)
+	AuthHeader       string        // Auth Header to use while making ZMS calls
+	CACert           []byte        // Optional CA certpem to validate the ZTS server
+	PrefetchInterval time.Duration // the interval at which the role token cache is refreshed in the background
 }
 
 type roleToken struct {
-	domain     string
-	opts       RoleTokenOptions
-	l          sync.RWMutex
-	tok        zmssvctoken.Token
-	certFile   string
-	keyFile    string
-	zToken     string
-	expireTime time.Time
+	domain          string
+	opts            RoleTokenOptions
+	l               sync.RWMutex
+	tok             zmssvctoken.Token
+	certFile        string
+	keyFile         string
+	zToken          string
+	expireTime      time.Time
+	ticker          *time.Ticker
+	tickerLock      sync.Mutex
+	isTickerStarted bool
+	stopCh          chan struct{}
 }
 
 func getClientTLSConfig(certFile, keyFile string) (*tls.Config, error) {
@@ -153,6 +162,7 @@ func (r *roleToken) updateRoleToken() (string, error) {
 	}
 	r.zToken = rt.Token
 	r.expireTime = time.Unix(rt.ExpiryTime, 0)
+	log.Printf("[%s] Role token cache has been refreshed (expiration time: %s)", r.domain, r.expireTime.Format(time.RFC3339))
 	return r.zToken, nil
 }
 
@@ -163,9 +173,55 @@ func (r *roleToken) RoleTokenValue() (string, error) {
 	r.l.RUnlock()
 
 	if time.Now().Add(expirationDrift).After(e) {
+		log.Printf("[%s] Valid role token is not cached so new one will be fetched (expiration time: %s)", r.domain, e.Format(time.RFC3339))
 		return r.updateRoleToken()
 	}
 	return ztok, nil
+}
+
+func (r *roleToken) StartPrefetcher() error {
+	r.tickerLock.Lock()
+	defer r.tickerLock.Unlock()
+	if r.isTickerStarted {
+		return fmt.Errorf("Prefetcher has already been started")
+	}
+	prefetchInterval := defaultPrefetchInterval
+	if r.opts.PrefetchInterval > 0 {
+		prefetchInterval = r.opts.PrefetchInterval
+	}
+	r.ticker = time.NewTicker(prefetchInterval)
+	r.stopCh = make(chan struct{})
+	r.isTickerStarted = true
+	go func() {
+		for {
+			select {
+			case <-r.stopCh:
+				return
+			case <-r.ticker.C:
+				_, err := r.updateRoleToken()
+				if err != nil {
+					log.Printf("[%s] Failed to prefetch new role token: %v", r.domain, err)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (r *roleToken) StopPrefetcher() error {
+	r.tickerLock.Lock()
+	defer r.tickerLock.Unlock()
+	if !r.isTickerStarted {
+		return fmt.Errorf("Prefetcher has already been stopped")
+	}
+	if r.ticker != nil {
+		r.ticker.Stop()
+	}
+	if r.stopCh != nil {
+		close(r.stopCh)
+	}
+	r.isTickerStarted = false
+	return nil
 }
 
 // NewRoleToken returns a RoleToken implementation based on principal tokens


### PR DESCRIPTION
# Description

The Java ZTS client has the feature of prefetching role tokens, but the Go client has no such feature. Therefore, I added a feature to `ztsroletoken` that periodically refreshes the role token cache in the background.

Unlike Java, the ticker responsible for prefetching role tokens does not start automatically, but only when the `StartPrefetcher()` method is called by the user. I implemented it this way because I didn't want to affect existing users and I wanted users who want to enable prefetching to be aware that they need to stop the ticker by calling the `StopPrefetcher()` method.

Example usage:
```go
package main

import (
        "log"
        "regexp"
        "time"

        zts "github.com/AthenZ/athenz/libs/go/ztsroletoken"
)

func main() {
        certFile := "/path/to/cert.pem"
        keyFile := "/path/to/key.pem"
        domain := "test.provider"

        opts := zts.RoleTokenOptions{
                BaseZTSURL:       "https://foo.bar.example.com:443/zts/v1",
                MinExpire:        2 * time.Hour,
                MaxExpire:        24 * time.Hour,
                PrefetchInterval: 1 * time.Minute,
        }

        re := regexp.MustCompile(`;(e=[0-9]+)`)

        roleToken := zts.RoleToken(zts.NewRoleTokenFromCert(certFile, keyFile, domain, opts))
        roleToken.StartPrefetcher()
        defer roleToken.StopPrefetcher()

        for i := 0; i < 30; i++ {
                tok, err := roleToken.RoleTokenValue()
                if err != nil {
                        log.Fatal(err)
                } else {
                        log.Printf("[%d] Got role token: %s", i, re.FindStringSubmatch(tok)[1])
                }
                time.Sleep(10 * time.Second)
        }
}
```
```sh
$ go run athenz.go

2025/02/20 18:06:50 [test.provider] Valid role token is not cached so new one will be fetched (expiration time: 0001-01-01T00:00:00Z)
2025/02/20 18:06:50 [test.provider] Role token cache has been refreshed (expiration time: 2025-02-21T18:06:50+09:00)
2025/02/20 18:06:50 [0] Got role token: e=1740128810
2025/02/20 18:07:00 [1] Got role token: e=1740128810
2025/02/20 18:07:10 [2] Got role token: e=1740128810
2025/02/20 18:07:20 [3] Got role token: e=1740128810
2025/02/20 18:07:30 [4] Got role token: e=1740128810
2025/02/20 18:07:40 [5] Got role token: e=1740128810
2025/02/20 18:07:50 [test.provider] Role token cache has been refreshed (expiration time: 2025-02-21T18:07:50+09:00)
2025/02/20 18:07:50 [6] Got role token: e=1740128870
2025/02/20 18:08:00 [7] Got role token: e=1740128870
2025/02/20 18:08:10 [8] Got role token: e=1740128870
2025/02/20 18:08:20 [9] Got role token: e=1740128870
2025/02/20 18:08:30 [10] Got role token: e=1740128870
2025/02/20 18:08:40 [11] Got role token: e=1740128870
2025/02/20 18:08:50 [test.provider] Role token cache has been refreshed (expiration time: 2025-02-21T18:08:50+09:00)
2025/02/20 18:08:50 [12] Got role token: e=1740128930
2025/02/20 18:09:00 [13] Got role token: e=1740128930
...
```

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

