### PR TITLE
Feat: New Property `athenz.zts.github_actions.prop_file_path` for `GitHubActionInstanceProvider`

### DIFF
--- a/docs/provider_github_actions.md
+++ b/docs/provider_github_actions.md
@@ -175,3 +175,45 @@ The following changes are necessary for the ZTS server to support GitHub Actions
 - ZTS enforces IP ranges where services are authorized to request identities for service identities from a given provider.
 It is expected that the worker nodes for a team will be configured to run in their own private AWS accounts, for example,
 and as such the team needs to provide the NAT gateway IP addresses for the account, so they can be authorized.
+
+
+The following attributes must be configured in the ZTS server configuration file:
+
+```sh
+athenz.zts.github_actions.provider_dns_suffix=
+athenz.zts.github_actions.issuer=
+athenz.zts.github_actions.audience=
+```
+
+By default, your `issuer` value will generate a derived `jwks_uri` with the suffix `/.well-known/openid-configuration`, which is used to fetch the public keys for validating the OIDC token signature. If you want to use a different endpoint for fetching the public keys, you can specify `jwks_uri`:
+
+```sh
+athenz.zts.github_actions.jwks_uri=https://your-jwk-uri.com/_services/token/.well-known/jwks
+```
+
+If you want to use multiple environments for the same GitHub Actions provider, you can create a JSON file locally on your ZTS server and specify its path with `athenz.zts.github_actions.prop_file_path` in your ZTS server configuration file. The JSON file should contain an array of objects with the following attributes:
+
+> **Warning:**
+> It is recommended to use the `prop_file_path` attribute only if you want to offer multiple environments for the same GitHub Actions provider. If you want to use only one environment, you can set the attributes directly in the ZTS server configuration file. The `prop_file_path` will override your direct configuration in the ZTS server configuration file if the same issuer is used in the JSON file
+
+```json
+{
+  "props": [
+    {
+      "provider_dns_suffix": "test-provider-suffix,another-test-provider-suffix",
+      "enterprise": "test-enterprise",
+      "audience": "test-audience",
+      "issuer": "test-issuer",
+      "jwks_uri": "https://test-jwks-uri.com/openid/v1/jwks"
+    },
+    {
+      "provider_dns_suffix": "test-provider-suffix,another-test-provider-suffix",
+      "enterprise": "test-enterprise",
+      "audience": "test-audience",
+      "issuer": "test-issuer",
+      "jwks_uri": "https://test-jwks-uri.com/openid/v1/jwks"
+    },
+    ...
+  ]
+}
+```

--- a/docs/provider_github_actions.md
+++ b/docs/provider_github_actions.md
@@ -193,7 +193,7 @@ athenz.zts.github_actions.jwks_uri=https://your-jwk-uri.com/_services/token/.wel
 
 If you want to use multiple environments for the same GitHub Actions provider, you can create a JSON file locally on your ZTS server and specify its path with `athenz.zts.github_actions.prop_file_path` in your ZTS server configuration file. The JSON file should contain an array of objects with the following attributes:
 
-> **Warning:**
+> [!WARNING]
 > It is recommended to use the `prop_file_path` attribute only if you want to offer multiple environments for the same GitHub Actions provider. If you want to use only one environment, you can set the attributes directly in the ZTS server configuration file. The `prop_file_path` will override your direct configuration in the ZTS server configuration file if the same issuer is used in the JSON file
 
 ```json

--- a/docs/provider_github_actions.md
+++ b/docs/provider_github_actions.md
@@ -188,7 +188,7 @@ athenz.zts.github_actions.audience=
 By default, your `issuer` value will generate a derived `jwks_uri` with the suffix `/.well-known/openid-configuration`, which is used to fetch the public keys for validating the OIDC token signature. If you want to use a different endpoint for fetching the public keys, you can specify `jwks_uri`:
 
 ```sh
