### PR TITLE
docs: fix typos in policy, redux and util docs

### DIFF
--- a/docs/zpu_policy_file.md
+++ b/docs/zpu_policy_file.md
@@ -47,7 +47,7 @@ public-key:
 The public key is encoded in YBase64 encoding so it must be decoded
 before the public key can be used to validate the signature.
 
-Checkout [YBase64](https://github.com/AthenZ/athenz/blob/master/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/YBase64.java) class implemenation in `athenz-auth-core` library for details.
+Checkout [YBase64](https://github.com/AthenZ/athenz/blob/master/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/YBase64.java) class implementation in `athenz-auth-core` library for details.
 
 b) Validate the signature of the extracted `<zts-data>` string using Bouncycastle.
 `<signature>` field is also YBase64 encoded, so it must be decoded before
@@ -87,7 +87,7 @@ public-key:
 The public key is encoded in YBase64 encoding so it must be decoded
 before the public key can be used to validate the signature.
 
-Checkout [YBase64](https://github.com/AthenZ/athenz/blob/master/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/YBase64.java) class implemenation in `athenz-auth-core` library for details.
+Checkout [YBase64](https://github.com/AthenZ/athenz/blob/master/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/YBase64.java) class implementation in `athenz-auth-core` library for details.
 
 b) Validate the signature of the extracted `<zms-data>` string using Bouncycastle.
 `<signature>` field is also YBase64 encoded, so it must be decoded before

--- a/ui/src/redux/README.md
+++ b/ui/src/redux/README.md
@@ -8,7 +8,7 @@ to_store - using in the end of an add function in order to separate the backend 
 from_store - using in the end on a delete function in order to separate the backend delete data function and the function which delete the data from the store - (example: deleteRole, deleteRoleFromStore)
 
 Architecture:
-Store: the store seperated to 10 different reducers.
+Store: the store separated to 10 different reducers.
 each reducer in the store holds a domain name, expiry and the data. (for example the roles reducer look like: {domainData:'dom', expiry:'', roles:{} })
 in order to improve convince of writing code we transform the data from array to map (the data the server returns is an array but holds in the store as a map).
 the keys for the roles/groups/services/polices are full names (<domain-name>:role/group.<role-name>)

--- a/utils/zts-accesstoken/README.md
+++ b/utils/zts-accesstoken/README.md
@@ -21,7 +21,7 @@ $ zts-accesstoken -domain <domain> [-roles <roles>] [-service <service>] -ntoken
 The service identity ntoken can be obtained by using the zms-svctoken
 utility. The optional expire-time argument specifies how long the access
 token should be valid for. The value must be specified in minutes. The
-defualt if no value is specified is 120 minutes.
+default if no value is specified is 120 minutes.
 
 ## License
 

--- a/utils/zts-roletoken/README.md
+++ b/utils/zts-roletoken/README.md
@@ -27,7 +27,7 @@ $ zts-roletoken -domain <domain> [-role <role>] -ntoken <ntoken> -zts <ZTS url> 
 The service identity ntoken can be obtained by using the zms-svctoken
 utility. The optional expire-time argument specifies how long the role
 token should be valid for. The value must be specified in minutes. The
-defualt if no value is specified is 120 minutes.
+default if no value is specified is 120 minutes.
 
 ## License
 


### PR DESCRIPTION
Five typo fixes:

| File | Fix |
|---|---|
| `docs/zpu_policy_file.md:50,90` | `implemenation` → `implementation` |
| `ui/src/redux/README.md:11` | `seperated` → `separated` |
| `utils/zts-accesstoken/README.md:24` | `defualt` → `default` |
| `utils/zts-roletoken/README.md:30` | `defualt` → `default` |

### Deliberately not changed

`docs/email_notifications.md` contains `packge` several times, but those are inside Java example snippets — `package your.packge;`, `their.packge.TheirNotificationService`. `package` is a reserved word in Java, so `your.package` would not be a legal package name. Correcting the spelling there would produce invalid example code, so I left it alone; if you want those examples reworded, something like `your.pkg` would be needed instead.
