### PR TITLE
Add a Gauge method for recording event metrics

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/Metric.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/Metric.java
@@ -106,6 +106,19 @@ public interface Metric {
     }
 
     /**
+     * Set the gauge by the specified value for the given metric against the domainName
+     * @param metric Name of the gauge
+     * @param requestDomainName Name of the request domain. requestDomainName is
+     *            optional and can be passed as null to indicate that the counter is
+     *            global and not per-domain
+     * @param requestServiceName Name of the request service. requestServiceName is
+     *            optional and can be passed as null to indicate that the counter is
+     *            global and not per-domain
+     * @param value a value by which to set the gauge
+     */
+    void setGauge(String metric, String requestDomainName, String requestServiceName, long value);
+
+    /**
      * Start the latency timer for the specified metric for the given domainName.
      * The implementation must be able to support simultaneous handling of
      * multiple timer counters (but not the same metric). It's possible that

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/NoOpMetric.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/NoOpMetric.java
@@ -59,6 +59,10 @@ public class NoOpMetric implements Metric {
     }
 
     @Override
+    public void setGauge(String metric, String requestDomainName, String requestServiceName, long value) {
+    }
+
+    @Override
     public Object startTiming(String metric, String requestDomainName) {
         return null;
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
@@ -81,6 +81,10 @@ public class MetricsTest {
             }
 
             @Override
+            public void setGauge(String metric, String requestDomainName, String requestServiceName, long value) {
+            }
+
+            @Override
             public Object startTiming(String metric, String requestDomainName) {
                 return null;
             }
@@ -141,6 +145,9 @@ public class MetricsTest {
             @Override
             public void increment(String metric, String requestDomainName, int count) {
             }
+            @Override
+            public void setGauge(String metric, String requestDomainName, String requestServiceName, long value) {
+            }
 
             @Override
             public Object startTiming(String metric, String requestDomainName) {
@@ -181,4 +188,10 @@ public class MetricsTest {
         metric.flush();
         metric.quit();
     }
+
+    @Test
+    public void testMetrics() {
+
+    }
 }
+


### PR DESCRIPTION
# Description
Implemented an optimized metric registration: OpenTelemetryMetric now caches CounterBuilder instances in a concurrent map, 
- Registering each metric name only once instead of creating a new builder on every increment.
- Added a gauge(name, domain, service, value) method to record event metrics at scrape time.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

