### PR TITLE
remove config value output in logs

### DIFF
--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9421</code.coverage.min>
+    <code.coverage.min>0.9419</code.coverage.min>
   </properties>
 
   <dependencyManagement>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/config/ConfigManager.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/config/ConfigManager.java
@@ -381,36 +381,16 @@ public class ConfigManager implements Closeable {
         // Log all changes
 
         if (LOG.isInfoEnabled()) {
-            StringBuilder changesDescription = new StringBuilder();
+            LOG.info("{} configurations changed", changeLogs.size());
             for (ChangeLog changeLog : changeLogs) {
                 if ((changeLog.oldEntry != null) && (changeLog.newEntry != null)) {
-                    changesDescription.append("\n    Update config: ")
-                            .append(Utils.jsonSerializeForLog(changeLog.newEntry.key))
-                            .append(" = ")
-                            .append(Utils.jsonSerializeForLog(changeLog.newEntry.value))
-                            .append(" from ")
-                            .append(changeLog.newEntry.describeSource())
-                            .append("    Old-value: ")
-                            .append(Utils.jsonSerializeForLog(changeLog.oldEntry.value))
-                            .append(" from ")
-                            .append(changeLog.oldEntry.describeSource());
+                    LOG.info("configuration {} updated", Utils.jsonSerializeForLog(changeLog.newEntry.key));
                 } else if (changeLog.newEntry != null) {
-                    changesDescription.append("\n       New config: ")
-                            .append(Utils.jsonSerializeForLog(changeLog.newEntry.key))
-                            .append(" = ")
-                            .append(Utils.jsonSerializeForLog(changeLog.newEntry.value))
-                            .append(" from ")
-                            .append(changeLog.newEntry.describeSource());
+                    LOG.info("configuration {} created", Utils.jsonSerializeForLog(changeLog.newEntry.key));
                 } else if (changeLog.oldEntry != null) {
-                    changesDescription.append("\n    Delete config: ")
-                            .append(Utils.jsonSerializeForLog(changeLog.oldEntry.key))
-                            .append("    Old-value: ")
-                            .append(Utils.jsonSerializeForLog(changeLog.oldEntry.value))
-                            .append(" from ")
-                            .append(changeLog.oldEntry.describeSource());
+                    LOG.info("configuration {} deleted", Utils.jsonSerializeForLog(changeLog.oldEntry.key));
                 }
             }
-            LOG.info("{} configurations changed:{}", changeLogs.size(), changesDescription);
         }
 
         // Call change-callbacks


### PR DESCRIPTION
# Description
 previously the config manager would log all changes in the settings from the parameter store. however, since some of the settings could include sensitive data, we don't want them to be logged even at the debug level. so now we only log if the setting was created, updated or deleted.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

