### PR TITLE
Fix User-controlled data in numeric cast

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2711,6 +2711,10 @@ public class ZTSImpl implements ZTSHandler {
             idJwts = idToken.getSignedToken(privateKey.getKey(), privateKey.getId(), privateKey.getAlgorithm());
         }
 
+        // Ensure tokenTimeout is within int range to prevent truncation
+        if (tokenTimeout < 0 || tokenTimeout > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Token timeout value out of range");
+        }
         AccessTokenResponse response = new AccessTokenResponse().setAccess_token(accessJwts)
                 .setToken_type(OAUTH_BEARER_TOKEN).setExpires_in((int) tokenTimeout).setId_token(idJwts);
 


### PR DESCRIPTION
# Description
https://github.com/AthenZ/athenz/blob/3bdd5b8a5bb50b1a93c2207b32b32dd3344f86f3/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java#L2715-L2715
fix the problem, we should ensure that the value of `tokenTimeout` is within the valid range for an `int` before casting. The best way is to clamp or validate `tokenTimeout` before the cast, throwing an exception or using a safe default if the value is out of range. This should be done immediately before the cast in the `postAccessTokenRequest` method in `ZTSImpl.java`, around line 2715. No new imports are needed, as the required exception types are already available.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## References
SEI CERT Oracle Coding Standard for Java: [NUM12-J. Ensure conversions of numeric types to narrower types do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/java/NUM12-J.+Ensure+conversions+of+numeric+types+to+narrower+types+do+not+result+in+lost+or+misinterpreted+data)