### PR TITLE
expose on-call URL value in client-side config

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -34,8 +34,6 @@ const dev = process.env.NODE_ENV !== 'production';
 const nextApp = next({ dev });
 const debug = require('debug')('AthenzUI:server:app');
 
-process.env.NEXT_PUBLIC_ONCALL_URL = appConfig.onCallUrl || appConfig.serverURL;
-
 Promise.all([nextApp.prepare(), secrets.load(appConfig)])
     .then(() => handlers.api.load(appConfig, secrets))
     .then(

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,0 +1,7 @@
+const appConfig = require('./src/config/config')();
+
+module.exports = {
+    publicRuntimeConfig: {
+        onCallUrl: appConfig.onCallUrl || appConfig.serverURL,
+    },
+};

--- a/ui/src/components/constants/constants.js
+++ b/ui/src/components/constants/constants.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { CLIENT_CONFIG } from '../../config/client-config';
 
 export const MODAL_TIME_OUT = 2000;
 export const GROUP_NAME_REGEX =
@@ -287,4 +288,4 @@ export const PERCENTAGE_OF_DAYS_TILL_NEXT_REVIEW = 0.2;
 export const SEARCH_MAX_100_RESULTS_CAN_BE_DISPLAYED =
     'Maximum 100 results can be searched for at a time. Specify more characters in the search criteria to get better results.';
 
-export const ONCALL_URL = process.env.NEXT_PUBLIC_ONCALL_URL;
+export const ONCALL_URL = CLIENT_CONFIG.onCallUrl;

--- a/ui/src/config/client-config.js
+++ b/ui/src/config/client-config.js
@@ -1,0 +1,7 @@
+import getConfig from 'next/config';
+const { publicRuntimeConfig } = getConfig() || {};
+
+// Exposes values from config files that depend on Node.js APIs (not accessible client-side)
+export const CLIENT_CONFIG = {
+    onCallUrl: publicRuntimeConfig?.onCallUrl,
+};


### PR DESCRIPTION
# Description
* Remove `NEXT_PUBLIC` env var since these are baked during build time
* Read on-call URL from app config and export it for use in client-config
* Create client-config to expose on-call URL

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

