### PR TITLE
aws web identity: optional empty domain account and system level laun…

### DIFF
--- a/docker/zts/conf/zts.properties
+++ b/docker/zts/conf/zts.properties
@@ -374,6 +374,13 @@ athenz.zts.aws_public_cert=/opt/athenz/zts/conf/zts_server/aws_public.crt
 # org_id, principal_tags, etc.) in the web identity token.
 #athenz.zts.aws_web_identity_sts_claim_name=https://sts.amazonaws.com/
 
+# Optional system level authorization domain for the cross-account case (the token's
+# aws_account does not match the domain's account). When set, in addition to the
+# tenant domain launch policy, the provider service must be granted the launch action
+# against the resource {domain}:{token-aws-account}:{tenant-domain}:{tenant-service}
+# in this domain. When unset only the tenant domain launch policy is evaluated.
+#athenz.zts.aws_web_identity_cross_authz_domain=
+
 # Optional adopter com.yahoo.athenz.instance.provider.AttrValidatorFactory used to
 # validate the token subject (sub) and principal_tags. When configured it has the
 # final say on the principal; when unset the default binding (the token's IAM role

--- a/libs/java/instance_provider/docs/aws-attestation-validation.md
+++ b/libs/java/instance_provider/docs/aws-attestation-validation.md
@@ -74,20 +74,29 @@ AWSAttestationValidatorFactory (interface)
 
 ```java
 public interface AWSAttestationValidator {
-    void initialize(SSLContext sslContext, Authorizer authorizer);
+    void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal);
     boolean validateIdentity(InstanceConfirmation confirmation, AWSAttestationData info,
             String awsAccount, StringBuilder errMsg);
 }
 
 public interface AWSAttestationValidatorFactory {
-    AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer);
+    AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal);
 }
 ```
 
 `validateIdentity` returns `true` when the attestation proves the instance identity
 for the requested `confirmation` in `awsAccount`; on failure it returns `false` and
 appends a human-readable reason to `errMsg`. The `Authorizer` (supplied at init) is
-used for the cross-account launch check; the STS validator ignores it.
+used for the launch checks; the STS validator ignores it. The `providerPrincipal`
+identifies the provider service (e.g. `sys.auth.aws`) carrying out the system level
+launch check.
+
+`awsAccount` may be **empty** — the domain need not have an associated AWS account.
+Only `AWSWebIdentityTokenAttestationValidator.validateAwsAccount()` tolerates that
+(the request is then authorized purely through the launch policies below); every
+other consumer rejects an empty account as early as possible:
+`InstanceAWSProvider.validateAWSAccount()` (the instance document path) and
+`AWSStsCredentialsAttestationValidator.validateIdentity()`.
 
 ## 4. Request flow
 
@@ -124,9 +133,17 @@ identityToken present?  ── yes ──▶ AWSWebIdentityTokenAttestationValid
   2. Resolve (and cache per issuer) the issuer JWKS via its
      `/.well-known/openid-configuration`, then verify the token signature + expiry.
   3. `aud` must equal the configured audience.
-  4. The nested `aws_account` must equal the domain's AWS account; otherwise a
-     `launch` authorization is required — `authorizer.access("launch",
-     "<domain>:<service>:<tokenAwsAccount>", <domain>.<service>)` (mirrors EKS).
+  4. The nested `aws_account` must equal one of the domain's AWS accounts (the domain
+     may have none). Otherwise a **tenant** `launch` authorization is required —
+     `authorizer.access("launch", "<domain>:<service>:<tokenAwsAccount>",
+     <domain>.<service>)` (mirrors EKS). That policy is granted inside the tenant
+     domain itself, so when `athenz.zts.aws_web_identity_cross_authz_domain` is
+     configured a **system** `launch` authorization is evaluated first —
+     `authorizer.access("launch",
+     "<crossAuthzDomain>:<tokenAwsAccount>:<domain>:<service>", <providerPrincipal>)` —
+     letting the system administrators gate which account/service combinations may use
+     the cross-account path at all. Both checks must pass; when the property is unset
+     only the tenant check applies.
   5. `org_id` must be present and in the configured allowlist (mandatory).
   6. **Principal role binding (default).** The IAM role name in the token `sub`
      (`arn:aws:iam::<acct>:role/[path/]<name>` — the IAM path, if any, is stripped)
@@ -175,6 +192,7 @@ path). With none set, behavior is identical to the previous STS-only implementat
 | `athenz.zts.aws_web_identity_audience` | Expected JWT audience (`aud`) — set to the ZTS URL | *(unset → every token rejected)* |
 | `athenz.zts.aws_web_identity_issuer_regex` | Allowed issuer (`iss`) host pattern | `https://[a-z0-9-]+\.tokens\.sts\.global\.api\.aws` |
 | `athenz.zts.aws_web_identity_allowed_org_ids` | **Mandatory** `org_id` allowlist (CSV, dynamically reloadable) | *(empty → every token rejected)* |
+| `athenz.zts.aws_web_identity_cross_authz_domain` | Optional system level authorization domain for the cross-account case. When set, the provider service must additionally be granted `launch` on `<domain>:<tokenAwsAccount>:<tenantDomain>:<tenantService>` | *(unset → only the tenant launch policy is evaluated)* |
 | `athenz.zts.aws_web_identity_principal_validator_factory_class` | Optional adopter `AttrValidatorFactory` for `sub`/`principal_tags`. When set it has the final say on the principal (and overrides the default role-name binding); when unset the default binding is strictly enforced | *(unset → default binding enforced)* |
 | `athenz.zts.aws_web_identity_sts_claim_name` | Nested identity claim key | `https://sts.amazonaws.com/` |
 | `athenz.zts.aws_web_identity_discovery_proxy` | Optional HTTP proxy for issuer OIDC discovery + JWKS fetch | *(none)* |
@@ -248,11 +266,11 @@ Unit tests (TestNG + Mockito; module enforces 100% line coverage) under
 
 | Test | Covers |
 |---|---|
