### PR TITLE
support encryption/decryption of service secrets used to sign jwts

### DIFF
--- a/libs/java/auth_core/pom.xml
+++ b/libs/java/auth_core/pom.xml
@@ -27,7 +27,7 @@
   <description>Core Auth Interfaces</description>
 
   <properties>
-    <code.coverage.min>0.9170</code.coverage.min>
+    <code.coverage.min>0.9260</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/KeyStore.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/KeyStore.java
@@ -40,4 +40,14 @@ public interface KeyStore {
     default PublicKey getServicePublicKey(String domain, String service, String keyId) {
         return null;
     }
+
+    /**
+     * Return the configured secret for the given service.
+     * @param domain Name of the domain
+     * @param service Name of the service
+     * @return secret or null if not found
+     */
+    default byte[] getServiceSecret(String domain, String service) {
+        return null;
+    }
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsHelper.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/jwts/JwtsHelper.java
@@ -18,10 +18,7 @@ package com.yahoo.athenz.auth.token.jwts;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.*;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.ECDSAVerifier;
-import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.crypto.*;
 import com.nimbusds.jose.jwk.JWKSelector;
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import com.nimbusds.jose.proc.JWSVerificationKeySelector;
@@ -203,6 +200,10 @@ public class JwtsHelper {
                 return new ECDSAVerifier((ECPublicKey) publicKey);
         }
         throw new JOSEException("Unsupported algorithm: " + publicKey.getAlgorithm());
+    }
+
+    public static JWSVerifier getJWSVerifier(byte[] secret) throws JOSEException {
+        return new MACVerifier(secret);
     }
 
     public static ConfigurableJWTProcessor<SecurityContext> getJWTProcessor(JwtsSigningKeyResolver keyResolver) {

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/KeyStoreTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/KeyStoreTest.java
@@ -29,5 +29,6 @@ public class KeyStoreTest {
 
         assertEquals("public-key", keyStore.getPublicKey("domain", "service", "key1"));
         assertNull(keyStore.getServicePublicKey("domain", "service", "key1"));
+        assertNull(keyStore.getServiceSecret("domain", "service"));
     }
 }

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/JwtsHelperTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/jwts/JwtsHelperTest.java
@@ -176,7 +176,7 @@ public class JwtsHelperTest {
     }
 
     @Test
-    public void testGetJWSVerifier() throws JOSEException {
+    public void testGetJWSVerifierPublicKey() throws JOSEException {
 
         PublicKey publicKey = Crypto.loadPublicKey(new File("src/test/resources/jwt_public.key"));
         assertNotNull(JwtsHelper.getJWSVerifier(publicKey));
@@ -192,5 +192,12 @@ public class JwtsHelperTest {
         } catch (JOSEException ex) {
             assertTrue(ex.getMessage().contains("Unsupported algorithm: DSA"));
         }
+    }
+
+    @Test
+    public void testGetJWSVerifierSecret() throws JOSEException {
+
+        final byte[] secret = "athenz-service-authentication-authorization".getBytes(StandardCharsets.UTF_8);
+        assertNotNull(JwtsHelper.getJWSVerifier(secret));
     }
 }


### PR DESCRIPTION
# Description

- new methods in Crypto to encrypt/decrypt secrets with a symmetric key
- support oauth2 access tokens including hmac signatures

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

