### PR TITLE
support for per request/principal domain metrics

### DIFF
--- a/libs/java/server_common/conf/server_common.properties
+++ b/libs/java/server_common/conf/server_common.properties
@@ -1,0 +1,20 @@
+# The file contains system properties for Athenz server-common module.
+
+# This property specifies the name of the histogram metric that will be used to
+# record the latency in milliseconds for each API request. The default value is
+# 'athenz_api_request_duration_msecs'. You can override this value to provide
+# a different name for the histogram metric.
+athenz.otel_histogram_name=athenz_api_request_duration_msecs
+
+# This property specifies whether to separate metrics by Athenz domain name.
+# By default, only a single metric is recorded where the request and principal
+# domain names are specified as labels along with the API name, http status code.
+# and the http method. With this default behavior the cardinality of the metrics
+# could result in a large number of time series which could be difficult to manage.
+# By setting this property to true, 3 metrics are generated and reported:
+# {metric-name}_requestDomain - only contains a single attribute - requestDomainName
+# {metric-name}_principalDomain - only contains a single attribute - principalDomainName
+# {metric-name} - contains 3 attributes, httpMethod, apiName and httpStatusCode
+# This will significantly reduce the cardinality of the metrics recorded.
+# The default value is false.
+athenz.otel_separate_domain_metrics=false

--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9419</code.coverage.min>
+    <code.coverage.min>0.9424</code.coverage.min>
   </properties>
 
   <dependencyManagement>
@@ -238,6 +238,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
@@ -34,7 +34,8 @@ public class OpenTelemetryMetricFactory implements MetricFactory {
     private static final String HISTOGRAM_DEFAULT_NAME = "athenz_api_request_duration_msecs";
 
     private static final String HISTOGRAM_NAME = System.getProperty(PROP_HISTOGRAM_NAME, HISTOGRAM_DEFAULT_NAME);
-    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize(), HISTOGRAM_NAME);
+    private static final boolean SEPARATE_DOMAIN_METRICS = Boolean.parseBoolean(System.getProperty("athenz.otel_separate_domain_metrics", "false"));
+    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize(), HISTOGRAM_NAME, SEPARATE_DOMAIN_METRICS);
 
     @Override
     public Metric create() {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
@@ -38,6 +38,7 @@ public class MetricsTest {
         metric.increment("metric1", "athenz", "sports", 3);
         metric.increment("metric1", 1, "athenz", "sports", "api");
         metric.increment("apiRquestsMetric", "athenz", "sports", "POST", 200, "caller");
+        metric.setGauge("metric1", "athenz", "sports", 10);
 
         String[] attributes = new String[] {
                 "tag1", "value1",


### PR DESCRIPTION
# Description

 By default, only a single metric is recorded where the request and principal domain names are specified as labels along with the API name, http status code, and the http method. With this default behavior the cardinality of the metrics could result in a large number of time series which could be difficult to manage. By setting this property to true, 3 metrics are generated and reported:

-  {metric-name}_requestDomain - only contains a single attribute - requestDomainName
-  {metric-name}_principalDomain - only contains a single attribute - principalDomainName
-  {metric-name} - contains 3 attributes, httpMethod, apiName and httpStatusCode

This will significantly reduce the cardinality of the metrics recorded.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