-| `AWSStsCredentialsAttestationValidatorTest` | STS client creation, `GetCallerIdentity`, ARN match/mismatch, null/exception paths |
-| `AWSWebIdentityTokenAttestationValidator[Test]` | Issuer extraction + regex, per-issuer JWKS resolution & cache, signature/expiry, audience, nested `sts` claim, aws_account match, cross-account launch authorization (allow/deny/no-authorizer), mandatory org_id allowlist, default role-name binding (match / mismatch / IAM path / service-only / malformed / missing sub) and its `AttrValidator` override (mismatch allowed/denied), `AttrValidator` principal allow/deny/skip |
+| `AWSStsCredentialsAttestationValidatorTest` | STS client creation, `GetCallerIdentity`, ARN match/mismatch, empty aws account, null/exception paths |
+| `AWSWebIdentityTokenAttestationValidator[Test]` | Issuer extraction + regex, per-issuer JWKS resolution & cache, signature/expiry, audience, nested `sts` claim, aws_account match, empty domain account (allowed only here), tenant cross-account launch authorization (allow/deny/no-authorizer), system cross-account launch authorization (unconfigured/allow/deny, tenant check skipped on deny), mandatory org_id allowlist, default role-name binding (match / mismatch / IAM path / service-only / malformed / missing sub) and its `AttrValidator` override (mismatch allowed/denied), `AttrValidator` principal allow/deny/skip |
 | `CompositeAWSAttestationValidatorTest` | Routing (token → JWT, no token → STS), init delegation |
 | `DefaultAWSAttestationValidatorFactoryTest` | Factory returns an initialized composite |
-| `InstanceAWSProviderTest` | Factory selection (default/custom/invalid class), `setAuthorizer`, confirm/refresh delegation via `MockAWSAttestationValidator` |
+| `InstanceAWSProviderTest` | Factory selection (default/custom/invalid class), `setAuthorizer`, provider principal creation, empty aws account (rejected with an instance document, allowed without one), confirm/refresh delegation via `MockAWSAttestationValidator` |
 | `AWSAttestationDataTest` | `identityToken` getter/setter |
 
 `MockAWSAttestationValidator` is a shared test helper whose result can be toggled so

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/AWSAttestationValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/AWSAttestationValidator.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.instance.provider;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.instance.provider.impl.AWSAttestationData;
 
 import javax.net.ssl.SSLContext;
@@ -31,19 +32,25 @@ import javax.net.ssl.SSLContext;
 public interface AWSAttestationValidator {
 
     /**
-     * Initialize the validator with the given ssl context and authorizer. The
-     * ssl context is used when the validator needs to fetch remote data (e.g.
-     * the issuer's JWKS); the authorizer is used for any RBAC based checks.
+     * Initialize the validator with the given ssl context, authorizer and
+     * provider principal. The ssl context is used when the validator needs to
+     * fetch remote data (e.g. the issuer's JWKS); the authorizer is used for
+     * any RBAC based checks while the provider principal identifies the
+     * provider service carrying out those checks.
      * @param sslContext the ssl context to use for any outbound https calls
      * @param authorizer the authorizer to use for any RBAC based checks
+     * @param providerPrincipal the principal object for the provider service
      */
-    void initialize(SSLContext sslContext, Authorizer authorizer);
+    void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal);
 
     /**
      * Validates that the given attestation data proves the instance identity.
      * @param confirmation the instance confirmation request (domain, service, attributes)
      * @param info the parsed AWS attestation data from the confirmation request
-     * @param awsAccount the AWS account id associated with the requested identity
+     * @param awsAccount the AWS account id(s) associated with the requested identity. this
+     *                   may be empty if the domain has no associated aws account, in which
+     *                   case the implementation must either reject the request or authorize
+     *                   it through some other mechanism (e.g. a launch policy check)
      * @param errMsg StringBuilder to append error details to on failure
      * @return true if the attestation data is valid, otherwise false
      */

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/AWSAttestationValidatorFactory.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/AWSAttestationValidatorFactory.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.instance.provider;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 
 import javax.net.ssl.SSLContext;
 
@@ -30,7 +31,8 @@ public interface AWSAttestationValidatorFactory {
      * Creates and initializes an AWSAttestationValidator.
      * @param sslContext the ssl context to use for any outbound https calls
      * @param authorizer the authorizer to use for any RBAC based checks
+     * @param providerPrincipal the principal object for the provider service
      * @return an initialized AWSAttestationValidator
      */
-    AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer);
+    AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal);
 }

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/AWSStsCredentialsAttestationValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/AWSStsCredentialsAttestationValidator.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.instance.provider.impl;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.common.server.util.Utils;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidator;
 import com.yahoo.athenz.instance.provider.InstanceConfirmation;
@@ -47,7 +48,7 @@ public class AWSStsCredentialsAttestationValidator implements AWSAttestationVali
     String awsRegion;
 
     @Override
-    public void initialize(SSLContext sslContext, Authorizer authorizer) {
+    public void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
         awsRegion = System.getProperty(AWS_PROP_REGION_NAME);
     }
 
