### PR TITLE
fix acl policy regex

### DIFF
--- a/ui/src/server/utils/apiUtils.js
+++ b/ui/src/server/utils/apiUtils.js
@@ -163,6 +163,6 @@ module.exports.omitUndefined = (obj) => {
 
 module.exports.getMicrosegmentationActionRegex = () => {
     return new RegExp(
-        '^(TCP|UDP)-(IN|OUT):(\\d{1,5}-\\d{1,5}|\\d{1,5}):((?:\\d{1,5}|\\d{1,5}-\\d{1,5})(?:,\\d{1,5}|\\d{1,5}-\\d{1,5})*)$'
+        '^(TCP|UDP)-(IN|OUT):((?:\\d{1,5}|\\d{1,5}-\\d{1,5})(?:,\\d{1,5}|\\d{1,5}-\\d{1,5})*):((?:\\d{1,5}|\\d{1,5}-\\d{1,5})(?:,\\d{1,5}|\\d{1,5}-\\d{1,5})*)$'
     );
 };

--- a/ui/src/server/utils/reduxApiUtils.js
+++ b/ui/src/server/utils/reduxApiUtils.js
@@ -22,7 +22,7 @@ module.exports.extractAssertionId = (
 
 module.exports.getMicrosegmentationActionRegex = () => {
     return new RegExp(
-        '^(TCP|UDP)-(IN|OUT):(\\d{1,5}-\\d{1,5}|\\d{1,5}):((?:\\d{1,5}|\\d{1,5}-\\d{1,5})(?:,\\d{1,5}|\\d{1,5}-\\d{1,5})*)$'
+        '^(TCP|UDP)-(IN|OUT):((?:\\d{1,5}|\\d{1,5}-\\d{1,5})(?:,\\d{1,5}|\\d{1,5}-\\d{1,5})*):((?:\\d{1,5}|\\d{1,5}-\\d{1,5})(?:,\\d{1,5}|\\d{1,5}-\\d{1,5})*)$'
     );
 };
 


### PR DESCRIPTION
# Description
Fix ACL policy regex when filtering policies on first load and upon reload on submit.
Currently if the policy is created with ports that have comma separated values in the Source Ports section, it is being **filtered out** during initial display of Microsegmentation page and upon adding a new ACL policy.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

