### PR TITLE
return service resource owners in jws domains

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -6997,7 +6997,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                         .setProviderEndpoint(service.getProviderEndpoint())
                         .setX509CertSignerKeyId(service.getX509CertSignerKeyId())
                         .setSshCertSignerKeyId(service.getSshCertSignerKeyId())
-                        .setTags(service.getTags());
+                        .setTags(service.getTags())
+                        .setResourceOwnership(service.getResourceOwnership());
                 if (publicKeys == Boolean.TRUE) {
                     newService.setPublicKeys(service.getPublicKeys());
                 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSServiceIdentityTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSServiceIdentityTest.java
@@ -278,7 +278,7 @@ public class ZMSServiceIdentityTest {
         ServiceIdentity service2 = zmsTestInitializer.createServiceObject(domainName,
                 "service2", "http://localhost", "/usr/bin/java", "yahoo",
                 "users", "host2");
-        zmsImpl.putServiceIdentity(ctx, domainName, "service2", auditRef, false, null, service2);
+        zmsImpl.putServiceIdentity(ctx, domainName, "service2", auditRef, false, "TF", service2);
 
         AthenzDomain domain = zmsImpl.getAthenzDomain(domainName, false);
         List<ServiceIdentity> services = zmsImpl.setupServiceIdentityList(domain,
@@ -296,6 +296,7 @@ public class ZMSServiceIdentityTest {
                     assertEquals(service.getPublicKeys().size(), 2);
                     assertEquals(service.getHosts().size(), 1);
                     assertEquals(service.getHosts().get(0), "host1");
+                    assertNull(service.getResourceOwnership());
                     service1Check = true;
                     break;
                 case "setup-service-keys-hosts.service2":
@@ -304,6 +305,7 @@ public class ZMSServiceIdentityTest {
                     assertEquals(service.getPublicKeys().size(), 2);
                     assertEquals(service.getHosts().size(), 1);
                     assertEquals(service.getHosts().get(0), "host2");
+                    assertEquals(service.getResourceOwnership().getObjectOwner(), "TF");
                     service2Check = true;
                     break;
             }


### PR DESCRIPTION
# Description
this was a regression bug where we stopped returned resource owners for services in full domain responses.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

