### PR TITLE
correct handling of resource ownership for self-serve roles

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/ResourceOwnership.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/ResourceOwnership.java
@@ -363,6 +363,15 @@ public class ResourceOwnership {
             return null;
         }
 
+        // if the role is configured as self-serve role then there is no
+        // point to specify the resource owner since any member can
+        // add or delete members to the role, and they're not all going
+        // to be mandated to be the resource owner
+
+        if (role.getSelfServe() == Boolean.TRUE) {
+            return null;
+        }
+
         boolean bOwnerSpecified = !StringUtil.isEmpty(resourceOwner);
         String resourceOwnerWithoutForceSuffix = getResourceOwnershipWithoutForceSuffix(resourceOwner, bOwnerSpecified);
         ResourceRoleOwnership requestOwnership = bOwnerSpecified ?
@@ -524,6 +533,15 @@ public class ResourceOwnership {
         // by either using the ignore value or the feature being disabled
 
         if (skipEnforceResourceOwnership(resourceOwner)) {
+            return null;
+        }
+
+        // if the group is configured as self-serve group then there is no
+        // point to specify the resource owner since any member can
+        // add or delete members to the group, and they're not all going
+        // to be mandated to be the resource owner
+
+        if (group.getSelfServe() == Boolean.TRUE) {
             return null;
         }
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/ResourceOwnershipTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/ResourceOwnershipTest.java
@@ -713,6 +713,16 @@ public class ResourceOwnershipTest {
             fail();
         }
 
+        // self-serve groups always return null
+
+        group = new Group().setName("group1").setSelfServe(true).setResourceOwnership(new ResourceGroupOwnership().setMembersOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyGroupMembersResourceOwnership(group, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
         // no changes needed when resource ownership is not set and no owner specified
         group = new Group().setName("group1").setResourceOwnership(new ResourceGroupOwnership().setMembersOwner(""));
         try {
@@ -1011,6 +1021,16 @@ public class ResourceOwnershipTest {
         ResourceRoleOwnership ownership;
         // no changes needed when resource ownership is same
         Role role = new Role().setName("role1").setResourceOwnership(new ResourceRoleOwnership().setMembersOwner("TF1"));
+        try {
+            ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, "TF1", "unit-test");
+            assertNull(ownership);
+        } catch (ServerResourceException ignored) {
+            fail();
+        }
+
+        // self-serve roles always return null
+
+        role = new Role().setName("role1").setSelfServe(true).setResourceOwnership(new ResourceRoleOwnership().setMembersOwner("TF1"));
         try {
             ownership = ResourceOwnership.verifyRoleMembersResourceOwnership(role, "TF1", "unit-test");
             assertNull(ownership);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -4396,6 +4396,13 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         try {
             resourceOwnership = ResourceOwnership.verifyRoleResourceOwnership(originalRole,
                     !ZMSUtils.isCollectionEmpty(role.getRoleMembers()), resourceOwner, caller);
+
+            // if the role has a self-serve option enabled then
+            // we cannot allow resource ownership to be set for members
+
+            if (resourceOwnership != null && role.getSelfServe() == Boolean.TRUE) {
+                resourceOwnership.setMembersOwner(null);
+            }
         } catch (ServerResourceException ex) {
             throw ZMSUtils.error(ex);
         }
@@ -11051,6 +11058,22 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         setRequestDomain(ctx, domainName);
         roleName = roleName.toLowerCase();
 
+        // extract our role object to get its attributes
+
+        AthenzDomain domain = getAthenzDomain(domainName, false);
+        Role role = getRoleFromDomain(roleName, domain);
+
+        if (role == null) {
+            throw ZMSUtils.requestError("Invalid role name specified", caller);
+        }
+
+        // if the group has a self-serve option enabled then
+        // we cannot allow resource ownership to be set for members
+
+        if (role.getSelfServe() == Boolean.TRUE) {
+            resourceOwnership.setMembersOwner(null);
+        }
+
         dbService.executePutResourceRoleOwnership(ctx, domainName, roleName, resourceOwnership, auditRef, caller);
     }
 
@@ -11326,6 +11349,13 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         try {
             resourceOwnership = ResourceOwnership.verifyGroupResourceOwnership(originalGroup,
                     !ZMSUtils.isCollectionEmpty(group.getGroupMembers()), resourceOwner, caller);
+
+            // if the group has a self-serve option enabled then
+            // we cannot allow resource ownership to be set for members
+
+            if (resourceOwnership != null && group.getSelfServe() == Boolean.TRUE) {
+                resourceOwnership.setMembersOwner(null);
+            }
         } catch (ServerResourceException ex) {
             throw ZMSUtils.error(ex);
         }
@@ -12347,6 +12377,22 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         domainName = domainName.toLowerCase();
         setRequestDomain(ctx, domainName);
         groupName = groupName.toLowerCase();
+
+        // extract our group object to get its attributes
+
+        AthenzDomain domain = getAthenzDomain(domainName, false);
+        Group group = getGroupFromDomain(groupName, domain);
+
+        if (group == null) {
+            throw ZMSUtils.requestError("Invalid group name specified", caller);
+        }
+
+        // if the group has a self-serve option enabled then
+        // we cannot allow resource ownership to be set for members
+
+        if (group.getSelfServe() == Boolean.TRUE) {
+            resourceOwnership.setMembersOwner(null);
+        }
 
         dbService.executePutResourceGroupOwnership(ctx, domainName, groupName, resourceOwnership, auditRef, caller);
     }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ServerResourceOwnershipTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ServerResourceOwnershipTest.java
@@ -16,11 +16,15 @@
 package com.yahoo.athenz.zms;
 
 import com.yahoo.athenz.common.server.ServerResourceException;
+import com.yahoo.athenz.common.server.store.AthenzDomain;
 import com.yahoo.athenz.common.server.store.ObjectStore;
 import com.yahoo.athenz.common.server.store.impl.JDBCConnection;
+import com.yahoo.athenz.common.server.util.ResourceUtils;
+import com.yahoo.rdl.Timestamp;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -325,6 +329,16 @@ public class ServerResourceOwnershipTest {
         role = zmsImpl.getRole(ctx, domainName, roleName, null, null, null);
         assertNull(role.getResourceOwnership());
 
+        // calling with an invalid role name should throw an invalid request exception
+
+        try {
+            zmsImpl.putResourceRoleOwnership(ctx, domainName, "invalid-role-name", auditRef, resourceOwnership);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Invalid role name specified"));
+        }
+
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }
 
@@ -342,6 +356,12 @@ public class ServerResourceOwnershipTest {
                 .setMetaOwner("UI").setMembersOwner("MDS");
 
         Mockito.when(mockJdbcConn.getDomain(domainName)).thenReturn(new Domain().setName(domainName));
+        AthenzDomain athenzDomain = new AthenzDomain(domainName);
+        athenzDomain.setDomain(new Domain().setName(domainName).setModified(Timestamp.fromCurrentTime()));
+        Role role = new Role().setName(ResourceUtils.roleResourceName(domainName, roleName));
+        athenzDomain.setRoles(new ArrayList<>());
+        athenzDomain.getRoles().add(role);
+        Mockito.when(mockJdbcConn.getAthenzDomain(domainName)).thenReturn(athenzDomain);
         Mockito.when(mockJdbcConn.setResourceRoleOwnership(domainName, roleName, resourceOwnership))
                 .thenThrow(new ResourceException(410));
 
@@ -375,6 +395,12 @@ public class ServerResourceOwnershipTest {
                 .setMetaOwner("UI").setMembersOwner("MDS");
 
         Mockito.when(mockJdbcConn.getDomain(domainName)).thenReturn(new Domain().setName(domainName));
+        AthenzDomain athenzDomain = new AthenzDomain(domainName);
+        athenzDomain.setDomain(new Domain().setName(domainName).setModified(Timestamp.fromCurrentTime()));
+        Role role = new Role().setName(ResourceUtils.roleResourceName(domainName, roleName));
+        athenzDomain.setRoles(new ArrayList<>());
+        athenzDomain.getRoles().add(role);
+        Mockito.when(mockJdbcConn.getAthenzDomain(domainName)).thenReturn(athenzDomain);
         Mockito.when(mockJdbcConn.setResourceRoleOwnership(domainName, roleName, resourceOwnership))
                 .thenReturn(false);
 
@@ -435,6 +461,16 @@ public class ServerResourceOwnershipTest {
         group = zmsImpl.getGroup(ctx, domainName, groupName, null, null);
         assertNull(group.getResourceOwnership());
 
+        // calling with an invalid group name should throw an invalid request exception
+
+        try {
+            zmsImpl.putResourceGroupOwnership(ctx, domainName, "invalid-group-name", auditRef, resourceOwnership);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Invalid group name specified"));
+        }
+
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }
 
@@ -452,6 +488,12 @@ public class ServerResourceOwnershipTest {
                 .setMetaOwner("UI").setMembersOwner("MDS");
 
         Mockito.when(mockJdbcConn.getDomain(domainName)).thenReturn(new Domain().setName(domainName));
+        AthenzDomain athenzDomain = new AthenzDomain(domainName);
+        athenzDomain.setDomain(new Domain().setName(domainName).setModified(Timestamp.fromCurrentTime()));
+        Group group = new Group().setName(ResourceUtils.groupResourceName(domainName, groupName));
+        athenzDomain.setGroups(new ArrayList<>());
+        athenzDomain.getGroups().add(group);
+        Mockito.when(mockJdbcConn.getAthenzDomain(domainName)).thenReturn(athenzDomain);
         Mockito.when(mockJdbcConn.setResourceGroupOwnership(domainName, groupName, resourceOwnership))
                 .thenThrow(new ResourceException(410));
 
@@ -485,6 +527,12 @@ public class ServerResourceOwnershipTest {
                 .setMetaOwner("UI").setMembersOwner("MDS");
 
         Mockito.when(mockJdbcConn.getDomain(domainName)).thenReturn(new Domain().setName(domainName));
+        AthenzDomain athenzDomain = new AthenzDomain(domainName);
+        athenzDomain.setDomain(new Domain().setName(domainName).setModified(Timestamp.fromCurrentTime()));
+        Group group = new Group().setName(ResourceUtils.groupResourceName(domainName, groupName));
+        athenzDomain.setGroups(new ArrayList<>());
+        athenzDomain.getGroups().add(group);
+        Mockito.when(mockJdbcConn.getAthenzDomain(domainName)).thenReturn(athenzDomain);
         Mockito.when(mockJdbcConn.setResourceGroupOwnership(domainName, groupName, resourceOwnership))
                 .thenReturn(false);
 
@@ -2547,6 +2595,141 @@ public class ServerResourceOwnershipTest {
         assertEquals(resourceOwnership.getObjectOwner(), "TF2");
         assertEquals(resourceOwnership.getHostsOwner(), "TF2");
         assertEquals(resourceOwnership.getPublicKeysOwner(), "TF3");
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+    }
+
+    @Test
+    public void testSelfServeRoleMembershipOwnership() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        final String domainName = "role-ownership-self-serve-members";
+        final String roleName = "role1";
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser(), "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        List<RoleMember> roleMembers = new ArrayList<>();
+        roleMembers.add(new RoleMember().setMemberName("user.user1").setActive(true));
+        Role role1 = zmsTestInitializer.createRoleObject(domainName, roleName, null, roleMembers);
+        role1.setSelfServe(true);
+        zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, null, role1);
+
+        Role role = zmsImpl.getRole(ctx, domainName, roleName, null, null, null);
+        assertNull(role.getResourceOwnership());
+
+        // try adding a member with the ownership set which should be allowed
+        // but the ownership must not be set since this is a self-serve role
+
+        Membership mbr = new Membership().setRoleName(roleName).setMemberName("user.user2");
+        zmsImpl.putMembership(ctx, domainName, roleName, "user.user2",
+                auditRef, false, "TF1", mbr);
+
+        // verify that membership ownership is not set since this is a self-serve role
+
+        role = zmsImpl.getRole(ctx, domainName, roleName, null, null, null);
+        ResourceRoleOwnership resourceOwnership = role.getResourceOwnership();
+        assertNull(resourceOwnership);
+
+        // now set the meta for role and verify the new ownership
+
+        resourceOwnership = new ResourceRoleOwnership().setMetaOwner("TF1").setObjectOwner("TF1")
+                        .setMembersOwner("TF1");
+        zmsImpl.putResourceRoleOwnership(ctx, domainName, roleName, auditRef, resourceOwnership);
+
+        // verify that membership ownership is not set since this is a self-serve role
+
+        role = zmsImpl.getRole(ctx, domainName, roleName, null, null, null);
+        resourceOwnership = role.getResourceOwnership();
+        assertNotNull(resourceOwnership);
+        assertEquals(resourceOwnership.getObjectOwner(), "TF1");
+        assertEquals(resourceOwnership.getMetaOwner(), "TF1");
+        assertNull(resourceOwnership.getMembersOwner());
+
+        // now create another role with resource ownership set
+
+        final String roleName2 = "role2";
+        Role role2 = zmsTestInitializer.createRoleObject(domainName, roleName2, null, roleMembers);
+        role2.setSelfServe(true);
+        zmsImpl.putRole(ctx, domainName, roleName2, auditRef, false, "TF1", role2);
+
+        // verify the role does not have any ownership set for members
+
+        role = zmsImpl.getRole(ctx, domainName, roleName2, null, null, null);
+        resourceOwnership = role.getResourceOwnership();
+        assertNotNull(resourceOwnership);
+        assertEquals(resourceOwnership.getObjectOwner(), "TF1");
+        assertEquals(resourceOwnership.getMetaOwner(), "TF1");
+        assertNull(resourceOwnership.getMembersOwner());
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+    }
+
+    @Test
+    public void testSelfServeGroupMembershipOwnership() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        final String domainName = "group-ownership";
+        final String groupName = "group1";
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", zmsTestInitializer.getAdminUser());
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        List<GroupMember> groupMembers = new ArrayList<>();
+        Group group1 = zmsTestInitializer.createGroupObject(domainName, groupName, groupMembers);
+        group1.setSelfServe(true);
+        zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, null, group1);
+
+        Group group = zmsImpl.getGroup(ctx, domainName, groupName, null, null);
+        assertNull(group.getResourceOwnership());
+
+        // try adding a member with the ownership set which should be allowed
+        // but the ownership must not be set since this is a self-serve group
+
+        GroupMembership mbr = new GroupMembership().setMemberName("user.user1").setGroupName(groupName);
+        zmsImpl.putGroupMembership(ctx, domainName, groupName, "user.user1",
+                auditRef, false, "TF1", mbr);
+
+        // verify that membership ownership is not set since this is a self-serve group
+
+        group = zmsImpl.getGroup(ctx, domainName, groupName, null, null);
+        ResourceGroupOwnership resourceOwnership = group.getResourceOwnership();
+        assertNull(resourceOwnership);
+
+        // now set the meta for group and verify the new ownership
+
+        resourceOwnership = new ResourceGroupOwnership().setObjectOwner("TF1")
+                .setMetaOwner("TF1").setMembersOwner("TF1");
+        zmsImpl.putResourceGroupOwnership(ctx, domainName, groupName, auditRef, resourceOwnership);
+
+        group = zmsImpl.getGroup(ctx, domainName, groupName, null, null);
+        resourceOwnership = group.getResourceOwnership();
+        assertNotNull(resourceOwnership);
+        assertEquals(resourceOwnership.getObjectOwner(), "TF1");
+        assertEquals(resourceOwnership.getMetaOwner(), "TF1");
+        assertNull(resourceOwnership.getMembersOwner());
+
+        // now create another group with resource ownership set
+
+        final String groupName2 = "group2";
+        Group group2 = zmsTestInitializer.createGroupObject(domainName, groupName2, groupMembers);
+        group2.setSelfServe(true);
+        zmsImpl.putGroup(ctx, domainName, groupName2, auditRef, false, "TF1", group2);
+
+        // verify the group does not have any ownership set for members
+
+        group = zmsImpl.getGroup(ctx, domainName, groupName2, null, null);
+        resourceOwnership = group.getResourceOwnership();
+        assertNotNull(resourceOwnership);
+        assertEquals(resourceOwnership.getObjectOwner(), "TF1");
+        assertEquals(resourceOwnership.getMetaOwner(), "TF1");
+        assertNull(resourceOwnership.getMembersOwner());
 
         zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
     }


### PR DESCRIPTION
# Description

if you have a role/group marked as self-serve then we have a problem when we set member resource ownership on the role/group (e.g. terraform) since that blocks all other users from adding themselves to the role/group directly which is the actual purpose of self-serve option.

we now always ignore the member ownership bit for roles/group with self-serve option enabled.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

