### PR TITLE
Disable TRACK and TRACE methods

### DIFF
--- a/containers/jetty/conf/athenz.properties
+++ b/containers/jetty/conf/athenz.properties
@@ -221,3 +221,10 @@ athenz.jetty_home=/home/athenz
 # the server, and you want to see which specific host behind the
 # load balancer is being used to handle the request.
 #athenz.send_host_header=true
+
+# Boolean flag to enable TRACE and TRACK method on Jetty container
+# By default this flag is true means Jetty container will block
+# any TRACE and TRACK traffic at container level. If you want to
+# allow TRACE and TRACK traffic at container level, set this boolean
+# option to false.
+#athenz.disable_trace_track=false

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -102,4 +102,6 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_GRACEFUL_SHUTDOWN_TIMEOUT = "athenz.graceful_shutdown_timeout";
 
     public static final String ATHENZ_PROP_RESPONSE_HEADERS_JSON_DEFAULT = "{ \"Strict-Transport-Security\": \"max-age=31536000; includeSubDomains\" }";
+
+    public static final String ATHENZ_PROP_DISABLE_TRACE_TRACK = "athenz.disable_trace_track";
 }

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -29,6 +29,7 @@ import com.yahoo.athenz.common.server.util.config.providers.ConfigProviderFile;
 import com.yahoo.athenz.container.config.PortConfig;
 import com.yahoo.athenz.container.config.PortUriConfiguration;
 import com.yahoo.athenz.container.config.PortUriConfigurationManager;
+import com.yahoo.athenz.container.filter.DisableTraceFilter;
 import com.yahoo.athenz.container.filter.HealthCheckFilter;
 import jakarta.servlet.DispatcherType;
 import org.eclipse.jetty.deploy.DeploymentManager;
