### PR TITLE
make otel metric options more configurable

### DIFF
--- a/libs/java/server_common/conf/server_common.properties
+++ b/libs/java/server_common/conf/server_common.properties
@@ -21,7 +21,7 @@ athenz.otel_histogram_name=athenz_api_request_duration_msecs
 # The default value is false.
 athenz.otel_separate_domain_histogram_metrics=false
 
-# This property furthers reduces the cardinality of the histogram metrics
+# This property further reduces the cardinality of the histogram metrics
 # by skipping the recording of the requestDomain and principalDomain metrics.
 # To enable this property, you must first set the athenz.otel_separate_domain_histogram_metrics
 # property to true. Once enabled, only the {metric-name} metric will be recorded
@@ -43,7 +43,7 @@ athenz.otel_skip_domain_histogram_metrics=true
 # The default value is false.
 athenz.otel_separate_domain_counter_metrics=false
 
-# This property furthers reduces the cardinality of the counter metrics
+# This property further reduces the cardinality of the counter metrics
 # by skipping the recording of the requestDomain and principalDomain metrics.
 # To enable this property, you must first set the athenz.otel_separate_domain_counter_metrics
 # property to true. Once enabled, only the {metric-name} metric will be recorded

--- a/libs/java/server_common/conf/server_common.properties
+++ b/libs/java/server_common/conf/server_common.properties
@@ -6,15 +6,47 @@
 # a different name for the histogram metric.
 athenz.otel_histogram_name=athenz_api_request_duration_msecs
 
-# This property specifies whether to separate metrics by Athenz domain name.
+# This property specifies whether to separate metrics by Athenz domain name
+# in the histogram metrics recording API request latencies.
 # By default, only a single metric is recorded where the request and principal
 # domain names are specified as labels along with the API name, http status code.
 # and the http method. With this default behavior the cardinality of the metrics
 # could result in a large number of time series which could be difficult to manage.
-# By setting this property to true, 3 metrics are generated and reported:
+# By setting this property to true, 3 metrics are generated and reported in the
+# configured histogram metric:
 # {metric-name}_requestDomain - only contains a single attribute - requestDomainName
 # {metric-name}_principalDomain - only contains a single attribute - principalDomainName
 # {metric-name} - contains 3 attributes, httpMethod, apiName and httpStatusCode
 # This will significantly reduce the cardinality of the metrics recorded.
 # The default value is false.
-athenz.otel_separate_domain_metrics=false
+athenz.otel_separate_domain_histogram_metrics=false
+
+# This property furthers reduces the cardinality of the histogram metrics
+# by skipping the recording of the requestDomain and principalDomain metrics.
+# To enable this property, you must first set the athenz.otel_separate_domain_histogram_metrics
+# property to true. Once enabled, only the {metric-name} metric will be recorded
+# with the 3 attributes, httpMethod, apiName and httpStatusCode in the histogram.
+# The default value is true.
+athenz.otel_skip_domain_histogram_metrics=true
+
+# This property specifies whether to separate metrics by Athenz domain name
+# in the counter metrics recording API request counts.
+# By default, only a single metric is recorded where the request and principal
+# domain names are specified as labels along with the API name, http status code.
+# and the http method. With this default behavior the cardinality of the metrics
+# could result in a large number of time series which could be difficult to manage.
+# By setting this property to true, 3 separate metrics are generated and reported:
+# {metric-name}_requestDomain - only contains a single attribute - requestDomainName
+# {metric-name}_principalDomain - only contains a single attribute - principalDomainName
+# {metric-name} - contains 3 attributes, httpMethod, apiName and httpStatusCode
+# This will significantly reduce the cardinality of the metrics recorded.
+# The default value is false.
+athenz.otel_separate_domain_counter_metrics=false
+
+# This property furthers reduces the cardinality of the counter metrics
+# by skipping the recording of the requestDomain and principalDomain metrics.
+# To enable this property, you must first set the athenz.otel_separate_domain_counter_metrics
+# property to true. Once enabled, only the {metric-name} metric will be recorded
+# with the 3 attributes, httpMethod, apiName and httpStatusCode in the counter.
+# The default value is false.
+athenz.otel_skip_domain_counter_metrics=false

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricFactory.java
@@ -34,8 +34,17 @@ public class OpenTelemetryMetricFactory implements MetricFactory {
     private static final String HISTOGRAM_DEFAULT_NAME = "athenz_api_request_duration_msecs";
 
     private static final String HISTOGRAM_NAME = System.getProperty(PROP_HISTOGRAM_NAME, HISTOGRAM_DEFAULT_NAME);
-    private static final boolean SEPARATE_DOMAIN_METRICS = Boolean.parseBoolean(System.getProperty("athenz.otel_separate_domain_metrics", "false"));
-    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize(), HISTOGRAM_NAME, SEPARATE_DOMAIN_METRICS);
+    private static final boolean SEPARATE_DOMAIN_HISTOGRAM_METRICS = Boolean.parseBoolean(
+            System.getProperty("athenz.otel_separate_domain_histogram_metrics", "false"));
+    private static final boolean SKIP_DOMAIN_HISTOGRAM_METRICS = Boolean.parseBoolean(
+            System.getProperty("athenz.otel_skip_domain_histogram_metrics", "true"));
+    private static final boolean SEPARATE_DOMAIN_COUNTER_METRICS = Boolean.parseBoolean(
+            System.getProperty("athenz.otel_separate_domain_counter_metrics", "false"));
+    private static final boolean SKIP_DOMAIN_COUNTER_METRICS = Boolean.parseBoolean(
+            System.getProperty("athenz.otel_skip_domain_counter_metrics", "false"));
+    private static final OpenTelemetryMetric INSTANCE = new OpenTelemetryMetric(initialize(), HISTOGRAM_NAME,
+            SEPARATE_DOMAIN_HISTOGRAM_METRICS, SKIP_DOMAIN_HISTOGRAM_METRICS,
+            SEPARATE_DOMAIN_COUNTER_METRICS, SKIP_DOMAIN_COUNTER_METRICS);
 
     @Override
     public Metric create() {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/metrics/impl/OpenTelemetryMetricTest.java
@@ -123,7 +123,6 @@ public class OpenTelemetryMetricTest {
 
     @Test
     public void testIncrementAllAttributesWithDomainMetrics() {
-        metric.separateDomainHistogramMetrics = true;
         metric.separateDomainCounterMetrics = true;
         metric.increment("testMetric", "athenz", "sports", "GET", 200, "getMetric");
         ArgumentCaptor<Attributes> captor = ArgumentCaptor.forClass(Attributes.class);
@@ -153,7 +152,6 @@ public class OpenTelemetryMetricTest {
         assertEquals(attributes.get(AttributeKey.stringKey("httpStatus")), "200");
         assertEquals(attributes.get(AttributeKey.stringKey("apiName")), "getMetric");
 
-        metric.separateDomainHistogramMetrics = false;
         metric.separateDomainCounterMetrics = false;
     }
 


### PR DESCRIPTION
# Description

To provide more control over the generated metrics and reduce cardinality issue

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

