### PR TITLE
Enforce domain expiration settings on roles

### DIFF
--- a/ui/src/__tests__/components/review/__snapshots__/ReviewTable.test.js.snap
+++ b/ui/src/__tests__/components/review/__snapshots__/ReviewTable.test.js.snap
@@ -751,10 +751,11 @@ exports[`ReviewTable should render review table 1`] = `
         >
           <span
             class="emotion-100 emotion-101"
+            data-testid="role-expiration-details"
           >
             Current default settings are - Member Expiry: 15 days. Service Expiry: 15 days. 
             <br />
-            To change it, please click 
+            To change it for the role, please click 
             <a
               class="emotion-102 emotion-103"
             >
@@ -1526,10 +1527,11 @@ exports[`ReviewTable should render review table with reminder settings 1`] = `
         >
           <span
             class="emotion-100 emotion-101"
+            data-testid="role-expiration-details"
           >
             Current default settings are - Member Review: 5 days. Service Review: 10 days. Group Review: 15 days. 
             <br />
-            To change it, please click 
+            To change it for the role, please click 
             <a
               class="emotion-102 emotion-103"
             >
@@ -2301,10 +2303,11 @@ exports[`ReviewTable should render review table without expiry settings 1`] = `
         >
           <span
             class="emotion-100 emotion-101"
+            data-testid="role-expiration-details"
           >
             Current default settings are - None
             <br />
-            To change it, please click 
+            To change it for the role, please click 
             <a
               class="emotion-102 emotion-103"
             >

--- a/ui/src/__tests__/spec/tests/roles.spec.js
+++ b/ui/src/__tests__/spec/tests/roles.spec.js
@@ -23,7 +23,8 @@ const historyTestRole = 'history-test-role';
 const multiSelectRole = 'multi-select-role';
 
 const TEST_DOMAIN = 'athenz.dev.functional-test';
-const FUNC_TEST_DOMAIN_URI = `/domain/${TEST_DOMAIN}/role`;
+const TEST_DOMAIN_SETTINGS_URI = `/domain/${TEST_DOMAIN}/domain-settings`;
+const TEST_DOMAIN_ROLE_URI = `/domain/${TEST_DOMAIN}/role`;
 
 const TEST_NAME_HISTORY_VISIBLE_AFTER_PAGE_REFRESH =
     'role history should be visible when navigating to it and after page refresh';
@@ -32,7 +33,9 @@ const TEST_NAME_DELEGATED_ROLE_ADDITIONAL_SETTINGS_ARE_DISABLED =
 const TEST_NAME_ADD_ROLE_MEMBER_INPUT_PRESERVES_CONTENTS_ON_BLUR =
     'member dropdown when creating a role and adding to existing role - should preserve input on blur, make input bold when selected in dropdown, reject unselected input';
 const TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED =
-    'Role Review - Extend radio button should be enabled only when Expiry/Review (Days) are set in settings';
+    'Role Review - Extend radio button should be enabled when Expiry/Review (Days) are set in settings';
+const TEST_DOMAIN_EXPIRY_ENFORCED_BY_DEFAULT =
+    'Role Review - Extend radio button should be enabled when domain expiry is set and role expiry is empty';
 const TEST_NAME_DOMAIN_FILTER =
     'Domain Filter - only principals matching specific domain(s) can be added to a role';
 const TEST_ADD_ROLE_WITH_MULTIPLE_MEMBERS = 'Add role with multiple members';
@@ -41,9 +44,32 @@ const TEST_ROLE_RULE_POLICIES_EXPANDED =
 const TEST_MULTISELECT_AUTHORITY_FILTERS =
     'Multiple authority filters for a role can be selected';
 
+async function resetDomainExpiry() {
+    await browser.newUser();
+    await browser.url(TEST_DOMAIN_SETTINGS_URI);
+
+    const memberExpiry = await $('input[id="setting-memberExpiryDays"]');
+    const groupExpiry = await $('input[id="setting-groupExpiryDays"]');
+    const serviceExpiry = await $('input[id="setting-serviceExpiryDays"]');
+
+    await memberExpiry.clearValue();
+    await memberExpiry.addValue(0);
+
+    await groupExpiry.clearValue()
+    await groupExpiry.addValue(0);
+
+    await serviceExpiry.clearValue();
+    await serviceExpiry.addValue(0);
+
+    await $('button*=Submit').click();
+
+    await $('button[data-testid="update-modal-update"]').click();
+    await $('div[data-wdio="alert-close"]').click();
+}
+
 async function deleteRoleIfExists(roleName) {
     await browser.newUser();
-    await browser.url(FUNC_TEST_DOMAIN_URI);
+    await browser.url(TEST_DOMAIN_ROLE_URI);
     await expect(browser).toHaveUrl(expect.stringContaining('athenz'));
 
     let deleteSvg = await $(
@@ -210,7 +236,7 @@ describe('role screen tests', () => {
         currentTest =
             TEST_NAME_ADD_ROLE_MEMBER_INPUT_PRESERVES_CONTENTS_ON_BLUR;
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
         await expect(browser).toHaveUrl(expect.stringContaining('athenz'));
 
         // click add role
@@ -356,7 +382,7 @@ describe('role screen tests', () => {
         currentTest = TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED;
         // open browser
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
 
         await createRoleWithMembers(reviewExtendTest, 'unix.yahoo');
 
@@ -483,11 +509,60 @@ describe('role screen tests', () => {
         await expect(extendRadio).toBeEnabled();
     });
 
+    it(TEST_DOMAIN_EXPIRY_ENFORCED_BY_DEFAULT, async () => {
+        currentTest = TEST_DOMAIN_EXPIRY_ENFORCED_BY_DEFAULT;
+
+        const MEMBER_EXPIRY_DAYS = 10;
+        const GROUP_EXPIRY_DAYS = 20;
+        const SERVICE_EXPIRY_DAYS = 30;
+
+        await browser.newUser();
+        await browser.url(TEST_DOMAIN_SETTINGS_URI);
+
+        await $('input[id="setting-memberExpiryDays"]').addValue(
+            MEMBER_EXPIRY_DAYS
+        );
+        await $('input[id="setting-groupExpiryDays"]').addValue(
+            GROUP_EXPIRY_DAYS
+        );
+        await $('input[id="setting-serviceExpiryDays"]').addValue(
+            SERVICE_EXPIRY_DAYS
+        );
+        await $('button*=Submit').click();
+
+        await $('button[data-testid="update-modal-update"]').click();
+        await $('div[data-wdio="alert-close"]').click();
+
+        await browser.url(TEST_DOMAIN_ROLE_URI);
+
+        await createRoleWithMembers(reviewExtendTest, 'unix.yahoo');
+
+        await $(
+            `.//*[local-name()="svg" and @data-wdio="${reviewExtendTest}-review"]`
+        ).click();
+
+        const extendRadio = await $('input[value="extend"]');
+        const expiryDetails = await $(
+            'span[data-testid="role-expiration-details"]'
+        ).getText();
+
+        expect(extendRadio).toBeEnabled();
+        expect(expiryDetails).toContain(
+            `Domain Member Expiry: ${MEMBER_EXPIRY_DAYS} days`
+        );
+        expect(expiryDetails).toContain(
+            `Domain Group Expiry: ${GROUP_EXPIRY_DAYS} days`
+        );
+        expect(expiryDetails).toContain(
+            `Domain Service Expiry: ${SERVICE_EXPIRY_DAYS} days`
+        );
+    });
+
     it(TEST_NAME_DOMAIN_FILTER, async () => {
         currentTest = TEST_NAME_DOMAIN_FILTER;
         // open browser
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
 
         // open add role modal
         let addiRoleButton = await $('button*=Add Role');
@@ -576,7 +651,7 @@ describe('role screen tests', () => {
         // uses existing role group
         // open browser
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
 
         // expand aws roles
         let rolesExpand = await $(
@@ -611,7 +686,7 @@ describe('role screen tests', () => {
         await browser.switchToWindow(windowHandles[tab]);
         // verify the URL of the new tab
         const url = await browser.getUrl();
-        expect(url.includes(`${FUNC_TEST_DOMAIN_URI}/${awsRole}/members`)).toBe(
+        expect(url.includes(`${TEST_DOMAIN_ROLE_URI}/${awsRole}/members`)).toBe(
             true
         );
 
@@ -624,7 +699,7 @@ describe('role screen tests', () => {
         currentTest = TEST_ADD_ROLE_WITH_MULTIPLE_MEMBERS;
         // open browser
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
 
         const user1 = 'unix.yahoo';
         const user2 = 'user.aporss';
@@ -650,7 +725,7 @@ describe('role screen tests', () => {
 
         // open browser
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
 
         // verify rule policy is expanded by default for role
         await $(
@@ -660,11 +735,9 @@ describe('role screen tests', () => {
         const roleRow = await $(
             `tr[data-wdio='${adminRole}-policy-rule-row']`
         ).$(`td*=${adminRole}`);
-      
+
         await expect(roleRow).toHaveText(
-            expect.stringContaining(
-                `${TEST_DOMAIN}:role.${adminRole}`
-            )
+            expect.stringContaining(`${TEST_DOMAIN}:role.${adminRole}`)
         );
     });
 
@@ -675,7 +748,7 @@ describe('role screen tests', () => {
 
         // open browser
         await browser.newUser();
-        await browser.url(FUNC_TEST_DOMAIN_URI);
+        await browser.url(TEST_DOMAIN_ROLE_URI);
 
         await createRoleWithMembers(multiSelectRole, 'unix.yahoo');
 
@@ -716,6 +789,10 @@ describe('role screen tests', () => {
                 break;
             case TEST_NAME_ROLE_REVIEW_EXTEND_DISABLED:
                 await deleteRoleIfExists(reviewExtendTest);
+                break;
+            case TEST_DOMAIN_EXPIRY_ENFORCED_BY_DEFAULT:
+                await deleteRoleIfExists(reviewExtendTest);
+                await resetDomainExpiry();
                 break;
             case TEST_NAME_DOMAIN_FILTER:
                 await deleteRoleIfExists(domainFilterTest);

--- a/ui/src/components/review/ReviewList.js
+++ b/ui/src/components/review/ReviewList.js
@@ -85,7 +85,8 @@ class ReviewList extends React.Component {
     }
 
     render() {
-        const { domain, collection, collectionDetails } = this.props;
+        const { domain, collection, collectionDetails, domainExpiration } =
+            this.props;
         return this.props.isLoading.length !== 0 ? (
             <ReduxPageLoader message={'Loading data'} />
         ) : (
@@ -109,6 +110,7 @@ class ReviewList extends React.Component {
                 {this.props.category === 'role' && (
                     <ReviewTable
                         domain={domain}
+                        domainExpiration={domainExpiration}
                         role={collection}
                         roleDetails={collectionDetails}
                         members={this.props.members}
@@ -117,10 +119,8 @@ class ReviewList extends React.Component {
                         onUpdateSuccess={this.submitSuccess}
                         justification={this.props.justification}
                         expiryOrReviewSettingIsSet={
-                            0 <
-                            getSmallestExpiryOrReview(
-                                this.props.collectionDetails
-                            )
+                            !!getSmallestExpiryOrReview(collectionDetails) ||
+                            !!getSmallestExpiryOrReview(domainExpiration)
                         }
                     />
                 )}

--- a/ui/src/components/review/ReviewTable.js
+++ b/ui/src/components/review/ReviewTable.js
@@ -26,7 +26,10 @@ import { connect } from 'react-redux';
 import { reviewRole } from '../../redux/thunks/roles';
 import produce from 'immer';
 import DeleteModal from '../modal/DeleteModal';
-import CollectionUtils from 'lodash';
+import {
+    domainExpirationIsConfigured,
+    roleExpirationIsConfigured,
+} from '../utils/ReviewUtils';
 
 const TitleDiv = styled.div`
     font-size: 16px;
@@ -231,70 +234,65 @@ export class ReviewTable extends React.Component {
     }
 
     getDefaultExpiryText() {
+        const { roleDetails, domainExpiration } = this.props;
         let text = 'Current default settings are - ';
-        let noDaysConfigured = true;
-        if (this.props.roleDetails && this.props.roleDetails.memberExpiryDays) {
-            text =
-                text +
-                'Member Expiry: ' +
-                this.props.roleDetails.memberExpiryDays +
-                ' days. ';
-            noDaysConfigured = false;
+
+        if (roleDetails?.memberExpiryDays) {
+            text += `Member Expiry: ${roleDetails.memberExpiryDays} days. `;
         }
+
+        if (roleDetails?.serviceExpiryDays) {
+            text += `Service Expiry: ${roleDetails.serviceExpiryDays} days. `;
+        }
+
+        if (roleDetails?.groupExpiryDays) {
+            text += `Group Expiry: ${roleDetails.groupExpiryDays} days. `;
+        }
+
+        if (roleDetails?.memberReviewDays) {
+            text += `Member Review: ${roleDetails.memberReviewDays} days. `;
+        }
+
+        if (roleDetails?.serviceReviewDays) {
+            text += `Service Review: ${roleDetails.serviceReviewDays} days. `;
+        }
+
+        if (roleDetails?.groupReviewDays) {
+            text += `Group Review: ${roleDetails.groupReviewDays} days. `;
+        }
+
+        // if role expiration is not configured, default to domain expiration
         if (
-            this.props.roleDetails &&
-            this.props.roleDetails.serviceExpiryDays
+            !roleExpirationIsConfigured(roleDetails) &&
+            domainExpirationIsConfigured(domainExpiration)
         ) {
-            text =
-                text +
-                'Service Expiry: ' +
-                this.props.roleDetails.serviceExpiryDays +
-                ' days. ';
-            noDaysConfigured = false;
+            text = 'Current domain settings are - ';
+
+            if (domainExpiration.memberExpiryDays) {
+                text += `Domain Member Expiry: ${domainExpiration.memberExpiryDays} days. `;
+            }
+
+            if (domainExpiration.serviceExpiryDays) {
+                text += `Domain Service Expiry: ${domainExpiration.serviceExpiryDays} days. `;
+            }
+
+            if (domainExpiration.groupExpiryDays) {
+                text += `Domain Group Expiry: ${domainExpiration.groupExpiryDays} days. `;
+            }
         }
-        if (this.props.roleDetails && this.props.roleDetails.groupExpiryDays) {
-            text =
-                text +
-                'Group Expiry: ' +
-                this.props.roleDetails.groupExpiryDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (this.props.roleDetails && this.props.roleDetails.memberReviewDays) {
-            text =
-                text +
-                'Member Review: ' +
-                this.props.roleDetails.memberReviewDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
+
+        // if neither role nor domain expiration settings are configured
         if (
-            this.props.roleDetails &&
-            this.props.roleDetails.serviceReviewDays
+            !roleExpirationIsConfigured(roleDetails) &&
+            !domainExpirationIsConfigured(domainExpiration)
         ) {
-            text =
-                text +
-                'Service Review: ' +
-                this.props.roleDetails.serviceReviewDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (this.props.roleDetails && this.props.roleDetails.groupReviewDays) {
-            text =
-                text +
-                'Group Review: ' +
-                this.props.roleDetails.groupReviewDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (noDaysConfigured) {
             text = text + 'None';
         }
 
-        const changeText = 'To change it, please click ';
+        const changeText = 'To change it for the role, please click ';
 
         return (
-            <SubmitTextSpan>
+            <SubmitTextSpan data-testid='role-expiration-details'>
                 {text}
                 <br />
                 {changeText}

--- a/ui/src/components/utils/ReviewUtils.js
+++ b/ui/src/components/utils/ReviewUtils.js
@@ -47,14 +47,41 @@ export function isReviewRequired(roleOrGroup) {
         .isAfter(lastReviewedDate);
 }
 
+export function domainExpirationIsConfigured(domain) {
+    return (
+        !!domain?.memberExpiryDays ||
+        !!domain?.groupExpiryDays ||
+        !!domain?.serviceExpiryDays
+    );
+}
+
+export function roleExpirationIsConfigured(roleDetails) {
+    return (
+        !!roleDetails?.memberExpiryDays ||
+        !!roleDetails?.memberReviewDays ||
+        !!roleDetails?.groupExpiryDays ||
+        !!roleDetails?.groupReviewDays ||
+        !!roleDetails?.serviceExpiryDays ||
+        !!roleDetails?.serviceReviewDays
+    );
+}
+
+export function getExpirationFromDomain(domainData) {
+    return {
+        groupExpiryDays: Number(domainData?.groupExpiryDays) || 0,
+        memberExpiryDays: Number(domainData?.memberExpiryDays) || 0,
+        serviceExpiryDays: Number(domainData?.serviceExpiryDays) || 0,
+    };
+}
+
 export function getSmallestExpiryOrReview(roleOrGroup) {
     const values = [
-        roleOrGroup.memberExpiryDays,
-        roleOrGroup.memberReviewDays,
-        roleOrGroup.groupExpiryDays,
-        roleOrGroup.groupReviewDays,
-        roleOrGroup.serviceExpiryDays,
-        roleOrGroup.serviceReviewDays,
+        roleOrGroup?.memberExpiryDays || 0,
+        roleOrGroup?.memberReviewDays || 0,
+        roleOrGroup?.groupExpiryDays || 0,
+        roleOrGroup?.groupReviewDays || 0,
+        roleOrGroup?.serviceExpiryDays || 0,
+        roleOrGroup?.serviceReviewDays || 0,
     ].filter((obj) => obj > 0); // pick only those that have days set and days > 0
 
     if (values.length > 0) {

--- a/ui/src/pages/domain/[domain]/role/[role]/review.js
+++ b/ui/src/pages/domain/[domain]/role/[role]/review.js
@@ -32,12 +32,12 @@ import { connect } from 'react-redux';
 import {
     selectReviewRoleMembers,
     selectRole,
-    selectRoleMembers,
 } from '../../../../../redux/selectors/roles';
 import { getRole } from '../../../../../redux/thunks/roles';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { ReduxPageLoader } from '../../../../../components/denali/ReduxPageLoader';
+import { getExpirationFromDomain } from '../../../../../components/utils/ReviewUtils';
 
 const AppContainerDiv = styled.div`
     align-items: stretch;
@@ -50,7 +50,11 @@ const AppContainerDiv = styled.div`
 const MainContentDiv = styled.div`
     flex: 1 1 calc(100vh - 60px);
     overflow: hidden;
-    font: 300 14px HelveticaNeue-Reg, Helvetica, Arial, sans-serif;
+    font:
+        300 14px HelveticaNeue-Reg,
+        Helvetica,
+        Arial,
+        sans-serif;
 `;
 
 const RolesContainerDiv = styled.div`
@@ -131,6 +135,7 @@ class ReviewPage extends React.Component {
             members,
             _csrf,
             isLoading,
+            domainData,
         } = this.props;
         if (reload || this.state.reload) {
             window.location.reload();
@@ -173,6 +178,9 @@ class ReviewPage extends React.Component {
                                     </PageHeaderDiv>
                                     <ReviewList
                                         domain={domainName}
+                                        domainExpiration={getExpirationFromDomain(
+                                            domainData
+                                        )}
                                         collection={roleName}
                                         collectionDetails={roleDetails}
                                         members={members}
@@ -200,6 +208,7 @@ const mapStateToProps = (state, props) => {
             props.domainName,
             props.roleName
         ),
+        domainData: state?.domainData?.domainData,
     };
 };
 

--- a/ui/src/redux/actions/user.js
+++ b/ui/src/redux/actions/user.js
@@ -46,15 +46,6 @@ export const addUsersToStore = (userList) => ({
 
 export const STORE_PENDING_ROLE = 'STORE_PENDING_ROLE';
 export const storePendingRole = (role, domainName, roleName) => {
-    console.log('ROLE: ', {
-        type: STORE_PENDING_ROLE,
-        payload: {
-            role,
-            domainName,
-            roleName,
-        },
-    });
-
     return {
         type: STORE_PENDING_ROLE,
         payload: {

--- a/ui/static/close.svg
+++ b/ui/static/close.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+    <title>close</title>
+    <g id="Layer_2" data-name="Layer 2">
+        <g id="invisible_box" data-name="invisible box">
+            <rect width="48" height="48" fill="none"/>
+        </g>
+        <g id="icons_Q2" data-name="icons Q2" fill="#606060">
+            <path d="M26.8,24,37.4,13.5a2.1,2.1,0,0,0,.2-2.7,1.9,1.9,0,0,0-3-.2L24,21.2,13.4,10.6a1.9,1.9,0,0,0-3,.2,2.1,2.1,0,0,0,.2,2.7L21.2,24,10.6,34.5a2.1,2.1,0,0,0-.2,2.7,1.9,1.9,0,0,0,3,.2L24,26.8,34.6,37.4a1.9,1.9,0,0,0,3-.2,2.1,2.1,0,0,0-.2-2.7Z"/>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
# Description
- Domain expiration settings are enforced by default if no role specific expiration settings are configured.
- Extend radio button is enabled to reflect this

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 
Role expiration is not configured
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/8784e2ff-106d-4062-9e3e-88d249a4cc70" />

Domain expiration is configured
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/7f38c6a0-5154-427c-bf0b-b2ea45d0804e" />

Domain expiration settings being enforced on the role by default
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/ecb7506f-be31-4079-8b00-24904baca090" />