@@ -64,7 +65,7 @@ import java.util.Map;
 import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
 
 public class AthenzJettyContainer {
-    
+
     private static final Logger LOG = LoggerFactory.getLogger(AthenzJettyContainer.class);
     private static String ROOT_DIR;
     private static final String DEFAULT_WEBAPP_DESCRIPTOR = "/etc/webdefault.xml";
@@ -91,7 +92,7 @@ public class AthenzJettyContainer {
 
         loadServicePrivateKey();
     }
-    
+
     Server getServer() {
         return server;
     }
@@ -99,9 +100,9 @@ public class AthenzJettyContainer {
     Handler.Sequence getHandlers() {
         return handlers;
     }
-    
+
     static String getServerHostName() {
-        
+
         String serverHostName = System.getProperty(AthenzConsts.ATHENZ_PROP_HOSTNAME);
         if (StringUtil.isEmpty(serverHostName)) {
             try {
@@ -112,26 +113,26 @@ public class AthenzJettyContainer {
                 serverHostName = "localhost";
             }
         }
-        
+
         return serverHostName;
     }
-    
+
     public static String getRootDir() {
-        
+
         if (ROOT_DIR == null) {
             ROOT_DIR = System.getProperty(AthenzConsts.ATHENZ_PROP_ROOT_DIR, AthenzConsts.STR_DEF_ROOT);
         }
 
         return ROOT_DIR;
     }
-    
+
     public void addRequestLogHandler() {
 
         // check to see if we have a slf4j logger name specified. if we don't
         // then we'll just use our NCSARequestLog extended Athenz logger
         // when using the slf4j logger we don't have the option to pass
         // our audit logger to keep track of unauthenticated requests
-        
+
         String accessSlf4jLogger = System.getProperty(AthenzConsts.ATHENZ_PROP_ACCESS_SLF4J_LOGGER);
         if (!StringUtil.isEmpty(accessSlf4jLogger)) {
 
@@ -185,7 +186,7 @@ public class AthenzJettyContainer {
         // Add response-headers, according to configuration
 
         final String responseHeadersJson = System.getProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON,
-            AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON_DEFAULT);
+                AthenzConsts.ATHENZ_PROP_RESPONSE_HEADERS_JSON_DEFAULT);
         if (!StringUtil.isEmpty(responseHeadersJson)) {
             HashMap<String, String> responseHeaders;
             try {
@@ -296,6 +297,14 @@ public class AthenzJettyContainer {
             }
         }
 
+        // Configurable DisableTraceFilter - when enabled blocks TRACE and TRACK http methods at Jetty Container level
+        // If this property is not set, Default option is to block the TRACE and TRACK method
+        if (Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_DISABLE_TRACE_TRACK, "true"))) {
+            FilterHolder disableTraceFilterHolder = new FilterHolder(DisableTraceFilter.class);
+            servletCtxHandler.addFilter(disableTraceFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+            LOG.info("TRACE/TRACK methods disabled via DisableTraceFilter");
+        }
+
         // PortFilter is applied to all webapps (e.g. ZTS API) via webdefault.xml; no need to add it here.
 
         contexts.addHandler(servletCtxHandler);
@@ -332,14 +341,14 @@ public class AthenzJettyContainer {
         File file = new File(webDefaultXML);
         if (!file.exists()) {
             throw new RuntimeException("webdefault.xml not found in " + webDefaultXML);
-        } 
+        }
         webappProvider.setDefaultsDescriptor(webDefaultXML);
     }
-    
+
     public HttpConfiguration newHttpConfiguration() {
 
         // HTTP Configuration
-        
+
         boolean sendServerVersion = Boolean.parseBoolean(
                 System.getProperty(AthenzConsts.ATHENZ_PROP_SEND_SERVER_VERSION, "false"));
         boolean sendDateHeader = Boolean.parseBoolean(
@@ -350,9 +359,9 @@ public class AthenzJettyContainer {
                 System.getProperty(AthenzConsts.ATHENZ_PROP_REQUEST_HEADER_SIZE, "8192"));
         int responseHeaderSize = Integer.parseInt(
                 System.getProperty(AthenzConsts.ATHENZ_PROP_RESPONSE_HEADER_SIZE, "8192"));
-        
+
         HttpConfiguration httpConfig = new HttpConfiguration();
-        
+
         httpConfig.setOutputBufferSize(outputBufferSize);
         httpConfig.setRequestHeaderSize(requestHeaderSize);
         httpConfig.setResponseHeaderSize(responseHeaderSize);
@@ -361,7 +370,7 @@ public class AthenzJettyContainer {
 
         return httpConfig;
     }
-    
+
     void loadServicePrivateKey() {
         String pkeyFactoryClass = System.getProperty(AthenzConsts.ATHENZ_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS,
                 AthenzConsts.ATHENZ_PKEY_STORE_FACTORY_CLASS);
@@ -374,9 +383,9 @@ public class AthenzJettyContainer {
         }
         this.privateKeyStore = pkeyFactory.create();
     }
-    
+
     SslContextFactory.Server createSSLContextObject(boolean needClientAuth) {
-        
+
         final String keyStorePath = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PATH);
         final String keyStorePasswordAppName = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PASSWORD_APPNAME);
         final String keyStorePasswordKeygroupName = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PASSWORD_KEYGROUPNAME);
@@ -426,15 +435,15 @@ public class AthenzJettyContainer {
         if (!StringUtil.isEmpty(includedCipherSuites)) {
             sslContextFactory.setIncludeCipherSuites(includedCipherSuites.split(","));
         }
-        
+
         if (!StringUtil.isEmpty(excludedCipherSuites)) {
             sslContextFactory.setExcludeCipherSuites(excludedCipherSuites.split(","));
         }
-        
+
         if (!excludedProtocols.isEmpty()) {
             sslContextFactory.setExcludeProtocols(excludedProtocols.split(","));
         }
-        
+
         if (needClientAuth) {
             sslContextFactory.setNeedClientAuth(true);
         } else {
@@ -446,9 +455,9 @@ public class AthenzJettyContainer {
 
         return sslContextFactory;
     }
-    
+
     void addHTTPConnector(HttpConfiguration httpConfig, int httpPort, boolean proxyProtocol,
-            String listenHost, int idleTimeout) {
+                          String listenHost, int idleTimeout) {
 
         ServerConnector connector;
         if (proxyProtocol) {
@@ -463,16 +472,16 @@ public class AthenzJettyContainer {
         connector.setIdleTimeout(idleTimeout);
         server.addConnector(connector);
     }
-    
+
     void addHTTPSConnector(HttpConfiguration httpsConfig, int httpsPort, boolean proxyProtocol,
-            String listenHost, int idleTimeout, boolean needClientAuth, JettyConnectionLogger connectionLogger) {
-        
+                           String listenHost, int idleTimeout, boolean needClientAuth, JettyConnectionLogger connectionLogger) {
+
         // SSL Context Factory
-    
+
         SslContextFactory.Server sslContextFactory = createSSLContextObject(needClientAuth);
 
         // SSL Connector
-        
+
         ServerConnector sslConnector;
         if (proxyProtocol) {
             sslConnector = new ServerConnector(server, new ProxyConnectionFactory(),
@@ -491,7 +500,7 @@ public class AthenzJettyContainer {
         if (connectionLogger != null) {
             sslConnector.addBean(connectionLogger);
         }
-        
+
         // Listen to when HTTP connections open/close/handshake.
 
         sslConnector.addBean(connectionListener);
@@ -525,7 +534,7 @@ public class AthenzJettyContainer {
     }
 
     public void addHTTPConnectors(HttpConfiguration httpConfig, int httpPort, int httpsPort,
-            int oidcPort, int statusPort) {
+                                  int oidcPort, int statusPort) {
 
         int idleTimeout = Integer.parseInt(
                 System.getProperty(AthenzConsts.ATHENZ_PROP_IDLE_TIMEOUT, "30000"));
@@ -566,7 +575,7 @@ public class AthenzJettyContainer {
      * Add HTTP/HTTPS connectors based on port-uri.json configuration
      */
     private void addConnectorsFromPortConfig(PortUriConfiguration config, HttpConfiguration httpConfig,
-            boolean proxyProtocol, String listenHost, int idleTimeout, JettyConnectionLogger connectionLogger) {
+                                             boolean proxyProtocol, String listenHost, int idleTimeout, JettyConnectionLogger connectionLogger) {
 
         for (PortConfig portConfig : config.getPorts()) {
             int port = portConfig.getPort();
@@ -640,11 +649,11 @@ public class AthenzJettyContainer {
     public void setBanner(String banner) {
         this.banner = banner;
     }
-    
+
     public void createServer(int maxThreads) {
-        
+
         // Setup Thread pool
-        
+
         QueuedThreadPool threadPool = new QueuedThreadPool();
         threadPool.setMaxThreads(maxThreads);
 
@@ -652,11 +661,11 @@ public class AthenzJettyContainer {
         handlers = new Handler.Sequence();
         server.setHandler(handlers);
     }
-    
+
     public static AthenzJettyContainer createJettyContainer() {
 
         // retrieve our http and https port numbers
-        
+
         int httpPort = ConfigProperties.getPortNumber(AthenzConsts.ATHENZ_PROP_HTTP_PORT,
                 AthenzConsts.ATHENZ_HTTP_PORT_DEFAULT);
         int httpsPort = ConfigProperties.getPortNumber(AthenzConsts.ATHENZ_PROP_HTTPS_PORT,
@@ -764,9 +773,9 @@ public class AthenzJettyContainer {
             AthenzJettyContainer container = createJettyContainer();
             container.run();
         } catch (Exception exc) {
-            
+
             // log that we are shutting down, re-throw the exception
-            
+
             LOG.error("Startup failure. Shutting down", exc);
             throw exc;
         }

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/DisableTraceFilter.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/DisableTraceFilter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.container.filter;
+
+/*
+ * Servlet filter that blocks HTTP TRACE and TRACK methods by returning
+ * 405 Method Not Allowed.
+ *
+ * CVE-2004-2320, CVE-2010-0386, CVE-2003-1567: TRACE/TRACK methods can be
+ * exploited for cross-site tracing (XST) attacks. This filter is registered
+ * on the root ServletContextHandler in AthenzJettyContainer so it covers all
+ * paths, including those outside any webapp context.
+ *
+ * Enabled via system property {@code athenz.disable_trace_track=true}
+ */
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class DisableTraceFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DisableTraceFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        LOGGER.info("DisableTraceFilter initialized - TRACE/TRACK methods will be blocked");
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
+                         FilterChain chain) throws IOException, ServletException {
+
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String method = request.getMethod();
+        if ("TRACE".equalsIgnoreCase(method) || "TRACK".equalsIgnoreCase(method)) {
+            LOGGER.debug("Blocked {} request to {}", method, request.getRequestURI());
+            response.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/filter/DisableTraceFilterTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/filter/DisableTraceFilterTest.java
@@ -1,0 +1,85 @@
+package com.yahoo.athenz.container.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+public class DisableTraceFilterTest {
+
+    private DisableTraceFilter filter;
+    private HttpServletRequest mockRequest;
+    private HttpServletResponse mockResponse;
+    private FilterChain mockChain;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        filter = new DisableTraceFilter();
+        filter.init(mock(FilterConfig.class));
+
+        mockRequest = mock(HttpServletRequest.class);
+        mockResponse = mock(HttpServletResponse.class);
+        mockChain = mock(FilterChain.class);
+
+    }
+
+    @DataProvider(name = "blockedMethods")
+    public Object[][] blockedMethods() {
+        return new Object[][]{
+                {"TRACE","/"},
+                {"TRACK","/"},
+                {"trace","/"},
+                {"track","/"},
+                {"TRACE","/zts"},
+                {"TRACK","/zts"},
+                {"TRACE","/zts/v1/domain"},
+                {"TRACK","/zts/v1/domain"},
+                {"TRACK","/any/path"}
+        };
+    }
+
+    @Test(dataProvider = "blockedMethods")
+    public void testBlockedMethods(String method, String uri) throws Exception {
+        when(mockRequest.getMethod()).thenReturn(method);
+        when(mockRequest.getRequestURI()).thenReturn(uri);
+
+        filter.doFilter(mockRequest, mockResponse, mockChain);
+
+        verify(mockResponse).setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        verifyNoInteractions(mockChain);
+    }
+
+    @DataProvider(name = "allowedMethods")
+    public Object[][] allowedMethods() {
+        return new Object[][]{
+                {"GET"},
+                {"POST"},
+                {"PUT"},
+                {"DELETE"},
+                {"PATCH"},
+                {"HEAD"},
+                {"OPTIONS"}
+        };
+    }
+
+    @Test(dataProvider = "allowedMethods")
+    public void testAllowedMethods(String method) throws Exception {
+        when(mockRequest.getMethod()).thenReturn(method);
+
+        filter.doFilter(mockRequest, mockResponse, mockChain);
+
+        verify(mockResponse, never()).setStatus(anyInt());
+        verify(mockChain).doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testDestroyNoOp() {
+        //destroy() is a no-op, just verify it doesn't throw error
+        filter.destroy();
+    }
+}


### PR DESCRIPTION
# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

## Summary

Add a configurable servlet filter to block HTTP TRACE and TRACK methods, mitigating Cross-Site Tracing (XST) vulnerabilities. By default this filter is set to true means HTTP TRACE and TRACK will be blocked by default at Jetty container level.

Fixes #3441

## Context

Athenz servers running on Jetty 12 are vulnerable to TRACE/TRACK method attacks. The existing `<security-constraint>` entries in `web.xml` are ineffective because Jetty 12 handles TRACE at the server level before the request reaches the servlet layer. A TRACE request to a running ZMS/ZTS instance returns `200 OK` with the request headers echoed back in the response body, enabling credential theft via XST.

**CVEs addressed:**
- [CVE-2004-2320](https://nvd.nist.gov/vuln/detail/CVE-2004-2320)
- [CVE-2010-0386](https://nvd.nist.gov/vuln/detail/CVE-2010-0386)
- [CVE-2003-1567](https://nvd.nist.gov/vuln/detail/CVE-2003-1567)

## Changes

### New files

- **`containers/jetty/src/main/java/.../filter/DisableTraceFilter.java`** — Servlet filter that returns `405 Method Not Allowed` for TRACE and TRACK requests. All other HTTP methods pass through to the filter chain unchanged.

- **`containers/jetty/src/test/java/.../filter/DisableTraceFilterTest.java`** — Unit tests covering:
  - TRACE and TRACK blocked with 405 on multiple URI paths
  - GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS pass through normally
  - [init()](cci:1://file:///Users/rqv035/git/wip-athenz-zts/athenz/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/DisableTraceFilter.java:44:4-47:5) and [destroy()](cci:1://file:///Users/rqv035/git/wip-athenz-zts/athenz/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/DisableTraceFilter.java:66:4-68:5) lifecycle methods

### Modified files

- **`containers/jetty/conf/etc/athenz.properties`** — Added commented property `athenz.disable_trace_track`.

- **`containers/jetty/src/main/java/.../AthenzConsts.java`** — Added system property constant `athenz.disable_trace_track`.

- **`containers/jetty/src/main/java/.../AthenzJettyContainer.java`** — Register [DisableTraceFilter](cci:2://file:///Users/rqv035/git/wip-athenz-zts/athenz/containers/jetty/src/main/java/com/yahoo/athenz/container/filter/DisableTraceFilter.java:40:0-69:1) on the root `ServletContextHandler` with `/*` path mapping when `athenz.disable_trace_track=true`. Filter is not added when the property is absent or `false`.

## Configuration

By default, athenz.disable_trace_track will be true.
To enable TRACE and TRACK method, set the system property: `-Dathenz.disable_trace_track=false`

## Testing

- All existing tests pass
- New [DisableTraceFilterTest](cci:2://file:///Users/rqv035/git/wip-athenz-zts/athenz/containers/jetty/src/test/java/com/yahoo/athenz/container/filter/DisableTraceFilterTest.java:31:0-101:1) covers blocked and allowed methods with full branch coverage
- Verified manually that TRACE returns 405 when enabled and 200 when disabled


# Contribution Checklist:
- [X] **The pull request does not introduce any breaking changes**
- [X] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request.**

Issue #3441

## Attach Screenshots (Optional) 

