### PR TITLE
make resource-access value rewrite configurable/generic

### DIFF
--- a/clients/go/zms/client.go
+++ b/clients/go/zms/client.go
@@ -3723,9 +3723,9 @@ func (client ZMSClient) GetAccessExt(action ActionName, resource string, domain 
 	}
 }
 
-func (client ZMSClient) GetResourceAccessList(principal ResourceName, action ActionName) (*ResourceAccessList, error) {
+func (client ZMSClient) GetResourceAccessList(principal ResourceName, action ActionName, filter SimpleName) (*ResourceAccessList, error) {
 	var data *ResourceAccessList
-	url := client.URL + "/resource" + encodeParams(encodeStringParam("principal", string(principal), ""), encodeStringParam("action", string(action), ""))
+	url := client.URL + "/resource" + encodeParams(encodeStringParam("principal", string(principal), ""), encodeStringParam("action", string(action), ""), encodeStringParam("filter", string(filter), ""))
 	resp, err := client.httpGet(url, nil)
 	if err != nil {
 		return data, err

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -2696,6 +2696,7 @@ func init() {
 	mGetResourceAccessList.Comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
 	mGetResourceAccessList.Input("principal", "ResourceName", false, "principal", "", true, nil, "specifies principal to query the resource list for")
 	mGetResourceAccessList.Input("action", "ActionName", false, "action", "", true, nil, "action as specified in the policy assertion")
+	mGetResourceAccessList.Input("filter", "SimpleName", false, "filter", "", true, nil, "resource filter for specific subset of resources")
 	mGetResourceAccessList.Auth("", "", true, "")
 	mGetResourceAccessList.Exception("BAD_REQUEST", "ResourceError", "")
 	mGetResourceAccessList.Exception("FORBIDDEN", "ResourceError", "")

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
@@ -3353,18 +3353,35 @@ public class ZMSClient implements Closeable {
      *                  Check with Athenz Service Administrators if you have a use case to
      *                  request all principals from Athenz Service
      * @param action    optional field specifying what action to filter assertions on
+     * @param filter    optional field to specify resource attribute filter if supported
      * @return ResourceAccessList object that lists the set of assertions per principal
      * @throws ZMSClientException in case of failure
      */
-    public ResourceAccessList getResourceAccessList(String principal, String action) {
+    public ResourceAccessList getResourceAccessList(String principal, String action, String filter) {
         updatePrincipal();
         try {
-            return client.getResourceAccessList(principal, action);
+            return client.getResourceAccessList(principal, action, filter);
         } catch (ClientResourceException ex) {
             throw new ZMSClientException(ex.getCode(), ex.getData());
         } catch (Exception ex) {
             throw new ZMSClientException(ClientResourceException.BAD_REQUEST, ex.getMessage());
         }
+    }
+
+    /**
+     * Retrieve the list of resources as defined in their respective assertions
+     * that the given principal has access to through their role membership
+     *
+     * @param principal the principal name (e.g. user.joe). Must have special
+     *                  privileges to execute this query without specifying the principal.
+     *                  Check with Athenz Service Administrators if you have a use case to
+     *                  request all principals from Athenz Service
+     * @param action    optional field specifying what action to filter assertions on
+     * @return ResourceAccessList object that lists the set of assertions per principal
+     * @throws ZMSClientException in case of failure
+     */
+    public ResourceAccessList getResourceAccessList(String principal, String action) {
+        return getResourceAccessList(principal, action, null);
     }
 
     /**

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
@@ -3724,7 +3724,7 @@ public class ZMSRDLGeneratedClient {
         }
     }
 
-    public ResourceAccessList getResourceAccessList(String principal, String action) throws URISyntaxException, IOException {
+    public ResourceAccessList getResourceAccessList(String principal, String action, String filter) throws URISyntaxException, IOException {
         UriTemplateBuilder uriTemplateBuilder = new UriTemplateBuilder(baseUrl, "/resource");
         URIBuilder uriBuilder = new URIBuilder(uriTemplateBuilder.getUri());
         if (principal != null) {
@@ -3732,6 +3732,9 @@ public class ZMSRDLGeneratedClient {
         }
         if (action != null) {
             uriBuilder.setParameter("action", action);
+        }
+        if (filter != null) {
+            uriBuilder.setParameter("filter", filter);
         }
         ClassicHttpRequest httpUriRequest = ClassicRequestBuilder.get()
             .setUri(uriBuilder.build())

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientMockTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientMockTest.java
@@ -837,8 +837,8 @@ public class ZMSClientMockTest {
 
         rsrcList.setResources(resources);
 
-        Mockito.doReturn(rsrcList).when(mockZMS).getResourceAccessList("user.user", "update");
-        Mockito.doReturn(rsrcEmptyList).when(mockZMS).getResourceAccessList("user.user1", "create");
+        Mockito.doReturn(rsrcList).when(mockZMS).getResourceAccessList("user.user", "update", null);
+        Mockito.doReturn(rsrcEmptyList).when(mockZMS).getResourceAccessList("user.user1", "create", null);
 
         ResourceAccessList rsrcAccessList = zclt.getResourceAccessList("user.user", "update");
         assertNotNull(rsrcAccessList);
@@ -847,7 +847,7 @@ public class ZMSClientMockTest {
         rsrcAccess = rsrcAccessList.getResources().get(0);
         assertEquals(rsrcAccess.getPrincipal(), "user.user");
 
-        rsrcAccessList = zclt.getResourceAccessList("user.user1", "create");
+        rsrcAccessList = zclt.getResourceAccessList("user.user1", "create", null);
         assertNotNull(rsrcAccessList);
         assertNull(rsrcAccessList.getResources());
     }

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
@@ -1821,14 +1821,14 @@ public class ZMSClientTest {
         ZMSRDLGeneratedClient c = Mockito.mock(ZMSRDLGeneratedClient.class);
         client.setZMSRDLGeneratedClient(c);
         try {
-            Mockito.when(c.getResourceAccessList("principal1", "action1")).thenThrow(new NullPointerException());
+            Mockito.when(c.getResourceAccessList("principal1", "action1", null)).thenThrow(new NullPointerException());
             client.getResourceAccessList("principal1", "action1");
             fail();
         } catch (ZMSClientException ex) {
             assertEquals(ex.getCode(), ZMSClientException.BAD_REQUEST);
         }
         try {
-            Mockito.when(c.getResourceAccessList("principal2", "action2")).thenThrow(new ClientResourceException(400));
+            Mockito.when(c.getResourceAccessList("principal2", "action2", null)).thenThrow(new ClientResourceException(400));
             client.getResourceAccessList("principal2", "action2");
             fail();
         } catch (ZMSClientException ex) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -3027,6 +3027,7 @@ public class ZMSSchema {
             .comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
             .queryParam("principal", "principal", "ResourceName", null, "specifies principal to query the resource list for")
             .queryParam("action", "action", "ActionName", null, "action as specified in the policy assertion")
+            .queryParam("filter", "filter", "SimpleName", null, "resource filter for specific subset of resources")
             .auth("", "", true)
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")

--- a/core/zms/src/main/rdl/Access.rdli
+++ b/core/zms/src/main/rdl/Access.rdli
@@ -63,9 +63,10 @@ type ResourceAccessList Struct {
 
 //Return list of resources that the given principal has access to. Even
 //though the principal is marked as optional, it must be specified
-resource ResourceAccessList GET "/resource?principal={principal}&action={action}" {
+resource ResourceAccessList GET "/resource?principal={principal}&action={action}&filter={filter}" {
     ResourceName principal (optional); //specifies principal to query the resource list for
     ActionName action (optional); //action as specified in the policy assertion
+    SimpleName filter (optional); //resource filter for specific subset of resources
     authenticate;
     expected OK;
     exceptions {

--- a/libs/go/zmscli/access.go
+++ b/libs/go/zmscli/access.go
@@ -86,8 +86,8 @@ func (cli Zms) ShowAccessExt(dn string, action string, resource string, altIdent
 	return cli.dumpByFormat(message, cli.buildYAMLOutput)
 }
 
-func (cli Zms) ShowResourceAccess(principal string, action string) (*string, error) {
-	rsrcAccessList, err := cli.Zms.GetResourceAccessList(zms.ResourceName(principal), zms.ActionName(action))
+func (cli Zms) ShowResourceAccess(principal, action, filter string) (*string, error) {
+	rsrcAccessList, err := cli.Zms.GetResourceAccessList(zms.ResourceName(principal), zms.ActionName(action), zms.SimpleName(filter))
 	if err != nil {
 		return nil, err
 	}

--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -354,8 +354,10 @@ func (cli Zms) EvalCommand(params []string) (*string, error) {
 			}
 			return nil, fmt.Errorf("no template specified")
 		case "show-resource":
-			if argc == 2 {
-				return cli.ShowResourceAccess(args[0], args[1])
+			if argc == 3 {
+				return cli.ShowResourceAccess(args[0], args[1], args[2])
+			} else if argc == 2 {
+				return cli.ShowResourceAccess(args[0], args[1], "")
 			}
 		case "list-user":
 			domainName := ""
@@ -2133,14 +2135,14 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   " + domainExample + " show-access-ext node_sudo coretech:node.host1 " + cli.UserDomain + ".john\n")
 	case "show-resource":
 		buf.WriteString(" syntax:\n")
-		buf.WriteString("   show-resource principal action\n")
+		buf.WriteString("   show-resource principal action [filter]\n")
 		buf.WriteString(" parameters:\n")
 		buf.WriteString("   principal    : show resources for this principal only\n")
 		buf.WriteString("   action       : assertion action value to filter on\n")
+		buf.WriteString("   filter       : assertion resource filter if supported\n")
 		buf.WriteString(" examples:\n")
 		buf.WriteString("   show-resource " + cli.UserDomain + ".user1 update\n")
-		buf.WriteString("   show-resource " + cli.UserDomain + ".user1 \"\"\n")
-		buf.WriteString("   show-resource \"\" assume_aws_role\n")
+		buf.WriteString("   show-resource " + cli.UserDomain + ".user1 assume_aws_role\n")
 	case "list-role":
 		buf.WriteString(" syntax:\n")
 		buf.WriteString("   " + domainParam + " list-role\n")

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/assertion/ResourceValueUpdater.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/assertion/ResourceValueUpdater.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.yahoo.athenz.common.server.assertion;
+
+import com.yahoo.athenz.zms.ResourceAccessList;
+import java.util.Map;
+
+/**
+ * An interface that allows system administrators to take extra additional
+ * action to write the assertion resource value based on the specific action.
+ * This interface is called for the ResourceAccessList API.
+ */
+public interface ResourceValueUpdater {
+
+    /**
+     * Update the resource value in the given access list based on the
+     * provided cloud information. The filter parameter is provided to
+     * allow the implementation to limit the update to a specific set
+     * of resources.
+     *
+     * @param accessList ResourceAccessList object containing the assertions
+     * @param cloudProviderMap map of cloud information if required
+     * @param filter filter string to limit the update scope
+     */
+    void updateResourceValue(ResourceAccessList accessList, Map<String, String> cloudProviderMap, final String filter);
+
+    /**
+     * Return the cloud provider map key required for the implementation.
+     * If the implementation does not require any cloud information then
+     * it should return null or empty string. If required, when calling
+     * the updateResourceValue method, the cloudMap parameter will
+     * contain the key with the corresponding cloud provider value.
+     * @return cloud provider map key required for the implementation
+     * currently supported values are "aws", "gcp", or "azure".
+     */
+    String cloudProviderMapRequired();
+}

--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -600,7 +600,7 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 #athenz.zms.notification_object_store_factory_class=
 
 # Specifies a comma separated list of actions along with classes that implement the
-# AssertionResourceUpdater interface used by the ZMS Server to update policy assertions
+# ResourceValueUpdater interface used by the ZMS Server to update policy assertions
 # when executing a ResourceAccessList api call. The classes must have a default constructor.
 # The default value includes the aws/gcp actions that were previously implemented in the
 # server.

--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -598,3 +598,12 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # Specifies the factory class that implements the NotificationObjectStore interface
 # used by the ZMS Server to store notification objects
 #athenz.zms.notification_object_store_factory_class=
+
+# Specifies a comma separated list of actions along with classes that implement the
+# AssertionResourceUpdater interface used by the ZMS Server to update policy assertions
+# when executing a ResourceAccessList api call. The classes must have a default constructor.
+# The default value includes the aws/gcp actions that were previously implemented in the
+# server.
+#athenz.zms.assertion_resource_updaters=assume_aws_role:com.yahoo.athenz.zms.assertion.AwsAssumeRoleResourceUpdater,
+#     assume_gcp_role:com.yahoo.athenz.zms.assertion.GcpAssumeRoleResourceUpdater,
+#     assume_gcp_service:com.yahoo.athenz.zms.assertion.GcpAssumeRoleResourceUpdater

--- a/servers/zms/pom.xml
+++ b/servers/zms/pom.xml
@@ -27,7 +27,7 @@
   <packaging>war</packaging>
 
   <properties>
-    <code.coverage.min>0.9736</code.coverage.min>
+    <code.coverage.min>0.9745</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
@@ -114,7 +114,7 @@ public interface ZMSHandler {
     void deleteProviderResourceGroupRoles(ResourceContext context, String tenantDomain, String provDomain, String provService, String resourceGroup, String auditRef);
     Access getAccess(ResourceContext context, String action, String resource, String domain, String checkPrincipal);
     Access getAccessExt(ResourceContext context, String action, String resource, String domain, String checkPrincipal);
-    ResourceAccessList getResourceAccessList(ResourceContext context, String principal, String action);
+    ResourceAccessList getResourceAccessList(ResourceContext context, String principal, String action, String filter);
     Response getSignedDomains(ResourceContext context, String domain, String metaOnly, String metaAttr, Boolean master, Boolean conditions, String matchingTag);
     Response getJWSDomain(ResourceContext context, String name, Boolean signatureP1363Format, String matchingTag);
     UserToken getUserToken(ResourceContext context, String userName, String serviceNames, Boolean header);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -10052,7 +10052,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
     @Override
     public ResourceAccessList getResourceAccessList(ResourceContext ctx, String principal,
-            String action) {
+            String action, String filter) {
 
         final String caller = ctx.getApiName();
         logPrincipal(ctx);
@@ -10064,7 +10064,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         Principal ctxPrincipal = ((RsrcCtxWrapper) ctx).principal();
         if (LOG.isDebugEnabled()) {
-            LOG.debug("getResourceAccessList:({}, {}, {})", ctxPrincipal, principal, action);
+            LOG.debug("getResourceAccessList:({}, {}, {}, {})", ctxPrincipal, principal, action, filter);
         }
 
         validate(principal, TYPE_RESOURCE_NAME, caller);
@@ -10075,7 +10075,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             action = action.toLowerCase();
         }
 
-        return dbService.getResourceAccessList(principal, action);
+        if (!StringUtil.isEmpty(filter)) {
+            validate(filter, TYPE_SIMPLE_NAME, caller);
+        }
+
+        return dbService.getResourceAccessList(principal, action, filter);
     }
 
     @Override

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -3946,13 +3946,14 @@ public class ZMSResources {
     @Operation(description = "Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
     public ResourceAccessList getResourceAccessList(
         @Parameter(description = "specifies principal to query the resource list for", required = false) @QueryParam("principal") String principal,
-        @Parameter(description = "action as specified in the policy assertion", required = false) @QueryParam("action") String action) {
+        @Parameter(description = "action as specified in the policy assertion", required = false) @QueryParam("action") String action,
+        @Parameter(description = "resource filter for specific subset of resources", required = false) @QueryParam("filter") String filter) {
         int code = ResourceException.OK;
         ResourceContext context = null;
         try {
             context = this.delegate.newResourceContext(this.servletContext, this.request, this.response, "getResourceAccessList");
             context.authenticate();
-            return this.delegate.getResourceAccessList(context, principal, action);
+            return this.delegate.getResourceAccessList(context, principal, action, filter);
         } catch (ResourceException e) {
             code = e.getCode();
             switch (code) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/AwsAssumeRoleResourceUpdater.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/AwsAssumeRoleResourceUpdater.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.assertion;
+
+import com.yahoo.athenz.common.server.assertion.ResourceValueUpdater;
+import com.yahoo.athenz.common.server.store.ObjectStoreConnection;
+import com.yahoo.athenz.zms.Assertion;
+import com.yahoo.athenz.zms.ResourceAccess;
+import com.yahoo.athenz.zms.ResourceAccessList;
+import com.yahoo.athenz.zms.utils.ZMSUtils;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class AwsAssumeRoleResourceUpdater implements ResourceValueUpdater {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AwsAssumeRoleResourceUpdater.class);
+
+    private static final String AWS_ARN_PREFIX  = "arn:aws:iam::";
+
+    @Override
+    public void updateResourceValue(ResourceAccessList accessList, Map<String, String> cloudProviderMap, String filter) {
+
+        // if aws domain list is empty then we'll be removing all resources
+
+        if (cloudProviderMap == null || cloudProviderMap.isEmpty()) {
+            accessList.setResources(Collections.emptyList());
+            return;
+        }
+
+        // we're going to update each assertion and generate the
+        // resource in the expected aws role format. however, we
+        // are going to remove any assertions where we do not have a
+        // valid syntax or no aws domain
+
+        List<ResourceAccess> resourceAccessList = accessList.getResources();
+        for (ResourceAccess resourceAccess : resourceAccessList) {
+            Iterator<Assertion> assertionIterator = resourceAccess.getAssertions().iterator();
+            while (assertionIterator.hasNext()) {
+
+                Assertion assertion = assertionIterator.next();
+
+                final String role = assertion.getRole();
+                final String resource = assertion.getResource();
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("processing assertion: {}/{}", role, resource);
+                }
+
+                // verify that role and resource domains match
+
+                final String resourceDomain = ZMSUtils.assertionDomainCheck(role, resource);
+                if (resourceDomain == null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("assertion domain check failed, removing assertion");
+                    }
+                    assertionIterator.remove();
+                    continue;
+                }
+
+                final String awsAccount = cloudProviderMap.get(resourceDomain);
+                if (awsAccount == null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("resource without aws account: {}", resourceDomain);
+                    }
+                    assertionIterator.remove();
+                    continue;
+                }
+
+                if (!StringUtil.isEmpty(filter) && !awsAccount.equals(filter)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("resource with aws account: {} not matching filter: {}", awsAccount, filter);
+                    }
+                    assertionIterator.remove();
+                    continue;
+                }
+                assertion.setResource(AWS_ARN_PREFIX + awsAccount + ":role/" + resource.substring(resourceDomain.length() + 1));
+            }
+        }
+    }
+
+    @Override
+    public String cloudProviderMapRequired() {
+        return ObjectStoreConnection.PROVIDER_AWS;
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/GcpAssumeRoleResourceUpdater.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/GcpAssumeRoleResourceUpdater.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.assertion;
+
+import com.yahoo.athenz.common.server.assertion.ResourceValueUpdater;
+import com.yahoo.athenz.common.server.store.ObjectStoreConnection;
+import com.yahoo.athenz.zms.Assertion;
+import com.yahoo.athenz.zms.ResourceAccess;
+import com.yahoo.athenz.zms.ResourceAccessList;
+import com.yahoo.athenz.zms.utils.ZMSUtils;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class GcpAssumeRoleResourceUpdater implements ResourceValueUpdater {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GcpAssumeRoleResourceUpdater.class);
+
+    private static final String GCP_ARN_PREFIX  = "projects/";
+
+    @Override
+    public void updateResourceValue(ResourceAccessList accessList, Map<String, String> cloudProviderMap, String filter) {
+
+        // if the gcp domain list is empty then we'll be removing all resources
+
+        if (cloudProviderMap == null || cloudProviderMap.isEmpty()) {
+            accessList.setResources(Collections.emptyList());
+            return;
+        }
+
+        // we're going to update each assertion and generate the
+        // resource in the expected gcp role format. however, we
+        // are going to remove any assertions where we do not have a
+        // valid syntax or no gcp domain
+
+        List<ResourceAccess> resourceAccessList = accessList.getResources();
+        for (ResourceAccess resourceAccess : resourceAccessList) {
+            Iterator<Assertion> assertionIterator = resourceAccess.getAssertions().iterator();
+            while (assertionIterator.hasNext()) {
+
+                Assertion assertion = assertionIterator.next();
+
+                final String role = assertion.getRole();
+                final String resource = assertion.getResource();
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("processing assertion: {}/{}", role, resource);
+                }
+
+                // verify that role and resource domains match
+
+                final String resourceDomain = ZMSUtils.assertionDomainCheck(role, resource);
+                if (resourceDomain == null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("assertion domain check failed, removing assertion");
+                    }
+                    assertionIterator.remove();
+                    continue;
+                }
+
+                final String gcpProject = cloudProviderMap.get(resourceDomain);
+                if (gcpProject == null) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("resource without gcp project: {}", resourceDomain);
+                    }
+                    assertionIterator.remove();
+                    continue;
+                }
+
+                if (!StringUtil.isEmpty(filter) && !gcpProject.equals(filter)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("resource with gcp project: {} not matching filter: {}", gcpProject, filter);
+                    }
+                    assertionIterator.remove();
+                    continue;
+                }
+
+                final String resourceObject = resource.substring(resourceDomain.length() + 1);
+                final String resourceComp = (resourceObject.startsWith("roles/") || resourceObject.startsWith("groups/")
+                        || resourceObject.startsWith("services/")) ? "/" : "/roles/";
+                assertion.setResource(GCP_ARN_PREFIX + gcpProject + resourceComp + resourceObject);
+            }
+        }
+    }
+
+    @Override
+    public String cloudProviderMapRequired() {
+        return ObjectStoreConnection.PROVIDER_GCP;
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/ResourceUpdaterManager.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/ResourceUpdaterManager.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.assertion;
+
+import com.yahoo.athenz.common.server.assertion.ResourceValueUpdater;
+import com.yahoo.athenz.zms.ZMSConsts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+
+public class ResourceUpdaterManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceUpdaterManager.class);
+
+    public static final String ZMS_PROP_ASSERTION_RESOURCE_UPDATERS = "athenz.zms.assertion_resource_updaters";
+
+    String awsAssumeRoleAction = null;
+    String gcpAssumeRoleAction = null;
+    String gcpAssumeServiceAction = null;
+    HashMap<String, ResourceValueUpdater> assertionResourceValueUpdaters;
+
+    public ResourceUpdaterManager() {
+
+        assertionResourceValueUpdaters = new HashMap<>();
+
+        final String resourceUpdaters = System.getProperty(ZMS_PROP_ASSERTION_RESOURCE_UPDATERS, "");
+
+        // if there are no custom resource updaters defined then we'll fall back
+        // to our default set of resource updaters to maintain backward compatibility
+
+        if (resourceUpdaters.isEmpty()) {
+
+            awsAssumeRoleAction = System.getProperty(ZMSConsts.ZMS_PROP_AWS_ASSUME_ROLE_ACTION,
+                    ZMSConsts.ACTION_ASSUME_AWS_ROLE);
+            gcpAssumeRoleAction = System.getProperty(ZMSConsts.ZMS_PROP_GCP_ASSUME_ROLE_ACTION,
+                    ZMSConsts.ACTION_ASSUME_GCP_ROLE);
+            gcpAssumeServiceAction = System.getProperty(ZMSConsts.ZMS_PROP_GCP_ASSUME_SERVICE_ACTION,
+                    ZMSConsts.ACTION_ASSUME_GCP_SERVICE);
+
+            assertionResourceValueUpdaters.put(awsAssumeRoleAction, new AwsAssumeRoleResourceUpdater());
+            assertionResourceValueUpdaters.put(gcpAssumeRoleAction, new GcpAssumeRoleResourceUpdater());
+            assertionResourceValueUpdaters.put(gcpAssumeServiceAction, new GcpAssumeRoleResourceUpdater());
+
+        } else {
+
+            // the format of the attribute is action:class,action:class,...
+            // so we'll parse it and load each of the classes
+
+            String[] resourceUpdaterList = resourceUpdaters.split(",");
+            for (String resourceUpdater : resourceUpdaterList) {
+                String[] actionAndClass = resourceUpdater.trim().split(":");
+                if (actionAndClass.length != 2) {
+                    throw new IllegalArgumentException("Invalid assertion resource updater: " + resourceUpdater);
+                }
+                assertionResourceValueUpdaters.put(actionAndClass[0].trim(),
+                        getResourceValueUpdater(actionAndClass[1].trim()));
+            }
+        }
+    }
+
+    ResourceValueUpdater getResourceValueUpdater(final String className) {
+
+        LOGGER.debug("Loading resource value updater {}...", className);
+
+        ResourceValueUpdater updater;
+        try {
+            updater = (ResourceValueUpdater) Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Invalid resource updater class: " + className, ex);
+        }
+        return updater;
+    }
+
+    public ResourceValueUpdater getResourceValueUpdaterForAction(final String action) {
+        return assertionResourceValueUpdaters.get(action);
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/ResourceUpdaterManager.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/assertion/ResourceUpdaterManager.java
@@ -28,9 +28,6 @@ public class ResourceUpdaterManager {
 
     public static final String ZMS_PROP_ASSERTION_RESOURCE_UPDATERS = "athenz.zms.assertion_resource_updaters";
 
-    String awsAssumeRoleAction = null;
-    String gcpAssumeRoleAction = null;
-    String gcpAssumeServiceAction = null;
     HashMap<String, ResourceValueUpdater> assertionResourceValueUpdaters;
 
     public ResourceUpdaterManager() {
@@ -44,11 +41,11 @@ public class ResourceUpdaterManager {
 
         if (resourceUpdaters.isEmpty()) {
 
-            awsAssumeRoleAction = System.getProperty(ZMSConsts.ZMS_PROP_AWS_ASSUME_ROLE_ACTION,
+            final String awsAssumeRoleAction = System.getProperty(ZMSConsts.ZMS_PROP_AWS_ASSUME_ROLE_ACTION,
                     ZMSConsts.ACTION_ASSUME_AWS_ROLE);
-            gcpAssumeRoleAction = System.getProperty(ZMSConsts.ZMS_PROP_GCP_ASSUME_ROLE_ACTION,
+            final String gcpAssumeRoleAction = System.getProperty(ZMSConsts.ZMS_PROP_GCP_ASSUME_ROLE_ACTION,
                     ZMSConsts.ACTION_ASSUME_GCP_ROLE);
-            gcpAssumeServiceAction = System.getProperty(ZMSConsts.ZMS_PROP_GCP_ASSUME_SERVICE_ACTION,
+            final String gcpAssumeServiceAction = System.getProperty(ZMSConsts.ZMS_PROP_GCP_ASSUME_SERVICE_ACTION,
                     ZMSConsts.ACTION_ASSUME_GCP_SERVICE);
 
             assertionResourceValueUpdaters.put(awsAssumeRoleAction, new AwsAssumeRoleResourceUpdater());

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -584,4 +584,28 @@ public class ZMSUtils {
             return userAuthorityExpiry;
         }
     }
+
+    public static String assertionDomainCheck(final String role, final String resource) {
+
+        // first extract and verify the index values
+
+        int rsrcIdx = resource.indexOf(':');
+        if (rsrcIdx == -1 || rsrcIdx == 0) {
+            return null;
+        }
+
+        int roleIdx = role.indexOf(':');
+        if (roleIdx == -1 || roleIdx == 0) {
+            return null;
+        }
+
+        if (rsrcIdx != roleIdx) {
+            return null;
+        }
+
+        // now extract and verify actual domain values
+
+        final String resourceDomain = resource.substring(0, rsrcIdx);
+        return resourceDomain.equals(role.substring(0, roleIdx)) ? resourceDomain : null;
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -46,7 +46,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.shaded.com.google.common.util.concurrent.Service;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -354,7 +353,7 @@ public class DBServiceTest {
         try {
             // currently in the filestore that we're using for our unit
             // we don't have an implementation for this method
-            zms.dbService.getResourceAccessList("principal", "UPDATE");
+            zms.dbService.getResourceAccessList("principal", "UPDATE", null);
             fail();
         } catch (Exception ex) {
             assertTrue(true);
@@ -12932,17 +12931,6 @@ public class DBServiceTest {
 
         zms.dbService.store = savedStore;
         zms.dbService.defaultRetryCount = savedRetryCount;
-    }
-
-    @Test
-    public void testAssertionDomainCheck() throws ServerResourceException {
-        assertNull(zms.dbService.assertionDomainCheck("", "resource.value"));
-        assertNull(zms.dbService.assertionDomainCheck("", ":resource.value"));
-        assertNull(zms.dbService.assertionDomainCheck("role.value", "athenz:resource.value"));
-        assertNull(zms.dbService.assertionDomainCheck(":role.value", "athenz:resource.value"));
-        assertNull(zms.dbService.assertionDomainCheck("ads:role.value", "athenz:resource.value"));
-        assertNull(zms.dbService.assertionDomainCheck("sports:role.value", "athenz:resource.value"));
-        assertEquals(zms.dbService.assertionDomainCheck("athenz:role.value", "athenz:resource.value"), "athenz");
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/assertion/AwsAssumeRoleResourceUpdaterTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/assertion/AwsAssumeRoleResourceUpdaterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.assertion;
+
+import com.yahoo.athenz.zms.ResourceAccess;
+import com.yahoo.athenz.zms.ResourceAccessList;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class AwsAssumeRoleResourceUpdaterTest {
+
+    @Test
+    public void testEmptyNullCloudMap() {
+        testEmptyCloudMap(null);
+        testEmptyCloudMap(Collections.emptyMap());
+    }
+
+    void testEmptyCloudMap(Map<String, String> cloudMap) {
+        AwsAssumeRoleResourceUpdater updater = new AwsAssumeRoleResourceUpdater();
+        ResourceAccessList resourceAccessList = new ResourceAccessList();
+        List<ResourceAccess> resourceList = new ArrayList<>();
+        resourceList.add(new ResourceAccess());
+        resourceAccessList.setResources(resourceList);
+        updater.updateResourceValue(resourceAccessList, cloudMap, null);
+        assertTrue(resourceAccessList.getResources().isEmpty());
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/assertion/GcpAssumeRoleResourceUpdaterTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/assertion/GcpAssumeRoleResourceUpdaterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.assertion;
+
+import com.yahoo.athenz.zms.ResourceAccess;
+import com.yahoo.athenz.zms.ResourceAccessList;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class GcpAssumeRoleResourceUpdaterTest {
+
+    @Test
+    public void testEmptyNullCloudMap() {
+        testEmptyCloudMap(null);
+        testEmptyCloudMap(Collections.emptyMap());
+    }
+
+    void testEmptyCloudMap(Map<String, String> cloudMap) {
+        GcpAssumeRoleResourceUpdater updater = new GcpAssumeRoleResourceUpdater();
+        ResourceAccessList resourceAccessList = new ResourceAccessList();
+        List<ResourceAccess> resourceList = new ArrayList<>();
+        resourceList.add(new ResourceAccess());
+        resourceAccessList.setResources(resourceList);
+        updater.updateResourceValue(resourceAccessList, cloudMap, null);
+        assertTrue(resourceAccessList.getResources().isEmpty());
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -19,6 +19,7 @@ import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.auth.impl.SimplePrincipal;
 import com.yahoo.athenz.common.metrics.Metric;
+import com.yahoo.athenz.common.server.ServerResourceException;
 import com.yahoo.athenz.common.server.log.AuditLogMsgBuilder;
 import com.yahoo.athenz.common.server.log.AuditLogger;
 import com.yahoo.athenz.common.server.log.AuditLoggerFactory;
@@ -499,5 +500,16 @@ public class ZMSUtilsTest {
         assertTrue(ZMSUtils.enforceUserAuthorityFilterCheck(mockAuthority, Set.of("attr1", "attr2", "attr3")));
 
         assertFalse(ZMSUtils.enforceUserAuthorityFilterCheck(mockAuthority, Set.of("attr2", "attr4")));
+    }
+
+    @Test
+    public void testAssertionDomainCheck() {
+        assertNull(ZMSUtils.assertionDomainCheck("", "resource.value"));
+        assertNull(ZMSUtils.assertionDomainCheck("", ":resource.value"));
+        assertNull(ZMSUtils.assertionDomainCheck("role.value", "athenz:resource.value"));
+        assertNull(ZMSUtils.assertionDomainCheck(":role.value", "athenz:resource.value"));
+        assertNull(ZMSUtils.assertionDomainCheck("ads:role.value", "athenz:resource.value"));
+        assertNull(ZMSUtils.assertionDomainCheck("sports:role.value", "athenz:resource.value"));
+        assertEquals(ZMSUtils.assertionDomainCheck("athenz:role.value", "athenz:resource.value"), "athenz");
     }
 }


### PR DESCRIPTION
# Description

getResourceAccessList api in ZMS had some special handling for a couple of actions. Rather than having the actions to be hardcoded in the server, there is now a new interface called ResourceValueUpdater that the system administrator may implement to extend the functionality in the server without having to include any company specific code into Athenz.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