@@ -84,6 +85,14 @@ public class AWSStsCredentialsAttestationValidator implements AWSAttestationVali
     @Override
     public boolean validateIdentity(InstanceConfirmation confirmation, AWSAttestationData info,
             final String awsAccount, StringBuilder errMsg) {
+
+        // the sts credentials attestation requires the domain to have an
+        // associated aws account id to match against the caller identity arn
+
+        if (StringUtil.isEmpty(awsAccount)) {
+            errMsg.append("no aws account id associated with the domain");
+            return false;
+        }
 
         if (StringUtil.isEmpty(awsRegion)) {
             errMsg.append("aws region is not configured");

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/AWSWebIdentityTokenAttestationValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/AWSWebIdentityTokenAttestationValidator.java
@@ -56,7 +56,9 @@ import static com.yahoo.athenz.instance.provider.InstanceProvider.ZTS_INSTANCE_A
  *   <li>the token signature and expiry (against the issuer JWKS),</li>
  *   <li>the audience matches the configured audience,</li>
  *   <li>the token's aws_account matches the domain's AWS account, or a launch
- *       authorization is granted for the token's account,</li>
+ *       authorization is granted for the token's account. when a cross authz
+ *       domain is configured, that cross-account case additionally requires a
+ *       system level launch authorization granted to the provider service,</li>
  *   <li>the org_id is present in the configured allowlist,</li>
  *   <li>the iam role name in the token subject matches the requested athenz
  *       service (the default binding that prevents one role from obtaining
@@ -77,6 +79,7 @@ public class AWSWebIdentityTokenAttestationValidator implements AWSAttestationVa
     static final String AWS_PROP_WEB_IDENTITY_ISSUER_REGEX    = "athenz.zts.aws_web_identity_issuer_regex";
     static final String AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS = "athenz.zts.aws_web_identity_allowed_org_ids";
     static final String AWS_PROP_WEB_IDENTITY_STS_CLAIM_NAME  = "athenz.zts.aws_web_identity_sts_claim_name";
+    static final String AWS_PROP_WEB_IDENTITY_CROSS_AUTHZ_DOMAIN = "athenz.zts.aws_web_identity_cross_authz_domain";
     static final String AWS_PROP_WEB_IDENTITY_PRINCIPAL_VALIDATOR_FACTORY_CLASS = "athenz.zts.aws_web_identity_principal_validator_factory_class";
 
     static final String AWS_DEFAULT_WEB_IDENTITY_ISSUER_REGEX = "https://[a-z0-9-]+\\.tokens\\.sts\\.global\\.api\\.aws";
@@ -91,9 +94,11 @@ public class AWSWebIdentityTokenAttestationValidator implements AWSAttestationVa
 
     String audience;
     String stsClaimName;
+    String crossAuthzDomain;
     Pattern issuerPattern;
     DynamicConfigCsv allowedOrgIds;
     Authorizer authorizer;
+    Principal providerPrincipal;
     AttrValidator principalValidator;
 
     final JwtsHelper jwtsHelper = new JwtsHelper();
@@ -101,12 +106,14 @@ public class AWSWebIdentityTokenAttestationValidator implements AWSAttestationVa
     String oidcDiscoveryProxy;
 
     @Override
-    public void initialize(SSLContext sslContext, Authorizer authorizer) {
+    public void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
 
         this.authorizer = authorizer;
+        this.providerPrincipal = providerPrincipal;
         audience = System.getProperty(AWS_PROP_WEB_IDENTITY_AUDIENCE, null);
         issuerPattern = Pattern.compile(System.getProperty(AWS_PROP_WEB_IDENTITY_ISSUER_REGEX, AWS_DEFAULT_WEB_IDENTITY_ISSUER_REGEX));
         stsClaimName = System.getProperty(AWS_PROP_WEB_IDENTITY_STS_CLAIM_NAME, AWS_DEFAULT_STS_CLAIM_NAME);
+        crossAuthzDomain = System.getProperty(AWS_PROP_WEB_IDENTITY_CROSS_AUTHZ_DOMAIN);
         allowedOrgIds = new DynamicConfigCsv(CONFIG_MANAGER, AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, null);
         oidcDiscoveryProxy = System.getProperty(AWS_PROP_WEB_IDENTITY_DISCOVERY_PROXY, null);
         principalValidator = newPrincipalValidator(sslContext);
@@ -303,10 +310,13 @@ public class AWSWebIdentityTokenAttestationValidator implements AWSAttestationVa
             return false;
         }
 
-        // if the token account matches one of the domain's (possibly
-        // comma-separated) accounts we're done
+        // this is the only validation path where the domain is allowed to have
+        // no associated aws account - in that case the request can only be
+        // authorized through the launch policy check below. otherwise, if the
+        // token account matches one of the domain's (possibly comma-separated)
+        // accounts we're done
 
-        if (Utils.parseAwsAccounts(awsAccount).contains(tokenAwsAccount)) {
+        if (!StringUtil.isEmpty(awsAccount) && Utils.parseAwsAccounts(awsAccount).contains(tokenAwsAccount)) {
             return true;
         }
 
@@ -320,6 +330,20 @@ public class AWSWebIdentityTokenAttestationValidator implements AWSAttestationVa
 
         final String domainName = confirmation.getDomain();
         final String serviceName = confirmation.getService();
+
+        // the tenant launch policy below is granted within the tenant domain itself,
+        // so when a cross authz domain is configured we first require the system
+        // administrators to have authorized this account/service combination as well
+
+        if (!StringUtil.isEmpty(crossAuthzDomain)) {
+            final String systemResource = String.format("%s:%s:%s:%s", crossAuthzDomain,
+                    tokenAwsAccount, domainName, serviceName);
+            if (!authorizer.access(ACTION_LAUNCH, systemResource, providerPrincipal, null)) {
+                errMsg.append("system launch authorization check failed for resource: ").append(systemResource);
+                return false;
+            }
+        }
+
         final String resource = String.format("%s:%s:%s", domainName, serviceName, tokenAwsAccount);
         Principal principal = SimplePrincipal.create(domainName, serviceName, (String) null);
         if (!authorizer.access(ACTION_LAUNCH, resource, principal, null)) {

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CompositeAWSAttestationValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CompositeAWSAttestationValidator.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.instance.provider.impl;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidator;
 import com.yahoo.athenz.instance.provider.InstanceConfirmation;
 import org.eclipse.jetty.util.StringUtil;
@@ -45,9 +46,9 @@ public class CompositeAWSAttestationValidator implements AWSAttestationValidator
     }
 
     @Override
-    public void initialize(SSLContext sslContext, Authorizer authorizer) {
-        stsCredentialsValidator.initialize(sslContext, authorizer);
-        webIdentityTokenValidator.initialize(sslContext, authorizer);
+    public void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
+        stsCredentialsValidator.initialize(sslContext, authorizer, providerPrincipal);
+        webIdentityTokenValidator.initialize(sslContext, authorizer, providerPrincipal);
     }
 
     @Override

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/DefaultAWSAttestationValidatorFactory.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/DefaultAWSAttestationValidatorFactory.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.instance.provider.impl;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidator;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidatorFactory;
 
@@ -29,9 +30,9 @@ import javax.net.ssl.SSLContext;
 public class DefaultAWSAttestationValidatorFactory implements AWSAttestationValidatorFactory {
 
     @Override
-    public AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer) {
+    public AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
         AWSAttestationValidator validator = new CompositeAWSAttestationValidator();
-        validator.initialize(sslContext, authorizer);
+        validator.initialize(sslContext, authorizer, providerPrincipal);
         return validator;
     }
 }

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProvider.java
@@ -27,6 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import com.yahoo.athenz.auth.Authorizer;
 import com.yahoo.athenz.auth.KeyStore;
+import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.impl.SimplePrincipal;
+import com.yahoo.athenz.auth.util.AthenzUtils;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidator;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidatorFactory;
 import com.yahoo.athenz.instance.provider.InstanceConfirmation;
@@ -79,6 +82,7 @@ public class InstanceAWSProvider implements InstanceProvider {
     List<IPBlock> systemAllowedIPAddresses;
     AWSAttestationValidator attestationValidator;
     Authorizer authorizer;
+    Principal providerPrincipal;
 
     @Override
     public void setAuthorizer(Authorizer authorizer) {
@@ -101,6 +105,12 @@ public class InstanceAWSProvider implements InstanceProvider {
         // create our helper object to validate aws documents
 
         awsUtils = new InstanceAWSUtils();
+
+        // generate our provider principal object based on the given
+        // provider service name. this is used by our attestation
+        // validators when carrying out any authorization checks
+
+        providerPrincipal = createProviderPrincipal(provider);
 
         // how long the instance must be booted in the past before we
         // stop validating the instance requests
@@ -141,7 +151,23 @@ public class InstanceAWSProvider implements InstanceProvider {
         // validator is configurable so adopters can swap the mechanism (e.g. STS
         // temporary credentials vs AWS web identity token) used for validation
 
-        attestationValidator = newAttestationValidatorFactory().create(sslContext, authorizer);
+        attestationValidator = newAttestationValidatorFactory().create(sslContext, authorizer, providerPrincipal);
+    }
+
+    static Principal createProviderPrincipal(final String provider) {
+
+        // our provider is a service identity in the <domain>.<service> format
+
+        if (StringUtil.isEmpty(provider)) {
+            LOGGER.error("No provider service name specified");
+            return null;
+        }
+        String[] providerComponents = AthenzUtils.splitPrincipalName(provider);
+        if (providerComponents == null) {
+            LOGGER.error("Invalid provider service name: {}", provider);
+            return null;
+        }
+        return SimplePrincipal.create(providerComponents[0], providerComponents[1], (String) null);
     }
 
     AWSAttestationValidatorFactory newAttestationValidatorFactory() {
@@ -174,6 +200,14 @@ public class InstanceAWSProvider implements InstanceProvider {
     }
 
     boolean validateAWSAccount(final String awsAccount, final String docAccount, StringBuilder errMsg) {
+
+        // the instance document based attestation requires the domain to have
+        // an associated aws account id to compare the document account against
+
+        if (StringUtil.isEmpty(awsAccount)) {
+            errMsg.append("no aws account id associated with the domain");
+            return false;
+        }
 
         for (String account : Utils.parseAwsAccounts(awsAccount)) {
             if (account.equalsIgnoreCase(docAccount)) {
@@ -296,20 +330,18 @@ public class InstanceAWSProvider implements InstanceProvider {
         final String instanceDomain = confirmation.getDomain();
         final String instanceService = confirmation.getService();
         
-        // before doing anything else we want to make sure our
-        // object has an associated aws account id
-        
+        // extract our aws account id. typically this would be a required
+        // value but if we're issuing an identity based on the oidc token
+        // with authorization, it could be empty
+
         final String awsAccount = InstanceUtils.getInstanceProperty(instanceAttributes, ZTS_INSTANCE_AWS_ACCOUNT);
-        if (StringUtil.isEmpty(awsAccount)) {
-            throw error("Unable to extract AWS Account id");
-        }
-        
+
         // validate that the domain/service given in the confirmation
         // request match the attestation data. the role can represent
         // either one of two formats: <domain>.<service> or <service>.
         // with just the <service> format we already verify the <domain>
         // component based on the aws account id in the arn
-        
+
         final String serviceName = instanceDomain + "." + instanceService;
         if (!(serviceName.equals(info.getRole()) || instanceService.equals(info.getRole()))) {
             throw error("Service name mismatch: " + info.getRole() + " vs. " + serviceName);
@@ -377,13 +409,11 @@ public class InstanceAWSProvider implements InstanceProvider {
         final String instanceDomain = confirmation.getDomain();
         final String instanceService = confirmation.getService();
         
-        // before doing anything else we want to make sure our
-        // object has an associated aws account id
-        
+        // extract our aws account id. typically this would be a required
+        // value but if we're issuing an identity based on the oidc token
+        // with authorization, it could be empty
+
         final String awsAccount = InstanceUtils.getInstanceProperty(instanceAttributes, ZTS_INSTANCE_AWS_ACCOUNT);
-        if (StringUtil.isEmpty(awsAccount)) {
-            throw error("Unable to extract AWS Account id");
-        }
 
         // validate that the domain/service given in the confirmation
         // request match the attestation data. the role can represent

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/AWSStsCredentialsAttestationValidatorTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/AWSStsCredentialsAttestationValidatorTest.java
@@ -44,7 +44,7 @@ public class AWSStsCredentialsAttestationValidatorTest {
     @Test
     public void testInitialize() {
         AWSStsCredentialsAttestationValidator validator = new AWSStsCredentialsAttestationValidator();
-        validator.initialize(null, null);
+        validator.initialize(null, null, null);
         assertNotNull(validator.awsRegion);
     }
 
@@ -86,6 +86,23 @@ public class AWSStsCredentialsAttestationValidatorTest {
 
         data.setToken("valid");
         assertNotNull(validator.getInstanceClient(data));
+    }
+
+    @Test
+    public void testValidateIdentityNoAwsAccount() {
+        // the domain has no associated aws account - the sts credentials path
+        // requires one so the request must be rejected right away
+        AWSStsCredentialsAttestationValidator validator = new AWSStsCredentialsAttestationValidator();
+        validator.awsRegion = "us-west-2";
+        AWSAttestationData info = new AWSAttestationData();
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(validator.validateIdentity(null, info, null, errMsg));
+        assertTrue(errMsg.toString().contains("no aws account id associated with the domain"));
+
+        errMsg.setLength(0);
+        assertFalse(validator.validateIdentity(null, info, "", errMsg));
+        assertTrue(errMsg.toString().contains("no aws account id associated with the domain"));
     }
 
     @Test

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/AWSWebIdentityTokenAttestationValidatorTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/AWSWebIdentityTokenAttestationValidatorTest.java
@@ -23,6 +23,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.yahoo.athenz.auth.Authorizer;
 import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.impl.SimplePrincipal;
 import com.yahoo.athenz.auth.token.jwts.JwtsSigningKeyResolver;
 import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.athenz.instance.provider.InstanceConfirmation;
@@ -41,7 +42,9 @@ import java.util.Objects;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class AWSWebIdentityTokenAttestationValidatorTest {
@@ -53,6 +56,8 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
     private static final String AWS_ISSUER = "https://a235ce0e-ece5-7bh3-b26c-62f78631444b.tokens.sts.global.api.aws";
     private static final String AUDIENCE = "https://zts.athenz.io/zts/v1";
     private static final String STS_CLAIM = "https://sts.amazonaws.com/";
+    private static final Principal PROVIDER_PRINCIPAL = SimplePrincipal.create("sys.auth", "aws", (String) null);
+    private static final String CROSS_AUTHZ_DOMAIN = "sys.auth.aws-launch";
 
     @AfterMethod
     public void shutdown() {
@@ -60,6 +65,7 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
         System.clearProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ISSUER_REGEX);
         System.clearProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS);
         System.clearProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_STS_CLAIM_NAME);
+        System.clearProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_CROSS_AUTHZ_DOMAIN);
         System.clearProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_PRINCIPAL_VALIDATOR_FACTORY_CLASS);
     }
 
@@ -105,7 +111,8 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
                 return new JwtsSigningKeyResolver(jwksUri, null, true);
             }
         };
-        validator.initialize(null, authorizer);
+        validator.initialize(null, authorizer, PROVIDER_PRINCIPAL);
+        assertEquals(validator.providerPrincipal, PROVIDER_PRINCIPAL);
         return validator;
     }
 
@@ -194,7 +201,7 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
                 return new JwtsSigningKeyResolver(jwksUri, null, true);
             }
         };
-        validator.initialize(null, null);
+        validator.initialize(null, null, null);
         final String token = generateToken(AWS_ISSUER, AUDIENCE, "sub", stsClaim("1234", "o-qwsedrftg3"));
         AWSAttestationData info = new AWSAttestationData();
         info.setIdentityToken(token);
@@ -214,7 +221,7 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
                 return null;
             }
         };
-        validator.initialize(null, null);
+        validator.initialize(null, null, null);
         final String token = generateToken(AWS_ISSUER, AUDIENCE, "sub", stsClaim("1234", "o-qwsedrftg3"));
         AWSAttestationData info = new AWSAttestationData();
         info.setIdentityToken(token);
@@ -225,7 +232,7 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
     @Test
     public void testGetSigningKeyResolverForIssuer() throws Exception {
         AWSWebIdentityTokenAttestationValidator validator = new AWSWebIdentityTokenAttestationValidator();
-        validator.initialize(null, null);
+        validator.initialize(null, null, null);
 
         // a valid openid configuration that points at the local jwks
         File issuerDir = new File("./src/test/resources/config-openid-aws-sts/");
@@ -313,6 +320,46 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
     }
 
     @Test
+    public void testValidateIdentityNoDomainAccountAuthorized() throws Exception {
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Mockito.when(authorizer.access(eq("launch"), eq("athenz:api:123456789012"), any(Principal.class), any()))
+                .thenReturn(true);
+        AWSWebIdentityTokenAttestationValidator validator = newValidator(authorizer);
+        final String token = generateToken(AWS_ISSUER, AUDIENCE, "arn:aws:iam::123456789012:role/athenz.api",
+                stsClaim("123456789012", "o-qwsedrftg3"));
+        AWSAttestationData info = new AWSAttestationData();
+        info.setIdentityToken(token);
+
+        // the domain has no associated aws account - this is the only validation
+        // path where that is allowed and the request is authorized via the launch
+        // policy for the token's account
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertTrue(validator.validateIdentity(confirmation(), info, null, errMsg));
+
+        errMsg.setLength(0);
+        assertTrue(validator.validateIdentity(confirmation(), info, "", errMsg));
+    }
+
+    @Test
+    public void testValidateIdentityNoDomainAccountDenied() throws Exception {
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Mockito.when(authorizer.access(any(), any(), any(Principal.class), any())).thenReturn(false);
+        AWSWebIdentityTokenAttestationValidator validator = newValidator(authorizer);
+        final String token = generateToken(AWS_ISSUER, AUDIENCE, "arn:aws:iam::123456789012:role/athenz.api",
+                stsClaim("123456789012", "o-qwsedrftg3"));
+        AWSAttestationData info = new AWSAttestationData();
+        info.setIdentityToken(token);
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(validator.validateIdentity(confirmation(), info, null, errMsg));
+        assertTrue(errMsg.toString().contains("launch authorization check failed"));
+    }
+
+    @Test
     public void testValidateIdentityMissingAwsAccountClaim() throws Exception {
         System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
         System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
@@ -370,6 +417,98 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
         StringBuilder errMsg = new StringBuilder(256);
         assertFalse(validator.validateIdentity(confirmation(), info, "1234", errMsg));
         assertTrue(errMsg.toString().contains("authorizer not available"));
+    }
+
+    @Test
+    public void testValidateIdentityCrossAccountNoSystemAuthzDomainConfigured() throws Exception {
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Mockito.when(authorizer.access(eq("launch"), eq("athenz:api:123456789012"), any(Principal.class), any()))
+                .thenReturn(true);
+        AWSWebIdentityTokenAttestationValidator validator = newValidator(authorizer);
+        assertNull(validator.crossAuthzDomain);
+        final String token = generateToken(AWS_ISSUER, AUDIENCE, "arn:aws:iam::123456789012:role/athenz.api",
+                stsClaim("123456789012", "o-qwsedrftg3"));
+        AWSAttestationData info = new AWSAttestationData();
+        info.setIdentityToken(token);
+        StringBuilder errMsg = new StringBuilder(256);
+        assertTrue(validator.validateIdentity(confirmation(), info, "1234", errMsg));
+
+        // without a configured cross authz domain the tenant launch check is the only one carried out
+
+        Mockito.verify(authorizer, Mockito.times(1)).access(any(), any(), any(Principal.class), any());
+    }
+
+    @Test
+    public void testValidateIdentityCrossAccountSystemAuthorized() throws Exception {
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_CROSS_AUTHZ_DOMAIN, CROSS_AUTHZ_DOMAIN);
+        final String systemResource = CROSS_AUTHZ_DOMAIN + ":123456789012:athenz:api";
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Mockito.when(authorizer.access(eq("launch"), eq(systemResource), eq(PROVIDER_PRINCIPAL), any()))
+                .thenReturn(true);
+        Mockito.when(authorizer.access(eq("launch"), eq("athenz:api:123456789012"), any(Principal.class), any()))
+                .thenReturn(true);
+        AWSWebIdentityTokenAttestationValidator validator = newValidator(authorizer);
+        assertEquals(validator.crossAuthzDomain, CROSS_AUTHZ_DOMAIN);
+        final String token = generateToken(AWS_ISSUER, AUDIENCE, "arn:aws:iam::123456789012:role/athenz.api",
+                stsClaim("123456789012", "o-qwsedrftg3"));
+        AWSAttestationData info = new AWSAttestationData();
+        info.setIdentityToken(token);
+        StringBuilder errMsg = new StringBuilder(256);
+
+        // both the system level and the tenant level launch checks are granted
+
+        assertTrue(validator.validateIdentity(confirmation(), info, "1234", errMsg));
+        Mockito.verify(authorizer).access(eq("launch"), eq(systemResource), eq(PROVIDER_PRINCIPAL), any());
+        Mockito.verify(authorizer).access(eq("launch"), eq("athenz:api:123456789012"), any(Principal.class), any());
+    }
+
+    @Test
+    public void testValidateIdentityCrossAccountSystemDenied() throws Exception {
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_CROSS_AUTHZ_DOMAIN, CROSS_AUTHZ_DOMAIN);
+        final String systemResource = CROSS_AUTHZ_DOMAIN + ":123456789012:athenz:api";
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Mockito.when(authorizer.access(eq("launch"), eq(systemResource), eq(PROVIDER_PRINCIPAL), any()))
+                .thenReturn(false);
+        // the tenant level check is granted but it must never be reached
+        Mockito.when(authorizer.access(eq("launch"), eq("athenz:api:123456789012"), any(Principal.class), any()))
+                .thenReturn(true);
+        AWSWebIdentityTokenAttestationValidator validator = newValidator(authorizer);
+        final String token = generateToken(AWS_ISSUER, AUDIENCE, "arn:aws:iam::123456789012:role/athenz.api",
+                stsClaim("123456789012", "o-qwsedrftg3"));
+        AWSAttestationData info = new AWSAttestationData();
+        info.setIdentityToken(token);
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(validator.validateIdentity(confirmation(), info, "1234", errMsg));
+        assertTrue(errMsg.toString().contains("system launch authorization check failed for resource: " + systemResource));
+        Mockito.verify(authorizer, Mockito.never())
+                .access(eq("launch"), eq("athenz:api:123456789012"), any(Principal.class), any());
+    }
+
+    @Test
+    public void testValidateIdentityNoDomainAccountSystemDenied() throws Exception {
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_AUDIENCE, AUDIENCE);
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_ALLOWED_ORG_IDS, "o-qwsedrftg3");
+        System.setProperty(AWSWebIdentityTokenAttestationValidator.AWS_PROP_WEB_IDENTITY_CROSS_AUTHZ_DOMAIN, CROSS_AUTHZ_DOMAIN);
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Mockito.when(authorizer.access(any(), any(), any(Principal.class), any())).thenReturn(false);
+        AWSWebIdentityTokenAttestationValidator validator = newValidator(authorizer);
+        final String token = generateToken(AWS_ISSUER, AUDIENCE, "arn:aws:iam::123456789012:role/athenz.api",
+                stsClaim("123456789012", "o-qwsedrftg3"));
+        AWSAttestationData info = new AWSAttestationData();
+        info.setIdentityToken(token);
+
+        // the domain has no associated aws account so the system level check applies here as well
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(validator.validateIdentity(confirmation(), info, null, errMsg));
+        assertTrue(errMsg.toString().contains("system launch authorization check failed for resource: "
+                + CROSS_AUTHZ_DOMAIN + ":123456789012:athenz:api"));
     }
 
     @Test
