### PR TITLE
support for per request/principal domain metrics

### DIFF
--- a/libs/java/server_common/conf/server_common.properties
+++ b/libs/java/server_common/conf/server_common.properties
@@ -1,0 +1,20 @@
+# The file contains system properties for Athenz server-common module.
+
+# This property specifies the name of the histogram metric that will be used to
+# record the latency in milliseconds for each API request. The default value is
+# 'athenz_api_request_duration_msecs'. You can override this value to provide
+# a different name for the histogram metric.
+athenz.otel_histogram_name=athenz_api_request_duration_msecs
+
+# This property specifies whether to separate metrics by Athenz domain name.
+# By default, only a single metric is recorded where the request and principal
+# domain names are specified as labels along with the API name, http status code.
+# and the http method. With this default behavior the cardinality of the metrics
+# could result in a large number of time series which could be difficult to manage.
+# By setting this property to true, 3 metrics are generated and reported:
+# {metric-name}_requestDomain - only contains a single attribute - requestDomainName
+# {metric-name}_principalDomain - only contains a single attribute - principalDomainName
+# {metric-name} - contains 3 attributes, httpMethod, apiName and httpStatusCode
+# This will significantly reduce the cardinality of the metrics recorded.
+# The default value is false.
+athenz.otel_separate_domain_metrics=false

--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9419</code.coverage.min>
+    <code.coverage.min>0.9425</code.coverage.min>
   </properties>
 
   <dependencyManagement>
