### PR TITLE
Add Java Crypki library so ZTS can mint X.509 certificates in-process.

### DIFF
--- a/docs/cert_signer.md
+++ b/docs/cert_signer.md
@@ -122,11 +122,10 @@ using the following system properties:
 
 Class: com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
 
-In-process KMS/HSM signing. This is new functionality and is off by default.
+In-process KMS/HSM signing. Selecting this factory enables the feature.
 Existing `HttpCertSigner` deployments are not changed.
 
 ```
-athenz.zts.java_crypki_enabled=true
 athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
 athenz.zts.java_crypki_factory_class=io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory
 ```

--- a/docs/cert_signer.md
+++ b/docs/cert_signer.md
@@ -6,6 +6,7 @@
 * [Provided Implementations](#provided-implementations)
     * [Self Cert Signer](#self-cert-signer)
     * [HTTP Cert Signer](#http-cert-signer)
+    * [Java Crypki (opt-in)](#java-crypki-opt-in)
 
 
 Athenz supports service authentication with X.509 certificates. 
@@ -115,3 +116,23 @@ using the following system properties:
   This setting specifies the number of times the request
   should be retried if it's not completed with the requested
   timeout value. We are setting it to 3.
+
+### Java Crypki (opt-in)
+------------------------
+
+Class: com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
+
+In-process KMS/HSM signing. This is new functionality and is off by default.
+Existing `HttpCertSigner` deployments are not changed.
+
+```
+athenz.zts.java_crypki_enabled=true
+athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
+athenz.zts.java_crypki_factory_class=io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory
+```
+
+Backend factory classes:
+
+* `io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory`
+* `io.athenz.server.aws.common.cert.impl.AwsCloudHsmCrypkiSignerFactory`
+* `io.athenz.server.gcp.common.cert.impl.GcpKmsCrypkiSignerFactory`

--- a/libs/java/crypki/README.md
+++ b/libs/java/crypki/README.md
@@ -44,18 +44,16 @@ SIA / instance provider
 ## Deployments
 
 Existing ZTS `HttpCertSigner` / `HttpCertSignerFactory` code is unchanged.
-In-process Java Crypki is opt-in and off by default:
+In-process Java Crypki is opt-in by selecting its factory:
 
 ```
-athenz.zts.java_crypki_enabled=true
 athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
 athenz.zts.java_crypki_factory_class=io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory
 ```
 
-Without `athenz.zts.java_crypki_enabled=true`, ZTS keeps using the original
-HTTP Crypki client.
+Without that factory class, ZTS keeps using the original HTTP Crypki client.
 
-Optional in-process backends (used only when the flag is true):
+Optional in-process backends:
 
 | Backend | Factory | Library |
 |---|---|---|
@@ -96,12 +94,12 @@ Go Crypki (`theparanoids/crypki`) is a **signing service**. This module is a
 | Key custody | PKCS#11 / HSM inside the Go process | Pluggable: remote Go Crypki, KMS, or HSM |
 | HTTP API | Owns `/sig/x509-cert/keys/...` | Optional client of that API (`HttpCrypkiSigner`) |
 | Cloud KMS | Not in-tree | AWS/GCP clients in the existing cloud common modules |
-| ZTS config | `HttpCertSignerFactory` + `athenz.zts.certsign_base_uri` | Unchanged unless `athenz.zts.java_crypki_enabled=true` |
+| ZTS config | `HttpCertSignerFactory` + `athenz.zts.certsign_base_uri` | Unchanged unless `cert_signer_factory_class` is `JavaCrypkiCertSignerFactory` |
 
 Compatibility kept on purpose:
 
 - Existing ZTS `HttpCertSigner` / `HttpCertSignerFactory` stay as they are.
-  In-process backends require `athenz.zts.java_crypki_enabled=true`.
+  In-process backends require `JavaCrypkiCertSignerFactory`.
 - Request shape (key meta, CSR, EKU ints, validity seconds, priority) matches
   the Go `/sig/x509-cert` contract.
 - Soft-fail HTTP behavior is unchanged: `sign()` may return `null` instead of

--- a/libs/java/crypki/README.md
+++ b/libs/java/crypki/README.md
@@ -1,0 +1,143 @@
+# athenz-crypki
+
+Generic Athenz X.509 signing library. ZTS builds a sign request and calls
+`CrypkiSigner`. Backends plug in without changing the ZTS cert-signer contract.
+
+This is a **library**, not a standalone signing service. The historical
+[Go Crypki](https://github.com/theparanoids/crypki) project is a separate
+process that talks to an HSM over PKCS#11 and exposes REST/gRPC. This module
+gives ZTS the same X.509 minting path either by calling that Go service over
+HTTP, or by signing in-process with KMS / HSM.
+
+See also the ZTS-facing page: [Certificate Signer](../../../docs/cert_signer.md).
+
+## How the library works
+
+ZTS already has a `CertSigner` SPI (`athenz.zts.cert_signer_factory_class`).
+This module sits under that SPI:
+
+1. `CrypkiRequestFactory` turns ZTS arguments (CSR PEM, provider, key usage,
+   expiry minutes, priority, signer key id) into a generic `X509SignRequest`.
+   Key-id resolution matches the historical HTTP client: explicit `signerKeyId`,
+   else a per-provider map, else `x509-key`.
+2. `CrypkiSigner.sign(X509SignRequest)` returns a PEM leaf certificate.
+   `getCACertificate(keyId)` returns the CA PEM that ZTS ships back to the client.
+3. `CrypkiCertSigner` is the `CertSigner` adapter used by the KMS/HSM factories.
+4. Cloud SDKs stay out of this jar. `KmsClient` and `HsmClient` are interfaces
+   here; AWS and GCP implement them in `athenz-server-aws-common` and
+   `athenz-server-gcp-common`.
+
+There is one CA for all identities this signer mints. Caller identity is
+in the leaf (CN, SAN, SPIFFE), not a per-tenant CA.
+
+```
+SIA / instance provider
+  → ZTS (validates CSR, Copper Argos)
+      → CertSigner
+          → CrypkiRequestFactory
+          → CrypkiSigner.sign()
+               → HttpCrypkiSigner     (remote Go Crypki)
+               → KmsCrypkiSigner      (AWS KMS / GCP KMS)
+               → HsmCrypkiSigner      (CloudHSM / PKCS#11)
+```
+
+## Deployments
+
+Existing ZTS `HttpCertSigner` / `HttpCertSignerFactory` code is unchanged.
+In-process Java Crypki is opt-in and off by default:
+
+```
+athenz.zts.java_crypki_enabled=true
+athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
+athenz.zts.java_crypki_factory_class=io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory
+```
+
+Without `athenz.zts.java_crypki_enabled=true`, ZTS keeps using the original
+HTTP Crypki client.
+
+Optional in-process backends (used only when the flag is true):
+
+| Backend | Factory | Library |
+|---|---|---|
+| Remote Go Crypki (HTTP) | `com.yahoo.athenz.crypki.http.HttpCrypkiSignerFactory` | this jar |
+| AWS KMS | `io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory` | athenz-server-aws-common |
+| AWS CloudHSM | `io.athenz.server.aws.common.cert.impl.AwsCloudHsmCrypkiSignerFactory` | athenz-server-aws-common |
+| GCP KMS | `io.athenz.server.gcp.common.cert.impl.GcpKmsCrypkiSignerFactory` | athenz-server-gcp-common |
+
+Environment-specific wiring (account, key alias, CA PEM path) belongs in the
+deploying repo, not this module.
+
+## Workflow
+
+1. A service (SIA) sends a CSR to ZTS.
+2. ZTS authenticates the instance and checks the CSR (domain, SAN, SPIFFE).
+3. ZTS calls `CertSigner.generateX509Certificate(...)`.
+4. `CrypkiRequestFactory` picks the key id, caps validity, and maps key usage
+   to Crypki EKU integers (`client` → 2, `codeSigning` → 3, `timestamping` → 8).
+5. The selected `CrypkiSigner` mints the leaf:
+   - **HTTP:** POST `/sig/x509-cert/keys/{keyId}` on Go Crypki; GET for the CA.
+   - **KMS:** `X509CertificateMinter` builds the TBS certificate; `KmsClient.sign`
+     produces the signature. The CA cert is loaded from
+     `athenz.crypki.kms.ca_cert_path`.
+   - **HSM:** same minter, but `HsmClient.getSigningKey(keyId)` supplies a
+     `SigningKey` whose private key never leaves the module.
+6. ZTS returns the leaf PEM plus the CA PEM to the client.
+
+## What changed from the Go library
+
+Go Crypki (`theparanoids/crypki`) is a **signing service**. This module is a
+**signer library** that ZTS embeds.
+
+| | Go Crypki | Java `athenz-crypki` |
+|---|---|---|
+| Form | Standalone daemon (REST + gRPC v3) | In-process jar used by ZTS |
+| Callers | ZTS, SSHCA, and other HTTP/gRPC clients | ZTS `CertSigner` only |
+| Certificates | X.509 and SSH | X.509 only |
+| Key custody | PKCS#11 / HSM inside the Go process | Pluggable: remote Go Crypki, KMS, or HSM |
+| HTTP API | Owns `/sig/x509-cert/keys/...` | Optional client of that API (`HttpCrypkiSigner`) |
+| Cloud KMS | Not in-tree | AWS/GCP clients in the existing cloud common modules |
+| ZTS config | `HttpCertSignerFactory` + `athenz.zts.certsign_base_uri` | Unchanged unless `athenz.zts.java_crypki_enabled=true` |
+
+Compatibility kept on purpose:
+
+- Existing ZTS `HttpCertSigner` / `HttpCertSignerFactory` stay as they are.
+  In-process backends require `athenz.zts.java_crypki_enabled=true`.
+- Request shape (key meta, CSR, EKU ints, validity seconds, priority) matches
+  the Go `/sig/x509-cert` contract.
+- Soft-fail HTTP behavior is unchanged: `sign()` may return `null` instead of
+  throwing, same as the old ZTS client.
+
+Intentionally not ported:
+
+- SSH certificate minting
+- A Java clone of the Go HTTP/gRPC server (no v3 facade unless a non-ZTS
+  caller appears)
+- Per-tenant CAs
+- Cloud SDK types inside `athenz-crypki` itself
+
+## Configuration
+
+HTTP (Go Crypki) — same properties as before:
+
+- `athenz.zts.certsign_base_uri`
+- `athenz.zts.certsign_connect_timeout`
+- `athenz.zts.certsign_request_timeout`
+- `athenz.zts.certsign_retry_count`
+- `athenz.zts.certsign_max_expiry_time`
+- `athenz.zts.certsign_provider_keys_fname`
+
+KMS / HSM:
+
+- `athenz.crypki.kms.key_id`
+- `athenz.crypki.kms.ca_cert_path`
+- `athenz.crypki.kms.signing_algorithm` (default `SHA256withRSA`)
+- `athenz.crypki.hsm.module_path` (CloudHSM default `/opt/cloudhsm/lib/libcloudhsm_pkcs11.so`)
+- `athenz.crypki.hsm.slot`
+- `athenz.crypki.hsm.key_label` (default `athenz-crypki-ca`)
+- `athenz.crypki.hsm.pin_path` (CloudHSM PIN file: `username:password`)
+- `athenz.crypki.hsm.ca_cert_path`
+
+AWS CloudHSM signing keys are label-only (no PKCS#11 certificate object).
+Put `cloudhsm-jce-*.jar` on the ZTS classpath so
+`AwsCloudHsmCrypkiSignerFactory` can load the key by label. SunPKCS11
+alone will not see those keys.

--- a/libs/java/crypki/pom.xml
+++ b/libs/java/crypki/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.9750</code.coverage.min>
+    <code.coverage.min>1.00</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/libs/java/crypki/pom.xml
+++ b/libs/java/crypki/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright The Athenz Authors
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.yahoo.athenz</groupId>
+    <artifactId>athenz</artifactId>
+    <version>1.12.48-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>athenz-crypki</artifactId>
+  <name>athenz-crypki</name>
+  <description>Generic Athenz X.509 Crypki signer SPI with pluggable backends</description>
+  <packaging>jar</packaging>
+
+  <properties>
+    <code.coverage.min>0.9750</code.coverage.min>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.yahoo.athenz</groupId>
+      <artifactId>athenz-auth-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.athenz</groupId>
+      <artifactId>athenz-server-common</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>${apache.httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson-annotations.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.server.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.server.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiCertSigner.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiCertSigner.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.Priority;
+
+/**
+ * ZTS {@link CertSigner} adapter: generate a {@link X509SignRequest} and
+ * call a pluggable {@link CrypkiSigner}.
+ */
+public class CrypkiCertSigner implements CertSigner {
+
+    private final CrypkiSigner signer;
+    private final CrypkiRequestFactory requestFactory;
+
+    public CrypkiCertSigner(CrypkiSigner signer) {
+        this(signer, new CrypkiRequestFactory());
+    }
+
+    public CrypkiCertSigner(CrypkiSigner signer, CrypkiRequestFactory requestFactory) {
+        this.signer = signer;
+        this.requestFactory = requestFactory;
+    }
+
+    @Override
+    public String generateX509Certificate(String provider, String certIssuer, String csr,
+            String keyUsage, int expiryTime, Priority priority, String signerKeyId) {
+        return signer.sign(requestFactory.create(provider, csr, keyUsage, expiryTime, priority, signerKeyId));
+    }
+
+    @Override
+    public String getCACertificate(String provider, String signerKeyId) {
+        return signer.getCACertificate(requestFactory.resolveKeyId(provider, signerKeyId));
+    }
+
+    @Override
+    public int getMaxCertExpiryTimeMins() {
+        return signer.getMaxCertExpiryTimeMins();
+    }
+
+    @Override
+    public void close() {
+        signer.close();
+    }
+
+    public CrypkiSigner getSigner() {
+        return signer;
+    }
+
+    public CrypkiRequestFactory getRequestFactory() {
+        return requestFactory;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiConsts.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiConsts.java
@@ -55,14 +55,6 @@ public final class CrypkiConsts {
     public static final String PROP_HSM_CA_CERT_PATH     = "athenz.crypki.hsm.ca_cert_path";
     public static final String DEFAULT_HSM_KEY_LABEL     = "athenz-crypki-ca";
 
-    public static final String PROP_JAVA_CRYPKI_ENABLED = "athenz.zts.java_crypki_enabled";
-
-    public static void requireJavaCrypkiEnabled() {
-        if (!Boolean.parseBoolean(System.getProperty(PROP_JAVA_CRYPKI_ENABLED, "false"))) {
-            throw new CrypkiException("Java Crypki is disabled; set " + PROP_JAVA_CRYPKI_ENABLED + "=true");
-        }
-    }
-
     public static final String DEFAULT_KEY_ID = "x509-key";
     public static final String CERT_USAGE_CLIENT = "client";
     public static final String CERT_USAGE_CODE_SIGNING = "codeSigning";

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiConsts.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiConsts.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+/**
+ * Property names shared by Crypki backends. HTTP property names match
+ * the existing ZTS {@code athenz.zts.certsign_*} settings so current
+ * deployments keep working.
+ */
+public final class CrypkiConsts {
+
+    public static final String PROP_CERTSIGN_BASE_URI            = "athenz.zts.certsign_base_uri";
+    public static final String PROP_CERTSIGN_REQUEST_TIMEOUT     = "athenz.zts.certsign_request_timeout";
+    public static final String PROP_CERTSIGN_CONNECT_TIMEOUT     = "athenz.zts.certsign_connect_timeout";
+    public static final String PROP_CERTSIGN_RETRY_COUNT         = "athenz.zts.certsign_retry_count";
+    public static final String PROP_CERTSIGN_MAX_EXPIRY_TIME     = "athenz.zts.certsign_max_expiry_time";
+    public static final String PROP_CERTSIGN_PROVIDER_KEYS_FNAME = "athenz.zts.certsign_provider_keys_fname";
+    public static final String PROP_CERTSIGN_RETRY_CONN_ONLY     = "athenz.zts.certsign_retry_conn_failures_only";
+    public static final String PROP_CERTSIGN_CONN_MAX_PER_ROUTE  = "athenz.zts.certsign_conn_max_per_route";
+    public static final String PROP_CERTSIGN_CONN_MAX_TOTAL      = "athenz.zts.certsign_conn_max_total";
+    public static final String PROP_CERTSIGN_CONN_TIME_TO_LIVE   = "athenz.zts.certsign_conn_time_to_live";
+    public static final String PROP_CERTSIGN_HANDSHAKE_TIMEOUT   = "athenz.zts.certsign_handshake_timeout";
+
+    public static final String PROP_PRIVATE_KEY_STORE_FACTORY_CLASS = "athenz.zts.private_key_store_factory_class";
+    public static final String DEFAULT_PRIVATE_KEY_STORE_FACTORY_CLASS =
+            "com.yahoo.athenz.auth.impl.FilePrivateKeyStoreFactory";
+
+    public static final String PROP_KEYSTORE_PATH        = "athenz.zts.ssl_key_store";
+    public static final String PROP_KEYSTORE_TYPE        = "athenz.zts.ssl_key_store_type";
+    public static final String PROP_KEYSTORE_PASSWORD    = "athenz.zts.ssl_key_store_password";
+    public static final String PROP_TRUSTSTORE_PATH      = "athenz.zts.ssl_trust_store";
+    public static final String PROP_TRUSTSTORE_TYPE      = "athenz.zts.ssl_trust_store_type";
+    public static final String PROP_TRUSTSTORE_PASSWORD  = "athenz.zts.ssl_trust_store_password";
+
+    public static final String PROP_KMS_KEY_ID           = "athenz.crypki.kms.key_id";
+    public static final String PROP_KMS_CA_CERT_PATH     = "athenz.crypki.kms.ca_cert_path";
+    public static final String PROP_KMS_SIGNING_ALGORITHM = "athenz.crypki.kms.signing_algorithm";
+    public static final String PROP_HSM_MODULE_PATH      = "athenz.crypki.hsm.module_path";
+    public static final String PROP_HSM_SLOT             = "athenz.crypki.hsm.slot";
+    public static final String PROP_HSM_KEY_LABEL        = "athenz.crypki.hsm.key_label";
+    public static final String PROP_HSM_PIN_PATH         = "athenz.crypki.hsm.pin_path";
+    public static final String PROP_HSM_CA_CERT_PATH     = "athenz.crypki.hsm.ca_cert_path";
+    public static final String DEFAULT_HSM_KEY_LABEL     = "athenz-crypki-ca";
+
+    public static final String PROP_JAVA_CRYPKI_ENABLED = "athenz.zts.java_crypki_enabled";
+
+    public static void requireJavaCrypkiEnabled() {
+        if (!Boolean.parseBoolean(System.getProperty(PROP_JAVA_CRYPKI_ENABLED, "false"))) {
+            throw new CrypkiException("Java Crypki is disabled; set " + PROP_JAVA_CRYPKI_ENABLED + "=true");
+        }
+    }
+
+    public static final String DEFAULT_KEY_ID = "x509-key";
+    public static final String CERT_USAGE_CLIENT = "client";
+    public static final String CERT_USAGE_CODE_SIGNING = "codeSigning";
+    public static final String CERT_USAGE_TIMESTAMPING = "timestamping";
+
+    public static final int DEFAULT_MAX_CERT_EXPIRY_TIME_MINS = 43200;
+
+    private CrypkiConsts() {
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiException.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+public class CrypkiException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    private final int code;
+
+    public CrypkiException(String message) {
+        this(500, message);
+    }
+
+    public CrypkiException(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public CrypkiException(String message, Throwable cause) {
+        super(message, cause);
+        this.code = 500;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiRequestFactory.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiRequestFactory.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.common.server.cert.Priority;
+import org.eclipse.jetty.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Builds a {@link X509SignRequest} from ZTS {@code CertSigner} arguments.
+ * Key-id resolution matches the historical HttpCertSigner behavior.
+ */
+public class CrypkiRequestFactory {
+
+    private final String defaultKeyId;
+    private final Map<String, String> providerSignerKeys;
+    private final int maxCertExpiryTimeMins;
+
+    public CrypkiRequestFactory() {
+        this(CrypkiConsts.DEFAULT_KEY_ID, Map.of(), CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS);
+    }
+
+    /**
+     * Default key id is {@code athenz.crypki.kms.key_id} so ZTS refresh
+     * (no {@code signerKeyId}) uses the KMS alias or key UUID, not
+     * {@code x509-key}.
+     */
+    public static CrypkiRequestFactory forKms() {
+        return new CrypkiRequestFactory(
+                System.getProperty(CrypkiConsts.PROP_KMS_KEY_ID, CrypkiConsts.DEFAULT_KEY_ID),
+                Map.of(), CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS);
+    }
+
+    /**
+     * Default key id is {@code athenz.crypki.hsm.key_label} so ZTS refresh
+     * (no {@code signerKeyId}) uses the PKCS#11 label, not {@code x509-key}.
+     */
+    public static CrypkiRequestFactory forHsm() {
+        return new CrypkiRequestFactory(
+                System.getProperty(CrypkiConsts.PROP_HSM_KEY_LABEL, CrypkiConsts.DEFAULT_HSM_KEY_LABEL),
+                Map.of(), CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS);
+    }
+
+    public CrypkiRequestFactory(String defaultKeyId, Map<String, String> providerSignerKeys,
+            int maxCertExpiryTimeMins) {
+        this.defaultKeyId = defaultKeyId == null || defaultKeyId.isEmpty()
+                ? CrypkiConsts.DEFAULT_KEY_ID : defaultKeyId;
+        this.providerSignerKeys = providerSignerKeys == null ? Map.of() : providerSignerKeys;
+        this.maxCertExpiryTimeMins = maxCertExpiryTimeMins <= 0
+                ? CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS : maxCertExpiryTimeMins;
+    }
+
+    public X509SignRequest create(String provider, String csr, String keyUsage, int expireMins,
+            Priority priority, String signerKeyId) {
+        return X509SignRequest.builder()
+                .keyId(resolveKeyId(provider, signerKeyId))
+                .csrPem(csr)
+                .validitySeconds(toValiditySeconds(expireMins))
+                .extKeyUsage(toExtKeyUsage(keyUsage))
+                .priority(priority)
+                .build();
+    }
+
+    public String resolveKeyId(String provider, String signerKeyId) {
+        if (!StringUtil.isEmpty(signerKeyId)) {
+            return signerKeyId;
+        }
+        if (StringUtil.isEmpty(provider)) {
+            return defaultKeyId;
+        }
+        final String keyId = providerSignerKeys.get(provider);
+        return keyId == null ? defaultKeyId : keyId;
+    }
+
+    public int toValiditySeconds(int expireMins) {
+        if (expireMins > 0 && expireMins < maxCertExpiryTimeMins) {
+            return (int) TimeUnit.SECONDS.convert(expireMins, TimeUnit.MINUTES);
+        }
+        return (int) TimeUnit.SECONDS.convert(maxCertExpiryTimeMins, TimeUnit.MINUTES);
+    }
+
+    public static List<Integer> toExtKeyUsage(String keyUsage) {
+        if (CrypkiConsts.CERT_USAGE_CLIENT.equals(keyUsage)) {
+            List<Integer> usage = new ArrayList<>();
+            usage.add(2);
+            return usage;
+        }
+        if (CrypkiConsts.CERT_USAGE_CODE_SIGNING.equals(keyUsage)) {
+            List<Integer> usage = new ArrayList<>();
+            usage.add(3);
+            return usage;
+        }
+        if (CrypkiConsts.CERT_USAGE_TIMESTAMPING.equals(keyUsage)) {
+            List<Integer> usage = new ArrayList<>();
+            usage.add(8);
+            return usage;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiSigner.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiSigner.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+/**
+ * Backend that signs an X.509 request. Implementations talk to a remote
+ * Crypki HTTP service, AWS KMS, AWS CloudHSM, GCP KMS, or a local key.
+ */
+public interface CrypkiSigner {
+
+    /**
+     * Sign the request and return a PEM-encoded leaf certificate.
+     * May return {@code null} when the backend treats the failure as soft
+     * (same contract as the historical HTTP Crypki client).
+     */
+    String sign(X509SignRequest request);
+
+    /**
+     * Return the CA certificate PEM for the given key identifier.
+     */
+    String getCACertificate(String keyId);
+
+    default int getMaxCertExpiryTimeMins() {
+        return CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS;
+    }
+
+    default void close() {
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiSignerFactory.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/CrypkiSignerFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+/**
+ * Creates a {@link CrypkiSigner}. Cloud implementations live in
+ * {@code athenz-server-aws-common} and {@code athenz-server-gcp-common}.
+ */
+public interface CrypkiSignerFactory {
+
+    CrypkiSigner createSigner();
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/X509SignRequest.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/X509SignRequest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.common.server.cert.Priority;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Generic sign request produced by {@link CrypkiRequestFactory} from ZTS
+ * {@code CertSigner} arguments.
+ */
+public final class X509SignRequest {
+
+    private final String keyId;
+    private final String csrPem;
+    private final int validitySeconds;
+    private final List<Integer> extKeyUsage;
+    private final Priority priority;
+
+    private X509SignRequest(Builder builder) {
+        this.keyId = builder.keyId;
+        this.csrPem = Objects.requireNonNull(builder.csrPem, "csrPem");
+        this.validitySeconds = builder.validitySeconds;
+        this.extKeyUsage = builder.extKeyUsage == null
+                ? Collections.emptyList() : List.copyOf(builder.extKeyUsage);
+        this.priority = builder.priority == null ? Priority.Unspecified_priority : builder.priority;
+    }
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public String getCsrPem() {
+        return csrPem;
+    }
+
+    public int getValiditySeconds() {
+        return validitySeconds;
+    }
+
+    public List<Integer> getExtKeyUsage() {
+        return extKeyUsage;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String keyId;
+        private String csrPem;
+        private int validitySeconds;
+        private List<Integer> extKeyUsage;
+        private Priority priority;
+
+        public Builder keyId(String keyId) {
+            this.keyId = keyId;
+            return this;
+        }
+
+        public Builder csrPem(String csrPem) {
+            this.csrPem = csrPem;
+            return this;
+        }
+
+        public Builder validitySeconds(int validitySeconds) {
+            this.validitySeconds = validitySeconds;
+            return this;
+        }
+
+        public Builder extKeyUsage(List<Integer> extKeyUsage) {
+            this.extKeyUsage = extKeyUsage;
+            return this;
+        }
+
+        public Builder priority(Priority priority) {
+            this.priority = priority;
+            return this;
+        }
+
+        public X509SignRequest build() {
+            return new X509SignRequest(this);
+        }
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/hsm/HsmClient.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/hsm/HsmClient.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.hsm;
+
+import com.yahoo.athenz.crypki.signer.SigningKey;
+
+/**
+ * HSM / PKCS#11 operations. AWS CloudHSM implements this in server-aws-common.
+ */
+public interface HsmClient {
+
+    SigningKey getSigningKey(String keyId);
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/hsm/HsmCrypkiSigner.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/hsm/HsmCrypkiSigner.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.hsm;
+
+import com.yahoo.athenz.crypki.signer.DefaultCrypkiSigner;
+
+/**
+ * In-process signer whose private key never leaves an HSM. AWS CloudHSM
+ * implements {@link HsmClient} in server-aws-common.
+ */
+public class HsmCrypkiSigner extends DefaultCrypkiSigner {
+
+    public HsmCrypkiSigner(HsmClient hsmClient) {
+        super(hsmClient::getSigningKey);
+    }
+
+    public HsmCrypkiSigner(HsmClient hsmClient, int maxCertExpiryTimeMins) {
+        super(hsmClient::getSigningKey, maxCertExpiryTimeMins);
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/HttpCrypkiSigner.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/HttpCrypkiSigner.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.net.ConnectException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.auth.PrivateKeyStoreFactory;
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.Priority;
+import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigBoolean;
+import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigInteger;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.X509SignRequest;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.config.TlsConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.ssl.TLS;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.apache.hc.core5.pool.PoolReusePolicy;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+
+import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
+
+/**
+ * This is an implementation of the Yahoo's Crypki certificate signer.
+ *          https://github.com/theparanoids/crypki
+ * Crypki is a service for interacting with an HSM or other PKCS #11 device.
+ * It supports minting and signing of both SSH and x509 certificates.
+ */
+public class HttpCrypkiSigner implements CertSigner, CrypkiSigner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpCrypkiSigner.class);
+
+    private static final String X509_CERTIFICATE_PATH = "/sig/x509-cert/keys/";
+    private static final String CONTENT_JSON = "application/json";
+    private static final String X509_KEY_META_IDENTIFIER = "x509-key";
+
+    //default certificate expiration value of 30 days in seconds
+    private static final int DEFAULT_CERT_EXPIRE_SECS = (int) TimeUnit.SECONDS.convert(30, TimeUnit.DAYS);
+
+    protected static final ObjectMapper JACKSON_MAPPER = new ObjectMapper();
+
+    private CloseableHttpClient httpClient;
+    private final PoolingHttpClientConnectionManager connManager;
+    private final SslContextFactory sslContextFactory;
+
+    String serverBaseUri;
+    DynamicConfigInteger certsignRequestRetryCount;
+    DynamicConfigBoolean retryConnFailuresOnly;
+    int maxCertExpiryTimeMins;
+    String defaultProviderSignerKeyId = X509_KEY_META_IDENTIFIER;
+    Map<String, String> providerSignerKeys = new ConcurrentHashMap<>();
+
+    public HttpCrypkiSigner() {
+
+        PrivateKeyStore privateKeyStore = loadServicePrivateKey();
+
+        // retrieve our default retry timer
+
+        certsignRequestRetryCount = new DynamicConfigInteger(CONFIG_MANAGER, CrypkiConsts.PROP_CERTSIGN_RETRY_COUNT, 2);
+        retryConnFailuresOnly = new DynamicConfigBoolean(CONFIG_MANAGER, CrypkiConsts.PROP_CERTSIGN_RETRY_CONN_ONLY, true);
+
+        // max expiry time in minutes.  Max is 30 days
+
+        maxCertExpiryTimeMins = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_MAX_EXPIRY_TIME, "43200"));
+
+        // Instantiate HttpClient with SSLContext
+        this.sslContextFactory = createSslContextFactory(privateKeyStore);
+        try {
+            this.sslContextFactory.start();
+        } catch (Exception e) {
+            LOGGER.error("HttpCrypkiSigner: unable to start SSL Context.");
+            throw new CrypkiException(500, "unable to start sslContextFactory");
+        }
+
+        serverBaseUri = System.getProperty(CrypkiConsts.PROP_CERTSIGN_BASE_URI);
+        if (serverBaseUri == null) {
+            LOGGER.error("HttpCrypkiSigner: no base uri specified");
+            throw new CrypkiException(500,
+                    "No CertSigner base uri specified: " + CrypkiConsts.PROP_CERTSIGN_BASE_URI);
+        }
+
+        this.connManager = createConnectionPooling(sslContextFactory.getSslContext());
+        this.httpClient = createHttpClient(this.connManager);
+
+        // load our provider signer key details
+
+        if (!loadProviderSignerKeyConfig()) {
+            throw new CrypkiException(500,
+                    "Unable to initialize provider signer key configuration");
+        }
+
+        LOGGER.info("HttpCrypkiSigner initialized with url: {}", serverBaseUri);
+        LOGGER.info("HttpCrypkiSigner connection pool stats {} ", this.connManager.getTotalStats().toString());
+    }
+
+    private boolean loadProviderSignerKeyConfig() {
+
+        // read the file list of providers and allowed IP addresses
+        // if the config is not set then we have no restrictions
+        // otherwise all providers must be specified in the list
+
+        final String providerSignerKeysFile =  System.getProperty(CrypkiConsts.PROP_CERTSIGN_PROVIDER_KEYS_FNAME);
+        if (StringUtil.isEmpty(providerSignerKeysFile)) {
+            return true;
+        }
+
+        byte[] data = readFileContents(providerSignerKeysFile);
+        if (data == null) {
+            return false;
+        }
+
+        ProviderSignerKeys signerKeys = null;
+        try {
+            signerKeys = JACKSON_MAPPER.readValue(data, ProviderSignerKeys.class);
+        } catch (Exception ex) {
+            LOGGER.error("Unable to parse Provider Signer Key file: {}", providerSignerKeysFile, ex);
+        }
+
+        if (signerKeys == null) {
+            return false;
+        }
+
+        // update our default key id if one was specified
+
+        if (!StringUtil.isEmpty(signerKeys.getDefaultKeyId())) {
+            defaultProviderSignerKeyId = signerKeys.getDefaultKeyId();
+        }
+
+        // load all configured provider key/name pairs
+
+        for (ProviderSignerKey providerKey : signerKeys.getProviderKeys()) {
+
+            final String keyId = providerKey.getKeyId();
+            if (StringUtil.isEmpty(keyId)) {
+                continue;
+            }
+            for (String provider : providerKey.getProviders()) {
+                providerSignerKeys.put(provider, keyId);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Create a http client connection manager based on given ssl context
+     * @param sslContext ssl context containing keystore with client key/cert
+     * @return connection manager object
+     */
+    PoolingHttpClientConnectionManager createConnectionPooling(SSLContext sslContext) {
+
+        int defaultMaxPerRoute = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_CONN_MAX_PER_ROUTE, "20"));
+        int maxTotal = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_CONN_MAX_TOTAL, "30"));
+        int timeToLive = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_CONN_TIME_TO_LIVE, "10"));
+        int connectionTimeoutSec = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_CONNECT_TIMEOUT, "10"));
+        int readTimeoutSec = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_REQUEST_TIMEOUT, "25"));
+        int handshakeTimeout = Integer.parseInt(System.getProperty(CrypkiConsts.PROP_CERTSIGN_HANDSHAKE_TIMEOUT, "30000"));
+
+        final TlsSocketStrategy tlsStrategy = new DefaultClientTlsStrategy(sslContext);
+
+        return PoolingHttpClientConnectionManagerBuilder.create()
+                .setTlsSocketStrategy(tlsStrategy)
+                .setDefaultTlsConfig(TlsConfig.custom()
+                        .setHandshakeTimeout(Timeout.ofMilliseconds(handshakeTimeout))
+                        .setSupportedProtocols(TLS.V_1_2, TLS.V_1_3)
+                        .build())
+                .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.STRICT)
+                .setConnPoolPolicy(PoolReusePolicy.LIFO)
+                .setDefaultConnectionConfig(ConnectionConfig.custom()
+                        .setSocketTimeout(Timeout.ofSeconds(readTimeoutSec))
+                        .setConnectTimeout(Timeout.ofSeconds(connectionTimeoutSec))
+                        .setTimeToLive(TimeValue.ofMinutes(timeToLive))
+                        .build())
+                .setMaxConnPerRoute(defaultMaxPerRoute)
+                .setMaxConnTotal(maxTotal)
+                .build();
+    }
+
+    /**
+     * Create a http client based on given configuration settings
+     * @param poolingHttpClientConnectionManager http connection manager object
+     * @return http client
+     */
+    CloseableHttpClient createHttpClient(PoolingHttpClientConnectionManager poolingHttpClientConnectionManager) {
+
+        //apache http client expects in milliseconds
+        RequestConfig config = RequestConfig.custom()
+                .setRedirectsEnabled(false)
+                .build();
+        return HttpClients.custom()
+                .setConnectionManager(poolingHttpClientConnectionManager)
+                .setDefaultRequestConfig(config)
+                .build();
+    }
+
+    public void setHttpClient(CloseableHttpClient client) {
+        this.httpClient = client;
+    }
+
+    @Override
+    public void close() {
+        try {
+            this.sslContextFactory.stop();
+            this.httpClient.close();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("connManager stats close(): {}", this.connManager.getTotalStats().toString());
+            }
+            this.connManager.close();
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Override
+    public int getMaxCertExpiryTimeMins() {
+        return maxCertExpiryTimeMins;
+    }
+
+    @Override
+    public String sign(X509SignRequest request) {
+        return postX509Certificate(null, request.getKeyId(), toHttpSigningRequest(request));
+    }
+
+    @Override
+    public String getCACertificate(String keyId) {
+        return getCACertificate(null, keyId);
+    }
+
+    /**
+     * Map a generic {@link X509SignRequest} onto the Go Crypki HTTP model
+     * without converting seconds to minutes or dropping EKU.
+     */
+    X509CertificateSigningRequest toHttpSigningRequest(X509SignRequest request) {
+        X509CertificateSigningRequest csrCert = new X509CertificateSigningRequest();
+        csrCert.setKeyMeta(new KeyMeta(getProviderKeyId(null, request.getKeyId())));
+        csrCert.setCsr(request.getCsrPem());
+        List<Integer> extKeyUsage = request.getExtKeyUsage();
+        if (extKeyUsage != null && !extKeyUsage.isEmpty()) {
+            csrCert.setExtKeyUsage(new ArrayList<>(extKeyUsage));
+        }
+        csrCert.setPriority(request.getPriority());
+        int maxSeconds = (int) TimeUnit.SECONDS.convert(getMaxCertExpiryTimeMins(), TimeUnit.MINUTES);
+        int validity = request.getValiditySeconds();
+        if (validity > 0) {
+            csrCert.setValidity(Math.min(validity, maxSeconds));
+        } else {
+            csrCert.setValidity(DEFAULT_CERT_EXPIRE_SECS);
+        }
+        return csrCert;
+    }
+
+    protected SslContextFactory createSslContextFactory(PrivateKeyStore privateKeyStore) {
+        SslContextFactory.Client factory = new SslContextFactory.Client();
+        String keyStorePath = System.getProperty(CrypkiConsts.PROP_KEYSTORE_PATH);
+        if (!StringUtil.isEmpty(keyStorePath)) {
+            factory.setKeyStorePath(keyStorePath);
+        }
+        String keyStorePassword = System.getProperty(CrypkiConsts.PROP_KEYSTORE_PASSWORD);
+        if (!StringUtil.isEmpty(keyStorePassword) && privateKeyStore != null) {
+            factory.setKeyStorePassword(String.valueOf(privateKeyStore.getSecret(
+                    System.getProperty("athenz.zts.ssl_key_store_password_appname"),
+                    System.getProperty("athenz.zts.ssl_key_store_password_keygroupname"),
+                    keyStorePassword)));
+        } else if (!StringUtil.isEmpty(keyStorePassword)) {
+            factory.setKeyStorePassword(keyStorePassword);
+        }
+        factory.setKeyStoreType(System.getProperty(CrypkiConsts.PROP_KEYSTORE_TYPE, "PKCS12"));
+        String trustStorePath = System.getProperty(CrypkiConsts.PROP_TRUSTSTORE_PATH);
+        if (!StringUtil.isEmpty(trustStorePath)) {
+            factory.setTrustStorePath(trustStorePath);
+        }
+        String trustStorePassword = System.getProperty(CrypkiConsts.PROP_TRUSTSTORE_PASSWORD);
+        if (!StringUtil.isEmpty(trustStorePassword)) {
+            factory.setTrustStorePassword(trustStorePassword);
+        }
+        factory.setTrustStoreType(System.getProperty(CrypkiConsts.PROP_TRUSTSTORE_TYPE, "PKCS12"));
+        factory.setIncludeProtocols("TLSv1.2");
+        return factory;
+    }
+
+    static byte[] readFileContents(final String filename) {
+        try {
+            return java.nio.file.Files.readAllBytes(java.nio.file.Path.of(filename));
+        } catch (Exception ex) {
+            LOGGER.error("Unable to read {}", filename, ex);
+            return null;
+        }
+    }
+
+    private PrivateKeyStore loadServicePrivateKey() {
+        String pkeyFactoryClass = System.getProperty(CrypkiConsts.PROP_PRIVATE_KEY_STORE_FACTORY_CLASS,
+                CrypkiConsts.DEFAULT_PRIVATE_KEY_STORE_FACTORY_CLASS);
+        PrivateKeyStoreFactory pkeyFactory;
+        try {
+            pkeyFactory = (PrivateKeyStoreFactory) Class.forName(pkeyFactoryClass).getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException |
+                 NoSuchMethodException | InvocationTargetException ex) {
+            LOGGER.error("Invalid PrivateKeyStoreFactory class: {}", pkeyFactoryClass, ex);
+            throw new IllegalArgumentException("Invalid private key store");
+        }
+        return pkeyFactory.create();
+    }
+
+    @Override
+    public String generateX509Certificate(String provider, String certIssuer, String csr, String keyUsage,
+            int expireMins, Priority priority, String signerKeyId) {
+        try {
+            return postX509Certificate(provider, signerKeyId,
+                    (X509CertificateSigningRequest) getX509CertSigningRequest(provider,
+                            csr, keyUsage, expireMins, priority, signerKeyId));
+        } catch (Exception ex) {
+            LOGGER.error("unable to generate csr", ex);
+            return null;
+        }
+    }
+
+    String postX509Certificate(String provider, String signerKeyId,
+            X509CertificateSigningRequest csrCert) {
+
+        StringEntity entity;
+        try {
+            entity = new StringEntity(JACKSON_MAPPER.writeValueAsString(csrCert));
+        } catch (Exception ex) {
+            LOGGER.error("unable to generate csr", ex);
+            return null;
+        }
+
+        final String x509CertUri = getX509CertUri(serverBaseUri, provider, signerKeyId);
+        HttpPost httpPost = new HttpPost(x509CertUri);
+        httpPost.setHeader("Accept", CONTENT_JSON);
+        httpPost.setHeader("Content-Type", CONTENT_JSON);
+        httpPost.setEntity(entity);
+
+        // Retry configured number of times before returning failure
+
+        for (int i = 0; i < certsignRequestRetryCount.get(); i++) {
+            try {
+                return processHttpResponse(httpPost, 201);
+            } catch (ConnectException ex) {
+                LOGGER.error("Unable to process x509 certificate request to url {}, retrying {}/{}",
+                        x509CertUri, i + 1, certsignRequestRetryCount.get(), ex);
+            } catch (IOException ex) {
+                LOGGER.error("Unable to process x509 certificate request to url {}, try: {}",
+                        x509CertUri, i + 1, ex);
+                if (retryConnFailuresOnly.get()) {
+                    break;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Process http response from crypki server
+     * @param request http request object
+     * @param expectedStatusCode expected http status code
+     * @return x509 Certificate or Null if expectedStatusCode doesn't match or empty response from the server.
+     * @throws IOException in case of general io errors
+     */
+    String processHttpResponse(HttpUriRequest request, int expectedStatusCode) throws IOException {
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("connManager stats before: {}" , this.connManager.getTotalStats().toString());
+        }
+        CloseableHttpResponse response = httpClient.execute(request);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("connManager stats after: {}" , this.connManager.getTotalStats().toString());
+        }
+        // check for status code first
+        int statusCode = response.getCode();
+        if (statusCode != expectedStatusCode) {
+            LOGGER.error("unable to fetch requested uri '{}' status: {}", request.getRequestUri(), statusCode);
+            // Close an inputstream so that connections can go back to the pool.
+            if (response.getEntity().getContent() != null) {
+                response.getEntity().getContent().close();
+            }
+            return null;
+        }
+        // check for content
+        try (InputStream data = response.getEntity().getContent()) {
+            if (data == null) {
+                LOGGER.error("received empty response from uri '{}', status: {}", request.getRequestUri(), statusCode);
+                return null;
+            }
+            return parseResponse(data);
+        }
+    }
+
+    @Override
+    public String getCACertificate(String provider, String signerKeyId) {
+        HttpGet httpGet = new HttpGet(getX509CertUri(serverBaseUri, provider, signerKeyId));
+        String data = null;
+        try {
+            data = processHttpResponse(httpGet, 200);
+        } catch (IOException e) {
+            LOGGER.error("Unable to process x509 CA certificate request", e);
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("getCACertificate: CA Certificate {}", data);
+        }
+        return data;
+    }
+
+    public String getProviderKeyId(String provider, String signerKeyId) {
+
+        // if we're given a signer key then we're going to use that
+
+        if (!StringUtil.isEmpty(signerKeyId)) {
+            return signerKeyId;
+        }
+
+        // otherwise, we'll look at the provider
+
+        if (StringUtil.isEmpty(provider)) {
+            return defaultProviderSignerKeyId;
+        }
+
+        final String keyId = providerSignerKeys.get(provider);
+        return keyId == null ? defaultProviderSignerKeyId : keyId;
+    }
+
+    public String getX509CertUri(String serverBaseUri, String provider, String signerKeyId) {
+        return serverBaseUri + X509_CERTIFICATE_PATH + getProviderKeyId(provider, signerKeyId);
+    }
+
+    public Object getX509CertSigningRequest(String provider, String csr, String keyUsage, int expireMins,
+            Priority priority, String signerKeyId) {
+
+        // Key Usage value used in Go - https://golang.org/src/crypto/x509/x509.go?s=18153:18173#L558
+
+        List<Integer> extKeyUsage = null;
+        if (CrypkiConsts.CERT_USAGE_CLIENT.equals(keyUsage)) {
+            extKeyUsage = new ArrayList<>();
+            extKeyUsage.add(2);
+        }
+
+        if (CrypkiConsts.CERT_USAGE_CODE_SIGNING.equals(keyUsage)) {
+            extKeyUsage = new ArrayList<>();
+            extKeyUsage.add(3);
+        }
+
+        if (CrypkiConsts.CERT_USAGE_TIMESTAMPING.equals(keyUsage)) {
+            extKeyUsage = new ArrayList<>();
+            extKeyUsage.add(8);
+        }
+
+        X509CertificateSigningRequest csrCert = new X509CertificateSigningRequest();
+        csrCert.setKeyMeta(new KeyMeta(getProviderKeyId(provider, signerKeyId)));
+        csrCert.setCsr(csr);
+        csrCert.setExtKeyUsage(extKeyUsage);
+        csrCert.setValidity(DEFAULT_CERT_EXPIRE_SECS);
+        csrCert.setPriority(priority);
+
+        // Validity period of the certificate in seconds in Crypki API.  Convert mins to seconds
+
+        if (expireMins > 0 && expireMins < getMaxCertExpiryTimeMins()) {
+            csrCert.setValidity((int) TimeUnit.SECONDS.convert(expireMins, TimeUnit.MINUTES));
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("keyMeta: {} keyUsage: {} expireSec: {} priority: {}", csrCert.getKeyMeta(),
+                    csrCert.getExtKeyUsage(), csrCert.getValidity(), priority.getPriorityValue());
+        }
+        return csrCert;
+    }
+
+    public String parseResponse(InputStream response) throws IOException {
+        X509Certificate cert = JACKSON_MAPPER.readValue(response, X509Certificate.class);
+        return cert.getCert();
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/HttpCrypkiSignerFactory.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/HttpCrypkiSignerFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.http;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.CertSignerFactory;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.CrypkiSignerFactory;
+
+/**
+ * Default factory for the remote Go Crypki HTTP backend.
+ */
+public class HttpCrypkiSignerFactory implements CrypkiSignerFactory, CertSignerFactory {
+
+    @Override
+    public CrypkiSigner createSigner() {
+        return new HttpCrypkiSigner();
+    }
+
+    @Override
+    public CertSigner create() {
+        return new HttpCrypkiSigner();
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/KeyMeta.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/KeyMeta.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.crypki.http;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class KeyMeta {
+    
+    public KeyMeta(String identifier) {
+        this.identifier = identifier;
+    }
+    
+    private String identifier;
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/ProviderSignerKey.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/ProviderSignerKey.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.http;
+
+import java.util.List;
+
+public class ProviderSignerKey {
+
+    private String keyId;
+    private List<String> providers;
+
+    public String getKeyId() {
+        return keyId;
+    }
+
+    public void setKeyId(String filename) {
+        this.keyId = filename;
+    }
+
+    public List<String> getProviders() {
+        return providers;
+    }
+
+    public void setProviders(List<String> providers) {
+        this.providers = providers;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/ProviderSignerKeys.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/ProviderSignerKeys.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.http;
+
+import java.util.List;
+
+public class ProviderSignerKeys {
+
+    private String defaultKeyId;
+    private List<ProviderSignerKey> providerKeys;
+
+    public String getDefaultKeyId() {
+        return defaultKeyId;
+    }
+
+    public void setDefaultKeyId(String defaultKeyId) {
+        this.defaultKeyId = defaultKeyId;
+    }
+
+    public List<ProviderSignerKey> getProviderKeys() {
+        return providerKeys;
+    }
+
+    public void setProviderKeys(List<ProviderSignerKey> providerKeys) {
+        this.providerKeys = providerKeys;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/X509Certificate.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/X509Certificate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.crypki.http;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class X509Certificate {
+
+    private String cert;
+
+    public String getCert() {
+        return cert;
+    }
+
+    public void setCert(String cert) {
+        this.cert = cert;
+    }
+
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/X509CertificateSigningRequest.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/http/X509CertificateSigningRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.crypki.http;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yahoo.athenz.common.server.cert.Priority;
+
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public class X509CertificateSigningRequest {
+
+    private KeyMeta keyMeta;
+    private String csr;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer validity;
+    
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<Integer> extKeyUsage;
+    
+    public X509CertificateSigningRequest() {
+    }
+    
+    public String getCsr() {
+        return csr;
+    }
+    
+    public void setCsr(String csr) {
+        this.csr = csr;
+    }
+
+    @JsonProperty("ext_key_usage")
+    public List<Integer> getExtKeyUsage() {
+        return extKeyUsage;
+    }
+
+    public void setExtKeyUsage(List<Integer> extKeyUsage) {
+        this.extKeyUsage = extKeyUsage;
+    }
+
+    public void setValidity(Integer validity) {
+        this.validity = validity;
+    }
+
+    public Integer getValidity() {
+        return validity;
+    }
+    
+    @JsonProperty("key_meta")
+    public KeyMeta getKeyMeta() {
+        return keyMeta;
+    }
+
+    public void setKeyMeta(KeyMeta keyMeta) {
+        this.keyMeta = keyMeta;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Priority priority;
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
+    }
+
+    public Priority getPriority() {
+        return priority;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/kms/KmsClient.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/kms/KmsClient.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.kms;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * Cloud KMS operations used by {@link com.yahoo.athenz.crypki.kms.KmsCrypkiSigner}.
+ * AWS and GCP implementations live in server-aws-common / server-gcp-common.
+ */
+public interface KmsClient {
+
+    byte[] sign(String keyId, byte[] data, String signingAlgorithm);
+
+    PublicKey getPublicKey(String keyId);
+
+    X509Certificate getCaCertificate(String keyId);
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/kms/KmsCrypkiSigner.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/kms/KmsCrypkiSigner.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.kms;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.X509SignRequest;
+import com.yahoo.athenz.crypki.x509.X509CertificateMinter;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
+/**
+ * In-process X.509 minting that asks a {@link KmsClient} to produce the
+ * signature. AWS KMS and GCP KMS plug in by implementing {@link KmsClient}.
+ */
+public class KmsCrypkiSigner implements CrypkiSigner {
+
+    private final KmsClient kmsClient;
+    private final String defaultKeyId;
+    private final String signingAlgorithm;
+    private final X509CertificateMinter minter;
+    private final int maxCertExpiryTimeMins;
+
+    public KmsCrypkiSigner(KmsClient kmsClient) {
+        this(kmsClient, System.getProperty(CrypkiConsts.PROP_KMS_KEY_ID, CrypkiConsts.DEFAULT_KEY_ID),
+                System.getProperty(CrypkiConsts.PROP_KMS_SIGNING_ALGORITHM, "SHA256withRSA"),
+                CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS);
+    }
+
+    public KmsCrypkiSigner(KmsClient kmsClient, String defaultKeyId, String signingAlgorithm,
+            int maxCertExpiryTimeMins) {
+        this.kmsClient = kmsClient;
+        this.defaultKeyId = defaultKeyId;
+        this.signingAlgorithm = signingAlgorithm;
+        this.maxCertExpiryTimeMins = maxCertExpiryTimeMins;
+        this.minter = new X509CertificateMinter(Math.multiplyExact(maxCertExpiryTimeMins, 60));
+    }
+
+    @Override
+    public String sign(X509SignRequest request) {
+        String keyId = resolveKeyId(request.getKeyId());
+        return minter.sign(new KmsContentSigner(kmsClient, keyId, signingAlgorithm),
+                kmsClient.getCaCertificate(keyId), request);
+    }
+
+    @Override
+    public String getCACertificate(String keyId) {
+        return Crypto.convertToPEMFormat(kmsClient.getCaCertificate(resolveKeyId(keyId)));
+    }
+
+    /**
+     * ZTS leaves {@code signerKeyId} empty, so {@link com.yahoo.athenz.crypki.CrypkiRequestFactory}
+     * fills in the HTTP Crypki default {@code x509-key}. That name is not a
+     * KMS key id (and {@code alias/...} cannot be sent as an RDL SimpleName).
+     * Use the configured {@code athenz.crypki.kms.key_id} instead.
+     */
+    public String resolveKeyId(String requested) {
+        if (requested == null || requested.isEmpty() || CrypkiConsts.DEFAULT_KEY_ID.equals(requested)) {
+            return defaultKeyId;
+        }
+        return requested;
+    }
+
+    @Override
+    public int getMaxCertExpiryTimeMins() {
+        return maxCertExpiryTimeMins;
+    }
+
+    static final class KmsContentSigner implements ContentSigner {
+        private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        private final KmsClient kmsClient;
+        private final String keyId;
+        private final String signingAlgorithm;
+
+        KmsContentSigner(KmsClient kmsClient, String keyId, String signingAlgorithm) {
+            this.kmsClient = kmsClient;
+            this.keyId = keyId;
+            this.signingAlgorithm = signingAlgorithm;
+        }
+
+        @Override
+        public AlgorithmIdentifier getAlgorithmIdentifier() {
+            return new DefaultSignatureAlgorithmIdentifierFinder().find(signingAlgorithm);
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return stream;
+        }
+
+        @Override
+        public byte[] getSignature() {
+            return kmsClient.sign(keyId, stream.toByteArray(), signingAlgorithm);
+        }
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/signer/DefaultCrypkiSigner.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/signer/DefaultCrypkiSigner.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.signer;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.X509SignRequest;
+import com.yahoo.athenz.crypki.x509.X509CertificateMinter;
+
+/**
+ * In-process signer over a {@link SigningKeyProvider} (local PEM, HSM, or a
+ * KMS-backed PrivateKey).
+ */
+public class DefaultCrypkiSigner implements CrypkiSigner {
+
+    private final SigningKeyProvider keyProvider;
+    private final X509CertificateMinter minter;
+    private final int maxCertExpiryTimeMins;
+
+    public DefaultCrypkiSigner(SigningKeyProvider keyProvider) {
+        this(keyProvider, CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS);
+    }
+
+    public DefaultCrypkiSigner(SigningKeyProvider keyProvider, int maxCertExpiryTimeMins) {
+        this.keyProvider = keyProvider;
+        this.maxCertExpiryTimeMins = maxCertExpiryTimeMins;
+        this.minter = new X509CertificateMinter(Math.multiplyExact(maxCertExpiryTimeMins, 60));
+    }
+
+    @Override
+    public String sign(X509SignRequest request) {
+        return minter.sign(keyProvider.get(request.getKeyId()), request);
+    }
+
+    @Override
+    public String getCACertificate(String keyId) {
+        return Crypto.convertToPEMFormat(keyProvider.get(keyId).getCaCertificate());
+    }
+
+    @Override
+    public int getMaxCertExpiryTimeMins() {
+        return maxCertExpiryTimeMins;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/signer/SigningKey.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/signer/SigningKey.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.signer;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+public final class SigningKey {
+
+    private final String identifier;
+    private final PrivateKey privateKey;
+    private final X509Certificate caCertificate;
+
+    public SigningKey(String identifier, PrivateKey privateKey, X509Certificate caCertificate) {
+        this.identifier = Objects.requireNonNull(identifier, "identifier");
+        this.privateKey = Objects.requireNonNull(privateKey, "privateKey");
+        this.caCertificate = Objects.requireNonNull(caCertificate, "caCertificate");
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+
+    public X509Certificate getCaCertificate() {
+        return caCertificate;
+    }
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/signer/SigningKeyProvider.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/signer/SigningKeyProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.signer;
+
+/**
+ * Resolves CA key material for an in-process {@link DefaultCrypkiSigner}.
+ */
+public interface SigningKeyProvider {
+
+    SigningKey get(String identifier);
+}

--- a/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/x509/X509CertificateMinter.java
+++ b/libs/java/crypki/src/main/java/com/yahoo/athenz/crypki/x509/X509CertificateMinter.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.x509;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.X509SignRequest;
+import com.yahoo.athenz.crypki.signer.SigningKey;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.X509KeyUsage;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
+
+import java.math.BigInteger;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Shared leaf-cert template: CSR subject/SAN, EKU, validity cap, 1-hour backdate.
+ */
+public class X509CertificateMinter {
+
+    public static final int EKU_SERVER_AUTH = 1;
+    public static final int EKU_CLIENT_AUTH = 2;
+    public static final int EKU_CODE_SIGNING = 3;
+    public static final int EKU_TIME_STAMPING = 8;
+    private static final int BACKDATE_SECONDS = 3600;
+
+    private final int maxValiditySeconds;
+
+    public X509CertificateMinter(int maxValiditySeconds) {
+        this.maxValiditySeconds = maxValiditySeconds;
+    }
+
+    public String sign(SigningKey signingKey, X509SignRequest request) {
+        return sign(contentSigner(signingKey.getPrivateKey()), signingKey.getCaCertificate(), request);
+    }
+
+    public String sign(ContentSigner contentSigner, X509Certificate caCertificate, X509SignRequest request) {
+        return Crypto.convertToPEMFormat(signCertificate(contentSigner, caCertificate, request));
+    }
+
+    public X509Certificate signCertificate(PrivateKey privateKey, X509Certificate caCertificate,
+            X509SignRequest request) {
+        return signCertificate(contentSigner(privateKey), caCertificate, request);
+    }
+
+    public X509Certificate signCertificate(ContentSigner contentSigner, X509Certificate caCertificate,
+            X509SignRequest request) {
+        if (request == null || request.getCsrPem() == null || request.getCsrPem().isEmpty()) {
+            throw new CrypkiException("CSR is required");
+        }
+        PKCS10CertificationRequest certReq;
+        try {
+            certReq = Crypto.getPKCS10CertRequest(request.getCsrPem());
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to parse CSR", ex);
+        }
+        if (certReq == null) {
+            throw new CrypkiException("Unable to parse CSR");
+        }
+        int validitySeconds = request.getValiditySeconds() > 0
+                ? Math.min(request.getValiditySeconds(), maxValiditySeconds) : maxValiditySeconds;
+        Instant notAfter = Instant.now();
+        Instant notBefore = notAfter.minusSeconds(BACKDATE_SECONDS);
+        notAfter = notBefore.plusSeconds(validitySeconds + BACKDATE_SECONDS);
+        try {
+            JcaPKCS10CertificationRequest jcaReq = new JcaPKCS10CertificationRequest(certReq);
+            PublicKey publicKey = jcaReq.getPublicKey();
+            verifyCsrSignature(jcaReq, publicKey);
+            X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                    new JcaX509CertificateHolder(caCertificate).getSubject(),
+                    new BigInteger(128, new SecureRandom()),
+                    Date.from(notBefore),
+                    Date.from(notAfter),
+                    certReq.getSubject(),
+                    publicKey)
+                    .addExtension(Extension.basicConstraints, false, new BasicConstraints(false))
+                    .addExtension(Extension.keyUsage, true,
+                            new X509KeyUsage(X509KeyUsage.digitalSignature | X509KeyUsage.keyEncipherment))
+                    .addExtension(Extension.extendedKeyUsage, false, toExtendedKeyUsage(request.getExtKeyUsage()))
+                    .addExtension(Extension.authorityKeyIdentifier, false,
+                            new JcaX509ExtensionUtils().createAuthorityKeyIdentifier(caCertificate));
+            addSubjectAlternativeNames(builder, jcaReq);
+            return new JcaX509CertificateConverter().getCertificate(builder.build(contentSigner));
+        } catch (CrypkiException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to sign X.509 certificate: " + ex.getMessage(), ex);
+        }
+    }
+
+    static void verifyCsrSignature(JcaPKCS10CertificationRequest jcaReq, PublicKey publicKey) {
+        try {
+            if (publicKey == null || !jcaReq.isSignatureValid(
+                    new JcaContentVerifierProviderBuilder().build(publicKey))) {
+                throw new CrypkiException("CSR signature is invalid");
+            }
+        } catch (CrypkiException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to verify CSR signature", ex);
+        }
+    }
+
+    static ContentSigner contentSigner(PrivateKey privateKey) {
+        String algorithm = "EC".equalsIgnoreCase(privateKey.getAlgorithm())
+                ? "SHA256withECDSA" : "SHA256withRSA";
+        try {
+            return new JcaContentSignerBuilder(algorithm).build(privateKey);
+        } catch (Exception first) {
+            for (Provider provider : Security.getProviders()) {
+                if (provider.getName().startsWith("SunPKCS11")) {
+                    try {
+                        return new JcaContentSignerBuilder(algorithm).setProvider(provider).build(privateKey);
+                    } catch (Exception ignored) {
+                        // try the next PKCS#11 provider
+                    }
+                }
+            }
+            throw new CrypkiException("Unable to create content signer", first);
+        }
+    }
+
+    static ExtendedKeyUsage toExtendedKeyUsage(List<Integer> extKeyUsage) {
+        List<Integer> values = (extKeyUsage == null || extKeyUsage.isEmpty())
+                ? List.of(EKU_SERVER_AUTH, EKU_CLIENT_AUTH) : extKeyUsage;
+        KeyPurposeId[] purposes = new KeyPurposeId[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            purposes[i] = toKeyPurposeId(values.get(i));
+        }
+        return new ExtendedKeyUsage(purposes);
+    }
+
+    static KeyPurposeId toKeyPurposeId(int eku) {
+        switch (eku) {
+            case EKU_SERVER_AUTH:
+                return KeyPurposeId.id_kp_serverAuth;
+            case EKU_CLIENT_AUTH:
+                return KeyPurposeId.id_kp_clientAuth;
+            case EKU_CODE_SIGNING:
+                return KeyPurposeId.id_kp_codeSigning;
+            case EKU_TIME_STAMPING:
+                return KeyPurposeId.id_kp_timeStamping;
+            default:
+                return KeyPurposeId.id_kp_clientAuth;
+        }
+    }
+
+    private static void addSubjectAlternativeNames(X509v3CertificateBuilder builder,
+            JcaPKCS10CertificationRequest jcaReq) throws Exception {
+        ArrayList<GeneralName> altNames = new ArrayList<>();
+        Attribute[] attributes = jcaReq.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest);
+        if (attributes == null) {
+            return;
+        }
+        for (Attribute attribute : attributes) {
+            Extensions extensions = Extensions.getInstance(attribute.getAttrValues().getObjectAt(0));
+            GeneralNames gns = GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+            if (gns == null) {
+                continue;
+            }
+            for (GeneralName name : gns.getNames()) {
+                switch (name.getTagNo()) {
+                    case GeneralName.dNSName:
+                    case GeneralName.iPAddress:
+                    case GeneralName.rfc822Name:
+                    case GeneralName.uniformResourceIdentifier:
+                        altNames.add(name);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        if (!altNames.isEmpty()) {
+            builder.addExtension(Extension.subjectAlternativeName, false,
+                    new GeneralNames(altNames.toArray(new GeneralName[0])));
+        }
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiCertSignerTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiCertSignerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.common.server.cert.Priority;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+public class CrypkiCertSignerTest {
+
+    @Test
+    public void testDelegatesToSigner() {
+        CrypkiSigner signer = new CrypkiSigner() {
+            @Override
+            public String sign(X509SignRequest request) {
+                return "CERT:" + request.getCsrPem() + ":" + request.getKeyId();
+            }
+
+            @Override
+            public String getCACertificate(String keyId) {
+                return "CA:" + keyId;
+            }
+
+            @Override
+            public int getMaxCertExpiryTimeMins() {
+                return 10;
+            }
+        };
+        CrypkiCertSigner certSigner = new CrypkiCertSigner(signer);
+        assertEquals(certSigner.generateX509Certificate("p", null, "csr", "client", 5,
+                Priority.High, "kid"), "CERT:csr:kid");
+        assertEquals(certSigner.getCACertificate("p", "kid"), "CA:kid");
+        assertEquals(certSigner.getMaxCertExpiryTimeMins(), 10);
+        assertSame(certSigner.getSigner(), signer);
+        assertSame(certSigner.getRequestFactory().resolveKeyId(null, null), "x509-key");
+        certSigner.close();
+    }
+
+    @Test
+    public void testDefaultCloseAndMaxExpiry() {
+        CrypkiSigner signer = new CrypkiSigner() {
+            @Override
+            public String sign(X509SignRequest request) {
+                return "ok";
+            }
+
+            @Override
+            public String getCACertificate(String keyId) {
+                return "ca";
+            }
+        };
+        assertEquals(signer.getMaxCertExpiryTimeMins(), 43200);
+        signer.close();
+        new CrypkiCertSigner(signer).close();
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiConstsTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiConstsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class CrypkiConstsTest {
+
+    @Test
+    public void testPrivateConstructor() throws Exception {
+        Constructor<CrypkiConsts> constructor = CrypkiConsts.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+        constructor.newInstance();
+    }
+
+    @Test
+    public void testRequireJavaCrypkiEnabled() {
+        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
+        expectThrows(CrypkiException.class, CrypkiConsts::requireJavaCrypkiEnabled);
+        System.setProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED, "true");
+        try {
+            CrypkiConsts.requireJavaCrypkiEnabled();
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
+        }
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiConstsTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiConstsTest.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.expectThrows;
 
 public class CrypkiConstsTest {
 
@@ -31,17 +30,5 @@ public class CrypkiConstsTest {
         assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
-    }
-
-    @Test
-    public void testRequireJavaCrypkiEnabled() {
-        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
-        expectThrows(CrypkiException.class, CrypkiConsts::requireJavaCrypkiEnabled);
-        System.setProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED, "true");
-        try {
-            CrypkiConsts.requireJavaCrypkiEnabled();
-        } finally {
-            System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
-        }
     }
 }

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiRequestFactoryTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/CrypkiRequestFactoryTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.common.server.cert.Priority;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class CrypkiRequestFactoryTest {
+
+    @Test
+    public void testCreateRequest() {
+        CrypkiRequestFactory factory = new CrypkiRequestFactory("x509-key",
+                Map.of("athenz.aws.us-east-1", "x509-aws-key"), 120);
+        X509SignRequest request = factory.create("athenz.aws.us-east-1", "csr",
+                CrypkiConsts.CERT_USAGE_CLIENT, 30, Priority.High, null);
+        assertEquals(request.getKeyId(), "x509-aws-key");
+        assertEquals(request.getCsrPem(), "csr");
+        assertEquals(request.getValiditySeconds(), 1800);
+        assertEquals(request.getExtKeyUsage(), List.of(2));
+        assertEquals(request.getPriority(), Priority.High);
+    }
+
+    @Test
+    public void testResolveKeyId() {
+        CrypkiRequestFactory factory = new CrypkiRequestFactory("x509-key",
+                Map.of("p1", "k1"), 43200);
+        assertEquals(factory.resolveKeyId("p1", null), "k1");
+        assertEquals(factory.resolveKeyId("p1", "explicit"), "explicit");
+        assertEquals(factory.resolveKeyId("unknown", ""), "x509-key");
+        assertEquals(factory.resolveKeyId(null, null), "x509-key");
+        assertEquals(new CrypkiRequestFactory().resolveKeyId("x", null), "x509-key");
+        assertEquals(new CrypkiRequestFactory("", Map.of(), 60).resolveKeyId(null, null),
+                CrypkiConsts.DEFAULT_KEY_ID);
+        expectThrows(NullPointerException.class, () -> X509SignRequest.builder().build());
+        assertEquals(X509SignRequest.builder().csrPem("csr").build().getPriority(),
+                Priority.Unspecified_priority);
+        assertTrue(X509SignRequest.builder().csrPem("csr").build().getExtKeyUsage().isEmpty());
+    }
+
+    @Test
+    public void testForKmsUsesConfiguredKeyId() {
+        System.setProperty(CrypkiConsts.PROP_KMS_KEY_ID, "alias/example-ca");
+        try {
+            CrypkiRequestFactory factory = CrypkiRequestFactory.forKms();
+            assertEquals(factory.resolveKeyId(null, null), "alias/example-ca");
+            assertEquals(factory.resolveKeyId("provider", ""), "alias/example-ca");
+            assertEquals(factory.resolveKeyId(null, "explicit-id"), "explicit-id");
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_KMS_KEY_ID);
+        }
+        assertEquals(CrypkiRequestFactory.forKms().resolveKeyId(null, null), CrypkiConsts.DEFAULT_KEY_ID);
+    }
+
+    @Test
+    public void testForHsmUsesConfiguredLabel() {
+        System.setProperty(CrypkiConsts.PROP_HSM_KEY_LABEL, "example-hsm-label");
+        try {
+            CrypkiRequestFactory factory = CrypkiRequestFactory.forHsm();
+            assertEquals(factory.resolveKeyId(null, null), "example-hsm-label");
+            assertEquals(factory.resolveKeyId("provider", ""), "example-hsm-label");
+            assertEquals(factory.resolveKeyId(null, "explicit-id"), "explicit-id");
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_HSM_KEY_LABEL);
+        }
+        assertEquals(CrypkiRequestFactory.forHsm().resolveKeyId(null, null),
+                CrypkiConsts.DEFAULT_HSM_KEY_LABEL);
+    }
+
+    @Test
+    public void testExtKeyUsage() {
+        assertEquals(CrypkiRequestFactory.toExtKeyUsage(CrypkiConsts.CERT_USAGE_CLIENT), List.of(2));
+        assertEquals(CrypkiRequestFactory.toExtKeyUsage(CrypkiConsts.CERT_USAGE_CODE_SIGNING), List.of(3));
+        assertEquals(CrypkiRequestFactory.toExtKeyUsage(CrypkiConsts.CERT_USAGE_TIMESTAMPING), List.of(8));
+        assertTrue(CrypkiRequestFactory.toExtKeyUsage(null).isEmpty());
+        assertTrue(CrypkiRequestFactory.toExtKeyUsage("server").isEmpty());
+    }
+
+    @Test
+    public void testValidityCap() {
+        CrypkiRequestFactory factory = new CrypkiRequestFactory(null, null, 0);
+        assertEquals(factory.toValiditySeconds(0), 43200 * 60);
+        assertEquals(factory.toValiditySeconds(999999), 43200 * 60);
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/DefaultCrypkiSignerTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/DefaultCrypkiSignerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.signer.DefaultCrypkiSigner;
+import com.yahoo.athenz.crypki.signer.SigningKey;
+import com.yahoo.athenz.crypki.x509.X509CertificateMinter;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.testng.annotations.Test;
+
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class DefaultCrypkiSignerTest {
+
+    static SigningKey selfSigned(String id) throws Exception {
+        PrivateKey caKey = Crypto.generateRSAPrivateKey(2048);
+        String csrPem = Crypto.generateX509CSR(caKey, "CN=Athenz Test CA,O=Athenz,C=US", null);
+        PKCS10CertificationRequest csr = Crypto.getPKCS10CertRequest(csrPem);
+        X509Certificate caCert = Crypto.generateX509Certificate(csr, caKey,
+                new X500Name("CN=Athenz Test CA,O=Athenz,C=US"), 365 * 24 * 60, true);
+        return new SigningKey(id, caKey, caCert);
+    }
+
+    @Test
+    public void testSignAndGetCa() throws Exception {
+        SigningKey ca = selfSigned("x509-key");
+        DefaultCrypkiSigner signer = new DefaultCrypkiSigner(keyId -> ca);
+        PrivateKey leafKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(leafKey, "CN=athenz.service.client,O=Athenz,C=US", null);
+        X509SignRequest request = X509SignRequest.builder()
+                .keyId("x509-key")
+                .csrPem(csr)
+                .validitySeconds(3600)
+                .extKeyUsage(java.util.List.of(X509CertificateMinter.EKU_CLIENT_AUTH))
+                .build();
+        String pem = signer.sign(request);
+        assertTrue(pem.contains("BEGIN CERTIFICATE"));
+        assertTrue(signer.getCACertificate("x509-key").contains("BEGIN CERTIFICATE"));
+        assertTrue(signer.getMaxCertExpiryTimeMins() > 0);
+        expectThrows(NullPointerException.class, () -> new SigningKey(null, ca.getPrivateKey(), ca.getCaCertificate()));
+        expectThrows(NullPointerException.class, () -> new SigningKey("id", null, ca.getCaCertificate()));
+        expectThrows(NullPointerException.class, () -> new SigningKey("id", ca.getPrivateKey(), null));
+        assertEquals(ca.getIdentifier(), "x509-key");
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/KmsAndHsmSignerTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/KmsAndHsmSignerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.hsm.HsmClient;
+import com.yahoo.athenz.crypki.hsm.HsmCrypkiSigner;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+import com.yahoo.athenz.crypki.kms.KmsCrypkiSigner;
+import com.yahoo.athenz.crypki.signer.SigningKey;
+import org.testng.annotations.Test;
+
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class KmsAndHsmSignerTest {
+
+    @Test
+    public void testKmsSigner() throws Exception {
+        SigningKey ca = DefaultCrypkiSignerTest.selfSigned("x509-key");
+        KmsClient kms = new KmsClient() {
+            @Override
+            public byte[] sign(String keyId, byte[] data, String signingAlgorithm) {
+                try {
+                    Signature signature = Signature.getInstance("SHA256withRSA");
+                    signature.initSign(ca.getPrivateKey());
+                    signature.update(data);
+                    return signature.sign();
+                } catch (Exception ex) {
+                    throw new CrypkiException("sign failed", ex);
+                }
+            }
+
+            @Override
+            public PublicKey getPublicKey(String keyId) {
+                return ca.getCaCertificate().getPublicKey();
+            }
+
+            @Override
+            public X509Certificate getCaCertificate(String keyId) {
+                return ca.getCaCertificate();
+            }
+        };
+        KmsCrypkiSigner signer = new KmsCrypkiSigner(kms, "x509-key", "SHA256withRSA", 60);
+        String csr = Crypto.generateX509CSR(Crypto.generateRSAPrivateKey(2048),
+                "CN=svc,O=Athenz,C=US", null);
+        String pem = signer.sign(X509SignRequest.builder().csrPem(csr).keyId("").validitySeconds(60).build());
+        assertTrue(pem.contains("BEGIN CERTIFICATE"));
+        assertTrue(signer.getCACertificate(null).contains("BEGIN CERTIFICATE"));
+        assertEquals(signer.getMaxCertExpiryTimeMins(), 60);
+    }
+
+    @Test
+    public void testKmsSignerUsesConfiguredKeyWhenRequestIsHttpDefault() throws Exception {
+        SigningKey ca = DefaultCrypkiSignerTest.selfSigned("alias/example-ca");
+        java.util.List<String> signedKeyIds = new java.util.ArrayList<>();
+        KmsClient kms = new KmsClient() {
+            @Override
+            public byte[] sign(String keyId, byte[] data, String signingAlgorithm) {
+                signedKeyIds.add(keyId);
+                try {
+                    Signature signature = Signature.getInstance("SHA256withRSA");
+                    signature.initSign(ca.getPrivateKey());
+                    signature.update(data);
+                    return signature.sign();
+                } catch (Exception ex) {
+                    throw new CrypkiException("sign failed", ex);
+                }
+            }
+
+            @Override
+            public PublicKey getPublicKey(String keyId) {
+                return ca.getCaCertificate().getPublicKey();
+            }
+
+            @Override
+            public X509Certificate getCaCertificate(String keyId) {
+                signedKeyIds.add("ca:" + keyId);
+                return ca.getCaCertificate();
+            }
+        };
+        KmsCrypkiSigner signer = new KmsCrypkiSigner(kms, "alias/example-ca", "SHA256withRSA", 60);
+        assertEquals(signer.resolveKeyId(null), "alias/example-ca");
+        assertEquals(signer.resolveKeyId(""), "alias/example-ca");
+        assertEquals(signer.resolveKeyId(CrypkiConsts.DEFAULT_KEY_ID), "alias/example-ca");
+        assertEquals(signer.resolveKeyId("explicit-key-id"), "explicit-key-id");
+        String csr = Crypto.generateX509CSR(Crypto.generateRSAPrivateKey(2048),
+                "CN=svc,O=Athenz,C=US", null);
+        signer.sign(X509SignRequest.builder().csrPem(csr).keyId(CrypkiConsts.DEFAULT_KEY_ID)
+                .validitySeconds(60).build());
+        assertTrue(signedKeyIds.contains("alias/example-ca"));
+        assertTrue(signer.getCACertificate(CrypkiConsts.DEFAULT_KEY_ID).contains("BEGIN CERTIFICATE"));
+    }
+
+    @Test
+    public void testHsmSigner() throws Exception {
+        SigningKey ca = DefaultCrypkiSignerTest.selfSigned("x509-key");
+        HsmClient hsm = keyId -> ca;
+        HsmCrypkiSigner signer = new HsmCrypkiSigner(hsm, 60);
+        String csr = Crypto.generateX509CSR(Crypto.generateRSAPrivateKey(2048),
+                "CN=svc,O=Athenz,C=US", null);
+        String pem = signer.sign(X509SignRequest.builder().csrPem(csr).keyId("x509-key").build());
+        assertTrue(pem.contains("BEGIN CERTIFICATE"));
+    }
+
+    @Test
+    public void testException() {
+        CrypkiException ex = new CrypkiException("msg");
+        assertEquals(ex.getCode(), 500);
+        assertEquals(ex.getMessage(), "msg");
+        assertEquals(new CrypkiException(400, "bad").getCode(), 400);
+        assertEquals(new CrypkiException("x", new IllegalStateException()).getCode(), 500);
+    }
+
+    @Test
+    public void testKmsDefaultConstructorAndHsmMaxExpiry() throws Exception {
+        SigningKey ca = DefaultCrypkiSignerTest.selfSigned("x509-key");
+        KmsClient kms = new KmsClient() {
+            @Override
+            public byte[] sign(String keyId, byte[] data, String signingAlgorithm) {
+                try {
+                    Signature signature = Signature.getInstance("SHA256withRSA");
+                    signature.initSign(ca.getPrivateKey());
+                    signature.update(data);
+                    return signature.sign();
+                } catch (Exception ex) {
+                    throw new CrypkiException("sign failed", ex);
+                }
+            }
+
+            @Override
+            public PublicKey getPublicKey(String keyId) {
+                return ca.getCaCertificate().getPublicKey();
+            }
+
+            @Override
+            public X509Certificate getCaCertificate(String keyId) {
+                return ca.getCaCertificate();
+            }
+        };
+        KmsCrypkiSigner signer = new KmsCrypkiSigner(kms);
+        assertEquals(signer.getMaxCertExpiryTimeMins(), CrypkiConsts.DEFAULT_MAX_CERT_EXPIRY_TIME_MINS);
+        HsmCrypkiSigner hsm = new HsmCrypkiSigner(keyId -> ca);
+        assertTrue(hsm.getMaxCertExpiryTimeMins() > 0);
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/http/HttpCrypkiSignerTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/http/HttpCrypkiSignerTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.http;
+
+import com.yahoo.athenz.common.server.cert.Priority;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.X509SignRequest;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class HttpCrypkiSignerTest {
+
+    @BeforeMethod
+    public void setup() {
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_BASE_URI, "https://localhost:443/v3");
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        System.clearProperty(CrypkiConsts.PROP_CERTSIGN_PROVIDER_KEYS_FNAME);
+        System.clearProperty(CrypkiConsts.PROP_CERTSIGN_RETRY_CONN_ONLY);
+        System.clearProperty(CrypkiConsts.PROP_CERTSIGN_MAX_EXPIRY_TIME);
+        System.clearProperty(CrypkiConsts.PROP_PRIVATE_KEY_STORE_FACTORY_CLASS);
+        System.clearProperty(CrypkiConsts.PROP_KEYSTORE_PATH);
+        System.clearProperty(CrypkiConsts.PROP_KEYSTORE_PASSWORD);
+        System.clearProperty(CrypkiConsts.PROP_TRUSTSTORE_PATH);
+        System.clearProperty(CrypkiConsts.PROP_TRUSTSTORE_PASSWORD);
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_BASE_URI, "https://localhost:443/v3");
+    }
+
+    @Test
+    public void testFactoryAndSign() throws Exception {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
+        HttpEntity entity = Mockito.mock(HttpEntity.class);
+        Mockito.when(response.getEntity()).thenReturn(entity);
+        Mockito.when(response.getCode()).thenReturn(201);
+        Mockito.when(entity.getContent()).thenReturn(
+                new ByteArrayInputStream("{\"cert\":\"pem-value\"}".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(response);
+        signer.setHttpClient(httpClient);
+
+        assertEquals(signer.sign(X509SignRequest.builder().csrPem("csr").keyId("x509-key")
+                .validitySeconds(45).extKeyUsage(List.of(2, 3)).priority(Priority.High).build()),
+                "pem-value");
+        assertEquals(signer.getProviderKeyId("unknown", null), "x509-key");
+        assertEquals(signer.getMaxCertExpiryTimeMins(), 43200);
+        X509CertificateSigningRequest mapped = signer.toHttpSigningRequest(
+                X509SignRequest.builder().csrPem("csr").keyId("x509-key")
+                        .validitySeconds(45).extKeyUsage(List.of(2, 3)).build());
+        assertEquals(mapped.getValidity(), Integer.valueOf(45));
+        assertEquals(mapped.getExtKeyUsage(), List.of(2, 3));
+        assertEquals(mapped.getCsr(), "csr");
+        assertEquals(signer.toHttpSigningRequest(X509SignRequest.builder().csrPem("csr").build())
+                .getValidity(), Integer.valueOf((int) TimeUnit.SECONDS.convert(30, TimeUnit.DAYS)));
+        assertNotNull(signer.getX509CertSigningRequest("aws", "csr", CrypkiConsts.CERT_USAGE_CLIENT,
+                30, Priority.High, null));
+        assertNotNull(signer.getX509CertSigningRequest("aws", "csr",
+                CrypkiConsts.CERT_USAGE_CODE_SIGNING, 15, Priority.High, null));
+        assertNotNull(signer.getX509CertSigningRequest("aws", "csr",
+                CrypkiConsts.CERT_USAGE_TIMESTAMPING, 15, Priority.High, null));
+        assertNotNull(signer.getX509CertSigningRequest("aws", "csr", null, 0, Priority.High, "kid"));
+        X509CertificateSigningRequest uncapped = (X509CertificateSigningRequest) signer
+                .getX509CertSigningRequest("aws", "csr", null, signer.getMaxCertExpiryTimeMins(),
+                        Priority.High, "kid");
+        assertEquals(uncapped.getValidity(),
+                Integer.valueOf((int) TimeUnit.SECONDS.convert(30, TimeUnit.DAYS)));
+        signer.close();
+    }
+
+    @Test
+    public void testMissingBaseUri() {
+        System.clearProperty(CrypkiConsts.PROP_CERTSIGN_BASE_URI);
+        expectThrows(CrypkiException.class, HttpCrypkiSigner::new);
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_BASE_URI, "https://localhost:443/v3");
+    }
+
+    @Test
+    public void testFactory() {
+        assertNotNull(new HttpCrypkiSignerFactory().create());
+        assertNotNull(new HttpCrypkiSignerFactory().createSigner());
+    }
+
+    @Test
+    public void testInvalidProviderFile() {
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_PROVIDER_KEYS_FNAME, "invalid-json-file");
+        expectThrows(CrypkiException.class, HttpCrypkiSigner::new);
+    }
+
+    @Test
+    public void testKeyMeta() {
+        KeyMeta keyMeta = new KeyMeta("keymeta");
+        assertEquals(keyMeta.getIdentifier(), "keymeta");
+        keyMeta.setIdentifier("");
+        assertEquals(keyMeta.getIdentifier(), "");
+        X509Certificate cert = new X509Certificate();
+        cert.setCert("pem");
+        assertEquals(cert.getCert(), "pem");
+        ProviderSignerKey providerKey = new ProviderSignerKey();
+        providerKey.setKeyId("k");
+        providerKey.setProviders(java.util.List.of("p"));
+        assertEquals(providerKey.getKeyId(), "k");
+        assertEquals(providerKey.getProviders(), java.util.List.of("p"));
+        ProviderSignerKeys keys = new ProviderSignerKeys();
+        keys.setDefaultKeyId("d");
+        keys.setProviderKeys(java.util.List.of(providerKey));
+        assertEquals(keys.getDefaultKeyId(), "d");
+        assertEquals(keys.getProviderKeys().size(), 1);
+        assertNull(HttpCrypkiSigner.readFileContents("/tmp/does-not-exist-crypki-keys.json"));
+    }
+
+    @Test
+    public void testSignPreservesSecondsAndRetries() throws Exception {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenThrow(new ConnectException());
+        signer.setHttpClient(httpClient);
+        assertNull(signer.sign(X509SignRequest.builder().csrPem("csr").validitySeconds(45)
+                .extKeyUsage(List.of(2)).build()));
+        Mockito.verify(httpClient, Mockito.times(2)).execute(Mockito.any(HttpPost.class));
+
+        Mockito.reset(httpClient);
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenThrow(new IOException());
+        assertNull(signer.generateX509Certificate("aws", null, "csr", null, 0,
+                Priority.Unspecified_priority, null));
+        Mockito.verify(httpClient, Mockito.times(1)).execute(Mockito.any(HttpPost.class));
+
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_RETRY_CONN_ONLY, "false");
+        HttpCrypkiSigner retrySigner = new HttpCrypkiSigner();
+        retrySigner.setHttpClient(httpClient);
+        Mockito.reset(httpClient);
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenThrow(new IOException());
+        assertNull(retrySigner.generateX509Certificate("aws", null, "csr", null, 0,
+                Priority.Unspecified_priority, null));
+        Mockito.verify(httpClient, Mockito.times(2)).execute(Mockito.any(HttpPost.class));
+        retrySigner.close();
+        signer.close();
+    }
+
+    @Test
+    public void testHttpStatusAndCaCertificate() throws Exception {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        signer.setHttpClient(httpClient);
+
+        CloseableHttpResponse bad = mockResponse(400, "error-body");
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(bad);
+        assertNull(signer.generateX509Certificate("aws", null, "csr", null, 0,
+                Priority.Unspecified_priority, null));
+
+        CloseableHttpResponse empty = mockResponse(201, null);
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(empty);
+        assertNull(signer.generateX509Certificate("aws", null, "csr", null, 0,
+                Priority.Unspecified_priority, null));
+
+        CloseableHttpResponse badJson = mockResponse(201, "not-json");
+        Mockito.when(httpClient.execute(Mockito.any(HttpPost.class))).thenReturn(badJson);
+        assertNull(signer.generateX509Certificate("aws", null, "csr", null, 0,
+                Priority.Unspecified_priority, null));
+
+        Mockito.when(httpClient.execute(Mockito.any(HttpGet.class))).thenThrow(new IOException());
+        assertNull(signer.getCACertificate("aws", null));
+        assertNull(signer.getCACertificate("x509-key"));
+
+        CloseableHttpResponse caBad = mockResponse(400, "nope");
+        Mockito.when(httpClient.execute(Mockito.any(HttpGet.class))).thenReturn(caBad);
+        assertNull(signer.getCACertificate("aws", "kid"));
+
+        CloseableHttpResponse caOk = mockResponse(200, "{\"cert\":\"ca-pem\"}");
+        Mockito.when(httpClient.execute(Mockito.any(HttpGet.class))).thenReturn(caOk);
+        assertEquals(signer.getCACertificate("aws", "kid"), "ca-pem");
+        signer.close();
+    }
+
+    @Test
+    public void testInvalidRequestBuildIsSoftFail() {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner() {
+            @Override
+            public Object getX509CertSigningRequest(String provider, String csr, String keyUsage,
+                    int expireMins, Priority priority, String signerKeyId) {
+                throw new IllegalArgumentException("bad csr");
+            }
+        };
+        assertNull(signer.generateX509Certificate("aws", null, "csr", null, 0,
+                Priority.High, "keyid"));
+        signer.close();
+    }
+
+    @Test
+    public void testProviderKeyFile() {
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_PROVIDER_KEYS_FNAME,
+                "src/test/resources/crypki_key_providers.json");
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        assertEquals(signer.getProviderKeyId("athenz.aws.us-east-1", null), "x509-aws-key");
+        assertEquals(signer.getProviderKeyId("unknown", null), "x509-key-data");
+        assertEquals(signer.getProviderKeyId(null, "explicit"), "explicit");
+        signer.close();
+    }
+
+    @Test
+    public void testProviderKeyFileMissingFields() {
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_PROVIDER_KEYS_FNAME,
+                "src/test/resources/crypki_key_providers_missing_fields.json");
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        assertEquals(signer.getProviderKeyId("athenz.aws.us-west-1", ""), "x509-aws-key");
+        assertEquals(signer.getProviderKeyId("athenz.aws.us-east-1", null), "x509-key");
+        signer.close();
+    }
+
+    @Test
+    public void testProviderKeyFileInvalidJson() {
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_PROVIDER_KEYS_FNAME,
+                "src/test/resources/crypki_key_providers_invalid.json");
+        expectThrows(CrypkiException.class, HttpCrypkiSigner::new);
+    }
+
+    @Test
+    public void testInvalidPrivateKeyStoreAndMaxExpiry() {
+        System.setProperty(CrypkiConsts.PROP_PRIVATE_KEY_STORE_FACTORY_CLASS, "invalid.class");
+        expectThrows(IllegalArgumentException.class, HttpCrypkiSigner::new);
+        System.clearProperty(CrypkiConsts.PROP_PRIVATE_KEY_STORE_FACTORY_CLASS);
+
+        System.setProperty(CrypkiConsts.PROP_CERTSIGN_MAX_EXPIRY_TIME, "1200");
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        assertEquals(signer.getMaxCertExpiryTimeMins(), 1200);
+        X509CertificateSigningRequest capped = signer.toHttpSigningRequest(
+                X509SignRequest.builder().csrPem("csr").validitySeconds(999999).build());
+        assertEquals(capped.getValidity(), Integer.valueOf(1200 * 60));
+        signer.close();
+    }
+
+    @Test
+    public void testSslFactoryProperties() throws Exception {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        java.io.File keyStore = java.io.File.createTempFile("crypki-ks", ".p12");
+        keyStore.deleteOnExit();
+        System.setProperty(CrypkiConsts.PROP_KEYSTORE_PATH, keyStore.getAbsolutePath());
+        System.setProperty(CrypkiConsts.PROP_KEYSTORE_PASSWORD, "changeit");
+        System.setProperty(CrypkiConsts.PROP_TRUSTSTORE_PATH, keyStore.getAbsolutePath());
+        System.setProperty(CrypkiConsts.PROP_TRUSTSTORE_PASSWORD, "changeit");
+        com.yahoo.athenz.auth.PrivateKeyStore pkey = Mockito.mock(com.yahoo.athenz.auth.PrivateKeyStore.class);
+        Mockito.when(pkey.getSecret(Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn("changeit".toCharArray());
+        assertNotNull(signer.createSslContextFactory(pkey));
+        assertNotNull(signer.createSslContextFactory(null));
+        signer.close();
+    }
+
+    @Test
+    public void testCloseSwallowsErrors() throws Exception {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+        Mockito.doThrow(new IOException("closed")).when(httpClient).close();
+        signer.setHttpClient(httpClient);
+        signer.close();
+    }
+
+    @Test
+    public void testSslContextStartFailure() throws Exception {
+        java.io.File emptyStore = java.io.File.createTempFile("crypki-bad-ks", ".p12");
+        emptyStore.deleteOnExit();
+        System.setProperty(CrypkiConsts.PROP_KEYSTORE_PATH, emptyStore.getAbsolutePath());
+        System.setProperty(CrypkiConsts.PROP_KEYSTORE_PASSWORD, "changeit");
+        expectThrows(CrypkiException.class, HttpCrypkiSigner::new);
+    }
+
+    @Test
+    public void testX509CertUri() {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        assertTrue(signer.getX509CertUri(signer.serverBaseUri, "aws", "kid")
+                .endsWith("/sig/x509-cert/keys/kid"));
+        assertTrue(signer.getX509CertUri(signer.serverBaseUri, null, null)
+                .endsWith("/sig/x509-cert/keys/x509-key"));
+        signer.close();
+    }
+
+    private static CloseableHttpResponse mockResponse(int status, String body) throws Exception {
+        CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
+        HttpEntity entity = Mockito.mock(HttpEntity.class);
+        Mockito.when(response.getEntity()).thenReturn(entity);
+        Mockito.when(response.getCode()).thenReturn(status);
+        if (body != null) {
+            Mockito.when(entity.getContent()).thenReturn(
+                    new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        }
+        return response;
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/http/HttpCrypkiSignerTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/http/HttpCrypkiSignerTest.java
@@ -309,6 +309,19 @@ public class HttpCrypkiSignerTest {
         signer.close();
     }
 
+    @Test
+    public void testPostX509CertificateSerializationFailure() {
+        HttpCrypkiSigner signer = new HttpCrypkiSigner();
+        X509CertificateSigningRequest bad = new X509CertificateSigningRequest() {
+            @Override
+            public String getCsr() {
+                throw new RuntimeException("cannot serialize");
+            }
+        };
+        assertNull(signer.postX509Certificate("aws", "kid", bad));
+        signer.close();
+    }
+
     private static CloseableHttpResponse mockResponse(int status, String body) throws Exception {
         CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
         HttpEntity entity = Mockito.mock(HttpEntity.class);

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/x509/X509CertificateMinterTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/x509/X509CertificateMinterTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.crypki.x509;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.X509SignRequest;
+import com.yahoo.athenz.crypki.signer.SigningKey;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.testng.annotations.Test;
+
+import javax.security.auth.x500.X500Principal;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class X509CertificateMinterTest {
+
+    @Test
+    public void testMintsLeafWithSanAndDefaultEku() throws Exception {
+        SigningKey ca = rsaCa();
+        PrivateKey leafKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(leafKey, "CN=athenz.api,O=Athenz,C=US",
+                new GeneralName[]{
+                        new GeneralName(GeneralName.uniformResourceIdentifier, "spiffe://athenz/sa/api"),
+                        new GeneralName(GeneralName.dNSName, "api.athenz.example")
+                });
+        X509CertificateMinter minter = new X509CertificateMinter(3600);
+        X509Certificate cert = minter.signCertificate(ca.getPrivateKey(), ca.getCaCertificate(),
+                X509SignRequest.builder().csrPem(csr).validitySeconds(60).build());
+        assertNotNull(cert);
+        assertTrue(Crypto.convertToPEMFormat(cert).contains("BEGIN CERTIFICATE"));
+        List<String> eku = cert.getExtendedKeyUsage();
+        assertTrue(eku.contains("1.3.6.1.5.5.7.3.1"));
+        assertTrue(eku.contains("1.3.6.1.5.5.7.3.2"));
+    }
+
+    @Test
+    public void testEkuMappingAndInvalidCsr() throws Exception {
+        assertEquals(X509CertificateMinter.toKeyPurposeId(X509CertificateMinter.EKU_SERVER_AUTH),
+                KeyPurposeId.id_kp_serverAuth);
+        assertEquals(X509CertificateMinter.toKeyPurposeId(X509CertificateMinter.EKU_CLIENT_AUTH),
+                KeyPurposeId.id_kp_clientAuth);
+        assertEquals(X509CertificateMinter.toKeyPurposeId(X509CertificateMinter.EKU_CODE_SIGNING),
+                KeyPurposeId.id_kp_codeSigning);
+        assertEquals(X509CertificateMinter.toKeyPurposeId(X509CertificateMinter.EKU_TIME_STAMPING),
+                KeyPurposeId.id_kp_timeStamping);
+        assertEquals(X509CertificateMinter.toKeyPurposeId(99), KeyPurposeId.id_kp_clientAuth);
+
+        X509CertificateMinter minter = new X509CertificateMinter(60);
+        expectThrows(CrypkiException.class, () -> minter.sign(rsaCa(), null));
+        expectThrows(CrypkiException.class, () -> minter.sign(rsaCa(),
+                X509SignRequest.builder().csrPem("").build()));
+        expectThrows(CrypkiException.class, () -> minter.sign(rsaCa(),
+                X509SignRequest.builder().csrPem("not-a-csr").build()));
+        expectThrows(CrypkiException.class, () -> minter.sign(rsaCa(),
+                X509SignRequest.builder().csrPem(mismatchedCsr()).build()));
+        JcaPKCS10CertificationRequest parsed = new JcaPKCS10CertificationRequest(
+                Crypto.getPKCS10CertRequest(Crypto.generateX509CSR(
+                        Crypto.generateRSAPrivateKey(2048), "CN=verify,O=Athenz,C=US", null)));
+        expectThrows(CrypkiException.class, () -> X509CertificateMinter.verifyCsrSignature(parsed, null));
+    }
+
+    @Test
+    public void testCodeSigningAndTimestamping() throws Exception {
+        SigningKey ca = rsaCa();
+        PrivateKey leafKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(leafKey, "CN=code.client,O=Athenz,C=US", null);
+        String codeSigning = new X509CertificateMinter(120).sign(ca,
+                X509SignRequest.builder().csrPem(csr).validitySeconds(30)
+                        .extKeyUsage(List.of(X509CertificateMinter.EKU_CODE_SIGNING)).build());
+        assertTrue(codeSigning.contains("BEGIN CERTIFICATE"));
+        String timestamping = new X509CertificateMinter(120).sign(ca,
+                X509SignRequest.builder().csrPem(csr).validitySeconds(30)
+                        .extKeyUsage(List.of(X509CertificateMinter.EKU_TIME_STAMPING)).build());
+        assertTrue(timestamping.contains("BEGIN CERTIFICATE"));
+    }
+
+    @Test
+    public void testSanIpEmailAndIgnoredTags() throws Exception {
+        SigningKey ca = rsaCa();
+        PrivateKey leafKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(leafKey, "CN=mixed.san,O=Athenz,C=US",
+                new GeneralName[]{
+                        new GeneralName(GeneralName.iPAddress, "192.0.2.10"),
+                        new GeneralName(GeneralName.rfc822Name, "ops@athenz.example"),
+                        new GeneralName(new X500Name("CN=directory-name"))
+                });
+        X509Certificate cert = new X509CertificateMinter(60).signCertificate(ca.getPrivateKey(),
+                ca.getCaCertificate(), X509SignRequest.builder().csrPem(csr).validitySeconds(0).build());
+        boolean sawIp = false;
+        boolean sawEmail = false;
+        boolean sawDirectory = false;
+        for (java.util.List<?> entry : cert.getSubjectAlternativeNames()) {
+            String value = String.valueOf(entry.get(1));
+            sawIp |= "192.0.2.10".equals(value);
+            sawEmail |= "ops@athenz.example".equals(value);
+            sawDirectory |= value.contains("directory-name");
+        }
+        assertTrue(sawIp);
+        assertTrue(sawEmail);
+        assertFalse(sawDirectory);
+    }
+
+    @Test
+    public void testExtensionRequestWithoutSan() throws Exception {
+        SigningKey ca = rsaCa();
+        KeyPair leaf = rsaKeyPair();
+        JcaPKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(
+                new X500Principal("CN=ext-only,O=Athenz,C=US"), leaf.getPublic());
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        extGen.addExtension(Extension.basicConstraints, false, new BasicConstraints(false));
+        builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
+        String csr = Crypto.convertToPEMFormat(builder.build(
+                new JcaContentSignerBuilder("SHA256withRSA").build(leaf.getPrivate())));
+        X509Certificate cert = new X509CertificateMinter(60).signCertificate(ca.getPrivateKey(),
+                ca.getCaCertificate(), X509SignRequest.builder().csrPem(csr).build());
+        assertNotNull(cert);
+        assertTrue(cert.getSubjectAlternativeNames() == null
+                || cert.getSubjectAlternativeNames().isEmpty());
+    }
+
+    @Test
+    public void testEcContentSignerAndInvalidPrivateKey() {
+        PrivateKey invalidEc = dummyPrivateKey("EC");
+        expectThrows(CrypkiException.class, () -> X509CertificateMinter.contentSigner(invalidEc));
+
+        Provider fakePkcs11 = new Provider("SunPKCS11-Test", "1.0", "test") {
+        };
+        Security.insertProviderAt(fakePkcs11, 1);
+        try {
+            expectThrows(CrypkiException.class, () -> X509CertificateMinter.contentSigner(dummyPrivateKey("RSA")));
+        } finally {
+            Security.removeProvider("SunPKCS11-Test");
+        }
+    }
+
+    private static SigningKey rsaCa() throws Exception {
+        PrivateKey caKey = Crypto.generateRSAPrivateKey(2048);
+        String csrPem = Crypto.generateX509CSR(caKey, "CN=Athenz Test CA,O=Athenz,C=US", null);
+        PKCS10CertificationRequest csr = Crypto.getPKCS10CertRequest(csrPem);
+        X509Certificate caCert = Crypto.generateX509Certificate(csr, caKey,
+                new X500Name("CN=Athenz Test CA,O=Athenz,C=US"), 365 * 24 * 60, true);
+        return new SigningKey("ca", caKey, caCert);
+    }
+
+    private static String mismatchedCsr() throws Exception {
+        KeyPair subject = rsaKeyPair();
+        KeyPair signer = rsaKeyPair();
+        return Crypto.convertToPEMFormat(new JcaPKCS10CertificationRequestBuilder(
+                new X500Principal("CN=pop-mismatch,O=Athenz,C=US"), subject.getPublic())
+                .build(new JcaContentSignerBuilder("SHA256withRSA").build(signer.getPrivate())));
+    }
+
+    private static KeyPair rsaKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
+    }
+
+    private static PrivateKey dummyPrivateKey(String algorithm) {
+        return new PrivateKey() {
+            @Override
+            public String getAlgorithm() {
+                return algorithm;
+            }
+
+            @Override
+            public String getFormat() {
+                return "PKCS#8";
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return new byte[0];
+            }
+        };
+    }
+}

--- a/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/x509/X509CertificateMinterTest.java
+++ b/libs/java/crypki/src/test/java/com/yahoo/athenz/crypki/x509/X509CertificateMinterTest.java
@@ -26,17 +26,23 @@ import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.ExtensionsGenerator;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequest;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import javax.security.auth.x500.X500Principal;
+import java.lang.reflect.Method;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.security.PublicKey;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -168,6 +174,74 @@ public class X509CertificateMinterTest {
         }
     }
 
+    @Test
+    public void testMalformedCsrThrowsParseError() throws Exception {
+        X509CertificateMinter minter = new X509CertificateMinter(60);
+        String malformedPem = "-----BEGIN CERTIFICATE REQUEST-----\n****\n-----END CERTIFICATE REQUEST-----\n";
+        CrypkiException ex = expectThrows(CrypkiException.class, () -> minter.sign(rsaCa(),
+                X509SignRequest.builder().csrPem(malformedPem).build()));
+        assertEquals(ex.getMessage(), "Unable to parse CSR");
+        assertNotNull(ex.getCause());
+    }
+
+    @Test
+    public void testSignWrapsUnexpectedErrors() throws Exception {
+        SigningKey ca = rsaCa();
+        String csr = Crypto.generateX509CSR(Crypto.generateRSAPrivateKey(2048),
+                "CN=wrap.errors,O=Athenz,C=US", null);
+        ContentSigner signer = X509CertificateMinter.contentSigner(ca.getPrivateKey());
+        X509Certificate badCa = Mockito.mock(X509Certificate.class);
+        Mockito.when(badCa.getEncoded()).thenThrow(new java.security.cert.CertificateEncodingException("bad ca"));
+        CrypkiException ex = expectThrows(CrypkiException.class, () ->
+                new X509CertificateMinter(60).signCertificate(signer, badCa,
+                        X509SignRequest.builder().csrPem(csr).build()));
+        assertTrue(ex.getMessage().startsWith("Unable to sign X.509 certificate"));
+    }
+
+    @Test
+    public void testVerifyCsrSignatureWrapsProviderErrors() throws Exception {
+        JcaPKCS10CertificationRequest parsed = new JcaPKCS10CertificationRequest(
+                Crypto.getPKCS10CertRequest(Crypto.generateX509CSR(
+                        Crypto.generateRSAPrivateKey(2048), "CN=verify-wrap,O=Athenz,C=US", null)));
+        CrypkiException ex = expectThrows(CrypkiException.class,
+                () -> X509CertificateMinter.verifyCsrSignature(parsed, dummyPublicKey()));
+        assertEquals(ex.getMessage(), "Unable to verify CSR signature");
+    }
+
+    @Test
+    public void testPkcs11ProviderFallbackSucceeds() {
+        Provider pkcs11 = new Provider("SunPKCS11-Coverage", "1.0", "test") {
+        };
+        Security.addProvider(pkcs11);
+        ContentSigner fallback = Mockito.mock(ContentSigner.class);
+        try (MockedConstruction<JcaContentSignerBuilder> mocked = Mockito.mockConstruction(
+                JcaContentSignerBuilder.class,
+                (mock, context) -> {
+                    Mockito.when(mock.setProvider(Mockito.any(Provider.class))).thenReturn(mock);
+                    if (context.getCount() == 1) {
+                        Mockito.when(mock.build(Mockito.any())).thenThrow(new RuntimeException("no default signer"));
+                    } else {
+                        Mockito.when(mock.build(Mockito.any())).thenReturn(fallback);
+                    }
+                })) {
+            assertEquals(X509CertificateMinter.contentSigner(dummyPrivateKey("RSA")), fallback);
+        } finally {
+            Security.removeProvider("SunPKCS11-Coverage");
+        }
+    }
+
+    @Test
+    public void testAddSanReturnsWhenAttributesMissing() throws Exception {
+        JcaPKCS10CertificationRequest jcaReq = Mockito.mock(JcaPKCS10CertificationRequest.class);
+        Mockito.when(jcaReq.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest)).thenReturn(null);
+        Method method = X509CertificateMinter.class.getDeclaredMethod("addSubjectAlternativeNames",
+                X509v3CertificateBuilder.class, JcaPKCS10CertificationRequest.class);
+        method.setAccessible(true);
+        X509v3CertificateBuilder builder = Mockito.mock(X509v3CertificateBuilder.class);
+        method.invoke(null, builder, jcaReq);
+        Mockito.verifyNoInteractions(builder);
+    }
+
     private static SigningKey rsaCa() throws Exception {
         PrivateKey caKey = Crypto.generateRSAPrivateKey(2048);
         String csrPem = Crypto.generateX509CSR(caKey, "CN=Athenz Test CA,O=Athenz,C=US", null);
@@ -206,6 +280,25 @@ public class X509CertificateMinterTest {
             @Override
             public byte[] getEncoded() {
                 return new byte[0];
+            }
+        };
+    }
+
+    private static PublicKey dummyPublicKey() {
+        return new PublicKey() {
+            @Override
+            public String getAlgorithm() {
+                return "RSA";
+            }
+
+            @Override
+            public String getFormat() {
+                return "X.509";
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return new byte[]{0x00};
             }
         };
     }

--- a/libs/java/crypki/src/test/resources/crypki_key_providers.json
+++ b/libs/java/crypki/src/test/resources/crypki_key_providers.json
@@ -1,0 +1,21 @@
+{
+    "defaultKeyId": "x509-key-data",
+    "providerKeys": [
+        {
+            "keyId": "x509-aws-key",
+            "providers": [
+                "athenz.aws.us-east-1",
+                "athenz.aws.us-east-2",
+                "athenz.aws.us-west-1",
+                "athenz.aws.us-west-2"
+            ]
+        },
+        {
+            "keyId": "x509-azure-key",
+            "providers": [
+                "athenz.azure.eastus",
+                "athenz.azure.westus"
+            ]
+        }
+    ]
+}

--- a/libs/java/crypki/src/test/resources/crypki_key_providers_invalid.json
+++ b/libs/java/crypki/src/test/resources/crypki_key_providers_invalid.json
@@ -1,0 +1,8 @@
+{
+    "defaultKeyId": "x509-key-data",
+    "providerKeys": [
+        {
+            "keyId": "x509-aws-key",
+            "providers": [
+                "athenz.aws.us-east-1",
+                "athenz.aws.us-east-2",

--- a/libs/java/crypki/src/test/resources/crypki_key_providers_missing_fields.json
+++ b/libs/java/crypki/src/test/resources/crypki_key_providers_missing_fields.json
@@ -1,0 +1,29 @@
+{
+    "providerKeys": [
+        {
+            "keyId": "x509-aws-key",
+            "providers": [
+                "athenz.aws.us-west-1",
+                "athenz.aws.us-west-2"
+            ]
+        },
+        {
+            "providers": [
+                "athenz.aws.us-east-1"
+            ]
+        },
+        {
+            "keyId": "",
+            "providers": [
+                "athenz.aws.us-east-2"
+            ]
+        },
+        {
+            "keyId": "x509-azure-key",
+            "providers": [
+                "athenz.azure.eastus",
+                "athenz.azure.westus"
+            ]
+        }
+    ]
+}

--- a/libs/java/server_aws_common/pom.xml
+++ b/libs/java/server_aws_common/pom.xml
@@ -119,6 +119,11 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.yahoo.athenz</groupId>
+      <artifactId>athenz-crypki</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>athenz-dynamodb-client-factory</artifactId>
       <version>${project.parent.version}</version>

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsCloudHsmClient.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsCloudHsmClient.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.aws.common.cert.impl;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.hsm.HsmClient;
+import com.yahoo.athenz.crypki.signer.SigningKey;
+import org.eclipse.jetty.util.StringUtil;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.AuthProvider;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import javax.security.auth.callback.PasswordCallback;
+
+/**
+ * CloudHSM {@link HsmClient}: CloudHSM JCE when present, otherwise
+ * SunPKCS11. The CA PEM is loaded from disk. The private key never
+ * leaves the HSM.
+ *
+ * <p>SunPKCS11's PKCS#11 {@code KeyStore} only exposes private keys that
+ * have a matching certificate object, so CloudHSM JCE
+ * ({@code /opt/cloudhsm/java/cloudhsm-jce-*.jar}) is required for a
+ * label-only sign key.
+ */
+public class AwsCloudHsmClient implements HsmClient {
+
+    static final String DEFAULT_MODULE = "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so";
+
+    private final String defaultLabel;
+    private final SigningKey signingKey;
+
+    public AwsCloudHsmClient() {
+        this(System.getProperty(CrypkiConsts.PROP_HSM_MODULE_PATH, DEFAULT_MODULE),
+                System.getProperty(CrypkiConsts.PROP_HSM_SLOT),
+                System.getProperty(CrypkiConsts.PROP_HSM_KEY_LABEL, CrypkiConsts.DEFAULT_HSM_KEY_LABEL),
+                System.getProperty(CrypkiConsts.PROP_HSM_PIN_PATH),
+                System.getProperty(CrypkiConsts.PROP_HSM_CA_CERT_PATH));
+    }
+
+    public AwsCloudHsmClient(String modulePath, String slot, String keyLabel, String pinPath,
+            String caCertPath) {
+        this.defaultLabel = StringUtil.isEmpty(keyLabel)
+                ? CrypkiConsts.DEFAULT_HSM_KEY_LABEL : keyLabel;
+        this.signingKey = loadSigningKey(modulePath, slot, this.defaultLabel, pinPath, caCertPath);
+    }
+
+    AwsCloudHsmClient(SigningKey signingKey, String defaultLabel) {
+        this.signingKey = signingKey;
+        this.defaultLabel = defaultLabel;
+    }
+
+    @Override
+    public SigningKey getSigningKey(String keyId) {
+        final String label = resolveLabel(keyId);
+        if (!defaultLabel.equals(label) && !signingKey.getIdentifier().equals(label)) {
+            throw new CrypkiException("CloudHSM key label is not loaded: " + label
+                    + " (configured " + defaultLabel + ")");
+        }
+        return signingKey;
+    }
+
+    String resolveLabel(String requested) {
+        if (requested == null || requested.isEmpty() || CrypkiConsts.DEFAULT_KEY_ID.equals(requested)) {
+            return defaultLabel;
+        }
+        return requested;
+    }
+
+    static SigningKey loadSigningKey(String modulePath, String slot, String label, String pinPath,
+            String caCertPath) {
+        char[] pin = readPin(pinPath);
+        X509Certificate caCertificate = loadCaCertificate(caCertPath);
+        try {
+            if (cloudHsmJcePresent()) {
+                return loadCloudHsmJce(label, pin, caCertificate);
+            }
+            if (modulePath == null || !new File(modulePath).isFile()) {
+                throw new CrypkiException("AWS CloudHSM PKCS#11 module not found: " + modulePath);
+            }
+            return loadSunPkcs11(modulePath, slot, label, pin, caCertificate);
+        } catch (CrypkiException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to load CloudHSM key " + label
+                    + ": " + ex.getMessage(), ex);
+        } finally {
+            java.util.Arrays.fill(pin, '\0');
+        }
+    }
+
+    static boolean cloudHsmJcePresent() {
+        try {
+            Class.forName("com.amazonaws.cloudhsm.jce.provider.CloudHsmProvider");
+            return true;
+        } catch (ClassNotFoundException ex) {
+            return false;
+        }
+    }
+
+    static SigningKey loadCloudHsmJce(String label, char[] pin, X509Certificate caCertificate)
+            throws Exception {
+        Class<?> providerClass = Class.forName("com.amazonaws.cloudhsm.jce.provider.CloudHsmProvider");
+        Provider created = (Provider) providerClass.getDeclaredConstructor().newInstance();
+        Provider provider = Security.getProvider(created.getName());
+        if (provider == null) {
+            Security.addProvider(created);
+            provider = created;
+        }
+        if (provider instanceof AuthProvider) {
+            ((AuthProvider) provider).login(null, callbacks -> {
+                for (javax.security.auth.callback.Callback callback : callbacks) {
+                    if (callback instanceof PasswordCallback) {
+                        ((PasswordCallback) callback).setPassword(pin);
+                    }
+                }
+            });
+        }
+        PrivateKey privateKey = loadCloudHsmJcePrivateKey(provider, label, pin);
+        if (privateKey == null) {
+            throw new CrypkiException("CloudHSM JCE key not found for label " + label);
+        }
+        return new SigningKey(label, privateKey, caCertificate);
+    }
+
+    /**
+     * Prefer {@code KeyStoreWithAttributes} so a public/private pair that
+     * shares a label (CloudHSM default) still resolves to the private key.
+     * {@code KeyStore.getKey(alias)} throws when two objects have that label.
+     */
+    static PrivateKey loadCloudHsmJcePrivateKey(Provider provider, String label, char[] pin)
+            throws Exception {
+        PrivateKey byAttributes = loadCloudHsmJcePrivateKeyByAttributes(provider, label, pin);
+        if (byAttributes != null) {
+            return byAttributes;
+        }
+        KeyStore keyStore = KeyStore.getInstance(provider.getName(), provider);
+        keyStore.load(null, pin);
+        return (PrivateKey) keyStore.getKey(label, pin);
+    }
+
+    /**
+     * CloudHSM Client SDK 5: {@code KeyAttributesMapBuilder.put(LABEL/OBJECT_CLASS)}
+     * and {@code KeyStoreWithAttributes.getKey(KeyAttributesMap)}.
+     */
+    static PrivateKey loadCloudHsmJcePrivateKeyByAttributes(Provider provider, String label,
+            char[] pin) {
+        try {
+            Class<?> ksClass = Class.forName(
+                    "com.amazonaws.cloudhsm.jce.provider.KeyStoreWithAttributes");
+            Class<?> mapClass = Class.forName(
+                    "com.amazonaws.cloudhsm.jce.provider.attributes.KeyAttributesMap");
+            Class<?> builderClass = Class.forName(
+                    "com.amazonaws.cloudhsm.jce.provider.attributes.KeyAttributesMapBuilder");
+            Class<?> attrClass = Class.forName(
+                    "com.amazonaws.cloudhsm.jce.provider.attributes.KeyAttribute");
+            Class<?> classType = Class.forName(
+                    "com.amazonaws.cloudhsm.jce.provider.attributes.ObjectClassType");
+            Object spec = cloudHsmKeyAttributes(builderClass, attrClass, classType, label);
+            Object keyStore = ksClass.getMethod("getInstance", String.class).invoke(null, "CloudHSM");
+            ksClass.getMethod("load", java.io.InputStream.class, char[].class)
+                    .invoke(keyStore, null, pin);
+            Object key = ksClass.getMethod("getKey", mapClass).invoke(keyStore, spec);
+            return key instanceof PrivateKey ? (PrivateKey) key : null;
+        } catch (ClassNotFoundException ex) {
+            return null;
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to load CloudHSM JCE private key " + label
+                    + ": " + ex.getMessage(), ex);
+        }
+    }
+
+    static Object cloudHsmKeyAttributes(Class<?> builderClass, Class<?> attrClass,
+            Class<?> classType, String label) throws Exception {
+        Object builder = builderClass.getDeclaredConstructor().newInstance();
+        Object labelAttr = Enum.valueOf(attrClass.asSubclass(Enum.class), "LABEL");
+        Object classAttr = Enum.valueOf(attrClass.asSubclass(Enum.class), "OBJECT_CLASS");
+        Object privateClass = Enum.valueOf(classType.asSubclass(Enum.class), "PRIVATE_KEY");
+        builderClass.getMethod("put", attrClass, Object.class).invoke(builder, labelAttr, label);
+        builderClass.getMethod("put", attrClass, Object.class)
+                .invoke(builder, classAttr, privateClass);
+        return builderClass.getMethod("build").invoke(builder);
+    }
+
+    static SigningKey loadSunPkcs11(String modulePath, String slot, String label, char[] pin,
+            X509Certificate caCertificate) throws Exception {
+        Provider provider = pkcs11Provider(modulePath, slot);
+        KeyStore keyStore = KeyStore.getInstance("PKCS11", provider);
+        keyStore.load(null, pin);
+        PrivateKey privateKey = (PrivateKey) keyStore.getKey(label, pin);
+        if (privateKey == null) {
+            throw new CrypkiException("CloudHSM PKCS#11 key not found for label " + label
+                    + " (install cloudhsm-jce or store a certificate object with the key)");
+        }
+        return new SigningKey(label, privateKey, caCertificate);
+    }
+
+    static Provider pkcs11Provider(String modulePath, String slot) {
+        Provider prototype = Security.getProvider("SunPKCS11");
+        if (prototype == null) {
+            throw new CrypkiException("SunPKCS11 provider is not available");
+        }
+        String config = pkcs11Config(modulePath, slot);
+        try {
+            Provider configured = prototype.configure(config);
+            if (Security.getProvider(configured.getName()) == null) {
+                Security.addProvider(configured);
+            }
+            return configured;
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to configure SunPKCS11 for " + modulePath
+                    + ": " + ex.getMessage(), ex);
+        }
+    }
+
+    static String pkcs11Config(String modulePath, String slot) {
+        StringBuilder config = new StringBuilder();
+        config.append("--name=AthenzCrypkiHsm\n");
+        config.append("library=").append(modulePath).append('\n');
+        if (StringUtil.isEmpty(slot)) {
+            config.append("slotListIndex=0\n");
+        } else {
+            config.append("slot=").append(slot).append('\n');
+        }
+        return config.toString();
+    }
+
+    static char[] readPin(String pinPath) {
+        if (StringUtil.isEmpty(pinPath)) {
+            throw new CrypkiException("Missing " + CrypkiConsts.PROP_HSM_PIN_PATH);
+        }
+        try {
+            String pin = Files.readString(Path.of(pinPath)).strip();
+            if (pin.isEmpty()) {
+                throw new CrypkiException("CloudHSM PIN file is empty: " + pinPath);
+            }
+            return pin.toCharArray();
+        } catch (CrypkiException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to read CloudHSM PIN file: " + pinPath, ex);
+        }
+    }
+
+    static X509Certificate loadCaCertificate(String caCertPath) {
+        if (StringUtil.isEmpty(caCertPath)) {
+            throw new CrypkiException("Missing " + CrypkiConsts.PROP_HSM_CA_CERT_PATH);
+        }
+        try {
+            return Crypto.loadX509Certificate(Files.readString(Path.of(caCertPath)));
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to load CloudHSM CA certificate: " + caCertPath, ex);
+        }
+    }
+}

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsCloudHsmCrypkiSignerFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsCloudHsmCrypkiSignerFactory.java
@@ -18,7 +18,6 @@ package io.athenz.server.aws.common.cert.impl;
 import com.yahoo.athenz.common.server.cert.CertSigner;
 import com.yahoo.athenz.common.server.cert.CertSignerFactory;
 import com.yahoo.athenz.crypki.CrypkiCertSigner;
-import com.yahoo.athenz.crypki.CrypkiConsts;
 import com.yahoo.athenz.crypki.CrypkiRequestFactory;
 import com.yahoo.athenz.crypki.CrypkiSigner;
 import com.yahoo.athenz.crypki.CrypkiSignerFactory;
@@ -50,7 +49,6 @@ public class AwsCloudHsmCrypkiSignerFactory implements CertSignerFactory, Crypki
 
     @Override
     public CertSigner create() {
-        CrypkiConsts.requireJavaCrypkiEnabled();
         return new CrypkiCertSigner(createSigner(), CrypkiRequestFactory.forHsm());
     }
 

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsCloudHsmCrypkiSignerFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsCloudHsmCrypkiSignerFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.aws.common.cert.impl;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.CertSignerFactory;
+import com.yahoo.athenz.crypki.CrypkiCertSigner;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiRequestFactory;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.CrypkiSignerFactory;
+import com.yahoo.athenz.crypki.hsm.HsmClient;
+import com.yahoo.athenz.crypki.hsm.HsmCrypkiSigner;
+
+/**
+ * ZTS factory: {@code athenz.zts.cert_signer_factory_class=io.athenz.server.aws.common.cert.impl.AwsCloudHsmCrypkiSignerFactory}
+ *
+ * Uses the Crypki {@link HsmClient} SPI. Default CloudHSM PKCS#11 module path is
+ * {@code /opt/cloudhsm/lib/libcloudhsm_pkcs11.so}.
+ */
+public class AwsCloudHsmCrypkiSignerFactory implements CertSignerFactory, CrypkiSignerFactory {
+
+    private final HsmClient hsmClient;
+
+    public AwsCloudHsmCrypkiSignerFactory() {
+        this(null);
+    }
+
+    public AwsCloudHsmCrypkiSignerFactory(HsmClient hsmClient) {
+        this.hsmClient = hsmClient;
+    }
+
+    @Override
+    public CrypkiSigner createSigner() {
+        return new HsmCrypkiSigner(hsmClient == null ? newCloudHsmClient() : hsmClient);
+    }
+
+    @Override
+    public CertSigner create() {
+        CrypkiConsts.requireJavaCrypkiEnabled();
+        return new CrypkiCertSigner(createSigner(), CrypkiRequestFactory.forHsm());
+    }
+
+    HsmClient newCloudHsmClient() {
+        return new AwsCloudHsmClient();
+    }
+}

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsKmsClient.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsKmsClient.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.aws.common.cert.impl;
+
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
+import software.amazon.awssdk.services.kms.model.MessageType;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Map;
+
+/**
+ * AWS KMS implementation of the Crypki {@link KmsClient} SPI.
+ */
+public class AwsKmsClient implements KmsClient {
+
+    private final software.amazon.awssdk.services.kms.KmsClient client;
+    private final String caCertPath;
+
+    public AwsKmsClient() {
+        this(software.amazon.awssdk.services.kms.KmsClient.create(),
+                System.getProperty(CrypkiConsts.PROP_KMS_CA_CERT_PATH));
+    }
+
+    public AwsKmsClient(software.amazon.awssdk.services.kms.KmsClient client, String caCertPath) {
+        this.client = client;
+        this.caCertPath = caCertPath;
+    }
+
+    @Override
+    public byte[] sign(String keyId, byte[] data, String signingAlgorithm) {
+        return client.sign(SignRequest.builder()
+                .keyId(keyId)
+                .message(SdkBytes.fromByteArray(data))
+                .messageType(MessageType.RAW)
+                .signingAlgorithm(toAwsAlgorithm(signingAlgorithm))
+                .build()).signature().asByteArray();
+    }
+
+    @Override
+    public PublicKey getPublicKey(String keyId) {
+        GetPublicKeyResponse response = client.getPublicKey(
+                GetPublicKeyRequest.builder().keyId(keyId).build());
+        byte[] der = response.publicKey().asByteArray();
+        try {
+            return KeyFactory.getInstance(publicKeyAlgorithm(response.keySpec(), der))
+                    .generatePublic(new X509EncodedKeySpec(der));
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to parse KMS public key for " + keyId, ex);
+        }
+    }
+
+    static String publicKeyAlgorithm(software.amazon.awssdk.services.kms.model.KeySpec keySpec,
+            byte[] der) {
+        if (keySpec != null) {
+            String name = keySpec.toString();
+            if (name.startsWith("ECC") || name.startsWith("SM2")) {
+                return "EC";
+            }
+            if (name.startsWith("RSA")) {
+                return "RSA";
+            }
+        }
+        return encodedKeyAlgorithm(der);
+    }
+
+    static String encodedKeyAlgorithm(byte[] der) {
+        X509EncodedKeySpec spec = new X509EncodedKeySpec(der);
+        try {
+            KeyFactory.getInstance("EC").generatePublic(spec);
+            return "EC";
+        } catch (InvalidKeySpecException | java.security.NoSuchAlgorithmException ignored) {
+            return "RSA";
+        }
+    }
+
+    @Override
+    public X509Certificate getCaCertificate(String keyId) {
+        if (caCertPath == null || caCertPath.isEmpty()) {
+            throw new CrypkiException("Missing " + CrypkiConsts.PROP_KMS_CA_CERT_PATH
+                    + " for KMS key " + keyId);
+        }
+        try {
+            return Crypto.loadX509Certificate(Files.readString(Path.of(caCertPath)));
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to load KMS CA certificate: " + caCertPath, ex);
+        }
+    }
+
+    private static final Map<String, SigningAlgorithmSpec> AWS_ALGORITHMS = Map.ofEntries(
+            Map.entry("SHA256withRSA", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256),
+            Map.entry("SHA384withRSA", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384),
+            Map.entry("SHA512withRSA", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512),
+            Map.entry("SHA256withRSAandMGF1", SigningAlgorithmSpec.RSASSA_PSS_SHA_256),
+            Map.entry("SHA384withRSAandMGF1", SigningAlgorithmSpec.RSASSA_PSS_SHA_384),
+            Map.entry("SHA512withRSAandMGF1", SigningAlgorithmSpec.RSASSA_PSS_SHA_512),
+            Map.entry("SHA256withECDSA", SigningAlgorithmSpec.ECDSA_SHA_256),
+            Map.entry("SHA384withECDSA", SigningAlgorithmSpec.ECDSA_SHA_384),
+            Map.entry("SHA512withECDSA", SigningAlgorithmSpec.ECDSA_SHA_512));
+
+    static SigningAlgorithmSpec toAwsAlgorithm(String signingAlgorithm) {
+        if (signingAlgorithm == null || signingAlgorithm.isEmpty()) {
+            throw new CrypkiException("Missing KMS signing algorithm");
+        }
+        SigningAlgorithmSpec spec = AWS_ALGORITHMS.get(signingAlgorithm);
+        if (spec == null) {
+            throw new CrypkiException("Unsupported KMS signing algorithm: " + signingAlgorithm);
+        }
+        return spec;
+    }
+}

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsKmsCrypkiSignerFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsKmsCrypkiSignerFactory.java
@@ -18,7 +18,6 @@ package io.athenz.server.aws.common.cert.impl;
 import com.yahoo.athenz.common.server.cert.CertSigner;
 import com.yahoo.athenz.common.server.cert.CertSignerFactory;
 import com.yahoo.athenz.crypki.CrypkiCertSigner;
-import com.yahoo.athenz.crypki.CrypkiConsts;
 import com.yahoo.athenz.crypki.CrypkiRequestFactory;
 import com.yahoo.athenz.crypki.CrypkiSigner;
 import com.yahoo.athenz.crypki.CrypkiSignerFactory;
@@ -47,7 +46,6 @@ public class AwsKmsCrypkiSignerFactory implements CertSignerFactory, CrypkiSigne
 
     @Override
     public CertSigner create() {
-        CrypkiConsts.requireJavaCrypkiEnabled();
         return new CrypkiCertSigner(createSigner(), CrypkiRequestFactory.forKms());
     }
 

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsKmsCrypkiSignerFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AwsKmsCrypkiSignerFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.aws.common.cert.impl;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.CertSignerFactory;
+import com.yahoo.athenz.crypki.CrypkiCertSigner;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiRequestFactory;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.CrypkiSignerFactory;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+import com.yahoo.athenz.crypki.kms.KmsCrypkiSigner;
+
+/**
+ * ZTS factory: {@code athenz.zts.cert_signer_factory_class=io.athenz.server.aws.common.cert.impl.AwsKmsCrypkiSignerFactory}
+ */
+public class AwsKmsCrypkiSignerFactory implements CertSignerFactory, CrypkiSignerFactory {
+
+    private final KmsClient kmsClient;
+
+    public AwsKmsCrypkiSignerFactory() {
+        this(null);
+    }
+
+    public AwsKmsCrypkiSignerFactory(KmsClient kmsClient) {
+        this.kmsClient = kmsClient;
+    }
+
+    @Override
+    public CrypkiSigner createSigner() {
+        return new KmsCrypkiSigner(kmsClient == null ? newKmsClient() : kmsClient);
+    }
+
+    @Override
+    public CertSigner create() {
+        CrypkiConsts.requireJavaCrypkiEnabled();
+        return new CrypkiCertSigner(createSigner(), CrypkiRequestFactory.forKms());
+    }
+
+    KmsClient newKmsClient() {
+        return new AwsKmsClient();
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/CloudHsmProvider.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/CloudHsmProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.login.LoginException;
+import java.security.AuthProvider;
+
+/**
+ * Test double for the AWS CloudHSM JCE provider so unit tests can exercise
+ * {@code AwsCloudHsmClient} without the proprietary CloudHSM SDK.
+ */
+public class CloudHsmProvider extends AuthProvider {
+
+    public static boolean failLogin;
+    public boolean loggedIn;
+
+    public CloudHsmProvider() {
+        super("CloudHsmProvider", 1.0, "Athenz unit-test stub");
+        put("KeyStore.CloudHsmProvider", StubKeyStoreSpi.class.getName());
+    }
+
+    @Override
+    public void login(Subject subject, CallbackHandler handler) throws LoginException {
+        loggedIn = true;
+        if (failLogin) {
+            throw new LoginException("login denied");
+        }
+        try {
+            PasswordCallback callback = new PasswordCallback("pin", false);
+            handler.handle(new Callback[]{callback, new PasswordCallback("other", false)});
+        } catch (Exception ex) {
+            throw new LoginException(ex.getMessage());
+        }
+    }
+
+    @Override
+    public void logout() {
+    }
+
+    @Override
+    public void setCallbackHandler(CallbackHandler handler) {
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/KeyStoreWithAttributes.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/KeyStoreWithAttributes.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider;
+
+import com.amazonaws.cloudhsm.jce.provider.attributes.KeyAttributesMap;
+
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Provider;
+
+public class KeyStoreWithAttributes extends KeyStore {
+
+    public static boolean throwOnGetInstance;
+    public static boolean returnNonPrivateKey;
+    public static boolean returnNullKey;
+
+    public KeyStoreWithAttributes(Provider provider) {
+        super(new StubKeyStoreSpi(), provider, provider.getName());
+    }
+
+    public static KeyStoreWithAttributes getInstance(String type) {
+        if (throwOnGetInstance) {
+            throw new IllegalStateException("attribute lookup failed");
+        }
+        return new KeyStoreWithAttributes(new CloudHsmProvider());
+    }
+
+    public static KeyStore getInstance(String type, Provider provider) {
+        if (throwOnGetInstance) {
+            throw new IllegalStateException("attribute lookup failed");
+        }
+        return new KeyStoreWithAttributes(provider);
+    }
+
+    public Object getKey(KeyAttributesMap spec) {
+        return lookupKey();
+    }
+
+    public Object getKey(KeyAttributesMap spec, char[] pin) {
+        return lookupKey();
+    }
+
+    private Object lookupKey() {
+        if (returnNullKey) {
+            return null;
+        }
+        if (returnNonPrivateKey) {
+            return "not-a-private-key";
+        }
+        return StubKeyStoreSpi.key instanceof PrivateKey ? StubKeyStoreSpi.key : null;
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/StubKeyStoreSpi.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/StubKeyStoreSpi.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStoreSpi;
+import java.security.cert.Certificate;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+
+public class StubKeyStoreSpi extends KeyStoreSpi {
+
+    public static Key key;
+
+    @Override
+    public Key engineGetKey(String alias, char[] password) {
+        return key;
+    }
+
+    @Override
+    public Certificate[] engineGetCertificateChain(String alias) {
+        return null;
+    }
+
+    @Override
+    public Certificate engineGetCertificate(String alias) {
+        return null;
+    }
+
+    @Override
+    public Date engineGetCreationDate(String alias) {
+        return null;
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, Key key, char[] password, Certificate[] chain) {
+    }
+
+    @Override
+    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) {
+    }
+
+    @Override
+    public void engineSetCertificateEntry(String alias, Certificate cert) {
+    }
+
+    @Override
+    public void engineDeleteEntry(String alias) {
+    }
+
+    @Override
+    public Enumeration<String> engineAliases() {
+        return Collections.emptyEnumeration();
+    }
+
+    @Override
+    public boolean engineContainsAlias(String alias) {
+        return false;
+    }
+
+    @Override
+    public int engineSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean engineIsKeyEntry(String alias) {
+        return false;
+    }
+
+    @Override
+    public boolean engineIsCertificateEntry(String alias) {
+        return false;
+    }
+
+    @Override
+    public String engineGetCertificateAlias(Certificate cert) {
+        return null;
+    }
+
+    @Override
+    public void engineStore(OutputStream stream, char[] password) {
+    }
+
+    @Override
+    public void engineLoad(InputStream stream, char[] password) {
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/KeyAttribute.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/KeyAttribute.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider.attributes;
+
+public enum KeyAttribute {
+    LABEL,
+    OBJECT_CLASS
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/KeyAttributesMap.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/KeyAttributesMap.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider.attributes;
+
+import java.security.spec.KeySpec;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Test double for CloudHSM Client SDK 5 {@code KeyAttributesMap}.
+ */
+public class KeyAttributesMap implements KeySpec {
+
+    private final Map<KeyAttribute, Object> attributes = new EnumMap<>(KeyAttribute.class);
+
+    public Object put(KeyAttribute attribute, Object value) {
+        return attributes.put(attribute, value);
+    }
+
+    public Object get(KeyAttribute attribute) {
+        return attributes.get(attribute);
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/KeyAttributesMapBuilder.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/KeyAttributesMapBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider.attributes;
+
+public class KeyAttributesMapBuilder {
+
+    private final KeyAttributesMap map = new KeyAttributesMap();
+
+    public KeyAttributesMapBuilder put(KeyAttribute attribute, Object value) {
+        map.put(attribute, value);
+        return this;
+    }
+
+    public KeyAttributesMap build() {
+        return map;
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/ObjectClassType.java
+++ b/libs/java/server_aws_common/src/test/java/com/amazonaws/cloudhsm/jce/provider/attributes/ObjectClassType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.cloudhsm.jce.provider.attributes;
+
+public enum ObjectClassType {
+    PRIVATE_KEY
+}

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/AwsCrypkiSignerFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/AwsCrypkiSignerFactoryTest.java
@@ -28,7 +28,6 @@ import com.yahoo.athenz.crypki.signer.SigningKey;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
@@ -53,14 +52,8 @@ import static org.testng.Assert.expectThrows;
 
 public class AwsCrypkiSignerFactoryTest {
 
-    @BeforeMethod
-    public void enableJavaCrypki() {
-        System.setProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED, "true");
-    }
-
     @AfterMethod
     public void resetCloudHsmStubs() {
-        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
         StubKeyStoreSpi.key = null;
         CloudHsmProvider.failLogin = false;
         KeyStoreWithAttributes.throwOnGetInstance = false;
@@ -68,13 +61,6 @@ public class AwsCrypkiSignerFactoryTest {
         KeyStoreWithAttributes.returnNullKey = false;
         Security.removeProvider("CloudHsmProvider");
         Security.removeProvider("AthenzCrypkiHsm");
-    }
-
-    @Test
-    public void testCreateRequiresJavaCrypkiEnabled() {
-        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
-        expectThrows(CrypkiException.class, () -> new AwsKmsCrypkiSignerFactory(Mockito.mock(KmsClient.class)).create());
-        expectThrows(CrypkiException.class, () -> new AwsCloudHsmCrypkiSignerFactory(Mockito.mock(HsmClient.class)).create());
     }
 
     @Test

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/AwsCrypkiSignerFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/AwsCrypkiSignerFactoryTest.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.aws.common.cert.impl;
+
+import com.amazonaws.cloudhsm.jce.provider.CloudHsmProvider;
+import com.amazonaws.cloudhsm.jce.provider.KeyStoreWithAttributes;
+import com.amazonaws.cloudhsm.jce.provider.StubKeyStoreSpi;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiCertSigner;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.hsm.HsmClient;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+import com.yahoo.athenz.crypki.signer.SigningKey;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
+import software.amazon.awssdk.services.kms.model.KeySpec;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class AwsCrypkiSignerFactoryTest {
+
+    @BeforeMethod
+    public void enableJavaCrypki() {
+        System.setProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED, "true");
+    }
+
+    @AfterMethod
+    public void resetCloudHsmStubs() {
+        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
+        StubKeyStoreSpi.key = null;
+        CloudHsmProvider.failLogin = false;
+        KeyStoreWithAttributes.throwOnGetInstance = false;
+        KeyStoreWithAttributes.returnNonPrivateKey = false;
+        KeyStoreWithAttributes.returnNullKey = false;
+        Security.removeProvider("CloudHsmProvider");
+        Security.removeProvider("AthenzCrypkiHsm");
+    }
+
+    @Test
+    public void testCreateRequiresJavaCrypkiEnabled() {
+        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
+        expectThrows(CrypkiException.class, () -> new AwsKmsCrypkiSignerFactory(Mockito.mock(KmsClient.class)).create());
+        expectThrows(CrypkiException.class, () -> new AwsCloudHsmCrypkiSignerFactory(Mockito.mock(HsmClient.class)).create());
+    }
+
+    @Test
+    public void testKmsFactoryWithInjectedClient() {
+        KmsClient kms = Mockito.mock(KmsClient.class);
+        AwsKmsCrypkiSignerFactory factory = new AwsKmsCrypkiSignerFactory(kms);
+        assertNotNull(factory.createSigner());
+        assertNotNull(factory.create());
+    }
+
+    @Test
+    public void testKmsFactoryWiresConfiguredKeyId() {
+        System.setProperty(CrypkiConsts.PROP_KMS_KEY_ID, "alias/example-ca");
+        try {
+            KmsClient kms = Mockito.mock(KmsClient.class);
+            CrypkiCertSigner signer = (CrypkiCertSigner) new AwsKmsCrypkiSignerFactory(kms).create();
+            assertEquals(signer.getRequestFactory().resolveKeyId(null, null), "alias/example-ca");
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_KMS_KEY_ID);
+        }
+    }
+
+    @Test
+    public void testCloudHsmFactoryWithInjectedClient() {
+        HsmClient hsm = Mockito.mock(HsmClient.class);
+        System.setProperty(CrypkiConsts.PROP_HSM_KEY_LABEL, "example-hsm-label");
+        try {
+            AwsCloudHsmCrypkiSignerFactory factory = new AwsCloudHsmCrypkiSignerFactory(hsm);
+            assertNotNull(factory.createSigner());
+            CrypkiCertSigner signer = (CrypkiCertSigner) factory.create();
+            assertNotNull(signer);
+            assertEquals(signer.getRequestFactory().resolveKeyId(null, null), "example-hsm-label");
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_HSM_KEY_LABEL);
+        }
+    }
+
+    @Test
+    public void testCloudHsmDefaultMissingModule() {
+        AwsCloudHsmCrypkiSignerFactory factory = new AwsCloudHsmCrypkiSignerFactory();
+        expectThrows(CrypkiException.class, factory::createSigner);
+    }
+
+    @Test
+    public void testAwsKmsClientSignAndCert() throws Exception {
+        software.amazon.awssdk.services.kms.KmsClient aws = Mockito.mock(
+                software.amazon.awssdk.services.kms.KmsClient.class);
+        Mockito.when(aws.sign(Mockito.any(SignRequest.class))).thenReturn(
+                SignResponse.builder().signature(SdkBytes.fromByteArray(new byte[]{1, 2, 3})).build());
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        KeyPair pair = kpg.generateKeyPair();
+        Mockito.when(aws.getPublicKey(Mockito.any(GetPublicKeyRequest.class))).thenReturn(
+                GetPublicKeyResponse.builder().publicKey(SdkBytes.fromByteArray(pair.getPublic().getEncoded())).build());
+
+        java.io.File certFile = java.io.File.createTempFile("cacert", ".pem");
+        certFile.deleteOnExit();
+        // minimal self-signed via Crypto
+        var caKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(caKey, "CN=ca,O=Athenz,C=US", null);
+        X509Certificate ca = Crypto.generateX509Certificate(Crypto.getPKCS10CertRequest(csr), caKey,
+                new org.bouncycastle.asn1.x500.X500Name("CN=ca,O=Athenz,C=US"), 60, true);
+        Files.writeString(certFile.toPath(), Crypto.convertToPEMFormat(ca));
+
+        AwsKmsClient client = new AwsKmsClient(aws, certFile.getAbsolutePath());
+        assertEquals(client.sign("kid", new byte[]{9}, "SHA256withRSA"), new byte[]{1, 2, 3});
+        assertNotNull(client.getPublicKey("kid"));
+        assertNotNull(client.getCaCertificate("kid"));
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA256withECDSA"), SigningAlgorithmSpec.ECDSA_SHA_256);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA384withECDSA"), SigningAlgorithmSpec.ECDSA_SHA_384);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA512withECDSA"), SigningAlgorithmSpec.ECDSA_SHA_512);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA256withRSA"), SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA384withRSA"), SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA512withRSA"), SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA256withRSAandMGF1"), SigningAlgorithmSpec.RSASSA_PSS_SHA_256);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA384withRSAandMGF1"), SigningAlgorithmSpec.RSASSA_PSS_SHA_384);
+        assertEquals(AwsKmsClient.toAwsAlgorithm("SHA512withRSAandMGF1"), SigningAlgorithmSpec.RSASSA_PSS_SHA_512);
+        expectThrows(CrypkiException.class, () -> AwsKmsClient.toAwsAlgorithm(null));
+        expectThrows(CrypkiException.class, () -> AwsKmsClient.toAwsAlgorithm("SHA1withRSA"));
+        expectThrows(CrypkiException.class, () -> new AwsKmsClient(aws, null).getCaCertificate("kid"));
+        expectThrows(CrypkiException.class, () -> new AwsKmsClient(aws, "/missing.pem").getCaCertificate("kid"));
+        assertEquals(AwsKmsClient.publicKeyAlgorithm(KeySpec.RSA_2048, pair.getPublic().getEncoded()), "RSA");
+        assertEquals(AwsKmsClient.publicKeyAlgorithm(KeySpec.ECC_NIST_P256, pair.getPublic().getEncoded()), "EC");
+        assertEquals(AwsKmsClient.encodedKeyAlgorithm(pair.getPublic().getEncoded()), "RSA");
+    }
+
+    @Test
+    public void testAwsKmsClientEcPublicKey() throws Exception {
+        software.amazon.awssdk.services.kms.KmsClient aws = Mockito.mock(
+                software.amazon.awssdk.services.kms.KmsClient.class);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(256);
+        KeyPair pair = kpg.generateKeyPair();
+        Mockito.when(aws.getPublicKey(Mockito.any(GetPublicKeyRequest.class))).thenReturn(
+                GetPublicKeyResponse.builder()
+                        .keySpec(KeySpec.ECC_NIST_P256)
+                        .publicKey(SdkBytes.fromByteArray(pair.getPublic().getEncoded())).build());
+        AwsKmsClient client = new AwsKmsClient(aws, null);
+        assertEquals(client.getPublicKey("kid").getAlgorithm(), "EC");
+        assertEquals(AwsKmsClient.encodedKeyAlgorithm(pair.getPublic().getEncoded()), "EC");
+        assertEquals(AwsKmsClient.encodedKeyAlgorithm(new byte[]{1, 2, 3}), "RSA");
+    }
+
+    @Test
+    public void testCloudHsmClientResolvesHttpDefaultLabel() throws Exception {
+        var caKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(caKey, "CN=hsm-ca,O=Athenz,C=US", null);
+        X509Certificate ca = Crypto.generateX509Certificate(Crypto.getPKCS10CertRequest(csr), caKey,
+                new org.bouncycastle.asn1.x500.X500Name("CN=hsm-ca,O=Athenz,C=US"), 60, true);
+        AwsCloudHsmClient client = new AwsCloudHsmClient(
+                new com.yahoo.athenz.crypki.signer.SigningKey("athenz-crypki-ca", caKey, ca),
+                "athenz-crypki-ca");
+        assertEquals(client.resolveLabel(null), "athenz-crypki-ca");
+        assertEquals(client.resolveLabel(""), "athenz-crypki-ca");
+        assertEquals(client.resolveLabel(CrypkiConsts.DEFAULT_KEY_ID), "athenz-crypki-ca");
+        assertTrue(AwsCloudHsmClient.cloudHsmJcePresent());
+        assertEquals(AwsCloudHsmClient.loadCloudHsmJcePrivateKeyByAttributes(
+                null, "athenz-crypki-ca", new char[]{'x'}), null);
+        assertEquals(client.getSigningKey(CrypkiConsts.DEFAULT_KEY_ID).getIdentifier(), "athenz-crypki-ca");
+        expectThrows(CrypkiException.class, () -> client.getSigningKey("other-label"));
+        assertEquals(AwsCloudHsmClient.pkcs11Config("/opt/cloudhsm/lib/libcloudhsm_pkcs11.so", null),
+                "--name=AthenzCrypkiHsm\nlibrary=/opt/cloudhsm/lib/libcloudhsm_pkcs11.so\nslotListIndex=0\n");
+        assertEquals(AwsCloudHsmClient.pkcs11Config("/opt/cloudhsm/lib/libcloudhsm_pkcs11.so", "1"),
+                "--name=AthenzCrypkiHsm\nlibrary=/opt/cloudhsm/lib/libcloudhsm_pkcs11.so\nslot=1\n");
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.readPin(null));
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.readPin("/missing-pin.txt"));
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.loadCaCertificate(null));
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.loadCaCertificate("/missing-ca.pem"));
+        java.io.File emptyPin = java.io.File.createTempFile("pin", ".txt");
+        emptyPin.deleteOnExit();
+        Files.writeString(emptyPin.toPath(), "\n");
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.readPin(emptyPin.getAbsolutePath()));
+        java.io.File pin = java.io.File.createTempFile("pin", ".txt");
+        pin.deleteOnExit();
+        Files.writeString(pin.toPath(), "crypto-user:example-pin\n");
+        assertEquals(new String(AwsCloudHsmClient.readPin(pin.getAbsolutePath())), "crypto-user:example-pin");
+
+        java.io.File certFile = java.io.File.createTempFile("hsmca", ".pem");
+        certFile.deleteOnExit();
+        Files.writeString(certFile.toPath(), Crypto.convertToPEMFormat(ca));
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.loadSigningKey(
+                "/missing-module.so", null, "athenz-crypki-ca", pin.getAbsolutePath(),
+                certFile.getAbsolutePath()));
+        KeyPair jcePair = rsaKeyPair();
+        StubKeyStoreSpi.key = jcePair.getPrivate();
+        assertEquals(AwsCloudHsmClient.loadSigningKey("/missing-module.so", null,
+                "athenz-crypki-ca", pin.getAbsolutePath(), certFile.getAbsolutePath())
+                .getPrivateKey(), jcePair.getPrivate());
+        StubKeyStoreSpi.key = null;
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.loadSigningKey(
+                modulePathForCoverage(), null, "athenz-crypki-ca", pin.getAbsolutePath(),
+                certFile.getAbsolutePath()));
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.pkcs11Provider(
+                modulePathForCoverage(), null));
+        expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.loadSunPkcs11(
+                modulePathForCoverage(), "1", "athenz-crypki-ca",
+                "crypto-user:example-pin".toCharArray(), ca));
+        assertNotNull(AwsCloudHsmClient.loadCaCertificate(certFile.getAbsolutePath()));
+        expectThrows(CrypkiException.class, AwsCloudHsmClient::new);
+        expectThrows(CrypkiException.class, () -> new AwsCloudHsmClient(
+                "/missing-module.so", null, "", pin.getAbsolutePath(), certFile.getAbsolutePath()));
+    }
+
+    private static String modulePathForCoverage() throws Exception {
+        java.io.File module = java.io.File.createTempFile("pkcs11", ".so");
+        module.deleteOnExit();
+        return module.getAbsolutePath();
+    }
+
+    @Test
+    public void testCloudHsmModulePresentWithoutPinFails() throws Exception {
+        java.io.File module = java.io.File.createTempFile("pkcs11", ".so");
+        module.deleteOnExit();
+        System.setProperty(CrypkiConsts.PROP_HSM_MODULE_PATH, module.getAbsolutePath());
+        try {
+            expectThrows(CrypkiException.class, () -> new AwsCloudHsmCrypkiSignerFactory().newCloudHsmClient());
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_HSM_MODULE_PATH);
+        }
+    }
+
+    @Test
+    public void testKmsFactoryDefaultNewClientOverride() {
+        KmsClient kms = Mockito.mock(KmsClient.class);
+        AwsKmsCrypkiSignerFactory factory = new AwsKmsCrypkiSignerFactory() {
+            @Override
+            KmsClient newKmsClient() {
+                return kms;
+            }
+        };
+        assertNotNull(factory.create());
+    }
+
+    @Test
+    public void testAwsKmsClientInvalidPublicKeyAndDefaultCtor() throws Exception {
+        software.amazon.awssdk.services.kms.KmsClient aws = Mockito.mock(
+                software.amazon.awssdk.services.kms.KmsClient.class);
+        Mockito.when(aws.getPublicKey(Mockito.any(GetPublicKeyRequest.class))).thenReturn(
+                GetPublicKeyResponse.builder().publicKey(SdkBytes.fromByteArray(new byte[]{1, 2, 3})).build());
+        AwsKmsClient client = new AwsKmsClient(aws, null);
+        expectThrows(CrypkiException.class, () -> client.getPublicKey("kid"));
+
+        try (MockedStatic<software.amazon.awssdk.services.kms.KmsClient> mocked =
+                Mockito.mockStatic(software.amazon.awssdk.services.kms.KmsClient.class)) {
+            mocked.when(software.amazon.awssdk.services.kms.KmsClient::create).thenReturn(aws);
+            assertNotNull(new AwsKmsClient());
+            assertNotNull(new AwsKmsCrypkiSignerFactory().newKmsClient());
+        }
+    }
+
+    @Test
+    public void testCloudHsmJceLoadsPrivateKeyByAttributes() throws Exception {
+        KeyPair pair = rsaKeyPair();
+        StubKeyStoreSpi.key = pair.getPrivate();
+        CloudHsmProvider alreadyRegistered = new CloudHsmProvider();
+        Security.addProvider(alreadyRegistered);
+        try {
+            SigningKey key = loadJceSigningKey("example-hsm-label");
+            assertEquals(key.getIdentifier(), "example-hsm-label");
+            assertEquals(key.getPrivateKey(), pair.getPrivate());
+            assertTrue(alreadyRegistered.loggedIn);
+            assertNotNull(new AwsCloudHsmClient(modulePathForCoverage(), null, "",
+                    pinFile("crypto-user:example-pin"), caCertFile()).getSigningKey(null));
+        } finally {
+            Security.removeProvider(alreadyRegistered.getName());
+        }
+    }
+
+    @Test
+    public void testCloudHsmJceFallsBackToKeyStoreWhenAttributesMiss() throws Exception {
+        KeyPair pair = rsaKeyPair();
+        StubKeyStoreSpi.key = pair.getPrivate();
+        KeyStoreWithAttributes.returnNullKey = true;
+        SigningKey key = loadJceSigningKey("fallback-label");
+        assertEquals(key.getPrivateKey(), pair.getPrivate());
+    }
+
+    @Test
+    public void testCloudHsmJceIgnoresNonPrivateAttributeKey() throws Exception {
+        KeyStoreWithAttributes.returnNonPrivateKey = true;
+        expectThrows(CrypkiException.class, () -> loadJceSigningKey("missing-label"));
+    }
+
+    @Test
+    public void testCloudHsmJceAttributeLookupFailure() {
+        KeyStoreWithAttributes.throwOnGetInstance = true;
+        expectThrows(CrypkiException.class, () -> loadJceSigningKey("broken-label"));
+    }
+
+    @Test
+    public void testCloudHsmJceLoginFailureIsWrapped() {
+        CloudHsmProvider.failLogin = true;
+        expectThrows(CrypkiException.class, () -> loadJceSigningKey("login-label"));
+    }
+
+    @Test
+    public void testGetSigningKeyMatchesLoadedIdentifier() throws Exception {
+        var caKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(caKey, "CN=hsm-ca,O=Athenz,C=US", null);
+        X509Certificate ca = Crypto.generateX509Certificate(Crypto.getPKCS10CertRequest(csr), caKey,
+                new org.bouncycastle.asn1.x500.X500Name("CN=hsm-ca,O=Athenz,C=US"), 60, true);
+        AwsCloudHsmClient client = new AwsCloudHsmClient(
+                new SigningKey("loaded-label", caKey, ca), "configured-label");
+        assertEquals(client.getSigningKey("loaded-label").getIdentifier(), "loaded-label");
+    }
+
+    @Test
+    public void testLoadSunPkcs11WithMockedProvider() throws Exception {
+        KeyPair pair = rsaKeyPair();
+        Provider prototype = Mockito.mock(Provider.class);
+        Provider configured = Mockito.mock(Provider.class);
+        Mockito.when(configured.getName()).thenReturn("AthenzCrypkiHsm");
+        Mockito.when(prototype.configure(Mockito.anyString())).thenReturn(configured);
+        KeyStore store = Mockito.mock(KeyStore.class);
+        Mockito.when(store.getKey(Mockito.eq("pkcs11-label"), Mockito.any())).thenReturn(pair.getPrivate());
+
+        var caKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(caKey, "CN=hsm-ca,O=Athenz,C=US", null);
+        X509Certificate ca = Crypto.generateX509Certificate(Crypto.getPKCS10CertRequest(csr), caKey,
+                new org.bouncycastle.asn1.x500.X500Name("CN=hsm-ca,O=Athenz,C=US"), 60, true);
+
+        try (MockedStatic<Security> security = Mockito.mockStatic(Security.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<KeyStore> keyStores = Mockito.mockStatic(KeyStore.class, Mockito.CALLS_REAL_METHODS)) {
+            security.when(() -> Security.getProvider("SunPKCS11")).thenReturn(prototype);
+            security.when(() -> Security.getProvider("AthenzCrypkiHsm")).thenReturn(null);
+            keyStores.when(() -> KeyStore.getInstance("PKCS11", configured)).thenReturn(store);
+
+            SigningKey key = AwsCloudHsmClient.loadSunPkcs11(
+                    "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so", null, "pkcs11-label",
+                    "pin".toCharArray(), ca);
+            assertEquals(key.getPrivateKey(), pair.getPrivate());
+
+            Mockito.when(store.getKey(Mockito.eq("missing"), Mockito.any())).thenReturn(null);
+            expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.loadSunPkcs11(
+                    "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so", "1", "missing",
+                    "pin".toCharArray(), ca));
+
+            security.when(() -> Security.getProvider("AthenzCrypkiHsm")).thenReturn(configured);
+            assertNotNull(AwsCloudHsmClient.pkcs11Provider(
+                    "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so", "1"));
+
+            security.when(() -> Security.getProvider("SunPKCS11")).thenReturn(null);
+            expectThrows(CrypkiException.class, () -> AwsCloudHsmClient.pkcs11Provider("/x.so", null));
+        }
+    }
+
+    private static SigningKey loadJceSigningKey(String label) throws Exception {
+        return AwsCloudHsmClient.loadSigningKey(modulePathForCoverage(), null, label,
+                pinFile("crypto-user:example-pin"), caCertFile());
+    }
+
+    private static KeyPair rsaKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
+    }
+
+    private static String pinFile(String pin) throws Exception {
+        java.io.File file = java.io.File.createTempFile("pin", ".txt");
+        file.deleteOnExit();
+        Files.writeString(file.toPath(), pin + "\n");
+        return file.getAbsolutePath();
+    }
+
+    private static String caCertFile() throws Exception {
+        var caKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(caKey, "CN=hsm-ca,O=Athenz,C=US", null);
+        X509Certificate ca = Crypto.generateX509Certificate(Crypto.getPKCS10CertRequest(csr), caKey,
+                new org.bouncycastle.asn1.x500.X500Name("CN=hsm-ca,O=Athenz,C=US"), 60, true);
+        java.io.File certFile = java.io.File.createTempFile("hsmca", ".pem");
+        certFile.deleteOnExit();
+        Files.writeString(certFile.toPath(), Crypto.convertToPEMFormat(ca));
+        return certFile.getAbsolutePath();
+    }
+}

--- a/libs/java/server_gcp_common/pom.xml
+++ b/libs/java/server_gcp_common/pom.xml
@@ -42,6 +42,15 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.yahoo.athenz</groupId>
+      <artifactId>athenz-crypki</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-kms</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-parametermanager</artifactId>
     </dependency>

--- a/libs/java/server_gcp_common/src/main/java/io/athenz/server/gcp/common/cert/impl/GcpKmsClient.java
+++ b/libs/java/server_gcp_common/src/main/java/io/athenz/server/gcp/common/cert/impl/GcpKmsClient.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.gcp.common.cert.impl;
+
+import com.google.cloud.kms.v1.AsymmetricSignRequest;
+import com.google.cloud.kms.v1.Digest;
+import com.google.cloud.kms.v1.GetPublicKeyRequest;
+import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.protobuf.ByteString;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Locale;
+
+/**
+ * GCP Cloud KMS implementation of the Crypki {@link KmsClient} SPI.
+ */
+public class GcpKmsClient implements KmsClient {
+
+    private final KeyManagementServiceClient client;
+    private final String caCertPath;
+
+    public GcpKmsClient(KeyManagementServiceClient client) {
+        this(client, System.getProperty(CrypkiConsts.PROP_KMS_CA_CERT_PATH));
+    }
+
+    public GcpKmsClient(KeyManagementServiceClient client, String caCertPath) {
+        this.client = client;
+        this.caCertPath = caCertPath;
+    }
+
+    @Override
+    public byte[] sign(String keyId, byte[] data, String signingAlgorithm) {
+        try {
+            return client.asymmetricSign(AsymmetricSignRequest.newBuilder()
+                    .setName(keyId)
+                    .setDigest(toDigest(data, signingAlgorithm))
+                    .build()).getSignature().toByteArray();
+        } catch (CrypkiException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new CrypkiException("GCP KMS sign failed for " + keyId + ": " + ex.getMessage(), ex);
+        }
+    }
+
+    static Digest toDigest(byte[] data, String signingAlgorithm) {
+        String jcaDigest = digestAlgorithm(signingAlgorithm);
+        try {
+            byte[] hash = MessageDigest.getInstance(jcaDigest).digest(data);
+            Digest.Builder digest = Digest.newBuilder();
+            switch (jcaDigest) {
+                case "SHA-512":
+                    return digest.setSha512(ByteString.copyFrom(hash)).build();
+                case "SHA-384":
+                    return digest.setSha384(ByteString.copyFrom(hash)).build();
+                default:
+                    return digest.setSha256(ByteString.copyFrom(hash)).build();
+            }
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to hash TBS for " + signingAlgorithm, ex);
+        }
+    }
+
+    static String digestAlgorithm(String signingAlgorithm) {
+        if (signingAlgorithm == null || signingAlgorithm.isEmpty()) {
+            throw new CrypkiException("Missing KMS signing algorithm");
+        }
+        String upper = signingAlgorithm.toUpperCase(Locale.ROOT);
+        if (upper.contains("SHA512")) {
+            return "SHA-512";
+        }
+        if (upper.contains("SHA384")) {
+            return "SHA-384";
+        }
+        if (upper.contains("SHA256")) {
+            return "SHA-256";
+        }
+        throw new CrypkiException("Unsupported KMS signing algorithm: " + signingAlgorithm);
+    }
+
+    @Override
+    public PublicKey getPublicKey(String keyId) {
+        String pem = client.getPublicKey(GetPublicKeyRequest.newBuilder().setName(keyId).build()).getPem();
+        return Crypto.loadPublicKey(pem);
+    }
+
+    @Override
+    public X509Certificate getCaCertificate(String keyId) {
+        if (caCertPath == null || caCertPath.isEmpty()) {
+            throw new CrypkiException("Missing " + CrypkiConsts.PROP_KMS_CA_CERT_PATH
+                    + " for KMS key " + keyId);
+        }
+        try {
+            return Crypto.loadX509Certificate(Files.readString(Path.of(caCertPath)));
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to load KMS CA certificate: " + caCertPath, ex);
+        }
+    }
+}

--- a/libs/java/server_gcp_common/src/main/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiSignerFactory.java
+++ b/libs/java/server_gcp_common/src/main/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiSignerFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.gcp.common.cert.impl;
+
+import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.CertSignerFactory;
+import com.yahoo.athenz.crypki.CrypkiCertSigner;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.CrypkiRequestFactory;
+import com.yahoo.athenz.crypki.CrypkiSigner;
+import com.yahoo.athenz.crypki.CrypkiSignerFactory;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+import com.yahoo.athenz.crypki.kms.KmsCrypkiSigner;
+
+import java.io.IOException;
+
+/**
+ * ZTS factory: {@code athenz.zts.cert_signer_factory_class=io.athenz.server.gcp.common.cert.impl.GcpKmsCrypkiSignerFactory}
+ */
+public class GcpKmsCrypkiSignerFactory implements CertSignerFactory, CrypkiSignerFactory {
+
+    private final KmsClient kmsClient;
+
+    public GcpKmsCrypkiSignerFactory() {
+        this(null);
+    }
+
+    public GcpKmsCrypkiSignerFactory(KmsClient kmsClient) {
+        this.kmsClient = kmsClient;
+    }
+
+    @Override
+    public CrypkiSigner createSigner() {
+        return new KmsCrypkiSigner(kmsClient == null ? newKmsClient() : kmsClient);
+    }
+
+    @Override
+    public CertSigner create() {
+        CrypkiConsts.requireJavaCrypkiEnabled();
+        return new CrypkiCertSigner(createSigner(), CrypkiRequestFactory.forKms());
+    }
+
+    KmsClient newKmsClient() {
+        try {
+            return new GcpKmsClient(createKeyManagementServiceClient());
+        } catch (Exception ex) {
+            throw new CrypkiException("Unable to create GCP KMS client: " + ex.getMessage(), ex);
+        }
+    }
+
+    KeyManagementServiceClient createKeyManagementServiceClient() throws IOException {
+        return KeyManagementServiceClient.create();
+    }
+}

--- a/libs/java/server_gcp_common/src/main/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiSignerFactory.java
+++ b/libs/java/server_gcp_common/src/main/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiSignerFactory.java
@@ -19,7 +19,6 @@ import com.google.cloud.kms.v1.KeyManagementServiceClient;
 import com.yahoo.athenz.common.server.cert.CertSigner;
 import com.yahoo.athenz.common.server.cert.CertSignerFactory;
 import com.yahoo.athenz.crypki.CrypkiCertSigner;
-import com.yahoo.athenz.crypki.CrypkiConsts;
 import com.yahoo.athenz.crypki.CrypkiException;
 import com.yahoo.athenz.crypki.CrypkiRequestFactory;
 import com.yahoo.athenz.crypki.CrypkiSigner;
@@ -51,7 +50,6 @@ public class GcpKmsCrypkiSignerFactory implements CertSignerFactory, CrypkiSigne
 
     @Override
     public CertSigner create() {
-        CrypkiConsts.requireJavaCrypkiEnabled();
         return new CrypkiCertSigner(createSigner(), CrypkiRequestFactory.forKms());
     }
 

--- a/libs/java/server_gcp_common/src/test/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiTest.java
+++ b/libs/java/server_gcp_common/src/test/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.athenz.server.gcp.common.cert.impl;
+
+import com.google.cloud.kms.v1.AsymmetricSignRequest;
+import com.google.cloud.kms.v1.AsymmetricSignResponse;
+import com.google.cloud.kms.v1.GetPublicKeyRequest;
+import com.google.cloud.kms.v1.KeyManagementServiceClient;
+import com.google.cloud.kms.v1.PublicKey;
+import com.google.protobuf.ByteString;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.crypki.CrypkiCertSigner;
+import com.yahoo.athenz.crypki.CrypkiConsts;
+import com.yahoo.athenz.crypki.CrypkiException;
+import com.yahoo.athenz.crypki.kms.KmsClient;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.security.cert.X509Certificate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class GcpKmsCrypkiTest {
+
+    @BeforeMethod
+    public void enableJavaCrypki() {
+        System.setProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED, "true");
+    }
+
+    @AfterMethod
+    public void clearJavaCrypki() {
+        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
+    }
+
+    @Test
+    public void testCreateRequiresJavaCrypkiEnabled() {
+        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
+        expectThrows(CrypkiException.class, () -> new GcpKmsCrypkiSignerFactory(Mockito.mock(KmsClient.class)).create());
+    }
+
+    @Test
+    public void testFactoryWithInjectedClient() {
+        KmsClient kms = Mockito.mock(KmsClient.class);
+        GcpKmsCrypkiSignerFactory factory = new GcpKmsCrypkiSignerFactory(kms);
+        assertNotNull(factory.createSigner());
+        assertNotNull(factory.create());
+    }
+
+    @Test
+    public void testFactoryWiresConfiguredKeyId() {
+        System.setProperty(CrypkiConsts.PROP_KMS_KEY_ID,
+                "projects/example/locations/global/keyRings/ring/cryptoKeys/ca");
+        try {
+            KmsClient kms = Mockito.mock(KmsClient.class);
+            CrypkiCertSigner signer = (CrypkiCertSigner) new GcpKmsCrypkiSignerFactory(kms).create();
+            assertEquals(signer.getRequestFactory().resolveKeyId(null, null),
+                    "projects/example/locations/global/keyRings/ring/cryptoKeys/ca");
+        } finally {
+            System.clearProperty(CrypkiConsts.PROP_KMS_KEY_ID);
+        }
+    }
+
+    @Test
+    public void testNewKmsClientWrapsFailure() {
+        GcpKmsCrypkiSignerFactory factory = new GcpKmsCrypkiSignerFactory() {
+            @Override
+            KeyManagementServiceClient createKeyManagementServiceClient() throws java.io.IOException {
+                throw new java.io.IOException("no adc");
+            }
+        };
+        expectThrows(CrypkiException.class, factory::createSigner);
+    }
+
+    @Test
+    public void testNewKmsClientUsesAdcClient() {
+        KeyManagementServiceClient grpc = Mockito.mock(KeyManagementServiceClient.class);
+        GcpKmsCrypkiSignerFactory factory = new GcpKmsCrypkiSignerFactory() {
+            @Override
+            KeyManagementServiceClient createKeyManagementServiceClient() {
+                return grpc;
+            }
+        };
+        assertNotNull(factory.createSigner());
+        assertNotNull(factory.create());
+    }
+
+    @Test
+    public void testNewKmsClientCallsCreate() {
+        KeyManagementServiceClient grpc = Mockito.mock(KeyManagementServiceClient.class);
+        try (org.mockito.MockedStatic<KeyManagementServiceClient> mocked =
+                Mockito.mockStatic(KeyManagementServiceClient.class)) {
+            mocked.when(KeyManagementServiceClient::create).thenReturn(grpc);
+            assertNotNull(new GcpKmsCrypkiSignerFactory().createSigner());
+        }
+    }
+
+    @Test
+    public void testGcpKmsClient() throws Exception {
+        KeyManagementServiceClient grpc = Mockito.mock(KeyManagementServiceClient.class);
+        Mockito.when(grpc.asymmetricSign(Mockito.any(AsymmetricSignRequest.class)))
+                .thenReturn(AsymmetricSignResponse.newBuilder()
+                        .setSignature(ByteString.copyFrom(new byte[]{4, 5})).build());
+        var caKey = Crypto.generateRSAPrivateKey(2048);
+        String csr = Crypto.generateX509CSR(caKey, "CN=ca,O=Athenz,C=US", null);
+        X509Certificate ca = Crypto.generateX509Certificate(Crypto.getPKCS10CertRequest(csr), caKey,
+                new org.bouncycastle.asn1.x500.X500Name("CN=ca,O=Athenz,C=US"), 60, true);
+        Mockito.when(grpc.getPublicKey(Mockito.any(GetPublicKeyRequest.class)))
+                .thenReturn(PublicKey.newBuilder().setPem(Crypto.convertToPEMFormat(ca.getPublicKey())).build());
+
+        java.io.File certFile = java.io.File.createTempFile("gca", ".pem");
+        certFile.deleteOnExit();
+        Files.writeString(certFile.toPath(), Crypto.convertToPEMFormat(ca));
+
+        GcpKmsClient client = new GcpKmsClient(grpc, certFile.getAbsolutePath());
+        assertEquals(client.sign("projects/p/locations/l/keyRings/r/cryptoKeys/k", new byte[]{1}, "SHA256withRSA"),
+                new byte[]{4, 5});
+        ArgumentCaptor<AsymmetricSignRequest> captor = ArgumentCaptor.forClass(AsymmetricSignRequest.class);
+        Mockito.verify(grpc).asymmetricSign(captor.capture());
+        assertTrue(captor.getValue().hasDigest());
+        assertTrue(captor.getValue().getDigest().hasSha256());
+
+        client.sign("projects/p/locations/l/keyRings/r/cryptoKeys/k", new byte[]{1}, "SHA384withECDSA");
+        client.sign("projects/p/locations/l/keyRings/r/cryptoKeys/k", new byte[]{1}, "SHA512withRSA");
+        assertEquals(GcpKmsClient.digestAlgorithm("SHA256withRSA"), "SHA-256");
+        assertEquals(GcpKmsClient.digestAlgorithm("SHA384withECDSA"), "SHA-384");
+        assertEquals(GcpKmsClient.digestAlgorithm("SHA512withRSA"), "SHA-512");
+        expectThrows(CrypkiException.class, () -> GcpKmsClient.digestAlgorithm(null));
+        expectThrows(CrypkiException.class, () -> GcpKmsClient.digestAlgorithm(""));
+        expectThrows(CrypkiException.class, () -> GcpKmsClient.digestAlgorithm("MD5withRSA"));
+        assertTrue(GcpKmsClient.toDigest(new byte[]{1}, "SHA256withRSA").hasSha256());
+        assertTrue(GcpKmsClient.toDigest(new byte[]{1}, "SHA384withECDSA").hasSha384());
+        assertTrue(GcpKmsClient.toDigest(new byte[]{1}, "SHA512withRSA").hasSha512());
+        expectThrows(CrypkiException.class, () -> GcpKmsClient.toDigest(null, "SHA256withRSA"));
+        expectThrows(CrypkiException.class, () -> client.sign(
+                "projects/p/locations/l/keyRings/r/cryptoKeys/k", new byte[]{1}, "MD5withRSA"));
+
+        assertNotNull(client.getPublicKey("projects/p/locations/l/keyRings/r/cryptoKeys/k"));
+        assertNotNull(client.getCaCertificate("k"));
+        expectThrows(CrypkiException.class, () -> new GcpKmsClient(grpc, null).getCaCertificate("k"));
+        expectThrows(CrypkiException.class, () -> new GcpKmsClient(grpc, "/missing.pem").getCaCertificate("k"));
+        Mockito.when(grpc.asymmetricSign(Mockito.any(AsymmetricSignRequest.class)))
+                .thenThrow(new RuntimeException("kms denied"));
+        expectThrows(CrypkiException.class, () -> client.sign("projects/p/locations/l/keyRings/r/cryptoKeys/k",
+                new byte[]{1}, "SHA256withRSA"));
+        new GcpKmsClient(grpc);
+    }
+}

--- a/libs/java/server_gcp_common/src/test/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiTest.java
+++ b/libs/java/server_gcp_common/src/test/java/io/athenz/server/gcp/common/cert/impl/GcpKmsCrypkiTest.java
@@ -28,8 +28,6 @@ import com.yahoo.athenz.crypki.CrypkiException;
 import com.yahoo.athenz.crypki.kms.KmsClient;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.nio.file.Files;
@@ -41,22 +39,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
 public class GcpKmsCrypkiTest {
-
-    @BeforeMethod
-    public void enableJavaCrypki() {
-        System.setProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED, "true");
-    }
-
-    @AfterMethod
-    public void clearJavaCrypki() {
-        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
-    }
-
-    @Test
-    public void testCreateRequiresJavaCrypkiEnabled() {
-        System.clearProperty(CrypkiConsts.PROP_JAVA_CRYPKI_ENABLED);
-        expectThrows(CrypkiException.class, () -> new GcpKmsCrypkiSignerFactory(Mockito.mock(KmsClient.class)).create());
-    }
 
     @Test
     public void testFactoryWithInjectedClient() {

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
     <module>clients/java/zms</module>
     <module>clients/java/zts</module>
     <module>libs/java/server_common</module>
+    <module>libs/java/crypki</module>
     <module>libs/java/server_k8s_common</module>
     <module>libs/java/dynamodb_client_factory</module>
     <module>libs/java/syncer_common</module>
@@ -493,6 +494,7 @@
         <module>libs/java/client_common</module>
         <module>libs/java/cert_refresher</module>
         <module>libs/java/server_common</module>
+        <module>libs/java/crypki</module>
         <module>libs/java/syncer_common</module>
         <module>libs/java/instance_provider</module>
         <module>libs/java/dynamodb_client_factory</module>

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -138,14 +138,13 @@ javax.net.ssl.trustStorePassword=athenz
 # interface used by the ZTS Server to sign any certificate requests
 athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSignerFactory
 
-# Opt-in Java Crypki in-process signer (KMS/HSM). Default false keeps the
-# existing HttpCertSigner / SelfCertSigner path unchanged. When true, also
-# set athenz.zts.cert_signer_factory_class to
-# com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory and
+# Opt-in Java Crypki in-process signer (KMS/HSM). Selecting
+# JavaCrypkiCertSignerFactory enables it; existing HttpCertSigner /
+# SelfCertSigner deployments are unchanged. Also set
 # athenz.zts.java_crypki_factory_class to the backend factory
 # (AwsKmsCrypkiSignerFactory, AwsCloudHsmCrypkiSignerFactory, or
 # GcpKmsCrypkiSignerFactory).
-#athenz.zts.java_crypki_enabled=false
+#athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory
 #athenz.zts.java_crypki_factory_class=
 
 # Specifies the factory class that implements ChangeLogStoreFactory

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -138,6 +138,16 @@ javax.net.ssl.trustStorePassword=athenz
 # interface used by the ZTS Server to sign any certificate requests
 athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSignerFactory
 
+# Opt-in Java Crypki in-process signer (KMS/HSM). Default false keeps the
+# existing HttpCertSigner / SelfCertSigner path unchanged. When true, also
+# set athenz.zts.cert_signer_factory_class to
+# com.yahoo.athenz.zts.cert.impl.crypki.JavaCrypkiCertSignerFactory and
+# athenz.zts.java_crypki_factory_class to the backend factory
+# (AwsKmsCrypkiSignerFactory, AwsCloudHsmCrypkiSignerFactory, or
+# GcpKmsCrypkiSignerFactory).
+#athenz.zts.java_crypki_enabled=false
+#athenz.zts.java_crypki_factory_class=
+
 # Specifies the factory class that implements ChangeLogStoreFactory
 # interface used by the ZTS Server to retrieve the latest changes
 # from the ZMS Server and save them locally

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -203,6 +203,8 @@ public final class ZTSConsts {
 
     public static final String ZTS_PROP_METRIC_FACTORY_CLASS             = "athenz.zts.metric_factory_class";
     public static final String ZTS_PROP_CERT_SIGNER_FACTORY_CLASS        = "athenz.zts.cert_signer_factory_class";
+    public static final String ZTS_PROP_JAVA_CRYPKI_ENABLED              = "athenz.zts.java_crypki_enabled";
+    public static final String ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS        = "athenz.zts.java_crypki_factory_class";
     public static final String ZTS_PROP_SSH_SIGNER_FACTORY_CLASS         = "athenz.zts.ssh_signer_factory_class";
     public static final String ZTS_PROP_AUDIT_LOGGER_FACTORY_CLASS       = "athenz.zts.audit_logger_factory_class";
     public static final String ZTS_PROP_CHANGE_LOG_STORE_FACTORY_CLASS   = "athenz.zts.change_log_store_factory_class";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -203,7 +203,6 @@ public final class ZTSConsts {
 
     public static final String ZTS_PROP_METRIC_FACTORY_CLASS             = "athenz.zts.metric_factory_class";
     public static final String ZTS_PROP_CERT_SIGNER_FACTORY_CLASS        = "athenz.zts.cert_signer_factory_class";
-    public static final String ZTS_PROP_JAVA_CRYPKI_ENABLED              = "athenz.zts.java_crypki_enabled";
     public static final String ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS        = "athenz.zts.java_crypki_factory_class";
     public static final String ZTS_PROP_SSH_SIGNER_FACTORY_CLASS         = "athenz.zts.ssh_signer_factory_class";
     public static final String ZTS_PROP_AUDIT_LOGGER_FACTORY_CLASS       = "athenz.zts.audit_logger_factory_class";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl.crypki;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.CertSignerFactory;
+import com.yahoo.athenz.zts.ResourceException;
+import com.yahoo.athenz.zts.ZTSConsts;
+import org.eclipse.jetty.util.StringUtil;
+
+/**
+ * Opt-in factory for the in-process Java Crypki backends. Existing
+ * {@link HttpCertSignerFactory} deployments are unchanged unless
+ * {@code athenz.zts.java_crypki_enabled=true} and this factory is
+ * selected via {@code athenz.zts.cert_signer_factory_class}.
+ */
+public class JavaCrypkiCertSignerFactory implements CertSignerFactory {
+
+    @Override
+    public CertSigner create() {
+        if (!Boolean.parseBoolean(System.getProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "false"))) {
+            throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
+                    "Java Crypki is disabled; set " + ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED + "=true");
+        }
+        final String factoryClass = System.getProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS);
+        if (StringUtil.isEmpty(factoryClass)) {
+            throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
+                    "Missing " + ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS);
+        }
+        try {
+            CertSignerFactory factory = (CertSignerFactory) Class.forName(factoryClass)
+                    .getDeclaredConstructor().newInstance();
+            return factory.create();
+        } catch (ResourceException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
+                    "Unable to create Java Crypki signer: " + ex.getMessage());
+        }
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactory.java
@@ -23,18 +23,13 @@ import org.eclipse.jetty.util.StringUtil;
 
 /**
  * Opt-in factory for the in-process Java Crypki backends. Existing
- * {@link HttpCertSignerFactory} deployments are unchanged unless
- * {@code athenz.zts.java_crypki_enabled=true} and this factory is
- * selected via {@code athenz.zts.cert_signer_factory_class}.
+ * {@link HttpCertSignerFactory} deployments are unchanged unless this
+ * factory is selected via {@code athenz.zts.cert_signer_factory_class}.
  */
 public class JavaCrypkiCertSignerFactory implements CertSignerFactory {
 
     @Override
     public CertSigner create() {
-        if (!Boolean.parseBoolean(System.getProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "false"))) {
-            throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
-                    "Java Crypki is disabled; set " + ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED + "=true");
-        }
         final String factoryClass = System.getProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS);
         if (StringUtil.isEmpty(factoryClass)) {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactoryTest.java
@@ -30,38 +30,28 @@ public class JavaCrypkiCertSignerFactoryTest {
 
     @AfterMethod
     public void cleanup() {
-        System.clearProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED);
         System.clearProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS);
     }
 
     @Test
-    public void testDisabledByDefault() {
+    public void testRequiresFactoryClass() {
         expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
     }
 
     @Test
-    public void testEnabledRequiresFactoryClass() {
-        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
-        expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
-    }
-
-    @Test
-    public void testEnabledCreatesBackendFactory() {
-        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
+    public void testCreatesBackendFactory() {
         System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS, DummyCertSignerFactory.class.getName());
         assertNotNull(new JavaCrypkiCertSignerFactory().create());
     }
 
     @Test
     public void testInvalidFactoryClass() {
-        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
         System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS, "invalid.Factory");
         expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
     }
 
     @Test
     public void testBackendResourceExceptionIsRethrown() {
-        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
         System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS, FailingCertSignerFactory.class.getName());
         expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/crypki/JavaCrypkiCertSignerFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl.crypki;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.common.server.cert.CertSignerFactory;
+import com.yahoo.athenz.zts.ResourceException;
+import com.yahoo.athenz.zts.ZTSConsts;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.expectThrows;
+
+public class JavaCrypkiCertSignerFactoryTest {
+
+    @AfterMethod
+    public void cleanup() {
+        System.clearProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED);
+        System.clearProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS);
+    }
+
+    @Test
+    public void testDisabledByDefault() {
+        expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
+    }
+
+    @Test
+    public void testEnabledRequiresFactoryClass() {
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
+        expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
+    }
+
+    @Test
+    public void testEnabledCreatesBackendFactory() {
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS, DummyCertSignerFactory.class.getName());
+        assertNotNull(new JavaCrypkiCertSignerFactory().create());
+    }
+
+    @Test
+    public void testInvalidFactoryClass() {
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS, "invalid.Factory");
+        expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
+    }
+
+    @Test
+    public void testBackendResourceExceptionIsRethrown() {
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_ENABLED, "true");
+        System.setProperty(ZTSConsts.ZTS_PROP_JAVA_CRYPKI_FACTORY_CLASS, FailingCertSignerFactory.class.getName());
+        expectThrows(ResourceException.class, () -> new JavaCrypkiCertSignerFactory().create());
+    }
+
+    public static final class DummyCertSignerFactory implements CertSignerFactory {
+        @Override
+        public CertSigner create() {
+            return Mockito.mock(CertSigner.class);
+        }
+    }
+
+    public static final class FailingCertSignerFactory implements CertSignerFactory {
+        @Override
+        public CertSigner create() {
+            throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR, "backend failed");
+        }
+    }
+}


### PR DESCRIPTION
# Description
Moves the HTTP Crypki client out of ZTS and adds pluggable KMS/HSM backends without changing existing HttpCertSignerFactory configuration.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

