### PR TITLE
make metric gauge method default void to maintain backward compatibility

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/Metric.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/Metric.java
@@ -116,7 +116,9 @@ public interface Metric {
      *            global and not per-domain
      * @param value a value by which to set the gauge
      */
-    void setGauge(String metric, String requestDomainName, String requestServiceName, long value);
+    default void setGauge(String metric, String requestDomainName, String requestServiceName, long value) {
+        // No op
+    }
 
     /**
      * Start the latency timer for the specified metric for the given domainName.

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
@@ -81,10 +81,6 @@ public class MetricsTest {
             }
 
             @Override
-            public void setGauge(String metric, String requestDomainName, String requestServiceName, long value) {
-            }
-
-            @Override
             public Object startTiming(String metric, String requestDomainName) {
                 return null;
             }
@@ -119,6 +115,7 @@ public class MetricsTest {
                 "tag3", "value3",
         };
         metric.increment("metric1", attributes);
+        metric.setGauge("metric1", "athenz", "sports", 10);
 
         assertNull(metric.startTiming("metric1", "athenz", "sports"));
         assertNull(metric.startTiming("apiRquestsMetric", "athenz", "sports", "POST", "caller"));
@@ -144,9 +141,6 @@ public class MetricsTest {
 
             @Override
             public void increment(String metric, String requestDomainName, int count) {
-            }
-            @Override
-            public void setGauge(String metric, String requestDomainName, String requestServiceName, long value) {
             }
 
             @Override
@@ -179,6 +173,7 @@ public class MetricsTest {
                 "tag3", "value3",
         };
         metric.increment("metric1", attributes);
+        metric.setGauge("metric1", "athenz", "sports", 10);
 
         assertNull(metric.startTiming("metric1", "athenz", "sports"));
         assertNull(metric.startTiming("apiRquestsMetric", "athenz", "sports", "POST", "caller"));


### PR DESCRIPTION
# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

