### PR TITLE
for mysql schema violation - return bad request error

### DIFF
--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCConnectionTest.java
@@ -7841,6 +7841,12 @@ public class JDBCConnectionTest {
         ex = new SQLTimeoutException("sql-reason", "sql-state", 1001);
         rEx = jdbcConn.sqlError(ex, "sqlError");
         assertEquals(rEx.getCode(), ServerResourceException.SERVICE_UNAVAILABLE);
+
+        ex = new SQLTimeoutException("sql-reason", "22001", 1406);
+        rEx = jdbcConn.sqlError(ex, "sqlError");
+        assertEquals(rEx.getCode(), ServerResourceException.BAD_REQUEST);
+        assertEquals(rEx.getMessage(), "Schema violation - data too long");
+
         jdbcConn.close();
     }
 


### PR DESCRIPTION
# Description
for some of the data attributes the backend store schema enforces the limits - e.g. I might decide to support actions that are 128 bytes long or increase that in my schema to be 1024 bytes. When the client submits a request that violates the schema, the store layer return an internal server error which is not quite correct since it's due to bad request with long data and there is nothing wrong with the server. 

the mysql db store layer now checks for the data too long error code 1406 and returns a bad request (400) server exception instead of the internal server error (500).

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

