### PR TITLE
Fix usage line of set-azure-subscription

### DIFF
--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -3696,7 +3696,7 @@ func (cli Zms) HelpListCommand() string {
 	buf.WriteString("   set-domain-meta description\n")
 	buf.WriteString("   set-audit-enabled audit-enabled\n")
 	buf.WriteString("   set-aws-account account-id\n")
-	buf.WriteString("   set-azure-subscription subscription-id\n")
+	buf.WriteString("   set-azure-subscription subscription-id tenant-id client-id\n")
 	buf.WriteString("   set-gcp-project project-id project-number\n")
 	buf.WriteString("   set-product-id product-id\n")
 	buf.WriteString("   set-application-id application-id\n")


### PR DESCRIPTION
# Description
The `set-azure-subscription` is wrongly listed as taking only a `subscription-id` argument.  In reality, two additional arguments are required: the `tenant-id` and `client-id`.

This updates the `help` command.  The `help set-azure-subscription` command is already correct.

# Contribution Checklist:
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [-] **Create an issue and link to the pull request.**
