### PR TITLE
github actions: optional authz check based on job_workflow_ref claim

### DIFF
--- a/libs/java/instance_provider/conf/github_actions.properties
+++ b/libs/java/instance_provider/conf/github_actions.properties
@@ -44,3 +44,17 @@
 # discovery document is unavailable or when testing with a local key set.
 # Default: not set (derived from issuer discovery document)
 #athenz.zts.github_actions.jwks_uri=
+
+# Enables a secondary authorization check based on the job_workflow_ref claim in
+# the OIDC token. The provider always carries out its authorization check first
+# against the resource <domain>:<subject claim>. When this option is enabled and
+# that check fails, the provider extracts the job_workflow_ref claim and, if the
+# claim is present and not empty, repeats the authorization check against the
+# resource <domain>:<job_workflow_ref claim> - e.g.
+# sports:athenz/sia/.github/workflows/build.yml@refs/heads/main. This allows a
+# domain to authorize a specific reusable workflow regardless of which
+# repository, branch or tag triggered the job. If both checks fail, the returned
+# error message includes both resource values separated by a space. This setting
+# is dynamic and does not require a server restart.
+# Default: false
+#athenz.zts.github_actions.job_workflow_ref_authz_check=false

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProvider.java
@@ -24,6 +24,7 @@ import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.auth.impl.SimplePrincipal;
 import com.yahoo.athenz.auth.token.jwts.JwtsHelper;
 import com.yahoo.athenz.auth.token.jwts.JwtsSigningKeyResolver;
+import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigBoolean;
 import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigLong;
 import com.yahoo.athenz.instance.provider.InstanceConfirmation;
 import com.yahoo.athenz.instance.provider.InstanceProvider;
