### PR TITLE
Make ZpeUpdPolLoader ScheduledExecutorService thread daemon

### DIFF
--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdPolLoader.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdPolLoader.java
@@ -83,7 +83,12 @@ public class ZpeUpdPolLoader implements Closeable {
     // find the java7 api for monitoring files
     // see http://docs.oracle.com/javase/tutorial/essential/io/notification.html
 
-    private final ScheduledExecutorService scheduledExecutorSvc = Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService scheduledExecutorSvc = Executors.newScheduledThreadPool(1, r -> {
+        Thread t = new Thread(r, "ZpeUpdPolLoader-scheduler-" + System.identityHashCode(r));
+        t.setDaemon(true);
+        return t;
+    });
+
     private ZpeUpdMonitor updMonWorker;
 
     // key is the domain name, value is a map keyed by role name with list of assertions


### PR DESCRIPTION
# Description

## Background

In our services, we frequently call the static method `AuthZpeClient.allowAccess` to determine whether access is allowed. The underlying `ZpeClient` which it relies on is initialized in `AuthZpeClient`'s  static block, so callers typically don’t pay attention to its initialization lifecycle.

`ZpeClient` (implemented by ZpeUpdater) depends on the `ZpeUpdPolLoader` instance. `ZpeUpdPolLoader` automatically creates a `ScheduledExecutorService`, which currently does not shut down automatically on process exit; it requires an explicit `close()` call from the caller. Recently, we observed that this executor remained alive during shutdown, which blocked Tomcat’s graceful exit.


## Pain point

The pain point is that when using the static allowAccess API, client code performs no initialization and is therefore unlikely to realize it must invoke close() to cascade the shutdown and release the underlying `ScheduledExecutorService`. This leads to negative impact on the service shutdown path.

## Proposal

To prevent threads created by `ZpeUpdPolLoader` from blocking Tomcat’s graceful shutdown, set them as daemon threads and give them explicit names to make troubleshooting easier.


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

#3085 
