### PR TITLE
handle 404 when principal is not part of any roles

### DIFF
--- a/ui/src/server/handlers/api.js
+++ b/ui/src/server/handlers/api.js
@@ -3233,14 +3233,18 @@ Fetchr.registerService({
             },
             (err, list) => {
                 if (err) {
-                    debug(
-                        `principal: ${req.session.shortId} rid: ${
-                            req.headers.rid
-                        } Error from ZMS while calling getResourceAccessList API: ${JSON.stringify(
-                            errorHandler.fetcherError(err)
-                        )}`
-                    );
-                    callback(errorHandler.fetcherError(err));
+                    if (err.status === 404) {
+                        callback(null, []);
+                    } else {
+                        debug(
+                            `principal: ${req.session.shortId} rid: ${
+                                req.headers.rid
+                            } Error from ZMS while calling getResourceAccessList API: ${JSON.stringify(
+                                errorHandler.fetcherError(err)
+                            )}`
+                        );
+                        callback(errorHandler.fetcherError(err));
+                    }
                 } else {
                     if (!list || !list.resources) {
                         callback(null, []);
@@ -3264,14 +3268,18 @@ Fetchr.registerService({
             { principal: principal },
             (err, data) => {
                 if (err) {
-                    debug(
-                        `principal: ${req.session.shortId} rid: ${
-                            req.headers.rid
-                        } Error from ZMS while calling getRolesForReview API: ${JSON.stringify(
-                            errorHandler.fetcherError(err)
-                        )}`
-                    );
-                    callback(errorHandler.fetcherError(err));
+                    if (err.status === 404) {
+                        callback(null, []);
+                    } else {
+                        debug(
+                            `principal: ${req.session.shortId} rid: ${
+                                req.headers.rid
+                            } Error from ZMS while calling getRolesForReview API: ${JSON.stringify(
+                                errorHandler.fetcherError(err)
+                            )}`
+                        );
+                        callback(errorHandler.fetcherError(err));
+                    }
                 } else {
                     if (!data || !data.list) {
                         callback(null, []);
@@ -3295,14 +3303,18 @@ Fetchr.registerService({
             { principal: principal },
             (err, data) => {
                 if (err) {
-                    debug(
-                        `principal: ${req.session.shortId} rid: ${
-                            req.headers.rid
-                        } Error from ZMS while calling getGroupsForReview API: ${JSON.stringify(
-                            errorHandler.fetcherError(err)
-                        )}`
-                    );
-                    callback(errorHandler.fetcherError(err));
+                    if (err.status === 404) {
+                        callback(null, []);
+                    } else {
+                        debug(
+                            `principal: ${req.session.shortId} rid: ${
+                                req.headers.rid
+                            } Error from ZMS while calling getGroupsForReview API: ${JSON.stringify(
+                                errorHandler.fetcherError(err)
+                            )}`
+                        );
+                        callback(errorHandler.fetcherError(err));
+                    }
                 } else {
                     if (!data || !data.list) {
                         callback(null, []);


### PR DESCRIPTION
# Description
when principal is not part of any roles then ZMS returns 404 "unknown principal". Client should handle this 404 code as an empty list for certain API calls
```
getResourceAccessList
getRolesForReview
getGroupsForReview
```

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