@@ -238,6 +238,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetric.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetric.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.common.Attributes;
+import org.eclipse.jetty.util.StringUtil;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class OpenTelemetryMetric implements Metric {
     final Meter meter;
     final DoubleHistogram histogram;
+    boolean separateDomainMetrics;
 
     private static final String TIMER_METRIC_NAME = "timerMetricName";
     private static final String REQUEST_DOMAIN_NAME = "requestDomainName";
@@ -40,58 +42,81 @@ public class OpenTelemetryMetric implements Metric {
     private static final String API_NAME = "apiName";
     private final Map<String, LongCounter> counters = new ConcurrentHashMap<>();
     private final Map<String, LongGauge> gaugeCounter = new ConcurrentHashMap<>();
-    public OpenTelemetryMetric(OpenTelemetry openTelemetry, final String histogramName) {
+
+    public OpenTelemetryMetric(OpenTelemetry openTelemetry, final String histogramName, boolean separateDomainMetrics) {
         meter = openTelemetry.getMeter("meter");
         histogram = meter.histogramBuilder(histogramName).build();
+        this.separateDomainMetrics = separateDomainMetrics;
     }
 
     @Override
     public void increment(String metric) {
-        LongCounter counter =  counters.computeIfAbsent(metric, name -> meter.counterBuilder(metric).build());
-        counter.add(1);
+        increment(metric, null, null, null, -1, null, 1);
     }
 
     @Override
     public void increment(String metric, String requestDomainName) {
-        increment(metric, requestDomainName, 1);
+        increment(metric, requestDomainName, null, null, -1, null, 1);
     }
 
     @Override
     public void increment(String metric, String requestDomainName, int count) {
-        LongCounter counter = counters.computeIfAbsent(metric, name -> meter.counterBuilder(metric).build());
-        Attributes attributes = Attributes.builder()
-                .put(REQUEST_DOMAIN_NAME, requestDomainName)
-                .build();
-        counter.add(count, attributes);
+        increment(metric, requestDomainName, null, null, -1, null, count);
     }
 
     @Override
     public void increment(String metric, String requestDomainName, String principalDomainName) {
-        increment(metric, requestDomainName, principalDomainName, 1);
+        increment(metric, requestDomainName, principalDomainName, null, -1, null, 1);
     }
 
     @Override
     public void increment(String metric, String requestDomainName, String principalDomainName, String httpMethod,
-                          int httpStatus, String apiName) {
-        LongCounter counter = counters.computeIfAbsent(metric, name -> meter.counterBuilder(metric).build());
-        Attributes attributes = Attributes.builder()
-                .put(REQUEST_DOMAIN_NAME, requestDomainName)
-                .put(PRINCIPAL_DOMAIN_NAME, principalDomainName)
-                .put(HTTP_METHOD_NAME, httpMethod)
-                .put(HTTP_STATUS, Integer.toString(httpStatus))
-                .put(API_NAME, apiName)
-                .build();
-        counter.add(1, attributes);
+            int httpStatus, String apiName) {
+        increment(metric, requestDomainName, principalDomainName, httpMethod, httpStatus, apiName, 1);
     }
 
     @Override
     public void increment(String metric, String requestDomainName, String principalDomainName, int count) {
+        increment(metric, requestDomainName, principalDomainName, null, -1, null, count);
+    }
+
+    void increment(final String metric, final String requestDomainName, final String principalDomainName,
+            final String httpMethod, int httpStatus, final String apiName, int count) {
+        if (separateDomainMetrics) {
+            if (!StringUtil.isEmpty(requestDomainName)) {
+                incrementSingleMetric(metric + "_requestDomain", requestDomainName, null, null, -1, null, count);
+            }
+            if (!StringUtil.isEmpty(principalDomainName)) {
+                incrementSingleMetric(metric + "_principalDomain", null, principalDomainName, null, -1, null, count);
+            }
+            incrementSingleMetric(metric, null, null, httpMethod, httpStatus, apiName, count);
+        } else {
+            incrementSingleMetric(metric, requestDomainName, principalDomainName, httpMethod, httpStatus, apiName, count);
+        }
+    }
+
+    void incrementSingleMetric(final String metric, final String requestDomainName, final String principalDomainName,
+            final String httpMethod, final int httpStatus, final String apiName, final int count) {
         LongCounter counter = counters.computeIfAbsent(metric, name -> meter.counterBuilder(metric).build());
-        Attributes attributes = Attributes.builder()
-                .put(REQUEST_DOMAIN_NAME, requestDomainName)
-                .put(PRINCIPAL_DOMAIN_NAME, principalDomainName)
-                .build();
-        counter.add(count, attributes);
+        AttributesBuilder builder = Attributes.builder();
+        addAttributeIfNotNull(builder, REQUEST_DOMAIN_NAME, requestDomainName);
+        addAttributeIfNotNull(builder, PRINCIPAL_DOMAIN_NAME, principalDomainName);
+        addAttributeIfNotNull(builder, HTTP_METHOD_NAME, httpMethod);
+        addAttributeIfNotNull(builder, API_NAME, apiName);
+        addAttributeIfNotMinusOne(builder, HTTP_STATUS, httpStatus);
+        counter.add(count, builder.build());
+    }
+
+    void addAttributeIfNotNull(AttributesBuilder builder, String key, String value) {
+        if (!StringUtil.isEmpty(value)) {
+            builder.put(key, value);
+        }
+    }
+
+    void addAttributeIfNotMinusOne(AttributesBuilder builder, String key, int value) {
+        if (value != -1) {
+            builder.put(key, Integer.toString(value));
+        }
     }
 
     @Override
@@ -143,19 +168,31 @@ public class OpenTelemetryMetric implements Metric {
                            String httpMethod, int httpStatus, String apiName) {
         Timer timer = (Timer) timerMetric;
         long duration = System.currentTimeMillis() - timer.getStart();
-        AttributesBuilder builder = Attributes.builder()
-                .put(TIMER_METRIC_NAME, timer.getMetricName())
-                .put(REQUEST_DOMAIN_NAME, requestDomainName)
-                .put(PRINCIPAL_DOMAIN_NAME, principalDomainName);
-        if (httpMethod != null) {
-            builder.put(HTTP_METHOD_NAME, httpMethod);
+        final String metricName = timer.getMetricName();
+        if (separateDomainMetrics) {
+            if (!StringUtil.isEmpty(requestDomainName)) {
+                stopTimingSingleMetric(metricName + "_requestDomain", duration, requestDomainName,
+                        null, null, -1, null);
+            }
+            if (!StringUtil.isEmpty(principalDomainName)) {
+                stopTimingSingleMetric(metricName + "_principalDomain", duration, null,
+                        principalDomainName, null, -1, null);
+            }
+            stopTimingSingleMetric(metricName, duration, null, null, httpMethod, httpStatus, apiName);
+        } else {
+            stopTimingSingleMetric(metricName, duration, requestDomainName,
+                    principalDomainName, httpMethod, httpStatus, apiName);
         }
-        if (httpStatus != -1) {
-            builder.put(HTTP_STATUS, Integer.toString(httpStatus));
-        }
-        if (apiName != null) {
-            builder.put(API_NAME, apiName);
-        }
+    }
+
+    void stopTimingSingleMetric(final String metricName, long duration, final String requestDomainName,
+            final String principalDomainName, final String httpMethod, int httpStatus, final String apiName) {
+        AttributesBuilder builder = Attributes.builder().put(TIMER_METRIC_NAME, metricName);
+        addAttributeIfNotNull(builder, REQUEST_DOMAIN_NAME, requestDomainName);
+        addAttributeIfNotNull(builder, PRINCIPAL_DOMAIN_NAME, principalDomainName);
+        addAttributeIfNotNull(builder, HTTP_METHOD_NAME, httpMethod);
+        addAttributeIfNotNull(builder, API_NAME, apiName);
+        addAttributeIfNotMinusOne(builder, HTTP_STATUS, httpStatus);
         histogram.record(duration, builder.build());
     }
 

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
@@ -34,7 +34,8 @@ public class OpenTelemetryMetricFactory implements MetricFactory {
     private static final String HISTOGRAM_DEFAULT_NAME = "athenz_api_request_duration_msecs";
 
     private static final String HISTOGRAM_NAME = System.getProperty(PROP_HISTOGRAM_NAME, HISTOGRAM_DEFAULT_NAME);
-    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize(), HISTOGRAM_NAME);
+    private static final boolean SEPARATE_DOMAIN_METRICS = Boolean.parseBoolean(System.getProperty("athenz.otel_separate_domain_metrics", "false"));
+    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize(), HISTOGRAM_NAME, SEPARATE_DOMAIN_METRICS);
 
     @Override
     public Metric create() {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/MetricsTest.java
@@ -38,6 +38,7 @@ public class MetricsTest {
         metric.increment("metric1", "athenz", "sports", 3);
         metric.increment("metric1", 1, "athenz", "sports", "api");
         metric.increment("apiRquestsMetric", "athenz", "sports", "POST", 200, "caller");
+        metric.setGauge("metric1", "athenz", "sports", 10);
 
         String[] attributes = new String[] {
                 "tag1", "value1",


### PR DESCRIPTION
# Description

 By default, only a single metric is recorded where the request and principal domain names are specified as labels along with the API name, http status code, and the http method. With this default behavior the cardinality of the metrics could result in a large number of time series which could be difficult to manage. By setting this property to true, 3 metrics are generated and reported:

-  {metric-name}_requestDomain - only contains a single attribute - requestDomainName
-  {metric-name}_principalDomain - only contains a single attribute - principalDomainName
-  {metric-name} - contains 3 attributes, httpMethod, apiName and httpStatusCode

This will significantly reduce the cardinality of the metrics recorded.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

