### PR TITLE
correct handling of empty proxy for principal in access token request

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2612,7 +2612,7 @@ public class ZTSImpl implements ZTSHandler {
         // remove any roles that are authorized by only one of the principals
 
         String proxyUser = null;
-        if (accessTokenRequest.getProxyForPrincipal() != null) {
+        if (!StringUtil.isEmpty(accessTokenRequest.getProxyForPrincipal())) {
 
             // we also need to verify that we are not returning id tokens.
             // proxy principal functionality is only valid for access tokens

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -9958,6 +9958,30 @@ public class ZTSImplTest {
     }
 
     @Test
+    public void testPostAccessTokenRequestEmptyProxyPrincipal() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        // set back to our zts rsa private key
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=U1;d=user_domain;n=user;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        final String scope = URLEncoder.encode("coretech:domain", StandardCharsets.UTF_8);
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=client_credentials&proxy_for_principal=&scope=" + scope);
+        assertNotNull(resp);
+        assertEquals(resp.getScope(), "coretech:role.writers");
+    }
+
+    @Test
     public void testPostAccessTokenRequestRoleAuthority() {
 
         System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");


### PR DESCRIPTION
# Description
during the previous code re-org we lost setting the value to null when it was empty.

addresses issue #2950 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

