### PR TITLE
SIA: reconcile sshd host certificate lines on key type change

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -575,10 +576,6 @@ func generateSshRequest(opts *sc.Options, primaryServiceName, hostname string) (
 	return sshCertRequest, sshCsr, err
 }
 
-func restartSshdService() error {
-	return exec.Command(util.GetUtilPath("systemctl"), "restart", "sshd").Run()
-}
-
 func updateSSH(sshCertFile, sshConfigFile, hostCert string, fileDirectUpdate bool) error {
 
 	//write the host cert file
@@ -587,47 +584,114 @@ func updateSSH(sshCertFile, sshConfigFile, hostCert string, fileDirectUpdate boo
 		return err
 	}
 
-	//Now update the config file, if needed. The format of the line we're going
-	//to insert is HostCertificate <sshCertFile>. so we'll see if the line exists
-	//or not and if not we'll insert one at the end of the file
-	if sshConfigFile != "" {
-		configPresent, err := hostCertificateLinePresent(sshConfigFile, sshCertFile)
-		if err != nil {
-			log.Printf("unable to check host certificate line for %s - error %v\n", sshConfigFile, err)
-			return err
-		}
-		if configPresent {
-			return nil
-		}
-		//update the sshconfig file to include HostCertificate line
-		err = updateSSHConfigFile(sshConfigFile, sshCertFile)
-		if err != nil {
-			return err
-		}
-		//and restart sshd to notice the changes.
-		return restartSshdService()
+	//if we're not asked to update the sshd config file then we're done
+	if sshConfigFile == "" {
+		return nil
 	}
-	return nil
+
+	//if our host certificate line is already present then this was a
+	//certificate refresh only and sshd does not need to be reloaded
+	configPresent, err := hostCertificateLinePresent(sshConfigFile, sshCertFile)
+	if err != nil {
+		log.Printf("unable to check host certificate line for %s - error %v\n", sshConfigFile, err)
+		return err
+	}
+	if configPresent {
+		return nil
+	}
+
+	//our host certificate line is not present which indicates the host
+	//key type has changed (or this is the initial setup). we add our host
+	//certificate line and comment out the lines of the other host key
+	//types since sia is no longer updating those certificates and sshd
+	//would keep presenting them until they expire
+	origContents, err := os.ReadFile(sshConfigFile)
+	if err != nil {
+		return err
+	}
+	err = updateSSHConfigFile(sshConfigFile, sshCertFile, fileDirectUpdate)
+	if err != nil {
+		return err
+	}
+
+	//validate the new configuration before asking sshd to re-read it. if
+	//it does not validate we restore the original configuration and leave
+	//the running daemon untouched since reloading into a broken config
+	//could lock us out of the instance
+	if err := checkSshdConfig(sshdCommand(), sshConfigFile); err != nil {
+		if restoreErr := util.UpdateFileContents(sshConfigFile, origContents, 0644, fileDirectUpdate, true); restoreErr != nil {
+			log.Printf("unable to restore %s after failed validation, error: %v\n", sshConfigFile, restoreErr)
+		}
+		return err
+	}
+
+	//and reload sshd to notice the changes
+	return reloadSshdService(util.GetUtilPath("systemctl"))
 }
 
-func updateSSHConfigFile(sshConfigFile, sshCertFile string) error {
-	//update the sshd config file to include HostCertificate line
-	file, err := os.OpenFile(sshConfigFile, os.O_APPEND|os.O_WRONLY, 0644)
+// updateSSHConfigFile updates the sshd config file to include the
+// HostCertificate line for the given cert file and comments out the host
+// certificate lines of the other host key types that sia supports
+func updateSSHConfigFile(sshConfigFile, sshCertFile string, fileDirectUpdate bool) error {
+	contents, err := os.ReadFile(sshConfigFile)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	certLine := fmt.Sprintf("\nHostCertificate %s\n", sshCertFile)
-	_, err = file.Write([]byte(certLine))
-	if err != nil {
-		return err
+	newContents := updatedSSHConfigContents(string(contents), sshCertFile)
+	return util.UpdateFileContents(sshConfigFile, []byte(newContents), 0644, fileDirectUpdate, true)
+}
+
+// updatedSSHConfigContents returns the sshd config contents with the
+// HostCertificate line for the given cert file added and the host
+// certificate lines of the other sia supported host key types commented
+// out. the new line is inserted before the first Match block, if present,
+// since HostCertificate is only valid in the global section of the file
+func updatedSSHConfigContents(contents, sshCertFile string) string {
+	staleCertFiles := siblingHostCertFiles(sshCertFile)
+	lines := strings.Split(contents, "\n")
+	insertIdx := len(lines)
+	for idx, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && strings.EqualFold(fields[0], "Match") && insertIdx == len(lines) {
+			insertIdx = idx
+		}
+		certFile := hostCertificateFile(line)
+		if certFile == "" {
+			continue
+		}
+		for _, staleCertFile := range staleCertFiles {
+			if certFile == staleCertFile {
+				log.Printf("commenting out sshd configuration line: %s\n", line)
+				lines[idx] = "#" + line
+				break
+			}
+		}
 	}
-	return nil
+	certLine := fmt.Sprintf("HostCertificate %s", sshCertFile)
+	lines = append(lines[:insertIdx], append([]string{certLine}, lines[insertIdx:]...)...)
+	newContents := strings.Join(lines, "\n")
+	if !strings.HasSuffix(newContents, "\n") {
+		newContents += "\n"
+	}
+	return newContents
+}
+
+// siblingHostCertFiles returns the host certificate file paths of all the
+// sia supported host key types other than the one for the given cert file
+func siblingHostCertFiles(sshCertFile string) []string {
+	sshDir := filepath.Dir(sshCertFile)
+	var certFiles []string
+	for _, keyType := range []hostkey.KeyType{hostkey.Rsa, hostkey.Ecdsa, hostkey.Ed25519} {
+		certFile := hostkey.CertFile(sshDir, keyType)
+		if certFile != sshCertFile {
+			certFiles = append(certFiles, certFile)
+		}
+	}
+	return certFiles
 }
 
 func hostCertificateLinePresent(sshConfigFile, sshCertFile string) (bool, error) {
 
-	certLine := fmt.Sprintf("HostCertificate %s", sshCertFile)
 	file, err := os.Open(sshConfigFile)
 	if err != nil {
 		return false, err
@@ -636,13 +700,65 @@ func hostCertificateLinePresent(sshConfigFile, sshCertFile string) (bool, error)
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		line := strings.Trim(scanner.Text(), " \t")
-		if strings.HasPrefix(line, certLine) {
+		line := scanner.Text()
+		if hostCertificateFile(line) == sshCertFile {
 			log.Printf("ssh configuration file already includes expected line: %s\n", line)
 			return true, nil
 		}
 	}
-	return false, nil
+	return false, scanner.Err()
+}
+
+// hostCertificateFile returns the certificate file configured in the given
+// sshd config line if the line is an active - not commented out - host
+// certificate line, otherwise it returns an empty string. sshd config
+// keywords are case-insensitive so the keyword is matched accordingly
+func hostCertificateFile(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "HostCertificate") {
+		return ""
+	}
+	return fields[1]
+}
+
+// checkSshdConfig validates the given sshd config file so that we never ask
+// the daemon to load a configuration that does not parse. the command output
+// is captured since the exit error alone does not indicate the reason
+func checkSshdConfig(sshd, sshConfigFile string) error {
+	out, err := exec.Command(sshd, "-t", "-f", sshConfigFile).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("sshd config validation failed: %v, output: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// sshdCommand returns the path to the sshd daemon binary which is installed
+// in /usr/sbin, a directory that util.GetUtilPath does not search
+func sshdCommand() string {
+	sshd := "/usr/sbin/sshd"
+	if _, err := os.Stat(sshd); err == nil {
+		return sshd
+	}
+	return "sshd"
+}
+
+// reloadSshdService reloads the sshd service so that it picks up the new
+// configuration and host certificate. reload is preferred over restart since
+// it does not stop the listener or affect established sessions, and systemd
+// falls back to a full start if the daemon is not running. the service unit
+// is named sshd on rhel/fedora based systems and ssh on debian/ubuntu where
+// the sshd alias link only exists while the unit is enabled, so both unit
+// names are tried in order
+func reloadSshdService(systemctl string) error {
+	var errs []string
+	for _, unit := range []string{"sshd", "ssh"} {
+		out, err := exec.Command(systemctl, "reload-or-restart", unit).CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		errs = append(errs, fmt.Sprintf("reload-or-restart %s: %v, output: %s", unit, err, strings.TrimSpace(string(out))))
+	}
+	return fmt.Errorf("unable to reload sshd service: %s", strings.Join(errs, "; "))
 }
 
 func SetupAgent(opts *sc.Options, siaAgentDir, siaLinkDir string) {

--- a/libs/go/sia/agent/agent_test.go
+++ b/libs/go/sia/agent/agent_test.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -423,10 +425,13 @@ func TestHostCertificateLinePresent(test *testing.T) {
 		{"valid-mid-mix", "PermitTunnel no\n \t HostCertificate /sshd.config\nUseDNS no", "/sshd.config", true},
 		{"valid-end", "PermitTunnel no\nHostCertificate /sshd.config", "/sshd.config", true},
 		{"valid-commented", "PermitTunnel no\n#HostCertificate /sshd.config\nUseDNS no", "/sshd.config", false},
+		{"valid-case-insensitive", "PermitTunnel no\nhostcertificate /sshd.config\nUseDNS no", "/sshd.config", true},
+		{"valid-tab-separator", "PermitTunnel no\nHostCertificate\t/sshd.config\nUseDNS no", "/sshd.config", true},
 		{"valid-not-present1", "PermitTunnel no\nHostCertificateOther /sshd.config\nUseDNS no", "/sshd.config", false},
 		{"valid-not-present2", "PermitTunnel no\nHostCertificate/sshd.config\nUseDNS no", "/sshd.config", false},
 		{"valid-not-present3", "PermitTunnel no\n\nUseDNS no\n", "/sshd.config", false},
 		{"valid-not-present3", "PermitTunnel no\nHostCertificate /sshd2.config\nUseDNS no\n", "/sshd.config", false},
+		{"valid-partial-match", "PermitTunnel no\nHostCertificate /sshd.config.old\nUseDNS no\n", "/sshd.config", false},
 	}
 	for _, tt := range tests {
 		test.Run(tt.name, func(t *testing.T) {
@@ -435,7 +440,7 @@ func TestHostCertificateLinePresent(test *testing.T) {
 				log.Fatal("Cannot create temporary file", err)
 			}
 			defer os.Remove(tmpFile.Name())
-			os.WriteFile(tmpFile.Name(), []byte(tt.data), 644)
+			os.WriteFile(tmpFile.Name(), []byte(tt.data), 0644)
 			result, _ := hostCertificateLinePresent(tmpFile.Name(), tt.certFile)
 			if result != tt.result {
 				test.Errorf("%s: invalid value returned - expected: %v, received %v", tt.name, tt.result, result)
@@ -446,12 +451,53 @@ func TestHostCertificateLinePresent(test *testing.T) {
 
 func TestUpdateSSHConfigFile(test *testing.T) {
 	tests := []struct {
-		name   string
-		data   string
-		result string
+		name     string
+		data     string
+		certFile string
+		result   string
 	}{
-		{"test1", "PermitTunnel no\nUseDNS no", "PermitTunnel no\nUseDNS no\nHostCertificate /sshd.config\n"},
-		{"test2", "PermitTunnel no\n#HostCertificate /sshd.config\nUseDNS no\n", "PermitTunnel no\n#HostCertificate /sshd.config\nUseDNS no\n\nHostCertificate /sshd.config\n"},
+		{
+			"append-at-end",
+			"PermitTunnel no\nUseDNS no",
+			"/sshd.config",
+			"PermitTunnel no\nUseDNS no\nHostCertificate /sshd.config\n",
+		},
+		{
+			"commented-line-not-considered",
+			"PermitTunnel no\n#HostCertificate /sshd.config\nUseDNS no\n",
+			"/sshd.config",
+			"PermitTunnel no\n#HostCertificate /sshd.config\nUseDNS no\n\nHostCertificate /sshd.config\n",
+		},
+		{
+			"rsa-to-ecdsa-comments-out-rsa",
+			"HostKey /etc/ssh/ssh_host_rsa_key\nHostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\nUseDNS no\n",
+			"/etc/ssh/ssh_host_ecdsa_key-cert.pub",
+			"HostKey /etc/ssh/ssh_host_rsa_key\n#HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\nUseDNS no\n\nHostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub\n",
+		},
+		{
+			"ecdsa-to-rsa-comments-out-ecdsa",
+			"HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub\nUseDNS no\n",
+			"/etc/ssh/ssh_host_rsa_key-cert.pub",
+			"#HostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub\nUseDNS no\n\nHostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\n",
+		},
+		{
+			"multiple-stale-types-commented-out",
+			"HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\nHostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub\n",
+			"/etc/ssh/ssh_host_ecdsa_key-cert.pub",
+			"#HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\n#HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub\n\nHostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub\n",
+		},
+		{
+			"custom-path-cert-not-touched",
+			"HostCertificate /etc/ssh/operator-managed-cert.pub\nUseDNS no\n",
+			"/etc/ssh/ssh_host_ecdsa_key-cert.pub",
+			"HostCertificate /etc/ssh/operator-managed-cert.pub\nUseDNS no\n\nHostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub\n",
+		},
+		{
+			"insert-before-match-block",
+			"UseDNS no\nHostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\nMatch User backup\n\tPermitTTY no\n",
+			"/etc/ssh/ssh_host_ecdsa_key-cert.pub",
+			"UseDNS no\n#HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub\nHostCertificate /etc/ssh/ssh_host_ecdsa_key-cert.pub\nMatch User backup\n\tPermitTTY no\n",
+		},
 	}
 	for _, tt := range tests {
 		test.Run(tt.name, func(t *testing.T) {
@@ -460,8 +506,8 @@ func TestUpdateSSHConfigFile(test *testing.T) {
 				log.Fatal("Cannot create temporary file", err)
 			}
 			defer os.Remove(tmpFile.Name())
-			os.WriteFile(tmpFile.Name(), []byte(tt.data), 644)
-			err = updateSSHConfigFile(tmpFile.Name(), "/sshd.config")
+			os.WriteFile(tmpFile.Name(), []byte(tt.data), 0644)
+			err = updateSSHConfigFile(tmpFile.Name(), tt.certFile, false)
 			if err != nil {
 				test.Errorf("%s: unable to update file %s - error: %v", tt.name, tmpFile.Name(), err)
 			}
@@ -469,6 +515,126 @@ func TestUpdateSSHConfigFile(test *testing.T) {
 			if tt.result != string(data) {
 				test.Errorf("%s: invalid value returned - expected: %v, received %v", tt.name, tt.result, string(data))
 			}
+		})
+	}
+}
+
+func TestSiblingHostCertFiles(test *testing.T) {
+	certFiles := siblingHostCertFiles("/etc/ssh/ssh_host_ecdsa_key-cert.pub")
+	assert.Equal(test, []string{"/etc/ssh/ssh_host_rsa_key-cert.pub", "/etc/ssh/ssh_host_ed25519_key-cert.pub"}, certFiles)
+	certFiles = siblingHostCertFiles("/etc/ssh/ssh_host_rsa_key-cert.pub")
+	assert.Equal(test, []string{"/etc/ssh/ssh_host_ecdsa_key-cert.pub", "/etc/ssh/ssh_host_ed25519_key-cert.pub"}, certFiles)
+}
+
+func TestHostCertificateFile(test *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		certFile string
+	}{
+		{"standard", "HostCertificate /etc/ssh/cert.pub", "/etc/ssh/cert.pub"},
+		{"leading-whitespace", " \t HostCertificate /etc/ssh/cert.pub", "/etc/ssh/cert.pub"},
+		{"case-insensitive", "HOSTCERTIFICATE /etc/ssh/cert.pub", "/etc/ssh/cert.pub"},
+		{"commented", "#HostCertificate /etc/ssh/cert.pub", ""},
+		{"no-value", "HostCertificate", ""},
+		{"other-keyword", "HostKey /etc/ssh/ssh_host_rsa_key", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		test.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.certFile, hostCertificateFile(tt.line))
+		})
+	}
+}
+
+// createFakeCommand creates an executable shell script with the given body
+// in the given directory and returns its path
+func createFakeCommand(test *testing.T, dir, name, body string) string {
+	command := filepath.Join(dir, name)
+	if err := os.WriteFile(command, []byte("#!/bin/sh\n"+body+"\n"), 0755); err != nil {
+		test.Fatalf("unable to create fake %s command, error: %v", name, err)
+	}
+	return command
+}
+
+func TestCheckSshdConfig(test *testing.T) {
+	dir := test.TempDir()
+	sshd := createFakeCommand(test, dir, "sshd", "exit 0")
+	if err := checkSshdConfig(sshd, "/sshd.config"); err != nil {
+		test.Errorf("unexpected error for valid config: %v", err)
+	}
+	sshd = createFakeCommand(test, dir, "sshd-bad", "echo \"/sshd.config line 5: Bad configuration option\" >&2\nexit 255")
+	err := checkSshdConfig(sshd, "/sshd.config")
+	if err == nil {
+		test.Fatal("expected error for invalid config")
+	}
+	if !strings.Contains(err.Error(), "Bad configuration option") {
+		test.Errorf("expected error to include sshd output, got: %v", err)
+	}
+}
+
+func TestReloadSshdService(test *testing.T) {
+	tests := []struct {
+		name            string
+		systemctlBody   string
+		expectedErrs    []string
+		expectedReloads []string
+	}{
+		{
+			//the common case: the sshd unit reloads
+			name:            "reload-sshd-unit",
+			systemctlBody:   "exit 0",
+			expectedReloads: []string{"reload-or-restart sshd"},
+		},
+		{
+			//debian/ubuntu without the sshd alias: the sshd unit is
+			//unknown so we must fall back to the ssh unit
+			name:            "fallback-to-ssh-unit",
+			systemctlBody:   "if [ \"$2\" = \"ssh\" ]; then exit 0; fi\necho \"Unit sshd.service not found.\" >&2\nexit 5",
+			expectedReloads: []string{"reload-or-restart sshd", "reload-or-restart ssh"},
+		},
+		{
+			//when both unit names fail the error must carry the
+			//output of both attempts
+			name:          "all-units-fail",
+			systemctlBody: "echo \"Job for $2.service failed.\" >&2\nexit 1",
+			expectedErrs: []string{
+				"unable to reload sshd service",
+				"reload-or-restart sshd", "Job for sshd.service failed.",
+				"reload-or-restart ssh", "Job for ssh.service failed.",
+			},
+			expectedReloads: []string{"reload-or-restart sshd", "reload-or-restart ssh"},
+		},
+	}
+	for _, tt := range tests {
+		test.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logFile := filepath.Join(dir, "systemctl.log")
+			//the fake systemctl records every invocation before
+			//executing the test case specific body
+			systemctl := createFakeCommand(t, dir, "systemctl",
+				"printf '%s\\n' \"$*\" >> \""+logFile+"\"\n"+tt.systemctlBody)
+			err := reloadSshdService(systemctl)
+			if len(tt.expectedErrs) == 0 {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				for _, expected := range tt.expectedErrs {
+					if !strings.Contains(err.Error(), expected) {
+						t.Errorf("expected error to contain %q, got: %v", expected, err)
+					}
+				}
+			}
+			contents, err := os.ReadFile(logFile)
+			if err != nil {
+				t.Fatalf("unable to read systemctl log file, error: %v", err)
+			}
+			reloads := strings.Split(strings.TrimSuffix(string(contents), "\n"), "\n")
+			assert.Equal(t, tt.expectedReloads, reloads)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

When the configured ssh host key type changes (e.g. `rsa` → `ecdsa`), `updateSSH` appends the new `HostCertificate` line to the sshd config and restarts sshd — but the previous key type's line is left in place. sshd keeps presenting a certificate that SIA is no longer refreshing, and once that stale certificate expires, sshd fails to start on the next restart/reboot, locking operators out of the instance.

Separately, the restart itself had robustness gaps: the config was never validated before restarting (a bad config bricks sshd), `systemctl restart` stops the listener when a reload suffices, and the hardcoded `sshd` unit name does not exist on debian/ubuntu systems where the unit is `ssh`.

## Change

**Reconcile in one pass.** When `updateSSH` adds its `HostCertificate` line (i.e. the key type changed or this is initial setup), it now also comments out the host certificate lines of the *other* SIA-supported key types in the same write. The stale path set is derived from the `hostkey` package (`hostkey.CertFile` for `Rsa`/`Ecdsa`/`Ed25519` in the same directory), so:
- only files SIA itself manages are ever touched — operator-managed certificates at custom paths are provably out of scope
- the logic is symmetric (rsa→ecdsa, ecdsa→rsa, →ed25519) and automatically covers any key type added to the enum later

The new line is inserted before the first `Match` block if one exists, since `HostCertificate` is only valid in the global section (previously a trailing `Match` block would produce an invalid config).

**Validate, then reload.** The updated config is checked with `sshd -t -f <config>` before the daemon is asked to re-read it. If validation fails, the original config is restored and the running daemon is left untouched. On success, `systemctl reload-or-restart` is used — sshd re-execs in place without stopping the listener or affecting established sessions, falling back to a full start if the daemon is not running — trying the `sshd` unit then `ssh` (debian/ubuntu; the `sshd` alias link only exists while the unit is enabled). Command output is captured into returned errors so failures are actionable from the SIA log.

**Parser fix.** `hostCertificateLinePresent` previously used a prefix match, so `HostCertificate /path/cert.pub.old` counted as a match for `/path/cert.pub`, and lowercase keywords (valid for sshd) were missed. It now parses by field with a case-insensitive keyword match, as sshd does.

**Steady state is unchanged**: when the certificate line is already present, refreshes do not touch the config file and do not reload sshd. `updateSSH`'s signature and both call sites are unchanged, and ssh update errors remain non-fatal to the agent.

## Testing

- `TestUpdateSSHConfigFile`: 7 cases — the 2 original cases (behavior preserved byte-for-byte), rsa→ecdsa, ecdsa→rsa, multiple stale types, custom-path certificate untouched, insertion before a `Match` block
- `TestHostCertificateLinePresent`: extended with case-insensitive keyword, tab separator, and partial-path-match cases (the last fails against the previous prefix-match implementation)
- `TestHostCertificateFile`, `TestSiblingHostCertFiles`: new helper coverage
- `TestCheckSshdConfig`, `TestReloadSshdService`: exercised with fake shell-script executables recording their invocations — covers the reload happy path, the debian/ubuntu `ssh`-unit fallback, and error aggregation when both units fail
- `go build`, `go vet`, and the full `libs/go/sia/agent` suite pass

The validate-then-reload behavior was also verified end-to-end on a live AWS EC2 instance (AlmaLinux 8.10) via a downstream build: migrating rsa→ecdsa commented out the stale line, `sshd -t` gated the reload, and journald showed a true SIGHUP reload with established sessions surviving.

## Notes

`provider/azure/sia-vm` has its own private copy of `restartSshdService` with the same unvalidated-restart pattern; updating it the same way is a candidate follow-up, left out to keep this change scoped to `libs/go/sia/agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)