@@ -52,14 +53,16 @@ public class InstanceGithubActionsProvider implements InstanceProvider {
     static final String GITHUB_ACTIONS_PROP_AUDIENCE             = "athenz.zts.github_actions.audience";
     static final String GITHUB_ACTIONS_PROP_ISSUER               = "athenz.zts.github_actions.issuer";
     static final String GITHUB_ACTIONS_PROP_JWKS_URI             = "athenz.zts.github_actions.jwks_uri";
+    static final String GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK = "athenz.zts.github_actions.job_workflow_ref_authz_check";
 
     static final String GITHUB_ACTIONS_ISSUER          = "https://token.actions.githubusercontent.com";
     static final String GITHUB_ACTIONS_ISSUER_JWKS_URI = "https://token.actions.githubusercontent.com/.well-known/jwks";
 
-    public static final String CLAIM_ENTERPRISE    = "enterprise";
-    public static final String CLAIM_RUN_ID        = "run_id";
-    public static final String CLAIM_EVENT_NAME    = "event_name";
-    public static final String CLAIM_REPOSITORY    = "repository";
+    public static final String CLAIM_ENTERPRISE       = "enterprise";
+    public static final String CLAIM_RUN_ID           = "run_id";
+    public static final String CLAIM_EVENT_NAME       = "event_name";
+    public static final String CLAIM_REPOSITORY       = "repository";
+    public static final String CLAIM_JOB_WORKFLOW_REF = "job_workflow_ref";
 
     Set<String> dnsSuffixes = null;
     Set<String> enterprises = null;
@@ -69,6 +72,7 @@ public class InstanceGithubActionsProvider implements InstanceProvider {
     ConfigurableJWTProcessor<SecurityContext> jwtProcessor = null;
     Authorizer authorizer = null;
     DynamicConfigLong bootTimeOffsetSeconds;
+    DynamicConfigBoolean jobWorkflowRefAuthzCheck;
     long certExpiryTime;
 
     @Override
@@ -99,6 +103,12 @@ public class InstanceGithubActionsProvider implements InstanceProvider {
 
         long timeout = TimeUnit.SECONDS.convert(5, TimeUnit.MINUTES);
         bootTimeOffsetSeconds = new DynamicConfigLong(CONFIG_MANAGER, GITHUB_ACTIONS_PROP_BOOT_TIME_OFFSET, timeout);
+
+        // determine if we should carry out a secondary authorization check based on
+        // the job_workflow_ref claim in the token when the subject based check fails
+
+        jobWorkflowRefAuthzCheck = new DynamicConfigBoolean(CONFIG_MANAGER,
+                GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK, false);
 
         // determine if we're running in enterprise mode - supports a comma-separated list of values
 
@@ -352,11 +362,31 @@ public class InstanceGithubActionsProvider implements InstanceProvider {
 
         final String resource = domainName + ":" + subject;
         Principal principal = SimplePrincipal.create(domainName, serviceName, (String) null);
-        boolean accessCheck = authorizer.access(action, resource, principal, null);
-        if (!accessCheck) {
-            errMsg.append("authorization check failed for action: ").append(action)
-                    .append(" resource: ").append(resource);
+        if (authorizer.access(action, resource, principal, null)) {
+            return true;
         }
-        return accessCheck;
+
+        // if the subject based authorization check failed and we're configured to
+        // support authorization checks based on the job_workflow_ref claim, then
+        // we'll extract that claim value and, if present, carry out a second
+        // authorization check based on that resource value
+
+        String workflowResource = null;
+        if (jobWorkflowRefAuthzCheck.get()) {
+            final String jobWorkflowRef = JwtsHelper.getStringClaim(claimsSet, CLAIM_JOB_WORKFLOW_REF);
+            if (!StringUtil.isEmpty(jobWorkflowRef)) {
+                workflowResource = domainName + ":" + jobWorkflowRef;
+                if (authorizer.access(action, workflowResource, principal, null)) {
+                    return true;
+                }
+            }
+        }
+
+        errMsg.append("authorization check failed for action: ").append(action)
+                .append(" resource: ").append(resource);
+        if (workflowResource != null) {
+            errMsg.append(" ").append(workflowResource);
+        }
+        return false;
     }
 }

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProviderTest.java
@@ -59,6 +59,7 @@ public class InstanceGithubActionsProviderTest {
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE);
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_ENTERPRISE);
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_ISSUER);
+        System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK);
     }
 
     static void createOpenIdConfigFile(File configFile, File jwksUri) throws IOException {
@@ -647,8 +648,171 @@ public class InstanceGithubActionsProviderTest {
         assertTrue(errMsg.toString().contains("authorization check failed for action"));
     }
 
+    @Test
+    public void testValidateOIDCTokenJobWorkflowRefAuthorizationDisabled() throws JOSEException {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE, "https://athenz.io");
+
+        InstanceGithubActionsProvider provider = new InstanceGithubActionsProvider();
+        provider.initialize("sys.auth.github_actions",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceGithubActionsProvider", null, null);
+
+        // the option is disabled by default so even though the job_workflow_ref based
+        // resource is authorized, our request must be rejected and the error message
+        // must only include the subject based resource value
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Principal principal = SimplePrincipal.create("sports", "api", (String) null);
+        Mockito.when(authorizer.access("github.push", "sports:repo:athenz/sia:ref:refs/heads/main", principal, null))
+                .thenReturn(false);
+        Mockito.when(authorizer.access("github.push",
+                "sports:athenz/sia/.github/workflows/build.yml@refs/heads/main", principal, null))
+                .thenReturn(true);
+        provider.setAuthorizer(authorizer);
+
+        String idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
+        assertFalse(result);
+        assertEquals(errMsg.toString(), "authorization check failed for action: github.push"
+                + " resource: sports:repo:athenz/sia:ref:refs/heads/main");
+    }
+
+    @Test
+    public void testValidateOIDCTokenJobWorkflowRefAuthorizationSuccess() throws JOSEException {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK, "true");
+
+        InstanceGithubActionsProvider provider = new InstanceGithubActionsProvider();
+        provider.initialize("sys.auth.github_actions",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceGithubActionsProvider", null, null);
+
+        // the subject based check fails but the job_workflow_ref based check is authorized
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Principal principal = SimplePrincipal.create("sports", "api", (String) null);
+        Mockito.when(authorizer.access("github.push", "sports:repo:athenz/sia:ref:refs/heads/main", principal, null))
+                .thenReturn(false);
+        Mockito.when(authorizer.access("github.push",
+                "sports:athenz/sia/.github/workflows/build.yml@refs/heads/main", principal, null))
+                .thenReturn(true);
+        provider.setAuthorizer(authorizer);
+
+        String idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
+        assertTrue(result);
+        assertEquals(errMsg.length(), 0);
+    }
+
+    @Test
+    public void testValidateOIDCTokenJobWorkflowRefSubjectAuthorizationSuccess() throws JOSEException {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK, "true");
+
+        InstanceGithubActionsProvider provider = new InstanceGithubActionsProvider();
+        provider.initialize("sys.auth.github_actions",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceGithubActionsProvider", null, null);
+
+        // the subject based check is authorized so we must not carry out the
+        // job_workflow_ref based authorization check
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Principal principal = SimplePrincipal.create("sports", "api", (String) null);
+        Mockito.when(authorizer.access("github.push", "sports:repo:athenz/sia:ref:refs/heads/main", principal, null))
+                .thenReturn(true);
+        provider.setAuthorizer(authorizer);
+
+        String idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
+        assertTrue(result);
+        assertEquals(errMsg.length(), 0);
+
+        Mockito.verify(authorizer, Mockito.never()).access("github.push",
+                "sports:athenz/sia/.github/workflows/build.yml@refs/heads/main", principal, null);
+    }
+
+    @Test
+    public void testValidateOIDCTokenJobWorkflowRefAuthorizationFailure() throws JOSEException {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK, "true");
+
+        InstanceGithubActionsProvider provider = new InstanceGithubActionsProvider();
+        provider.initialize("sys.auth.github_actions",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceGithubActionsProvider", null, null);
+
+        // both the subject and job_workflow_ref based checks fail so our error
+        // message must include both resource values separated by a space
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        provider.setAuthorizer(authorizer);
+
+        String idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, false, false);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
+        assertFalse(result);
+        assertEquals(errMsg.toString(), "authorization check failed for action: github.push"
+                + " resource: sports:repo:athenz/sia:ref:refs/heads/main"
+                + " sports:athenz/sia/.github/workflows/build.yml@refs/heads/main");
+    }
+
+    @Test
+    public void testValidateOIDCTokenJobWorkflowRefMissingClaim() throws JOSEException {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK, "true");
+
+        InstanceGithubActionsProvider provider = new InstanceGithubActionsProvider();
+        provider.initialize("sys.auth.github_actions",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceGithubActionsProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        provider.setAuthorizer(authorizer);
+
+        // our token does not include the job_workflow_ref claim, so the error
+        // message must only include the subject based resource value
+
+        String idToken = generateIdToken("https://token.actions.githubusercontent.com",
+                System.currentTimeMillis() / 1000, false, false, false, false, false, true);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:0001", errMsg);
+        assertFalse(result);
+        assertEquals(errMsg.toString(), "authorization check failed for action: github.push"
+                + " resource: sports:repo:athenz/sia:ref:refs/heads/main");
+    }
+
     private String generateIdToken(final String issuer, long currentTimeSecs, boolean skipSubject,
             boolean skipEventName, boolean skipIssuedAt, boolean skipRunId, boolean skipRepository) throws JOSEException {
+        return generateIdToken(issuer, currentTimeSecs, skipSubject, skipEventName, skipIssuedAt,
+                skipRunId, skipRepository, false);
+    }
+
+    private String generateIdToken(final String issuer, long currentTimeSecs, boolean skipSubject,
+            boolean skipEventName, boolean skipIssuedAt, boolean skipRunId, boolean skipRepository,
+            boolean skipJobWorkflowRef) throws JOSEException {
 
         PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
 
@@ -672,6 +836,9 @@ public class InstanceGithubActionsProviderTest {
         }
         if (!skipIssuedAt) {
             claimsSetBuilder.issueTime(Date.from(Instant.ofEpochSecond(currentTimeSecs)));
+        }
+        if (!skipJobWorkflowRef) {
+            claimsSetBuilder.claim("job_workflow_ref", "athenz/sia/.github/workflows/build.yml@refs/heads/main");
         }
 
         SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256).keyID("eckey1").build(),

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGithubActionsProviderTest.java
@@ -57,7 +57,6 @@ public class InstanceGithubActionsProviderTest {
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_ENTERPRISE);
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JWKS_URI);
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_AUDIENCE);
-        System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_ENTERPRISE);
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_ISSUER);
         System.clearProperty(InstanceGithubActionsProvider.GITHUB_ACTIONS_PROP_JOB_WORKFLOW_REF_AUTHZ_CHECK);
     }


### PR DESCRIPTION
Introduce athenz.zts.github_actions.job_workflow_ref_authz_check (dynamic, default false). When enabled and the subject based authorization check fails, the provider extracts the job_workflow_ref claim from the OIDC token and, if it's not empty, carries out a second authorization check against the <domain>:<job_workflow_ref> resource. This allows a domain to authorize a specific reusable workflow regardless of which repository, branch or tag triggered the job. If both checks fail, the error message includes both resource values separated by a space.

# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

