### PR TITLE
usercert: opt-in auto-close countdown on the IdP success page

### DIFF
--- a/libs/go/usercert/html.go
+++ b/libs/go/usercert/html.go
@@ -19,7 +19,11 @@ func closeWindowHTML(closeDelaySeconds int) string {
 	closeMsg := "You may close this window now."
 	closeScript := ""
 	if closeDelaySeconds > 0 {
-		closeMsg = fmt.Sprintf("This window will close in %d seconds.", closeDelaySeconds)
+		unit := "seconds"
+		if closeDelaySeconds == 1 {
+			unit = "second"
+		}
+		closeMsg = fmt.Sprintf("This window will close in %d %s.", closeDelaySeconds, unit)
 		closeScript = fmt.Sprintf(closeWindowScriptTemplate, closeDelaySeconds)
 	}
 	return strings.NewReplacer(

--- a/libs/go/usercert/html.go
+++ b/libs/go/usercert/html.go
@@ -3,7 +3,49 @@
 
 package usercert
 
-const closeWindowHTML = `<!DOCTYPE html>
+import (
+	"fmt"
+	"strings"
+)
+
+// closeWindowHTML returns the HTML page served on the /close endpoint after a
+// successful IdP callback. When closeDelaySeconds > 0 the page shows a live
+// countdown and attempts to close its own tab via window.close() when the
+// countdown reaches zero; otherwise it shows a static "You may close this
+// window now" message. window.close() is best-effort: some browsers only
+// honor it for script-opened tabs, in which case the countdown message simply
+// remains on screen.
+func closeWindowHTML(closeDelaySeconds int) string {
+	closeMsg := "You may close this window now."
+	closeScript := ""
+	if closeDelaySeconds > 0 {
+		closeMsg = fmt.Sprintf("This window will close in %d seconds.", closeDelaySeconds)
+		closeScript = fmt.Sprintf(closeWindowScriptTemplate, closeDelaySeconds)
+	}
+	return strings.NewReplacer(
+		"__CLOSE_MSG__", closeMsg,
+		"__CLOSE_SCRIPT__", closeScript,
+	).Replace(closeWindowHTMLTemplate)
+}
+
+const closeWindowScriptTemplate = `  <script>
+    (function() {
+      var secs = %d;
+      var el = document.getElementById('close-msg');
+      var iv = setInterval(function() {
+        secs--;
+        if (secs <= 0) {
+          clearInterval(iv);
+          window.close();
+        } else {
+          el.textContent = 'This window will close in ' + secs + ' second' + (secs === 1 ? '' : 's') + '.';
+        }
+      }, 1000);
+    })();
+  </script>
+`
+
+const closeWindowHTMLTemplate = `<!DOCTYPE html>
 <html>
 <head>
   <style>
@@ -41,7 +83,7 @@ const closeWindowHTML = `<!DOCTYPE html>
 <body>
   <div class="message-box">
     <b>Authentication successful.</b><br>
-    <span class="small-text">You may close this window now.</span>
+    <span class="small-text" id="close-msg">__CLOSE_MSG__</span>
   </div>
-</body>
+__CLOSE_SCRIPT__</body>
 </html>`

--- a/libs/go/usercert/idp.go
+++ b/libs/go/usercert/idp.go
@@ -100,7 +100,7 @@ func openIdpAuthURL(endPoint, clientId, scope, nonce, state string, callbackPort
 	return nil
 }
 
-func registerHandlers(mux *http.ServeMux, code chan<- string) {
+func registerHandlers(mux *http.ServeMux, code chan<- string, closeDelaySeconds int) {
 	authCode := make(chan string, 1)
 
 	mux.Handle("/oauth2/callback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -110,7 +110,7 @@ func registerHandlers(mux *http.ServeMux, code chan<- string) {
 
 	mux.Handle("/close", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprint(w, closeWindowHTML)
+		fmt.Fprint(w, closeWindowHTML(closeDelaySeconds))
 		select {
 		case c := <-authCode:
 			code <- c
@@ -120,12 +120,12 @@ func registerHandlers(mux *http.ServeMux, code chan<- string) {
 	}))
 }
 
-func getAuthCodeFromCallbackHandler(port, timeoutSeconds int, verbose bool) <-chan authResult {
+func getAuthCodeFromCallbackHandler(port, timeoutSeconds, closeDelaySeconds int, verbose bool) <-chan authResult {
 	result := make(chan authResult, 1)
 	code := make(chan string, 1)
 
 	mux := http.NewServeMux()
-	registerHandlers(mux, code)
+	registerHandlers(mux, code, closeDelaySeconds)
 
 	if verbose {
 		log.Printf("Starting callback server on port %d", port)
@@ -173,8 +173,16 @@ func getAuthCodeFromCallbackHandler(port, timeoutSeconds int, verbose bool) <-ch
 // verifier is returned so the caller can include it in the token exchange.
 // Returns the raw query string containing the code and state, the PKCE code
 // verifier (empty when pkce is false), or an error if the process fails.
+// The success page shows a static close instruction; set Options.CloseWindowDelay
+// and use RequestCertificate to have the page close its own tab after a countdown.
 func GetAuthCode(endPoint, clientId, scope string, callbackPort, timeoutSeconds int, pkce, verbose bool) (string, string, error) {
-	result := getAuthCodeFromCallbackHandler(callbackPort, timeoutSeconds, verbose)
+	return getAuthCode(endPoint, clientId, scope, callbackPort, timeoutSeconds, 0, pkce, verbose)
+}
+
+// getAuthCode implements GetAuthCode with an additional closeDelaySeconds
+// parameter controlling the auto-close countdown on the success page.
+func getAuthCode(endPoint, clientId, scope string, callbackPort, timeoutSeconds, closeDelaySeconds int, pkce, verbose bool) (string, string, error) {
+	result := getAuthCodeFromCallbackHandler(callbackPort, timeoutSeconds, closeDelaySeconds, verbose)
 
 	nonce, err := newCodeVerifier(24)
 	if err != nil {

--- a/libs/go/usercert/idp_test.go
+++ b/libs/go/usercert/idp_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"strings"
@@ -189,7 +190,7 @@ func TestGetIdpAuthURLCustomScope(t *testing.T) {
 func TestRegisterHandlersCallbackRedirect(t *testing.T) {
 	mux := http.NewServeMux()
 	codeChan := make(chan string, 1)
-	registerHandlers(mux, codeChan)
+	registerHandlers(mux, codeChan, 0)
 
 	// Find a free port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -233,7 +234,7 @@ func TestRegisterHandlersCallbackRedirect(t *testing.T) {
 func TestRegisterHandlersCallbackFollowRedirect(t *testing.T) {
 	mux := http.NewServeMux()
 	codeChan := make(chan string, 1)
-	registerHandlers(mux, codeChan)
+	registerHandlers(mux, codeChan, 0)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -289,7 +290,7 @@ func TestRegisterHandlersCallbackFollowRedirect(t *testing.T) {
 func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 	mux := http.NewServeMux()
 	codeChan := make(chan string, 1)
-	registerHandlers(mux, codeChan)
+	registerHandlers(mux, codeChan, 0)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -322,11 +323,31 @@ func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 	}
 }
 
+func TestRegisterHandlersCloseEndpointAutoClose(t *testing.T) {
+	mux := http.NewServeMux()
+	codeChan := make(chan string, 1)
+	registerHandlers(mux, codeChan, 7)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/close", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "This window will close in 7 seconds.") {
+		t.Error("expected /close to serve the countdown message when a close delay is set")
+	}
+	if !strings.Contains(body, "window.close()") {
+		t.Error("expected /close to serve the auto-close script when a close delay is set")
+	}
+}
+
 // --- getAuthCodeFromCallbackHandler tests ---
 
 func TestGetAuthCodeFromCallbackHandlerTimeout(t *testing.T) {
 	// Use port 0 to let OS pick a free port
-	result := getAuthCodeFromCallbackHandler(0, 1, false)
+	result := getAuthCodeFromCallbackHandler(0, 1, 0, false)
 	select {
 	case r := <-result:
 		if r.Error == nil {
@@ -349,7 +370,7 @@ func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
-	result := getAuthCodeFromCallbackHandler(port, 10, false)
+	result := getAuthCodeFromCallbackHandler(port, 10, 0, false)
 
 	// Wait briefly for the server to start
 	time.Sleep(200 * time.Millisecond)
@@ -796,13 +817,36 @@ func TestGetAuthCodeWithPKCEDisabled(t *testing.T) {
 // --- closeWindowHTML tests ---
 
 func TestCloseWindowHTMLContent(t *testing.T) {
-	if !strings.Contains(closeWindowHTML, "Authentication successful") {
+	page := closeWindowHTML(0)
+	if !strings.Contains(page, "Authentication successful") {
 		t.Error("closeWindowHTML should contain success message")
 	}
-	if !strings.Contains(closeWindowHTML, "close this window") {
+	if !strings.Contains(page, "close this window") {
 		t.Error("closeWindowHTML should contain close instruction")
 	}
-	if !strings.Contains(closeWindowHTML, "<!DOCTYPE html>") {
+	if !strings.Contains(page, "<!DOCTYPE html>") {
 		t.Error("closeWindowHTML should be valid HTML")
+	}
+	if strings.Contains(page, "<script>") {
+		t.Error("closeWindowHTML with no delay should not contain the auto-close script")
+	}
+}
+
+func TestCloseWindowHTMLAutoClose(t *testing.T) {
+	page := closeWindowHTML(5)
+	if !strings.Contains(page, "Authentication successful") {
+		t.Error("closeWindowHTML should contain success message")
+	}
+	if !strings.Contains(page, "This window will close in 5 seconds.") {
+		t.Error("closeWindowHTML with a delay should contain the countdown message")
+	}
+	if !strings.Contains(page, "window.close()") {
+		t.Error("closeWindowHTML with a delay should contain the auto-close script")
+	}
+	if !strings.Contains(page, "var secs = 5;") {
+		t.Error("closeWindowHTML should embed the configured delay in the script")
+	}
+	if strings.Contains(page, "__CLOSE_MSG__") || strings.Contains(page, "__CLOSE_SCRIPT__") {
+		t.Error("closeWindowHTML should replace all template placeholders")
 	}
 }

--- a/libs/go/usercert/usercert.go
+++ b/libs/go/usercert/usercert.go
@@ -60,6 +60,7 @@ type Options struct {
 	SignerKeyId        string              // signer key id for the user certificate
 	CallbackPort       int                 // local port for OAuth2 callback server
 	CallbackTimeout    int                 // seconds to wait for IdP callback
+	CloseWindowDelay   int                 // opt-in: seconds after which the success page tries to close its own browser tab (0 = disabled, static close message)
 	ExpiryTime         int                 // certificate expiry in minutes (0 = server default)
 	PKCE               bool                // enable PKCE for IdP auth flow
 	Proxy              bool                // use HTTP proxy from environment
@@ -101,8 +102,8 @@ func RequestCertificate(opts Options) (string, error) {
 	if scope == "" {
 		scope = "openid"
 	}
-	authCode, codeVerifier, err := GetAuthCode(opts.IdpEndpoint, opts.IdpClientId, scope, opts.CallbackPort,
-		opts.CallbackTimeout, opts.PKCE, opts.Verbose)
+	authCode, codeVerifier, err := getAuthCode(opts.IdpEndpoint, opts.IdpClientId, scope, opts.CallbackPort,
+		opts.CallbackTimeout, opts.CloseWindowDelay, opts.PKCE, opts.Verbose)
 	if err != nil {
 		return "", fmt.Errorf("failed to obtain IdP auth code: %v", err)
 	}

--- a/utils/zts-usercert/zts-usercert.go
+++ b/utils/zts-usercert/zts-usercert.go
@@ -44,7 +44,7 @@ func main() {
 	var idpEndpoint, idpClientId, caCertFile string
 	var subjC, subjO, subjOU, spiffeTrustDomain, deviceId string
 	var scope string
-	var callbackPort, callbackTimeout, expiryTime int
+	var callbackPort, callbackTimeout, closeWindowDelay, expiryTime int
 	var pkce, proxy, verbose, showVersion bool
 
 	flag.StringVar(&ztsURL, "zts", "", "url of the ZTS Service")
@@ -61,6 +61,7 @@ func main() {
 	flag.StringVar(&scope, "scope", "openid", "OIDC scope parameter")
 	flag.IntVar(&callbackPort, "callback-port", DefaultCallbackPort, "local port for IdP OAuth2 callback")
 	flag.IntVar(&callbackTimeout, "callback-timeout", DefaultCallbackTimeout, "timeout in seconds for IdP auth flow")
+	flag.IntVar(&closeWindowDelay, "close-window-delay", 0, "opt-in: seconds after which the browser success page auto-closes its tab (0 = disabled)")
 	flag.IntVar(&expiryTime, "expiry-time", 0, "expiry time in minutes for the certificate")
 	flag.StringVar(&caCertFile, "cacert", "", "CA certificate file")
 	flag.BoolVar(&pkce, "pkce", true, "enable PKCE for IdP auth flow")
@@ -90,6 +91,7 @@ func main() {
 		Scope:             scope,
 		CallbackPort:      callbackPort,
 		CallbackTimeout:   callbackTimeout,
+		CloseWindowDelay:  closeWindowDelay,
 		ExpiryTime:        expiryTime,
 		CACertFile:        caCertFile,
 		PKCE:              pkce,


### PR DESCRIPTION
## Summary

After a successful IdP callback, the `usercert` `/close` page shows "Authentication successful. You may close this window now." and the tab stays open. In CLI-driven certificate flows this leaves one stale browser tab behind per request.

This PR adds a **strictly opt-in** auto-close countdown to that success page:

- New `Options.CloseWindowDelay` (seconds). When set to N > 0, the `/close` page shows a live countdown ("This window will close in N seconds.") and calls `window.close()` when it reaches zero.
- **Opt-in contract:** the zero value (the default for every existing caller) serves exactly today's static page with no script at all — nothing changes for users who prefer to manage their own tabs.
- **No OS-level permissions involved:** the close is plain in-page JavaScript served by the local callback server — no AppleScript/automation, so macOS never prompts the user to grant the application control of the browser.
- The exported `GetAuthCode` signature is unchanged — the delay is threaded through an unexported `getAuthCode`, which `RequestCertificate` calls with `opts.CloseWindowDelay`.
- `window.close()` is best-effort: browsers that refuse to close a non-script-opened tab simply keep showing the countdown message, which is no worse than today's static page.
- The `zts-usercert` utility exposes the option as `-close-window-delay` (default 0 = disabled).

We have been running this auto-close approach in Yahoo's internal SSHCA client (`yinit`) OIDC flow and are upstreaming it so all `usercert` consumers can use it.

## Changes

- `libs/go/usercert/html.go`: `closeWindowHTML` const → function taking the delay; countdown message + script injected via placeholder replacement.
- `libs/go/usercert/idp.go`: thread `closeDelaySeconds` through `registerHandlers` / `getAuthCodeFromCallbackHandler`; `GetAuthCode` delegates with 0.
- `libs/go/usercert/usercert.go`: new `Options.CloseWindowDelay` (documented as opt-in), passed by `RequestCertificate`.
- `utils/zts-usercert/zts-usercert.go`: new `-close-window-delay` flag, default 0 (disabled).
- `libs/go/usercert/idp_test.go`: updated for new signatures; new tests for the countdown page content, the no-script-when-disabled default, and the `/close` handler with a delay.

## Testing

`go test ./libs/go/usercert/` — all tests pass, including new `TestCloseWindowHTMLAutoClose` and `TestRegisterHandlersCloseEndpointAutoClose`; `TestCloseWindowHTMLContent` now also asserts the default page contains no script. `go build ./utils/zts-usercert/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
