### PR TITLE
Adding singleton support to OtelTelemetryMetricFactory, and providing one increment() api implementation

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetric.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetric.java
@@ -89,6 +89,19 @@ public class OpenTelemetryMetric implements Metric {
     }
 
     @Override
+    public void increment(String metric, String ...attributes) {
+        LongCounter counter = meter.counterBuilder(metric).build();
+        io.opentelemetry.api.common.AttributesBuilder attributesBuilder = Attributes.builder();
+        for (int i = 0; i < attributes.length; i += 2) {
+            if (i + 1 >= attributes.length) {
+                break;
+            }
+            attributesBuilder.put(attributes[i], attributes[i + 1]);
+        }
+        counter.add(1, attributesBuilder.build());
+    }
+
+    @Override
     public Object startTiming(String metric, String requestDomainName) {
         Span span = tracer.spanBuilder(metric).startSpan();
         Context context = Context.current().with(span);

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
@@ -30,13 +30,18 @@ import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 */
 
 public class OpenTelemetryMetricFactory implements MetricFactory {
+    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize());
+
     @Override
     public Metric create() {
-        OpenTelemetry openTelemetry = initialize();
-        return new OpenTelemetryMetric(openTelemetry);
+        return INSTANCE;
     }
 
-    public OpenTelemetry initialize() {
+    public static OpenTelemetry initialize() {
         return AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
+    }
+
+    public static Metric getInstance() {
+        return INSTANCE;
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactoryTest.java
@@ -35,4 +35,16 @@ public class OpenTelemetryMetricFactoryTest {
         assertNotNull(metric);
         assertTrue(metric instanceof OpenTelemetryMetric);
     }
+
+    @Test
+    public void testGetInstance() {
+        Metric metric = factory.create();
+        assertNotNull(metric);
+        assertTrue(metric instanceof OpenTelemetryMetric);
+
+        Metric anotherMetric = OpenTelemetryMetricFactory.getInstance();
+        assertTrue(anotherMetric instanceof OpenTelemetryMetric);
+
+        assertTrue(metric == anotherMetric);
+    }
 }


### PR DESCRIPTION
When two different parts of code want to use OtelTelemetryMetricFactory, the second call is resulting in an exception. In effect, `AutoConfiguredOpenTelemetrySdk.initialize().` can only be called once. So, adding Singleton property to the factory class.

Along the way, I made `initialize()` method `static`. 

# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

