### PR TITLE
handle 404 error from getDomainRoleMembers

### DIFF
--- a/ui/src/server/handlers/api.js
+++ b/ui/src/server/handlers/api.js
@@ -2414,6 +2414,10 @@ Fetchr.registerService({
     read(req, resource, params, config, callback) {
         req.clients.zms.getPrincipalRoles(params, function (err, data) {
             if (err) {
+                if (err.status === 404) {
+                    // 404 from getPrincipalRoles is ok, principal is not part of any role
+                    return callback(null, []);
+                }
                 debug(
                     `principal: ${req.session.shortId} rid: ${
                         req.headers.rid


### PR DESCRIPTION
# Description
When principal (group) is not part of any roles then we get 404 error from ZMS. UI should consume this error and return empty array.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