@@ -576,7 +715,7 @@ public class AWSWebIdentityTokenAttestationValidatorTest {
                 "com.yahoo.athenz.instance.provider.impl.UnknownFactoryClass");
         AWSWebIdentityTokenAttestationValidator validator = new AWSWebIdentityTokenAttestationValidator();
         try {
-            validator.initialize(null, null);
+            validator.initialize(null, null, null);
             org.testng.Assert.fail();
         } catch (IllegalArgumentException ex) {
             assertTrue(ex.getMessage().contains("Invalid AWS web identity principal AttrValidatorFactory class"));

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/CompositeAWSAttestationValidatorTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/CompositeAWSAttestationValidatorTest.java
@@ -38,9 +38,9 @@ public class CompositeAWSAttestationValidatorTest {
         AWSAttestationValidator sts = Mockito.mock(AWSAttestationValidator.class);
         AWSAttestationValidator webId = Mockito.mock(AWSAttestationValidator.class);
         CompositeAWSAttestationValidator validator = new CompositeAWSAttestationValidator(sts, webId);
-        validator.initialize(null, null);
-        Mockito.verify(sts).initialize(any(), any());
-        Mockito.verify(webId).initialize(any(), any());
+        validator.initialize(null, null, null);
+        Mockito.verify(sts).initialize(any(), any(), any());
+        Mockito.verify(webId).initialize(any(), any(), any());
     }
 
     @Test

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/DefaultAWSAttestationValidatorFactoryTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/DefaultAWSAttestationValidatorFactoryTest.java
@@ -38,7 +38,7 @@ public class DefaultAWSAttestationValidatorFactoryTest {
     @Test
     public void testCreate() {
         DefaultAWSAttestationValidatorFactory factory = new DefaultAWSAttestationValidatorFactory();
-        AWSAttestationValidator validator = factory.create(null, null);
+        AWSAttestationValidator validator = factory.create(null, null, null);
         assertNotNull(validator);
         assertTrue(validator instanceof CompositeAWSAttestationValidator);
     }

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSProviderTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidator;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidatorFactory;
 import com.yahoo.athenz.instance.provider.InstanceProvider;
@@ -63,8 +64,36 @@ public class InstanceAWSProviderTest {
     }
     
     @Test
+    public void testCreateProviderPrincipal() {
+
+        Principal principal = InstanceAWSProvider.createProviderPrincipal("athenz.aws.us-west-2");
+        assertNotNull(principal);
+        assertEquals(principal.getDomain(), "athenz.aws");
+        assertEquals(principal.getName(), "us-west-2");
+
+        // invalid provider service names must not generate any principals
+
+        assertNull(InstanceAWSProvider.createProviderPrincipal(null));
+        assertNull(InstanceAWSProvider.createProviderPrincipal(""));
+        assertNull(InstanceAWSProvider.createProviderPrincipal("provider"));
+        assertNull(InstanceAWSProvider.createProviderPrincipal("athenz.aws."));
+        assertNull(InstanceAWSProvider.createProviderPrincipal(".us-west-2"));
+    }
+
+    @Test
+    public void testInitializeProviderPrincipal() {
+
+        InstanceAWSProvider provider = new InstanceAWSProvider();
+        provider.initialize("athenz.aws.us-west-2",
+                "com.yahoo.athenz.instance.provider.impl.InstanceAWSProvider", null, null);
+        assertNotNull(provider.providerPrincipal);
+        assertEquals(provider.providerPrincipal.getFullName(), "athenz.aws.us-west-2");
+        provider.close();
+    }
+
+    @Test
     public void testInitialize() {
-        
+
         InstanceAWSProvider provider = new InstanceAWSProvider();
         System.setProperty(InstanceAWSUtils.AWS_PROP_PUBLIC_CERT, "src/test/resources/aws_public.cert");
         System.setProperty(InstanceAWSProvider.AWS_PROP_BOOT_TIME_OFFSET, "60");
@@ -128,7 +157,24 @@ public class InstanceAWSProviderTest {
         assertFalse(provider.validateAWSAccount("1234,5678", "9999", errMsg));
         provider.close();
     }
-    
+
+    @Test
+    public void testValidateAWSAccountEmptyAccount() {
+
+        StringBuilder errMsg = new StringBuilder(256);
+        InstanceAWSProvider provider = new InstanceAWSProvider();
+
+        assertFalse(provider.validateAWSAccount(null, "1234", errMsg));
+        assertTrue(errMsg.toString().contains("no aws account id associated with the domain"));
+
+        errMsg.setLength(0);
+        assertFalse(provider.validateAWSAccount("", "1234", errMsg));
+        assertTrue(errMsg.toString().contains("no aws account id associated with the domain"));
+
+        provider.close();
+    }
+
+
     @Test
     public void testValidateAWSDocumentInvalidSignature() {
 
@@ -191,22 +237,63 @@ public class InstanceAWSProviderTest {
     
     @Test
     public void testConfirmInstanceNoAccountId() {
-        
+
+        // with an instance document present we require the domain to have an
+        // associated aws account id so the request must be rejected
+
+        System.setProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX, "athenz.cloud");
         MockInstanceAWSProvider provider = new MockInstanceAWSProvider();
         System.setProperty(InstanceAWSUtils.AWS_PROP_PUBLIC_CERT, "src/test/resources/aws_public.cert");
         provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceAWSProvider", null, null);
-        
+
+        String bootTime = Timestamp.fromMillis(System.currentTimeMillis() - 100).toString();
         InstanceConfirmation confirmation = new InstanceConfirmation()
-                .setAttestationData("{\"document\": \"document\",\"signature\": \"signature\",\"role\": \"athenz.service\"}")
-                .setDomain("athenz").setProvider("provider").setService("service");
-        
+                .setAttestationData("{\"document\": \"{\\\"accountId\\\": \\\"1234\\\",\\\"pendingTime\\\": \\\""
+                        + bootTime + "\\\",\\\"region\\\": \\\"us-west-2\\\",\\\"instanceId\\\": \\\"i-1234\\\"}\","
+                        + "\"signature\": \"signature\",\"role\": \"athenz.service\"}")
+                .setDomain("athenz").setProvider("athenz.aws.us-west-2").setService("service");
+        HashMap<String, String> attributes = new HashMap<>();
+        attributes.put("sanDNS", "service.athenz.athenz.cloud,i-1234.instanceid.athenz.athenz.cloud");
+        confirmation.setAttributes(attributes);
+
         try {
             provider.confirmInstance(confirmation);
             fail();
-        } catch (ProviderResourceException ignored) {
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("no aws account id associated with the domain"));
         }
+        System.clearProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX);
     }
-    
+
+    @Test
+    public void testConfirmInstanceNoAccountIdNoDocument() throws ProviderResourceException {
+
+        // without an instance document the account id is not required since the
+        // attestation validator may authorize the request based on the identity
+        // token contents alone
+
+        System.setProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX, "athenz.cloud");
+        MockInstanceAWSProvider provider = new MockInstanceAWSProvider();
+        System.setProperty(InstanceAWSUtils.AWS_PROP_PUBLIC_CERT, "src/test/resources/aws_public.cert");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceAWSProvider", null, null);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation()
+                .setAttestationData("{\"role\": \"athenz.service\"}")
+                .setDomain("athenz").setProvider("athenz.aws.us-west-2").setService("service");
+        HashMap<String, String> attributes = new HashMap<>();
+        attributes.put("sanDNS", "service.athenz.athenz.cloud,i-1234.instanceid.athenz.athenz.cloud");
+        confirmation.setAttributes(attributes);
+
+        InstanceConfirmation result = provider.confirmInstance(confirmation);
+        assertEquals(result.getDomain(), "athenz");
+        Map<String, String> attrs = result.getAttributes();
+        assertNotNull(attrs);
+        assertEquals(attrs.get("certExpiryTime"), Long.toString(7 * 24 * 60));
+        System.clearProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX);
+    }
+
+
     @Test
     public void testConfirmInstanceServiceMismatch() {
         
@@ -615,7 +702,7 @@ public class InstanceAWSProviderTest {
 
     public static class TestAttestationValidator implements AWSAttestationValidator {
         @Override
-        public void initialize(SSLContext sslContext, Authorizer authorizer) {
+        public void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
         }
         @Override
         public boolean validateIdentity(InstanceConfirmation confirmation, AWSAttestationData info,
@@ -626,9 +713,9 @@ public class InstanceAWSProviderTest {
 
     public static class TestAttestationValidatorFactory implements AWSAttestationValidatorFactory {
         @Override
-        public AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer) {
+        public AWSAttestationValidator create(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
             AWSAttestationValidator validator = new TestAttestationValidator();
-            validator.initialize(sslContext, authorizer);
+            validator.initialize(sslContext, authorizer, providerPrincipal);
             return validator;
         }
     }
@@ -793,23 +880,63 @@ public class InstanceAWSProviderTest {
 
     @Test
     public void testRefreshInstanceNoAccountId() {
-        
+
+        // with an instance document present we require the domain to have an
+        // associated aws account id so the request must be rejected
+
+        System.setProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX, "athenz.cloud");
         MockInstanceAWSProvider provider = new MockInstanceAWSProvider();
         System.setProperty(InstanceAWSUtils.AWS_PROP_PUBLIC_CERT, "src/test/resources/aws_public.cert");
         provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceAWSProvider", null, null);
-        
+
+        String bootTime = Timestamp.fromMillis(System.currentTimeMillis() - 100).toString();
         InstanceConfirmation confirmation = new InstanceConfirmation()
-                .setAttestationData("{\"document\": \"document\",\"signature\": \"signature\",\"role\": \"athenz.service\"}")
-                .setDomain("athenz").setProvider("provider").setService("service");
-        
+                .setAttestationData("{\"document\": \"{\\\"accountId\\\": \\\"1234\\\",\\\"pendingTime\\\": \\\""
+                        + bootTime + "\\\",\\\"region\\\": \\\"us-west-2\\\",\\\"instanceId\\\": \\\"i-1234\\\"}\","
+                        + "\"signature\": \"signature\",\"role\": \"athenz.service\"}")
+                .setDomain("athenz").setProvider("athenz.aws.us-west-2").setService("service");
+        HashMap<String, String> attributes = new HashMap<>();
+        attributes.put("sanDNS", "service.athenz.athenz.cloud,i-1234.instanceid.athenz.athenz.cloud");
+        attributes.put("instanceId", "i-1234");
+        confirmation.setAttributes(attributes);
+
         try {
             provider.refreshInstance(confirmation);
             fail();
         } catch (ProviderResourceException ex) {
             assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("no aws account id associated with the domain"));
         }
+        System.clearProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX);
     }
-    
+
+    @Test
+    public void testRefreshInstanceNoAccountIdNoDocument() throws ProviderResourceException {
+
+        // without an instance document the account id is not required since the
+        // attestation validator may authorize the request based on the identity
+        // token contents alone
+
+        System.setProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX, "athenz.cloud");
+        MockInstanceAWSProvider provider = new MockInstanceAWSProvider();
+        System.setProperty(InstanceAWSUtils.AWS_PROP_PUBLIC_CERT, "src/test/resources/aws_public.cert");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceAWSProvider", null, null);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation()
+                .setAttestationData("{\"role\": \"athenz.service\"}")
+                .setDomain("athenz").setProvider("athenz.aws.us-west-2").setService("service");
+        HashMap<String, String> attributes = new HashMap<>();
+        attributes.put("sanDNS", "service.athenz.athenz.cloud,i-1234.instanceid.athenz.athenz.cloud");
+        attributes.put("instanceId", "i-1234");
+        confirmation.setAttributes(attributes);
+
+        InstanceConfirmation result = provider.refreshInstance(confirmation);
+        assertEquals(result.getDomain(), "athenz");
+        assertEquals(result.getAttributes().get("certExpiryTime"), Long.toString(7 * 24 * 60));
+        System.clearProperty(InstanceAWSProvider.AWS_PROP_DNS_SUFFIX);
+    }
+
+
     @Test
     public void testRefreshInstanceServiceMismatch() {
         

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/MockAWSAttestationValidator.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/MockAWSAttestationValidator.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.instance.provider.impl;
 
 import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.instance.provider.AWSAttestationValidator;
 import com.yahoo.athenz.instance.provider.InstanceConfirmation;
 
@@ -30,7 +31,7 @@ public class MockAWSAttestationValidator implements AWSAttestationValidator {
     boolean identityResult = true;
 
     @Override
-    public void initialize(SSLContext sslContext, Authorizer authorizer) {
+    public void initialize(SSLContext sslContext, Authorizer authorizer, Principal providerPrincipal) {
     }
 
     @Override

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -415,6 +415,13 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # org_id, principal_tags, etc.) in the web identity token.
 #athenz.zts.aws_web_identity_sts_claim_name=https://sts.amazonaws.com/
 
+# Optional system level authorization domain for the cross-account case (the token's
+# aws_account does not match the domain's account). When set, in addition to the
+# tenant domain launch policy, the provider service must be granted the launch action
+# against the resource {domain}:{token-aws-account}:{tenant-domain}:{tenant-service}
+# in this domain. When unset only the tenant domain launch policy is evaluated.
+#athenz.zts.aws_web_identity_cross_authz_domain=
+
 # Optional adopter com.yahoo.athenz.instance.provider.AttrValidatorFactory used to
 # validate the token subject (sub) and principal_tags. When configured it has the
 # final say on the principal; when unset the default binding (the token's IAM role


### PR DESCRIPTION
…ch authz

Allow an AWS instance identity to be issued for a domain that has no associated aws account, and gate the cross-account web identity case behind an optional system level authorization check.

- InstanceAWSProvider confirmInstance/refreshInstance no longer reject an empty awsAccount up front. Every consumer that requires one now rejects it as early as possible instead: validateAWSAccount (the instance document path) and AWSStsCredentialsAttestationValidator. The web identity validator's validateAwsAccount is the only path that tolerates an empty account - there the request can only be authorized through the launch policies.

- The provider now builds a Principal for its own service and passes it through the validator factory to the validators.

- New optional property athenz.zts.aws_web_identity_cross_authz_domain. When set, the cross-account case (token aws_account does not match the domain's account) additionally requires the provider service to be granted launch on {cross-authz-domain}:{token-aws-account}:{domain}:{service}. That check runs before the tenant domain launch policy, which is granted inside the tenant domain itself, so system administrators can gate which account/service combinations may use the cross-account path at all. When unset only the tenant check applies - behavior is unchanged.

# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

