### PR TITLE
do not allow put admin role with no members

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -4365,6 +4365,13 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                     + role.getName(), caller);
         }
 
+        // do not allow admin role without any members
+
+        if (ADMIN_ROLE_NAME.equals(roleName) && ZMSUtils.isCollectionEmpty(role.getRoleMembers())
+                && StringUtil.isEmpty(role.getTrust())) {
+            throw ZMSUtils.requestError("putRole: Admin role must have at least one member", caller);
+        }
+
         // validate the user authority settings if they're provided
 
         validateUserAuthorityAttributes(role.getUserAuthorityFilter(), role.getUserAuthorityExpiration(), caller);


### PR DESCRIPTION
# Description

we already have the check for the putMembership call where we do not allow the last member to be deleted from the admin role. however, we allowed the user to make putRole call for the admin role with no members and we now block that as well.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

