### PR TITLE
provide option to skip error metrics

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -610,3 +610,9 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 
 # A flag indicating whether to automatically delete the tenant assume role assertions when the provider role is deleted.
 #athenz.zms.auto_delete_tenant_assume_role_assertions=false
+
+# A flag indicating whether to skip reporting error metrics. By default, the server reports
+# error metrics with name format: ERROR, error_{error_code}, and {caller}_error_{error_code}.
+# Setting this property to true well disable reporting these metrics to skip unnecessary
+# metrics if the administrator is never looking at them. The default value is false.
+#athenz.zms.skip_error_metrics=false

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -78,6 +78,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_DOMAIN_CONTACT_TYPES    = "athenz.zms.domain_contact_types";
     public static final String ZMS_PROP_DOMAIN_ENVIRONMENTS     = "athenz.zms.domain_environments";
     public static final String ZMS_DEFAULT_DOMAIN_ENVIRONMENTS  = "production,integration,staging,sandbox,qa,development";
+    public static final String ZMS_PROP_SKIP_ERROR_METRICS      = "athenz.zms.skip_error_metrics";
 
     public static final String ZMS_PROP_DEFAULT_MAX_USER_EXPIRY  = "athenz.zms.default_max_user_expiry_days";
     public static final String ZMS_PROP_DEFAULT_MAX_SERVICE_EXPIRY  = "athenz.zms.default_max_service_expiry_days";

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -851,3 +851,9 @@ athenz.zts.k8s_provider_distribution_validator_factory_class=com.yahoo.athenz.in
 # the authorization is carried out against the principal but then each
 # endpoint carries out the necessary role based checks.
 #athenz.zts.role_based_authz_support=false
+
+# A flag indicating whether to skip reporting error metrics. By default, the server reports
+# error metrics with name format: ERROR, error_{error_code}, and {caller}_error_{error_code}.
+# Setting this property to true well disable reporting these metrics to skip unnecessary
+# metrics if the administrator is never looking at them. The default value is false.
+#athenz.zts.skip_error_metrics=false

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -54,6 +54,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_READ_ONLY_MODE         = "athenz.zts.read_only_mode";
     public static final String ZTS_PROP_HEALTH_CHECK_PATH      = "athenz.zts.health_check_path";
     public static final String ZTS_PROP_SERVER_REGION          = "athenz.zts.server_region";
+    public static final String ZTS_PROP_SKIP_ERROR_METRICS     = "athenz.zts.skip_error_metrics";
 
     public static final String ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT             = "athenz.zts.aws_creds_cache_timeout";
     public static final String ZTS_PROP_AWS_CREDS_INVALID_CACHE_TIMEOUT     = "athenz.zts.aws_creds_invalid_cache_timeout";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -64,8 +64,12 @@ public class ZTSUtils {
     public static final List<String> ZTS_CERT_DNS_SUFFIX = Arrays.asList(
             System.getProperty(ZTSConsts.ZTS_PROP_CERT_DNS_SUFFIX, ZTSConsts.ZTS_CERT_DNS_SUFFIX).split(","));
 
-    public static final long CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY = Long.parseLong(System.getProperty(ZTSConsts.ZTS_PROP_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY, ZTSConsts.ZTS_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY_DEFAULT));
-    public static final long CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY = Long.parseLong(System.getProperty(ZTSConsts.ZTS_PROP_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY, ZTSConsts.ZTS_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY_DEFAULT));
+    public static final long CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY = Long.parseLong(System.getProperty(
+            ZTSConsts.ZTS_PROP_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY, ZTSConsts.ZTS_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY_DEFAULT));
+    public static final long CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY = Long.parseLong(System.getProperty(
+            ZTSConsts.ZTS_PROP_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY, ZTSConsts.ZTS_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY_DEFAULT));
+    private static final boolean SKIP_ERROR_METRICS = Boolean.parseBoolean(System.getProperty(
+            ZTSConsts.ZTS_PROP_SKIP_ERROR_METRICS, "false"));
 
     private static final String ATHENZ_PROP_KEYSTORE_PATH                    = "athenz.ssl_key_store";
     private static final String ATHENZ_PROP_KEYSTORE_TYPE                    = "athenz.ssl_key_store_type";
@@ -166,10 +170,7 @@ public class ZTSUtils {
     public static boolean emitMonmetricError(int errorCode, String caller,
             String requestDomain, String principalDomain, Metric metric) {
 
-        if (errorCode < 1) {
-            return false;
-        }
-        if (StringUtil.isEmpty(caller)) {
+        if (SKIP_ERROR_METRICS || errorCode < 1 || StringUtil.isEmpty(caller)) {
             return false;
         }
 


### PR DESCRIPTION
# Description

By default, the zts and zms servers report error metrics with name format: ERROR, error_{error_code}, and {caller}_error_{error_code} any time there is a failure. However, if the administrator is not looking at these metrics, they're just wasted and there is no point of generating these metrics.

We now have a per service property setting that if set to true well disable reporting these metrics. The default value is false to maintain current functionality

athenz.zms.skip_error_metrics=false
athenz.zts.skip_error_metrics=false

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

