### PR TITLE
make auth-history object fields optional

### DIFF
--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -6468,27 +6468,27 @@ type AuthHistory struct {
 	//
 	// Name of the domain from URI
 	//
-	UriDomain DomainName `json:"uriDomain"`
+	UriDomain DomainName `json:"uriDomain,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// Principal domain
 	//
-	PrincipalDomain DomainName `json:"principalDomain"`
+	PrincipalDomain DomainName `json:"principalDomain,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// Principal name
 	//
-	PrincipalName SimpleName `json:"principalName"`
+	PrincipalName SimpleName `json:"principalName,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// Last authorization event timestamp
 	//
-	Timestamp rdl.Timestamp `json:"timestamp"`
+	Timestamp *rdl.Timestamp `json:"timestamp,omitempty" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// Last authorization endpoint used
 	//
-	Endpoint string `json:"endpoint"`
+	Endpoint string `json:"endpoint" rdl:"optional" yaml:",omitempty"`
 
 	//
 	// Time until the record will expire
@@ -6523,36 +6523,25 @@ func (self *AuthHistory) UnmarshalJSON(b []byte) error {
 
 // Validate - checks for missing required fields, etc
 func (self *AuthHistory) Validate() error {
-	if self.UriDomain == "" {
-		return fmt.Errorf("AuthHistory.uriDomain is missing but is a required field")
-	} else {
+	if self.UriDomain != "" {
 		val := rdl.Validate(ZMSSchema(), "DomainName", self.UriDomain)
 		if !val.Valid {
 			return fmt.Errorf("AuthHistory.uriDomain does not contain a valid DomainName (%v)", val.Error)
 		}
 	}
-	if self.PrincipalDomain == "" {
-		return fmt.Errorf("AuthHistory.principalDomain is missing but is a required field")
-	} else {
+	if self.PrincipalDomain != "" {
 		val := rdl.Validate(ZMSSchema(), "DomainName", self.PrincipalDomain)
 		if !val.Valid {
 			return fmt.Errorf("AuthHistory.principalDomain does not contain a valid DomainName (%v)", val.Error)
 		}
 	}
-	if self.PrincipalName == "" {
-		return fmt.Errorf("AuthHistory.principalName is missing but is a required field")
-	} else {
+	if self.PrincipalName != "" {
 		val := rdl.Validate(ZMSSchema(), "SimpleName", self.PrincipalName)
 		if !val.Valid {
 			return fmt.Errorf("AuthHistory.principalName does not contain a valid SimpleName (%v)", val.Error)
 		}
 	}
-	if self.Timestamp.IsZero() {
-		return fmt.Errorf("AuthHistory: Missing required field: timestamp")
-	}
-	if self.Endpoint == "" {
-		return fmt.Errorf("AuthHistory.endpoint is missing but is a required field")
-	} else {
+	if self.Endpoint != "" {
 		val := rdl.Validate(ZMSSchema(), "String", self.Endpoint)
 		if !val.Valid {
 			return fmt.Errorf("AuthHistory.endpoint does not contain a valid String (%v)", val.Error)

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -650,11 +650,11 @@ func init() {
 	sb.AddType(tDomainMetaStoreValidValuesList.Build())
 
 	tAuthHistory := rdl.NewStructTypeBuilder("Struct", "AuthHistory")
-	tAuthHistory.Field("uriDomain", "DomainName", false, nil, "Name of the domain from URI")
-	tAuthHistory.Field("principalDomain", "DomainName", false, nil, "Principal domain")
-	tAuthHistory.Field("principalName", "SimpleName", false, nil, "Principal name")
-	tAuthHistory.Field("timestamp", "Timestamp", false, nil, "Last authorization event timestamp")
-	tAuthHistory.Field("endpoint", "String", false, nil, "Last authorization endpoint used")
+	tAuthHistory.Field("uriDomain", "DomainName", true, nil, "Name of the domain from URI")
+	tAuthHistory.Field("principalDomain", "DomainName", true, nil, "Principal domain")
+	tAuthHistory.Field("principalName", "SimpleName", true, nil, "Principal name")
+	tAuthHistory.Field("timestamp", "Timestamp", true, nil, "Last authorization event timestamp")
+	tAuthHistory.Field("endpoint", "String", true, nil, "Last authorization endpoint used")
 	tAuthHistory.Field("ttl", "Int64", false, nil, "Time until the record will expire")
 	sb.AddType(tAuthHistory.Build())
 

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/AuthHistory.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/AuthHistory.java
@@ -4,6 +4,7 @@
 
 package com.yahoo.athenz.zms;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yahoo.rdl.*;
 
 //
@@ -11,10 +12,20 @@ import com.yahoo.rdl.*;
 //
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AuthHistory {
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String uriDomain;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String principalDomain;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String principalName;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Timestamp timestamp;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String endpoint;
     public long ttl;
 

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -565,11 +565,11 @@ public class ZMSSchema {
             .arrayField("validValues", "String", false, "list of valid values for attribute");
 
         sb.structType("AuthHistory")
-            .field("uriDomain", "DomainName", false, "Name of the domain from URI")
-            .field("principalDomain", "DomainName", false, "Principal domain")
-            .field("principalName", "SimpleName", false, "Principal name")
-            .field("timestamp", "Timestamp", false, "Last authorization event timestamp")
-            .field("endpoint", "String", false, "Last authorization endpoint used")
+            .field("uriDomain", "DomainName", true, "Name of the domain from URI")
+            .field("principalDomain", "DomainName", true, "Principal domain")
+            .field("principalName", "SimpleName", true, "Principal name")
+            .field("timestamp", "Timestamp", true, "Last authorization event timestamp")
+            .field("endpoint", "String", true, "Last authorization endpoint used")
             .field("ttl", "Int64", false, "Time until the record will expire");
 
         sb.structType("AuthHistoryDependencies")

--- a/core/zms/src/main/rdl/Domain.rdli
+++ b/core/zms/src/main/rdl/Domain.rdli
@@ -307,11 +307,11 @@ resource DomainMetaStoreValidValuesList GET "/domain/metastore?attribute={attrib
 }
 
 type AuthHistory Struct {
-    DomainName uriDomain; // Name of the domain from URI
-    DomainName principalDomain; // Principal domain
-    SimpleName principalName; // Principal name
-    Timestamp timestamp; // Last authorization event timestamp
-    String endpoint; // Last authorization endpoint used
+    DomainName uriDomain (optional); // Name of the domain from URI
+    DomainName principalDomain (optional); // Principal domain
+    SimpleName principalName (optional); // Principal name
+    Timestamp timestamp (optional); // Last authorization event timestamp
+    String endpoint (optional); // Last authorization endpoint used
     Int64 ttl; // Time until the record will expire
 }
 


### PR DESCRIPTION
# Description

If for any reason the auth history record stored in the supported storage store (e.g. ddb) does not have all the fields specified, any application using the zms go client library will fail to retrieve and parse the result since all the fields in the record as set as required. To provide better flexibility, the fields have been set as optional.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

