### PR TITLE
OIDC browser support windows

### DIFF
--- a/libs/go/usercert/idp.go
+++ b/libs/go/usercert/idp.go
@@ -77,6 +77,8 @@ func openBrowser(url string) error {
 		cmd = exec.Command("/usr/bin/open", url)
 	case "linux":
 		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", url)
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}


### PR DESCRIPTION
Enable the OIDC user-certificate flow to open the authorization URL on Windows using rundll32.exe with url.dll,FileProtocolHandler. Existing macOS and Linux behavior remains unchanged.