-athenz.zts.github_actions.jwks_uri=https://your-jwk-uri.com/_services/token/.well-known/jwks
+athenz.zts.github_actions.jwks_uri=https://your-github-website.com/_services/token/.well-known/jwks
 ```
 
 If you want to use multiple environments for the same GitHub Actions provider, you can create a JSON file locally on your ZTS server and specify its path with `athenz.zts.github_actions.prop_file_path` in your ZTS server configuration file. The JSON file should contain an array of objects with the following attributes:

--- a/docs/provider_github_actions.md
+++ b/docs/provider_github_actions.md
@@ -194,7 +194,7 @@ athenz.zts.github_actions.jwks_uri=https://your-jwk-uri.com/_services/token/.wel
 If you want to use multiple environments for the same GitHub Actions provider, you can create a JSON file locally on your ZTS server and specify its path with `athenz.zts.github_actions.prop_file_path` in your ZTS server configuration file. The JSON file should contain an array of objects with the following attributes:
 
 > [!WARNING]
-> It is recommended to use the `prop_file_path` attribute only if you want to offer multiple environments for the same GitHub Actions provider. If you want to use only one environment, you can set the attributes directly in the ZTS server configuration file. The `prop_file_path` will override your direct configuration in the ZTS server configuration file if the same issuer is used in the JSON file
+> It is recommended to use the `prop_file_path` attribute only if you want to offer multiple environments for the same GitHub Actions provider. If you want to use only one environment, you can set the attributes directly in the ZTS server configuration file. The `prop_file_path` will override your direct configuration in the ZTS server configuration file if the same `issuer` is used in the JSON file
 
 ```json
 {

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProvider.java
@@ -104,7 +104,7 @@ public class InstanceGithubActionsProvider implements InstanceProvider {
         try {
             Map<String, List<Map<String, Object>>> propJson = new ObjectMapper().readValue(
                 Files.readAllBytes(path),
-                new TypeReference<Map<String, List<Map<String, Object>>>>() {}
+                new TypeReference<Map<String, List<Map<String, Object>>>>() { }
             );
 
             for (Map<String, Object> prop : propJson.get("props")) {

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProvider.java
@@ -328,18 +328,8 @@ public class InstanceGithubActionsProvider implements InstanceProvider {
         return true;
     }
 
-    boolean validateOIDCToken(final String issuer, final String jwToken, final String domainName, final String serviceName,
+    boolean validateOIDCToken(final String claimIssuer, final String jwToken, final String domainName, final String serviceName,
             final String instanceId, StringBuilder errMsg) {
-
-        String claimIssuer = null;
-        try {
-            // parse the token and get the issuer claim
-            claimIssuer = SignedJWT.parse(jwToken).getJWTClaimsSet().getIssuer();
-        } catch (Exception ex) {
-            errMsg.append("Unable to parse token: ").append(ex.getMessage());
-            return false;
-        }
-
         if (StringUtil.isEmpty(claimIssuer)) {
             errMsg.append("token does not contain required issuer claim");
             return false;

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsSample.json
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsSample.json
@@ -1,0 +1,11 @@
+{
+  "props": [
+    {
+      "provider_dns_suffix": "test-provider-suffix,another-test-provider-suffix",
+      "enterprise": "test-enterprise",
+      "audience": "test-audience",
+      "issuer": "test-issuer",
+      "jwks_uri": "https://test-jwks-uri.com/openid/v1/jwks"
+    }
+  ]
+}


### PR DESCRIPTION
# Description
You may use json file for multiple environment configuration as the following:
```json
{
  "props": [
    {
      "provider_dns_suffix": "test-provider-suffix,another-test-provider-suffix",
      "enterprise": "test-enterprise",
      "audience": "test-audience",
      "issuer": "test-issuer",
      "jwks_uri": "https://test-jwks-uri.com/openid/v1/jwks"
    },
    {
      "provider_dns_suffix": "test-provider-suffix,another-test-provider-two-suffix",
      "enterprise": "test-enterprise-two",
      "audience": "test-audience-two",
      "issuer": "test-issuer-two",
      "jwks_uri": "https://test-jwks-uri-two.com/openid/v1/jwks"
    }
  ]
}
```
And set the following attribute:
```
athenz.zts.github_actions.prop_file_path=/path/to/file/for/the/config.json
```

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

