### PR TITLE
Persist autoDeleteTenantAssumeRoleAssertions for subdomain and user domain creation

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -2091,6 +2091,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 .setEnvironment(detail.getEnvironment())
                 .setSlackChannel(detail.getSlackChannel())
                 .setOnCall(detail.getOnCall())
+                .setAutoDeleteTenantAssumeRoleAssertions(detail.getAutoDeleteTenantAssumeRoleAssertions())
                 .setClientIdSelfUpdate(detail.getClientIdSelfUpdate());
 
         // before processing validate the fields
@@ -2199,6 +2200,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 .setSshCertSignerKeyId(detail.getSshCertSignerKeyId())
                 .setSlackChannel(detail.getSlackChannel())
                 .setOnCall(detail.getOnCall())
+                .setAutoDeleteTenantAssumeRoleAssertions(detail.getAutoDeleteTenantAssumeRoleAssertions())
                 .setClientIdSelfUpdate(detail.getClientIdSelfUpdate());
 
         // before processing validate the fields

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -1009,6 +1009,7 @@ public class ZMSImplTest {
 
         SubDomain dom2 = zmsTestInitializer.createSubDomainObject("AddSubDom2", "AddSubDom1",
                 "Test Domain2", null, zmsTestInitializer.getAdminUser());
+        dom2.setAutoDeleteTenantAssumeRoleAssertions(true);
         Domain resDom1 = zmsImpl.postSubDomain(ctx, "AddSubDom1", auditRef, null, dom2);
         assertNotNull(resDom1);
 
@@ -1017,6 +1018,7 @@ public class ZMSImplTest {
 
         assertEquals(dom2.getOrg(), "testorg");
         assertFalse(resDom2.getAuditEnabled());
+        assertTrue(resDom2.getAutoDeleteTenantAssumeRoleAssertions());
 
         zmsImpl.deleteSubDomain(ctx, "AddSubDom1", "AddSubDom2", auditRef, null);
         zmsImpl.deleteTopLevelDomain(ctx, "AddSubDom1", auditRef, null);
@@ -1062,6 +1064,7 @@ public class ZMSImplTest {
 
         RsrcCtxWrapper ctx = zmsTestInitializer.contextWithMockPrincipal("postUserDomain");
         UserDomain dom1 = zmsTestInitializer.createUserDomainObject("john-doe", "Test Domain1", "testOrg");
+        dom1.setAutoDeleteTenantAssumeRoleAssertions(true);
         zmsImpl.postUserDomain(ctx, "john-doe", auditRef, null, dom1);
 
         assertSingleChangeMessage(ctx.getDomainChangeMessages(), DOMAIN, "user.john-doe",
@@ -1069,6 +1072,7 @@ public class ZMSImplTest {
 
         Domain resDom2 = zmsImpl.getDomain(ctx, "user.john-doe");
         assertNotNull(resDom2);
+        assertTrue(resDom2.getAutoDeleteTenantAssumeRoleAssertions());
 
         RsrcCtxWrapper deleteCtx = zmsTestInitializer.contextWithMockPrincipal("deleteUserDomain");
         zmsImpl.deleteUserDomain(deleteCtx, "john-doe", auditRef, null);


### PR DESCRIPTION
# Description
The https://github.com/AthenZ/athenz/pull/3027 that introduced autoDeleteTenantAssumeRoleAssertions missed the corresponding changes for subdomain and user domain creation.
This PR persists the field when creating those domain types and adds regression tests for both creation paths.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

