### PR TITLE
Fix `token-only` option bug for JAG token issue flow in zts-accesstoken CLI

### DIFF
--- a/utils/zts-accesstoken/zts-accesstoken.go
+++ b/utils/zts-accesstoken/zts-accesstoken.go
@@ -302,7 +302,7 @@ func fetchJAGTokenIssue(domain, roles, ztsURL, svcKeyFile, svcCertFile, svcCACer
 	}
 
 	if tokenOnly {
-		fmt.Print(accessTokenResponse.Id_token)
+		fmt.Print(accessTokenResponse.Access_token)
 		return
 	}
 


### PR DESCRIPTION
# Description
- Fixed a bug where `zts-accesstoken -grant-type token-exchange -requested-token-type id-jag ... -token-only`
  (the JAG Token Issue flow: external IdP ID Token -> ID-JAG token) produced empty output when
  `-token-only` was specified.
- On the server side, `ZTSImpl.processJAGTokenIssueRequest` always places the issued ID-JAG token
  in the `access_token` field of `AccessTokenResponse` — `id_token` is never set for this flow.
- However, `fetchJAGTokenIssue` in the CLI printed `accessTokenResponse.Id_token` when `-token-only`
  was set, so it always printed an empty string. This went unnoticed because the default (non
  `-token-only`) JSON output correctly includes the token under `access_token`.
- Fixed by printing `accessTokenResponse.Access_token` instead.


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

