### PR TITLE
sia ec2 option for main dir

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -48,7 +48,12 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-const siaMainDir = "/var/lib/sia"
+func mainDir(opts *sc.Options) string {
+	if opts.MainDir != "" {
+		return opts.MainDir
+	}
+	return "/var/lib/sia"
+}
 
 func readCertificate(certFile string) (*x509.Certificate, error) {
 	data, err := os.ReadFile(certFile)
@@ -98,7 +103,7 @@ func GetRequiredRoleCertificates(ztsUrl string, opts *sc.Options) error {
 	for i := 0; i < 9; i++ {
 		_, failures := GetRoleCertificates(ztsUrl, opts)
 		if len(failures) == 0 {
-			util.TouchDoneFile(siaMainDir, "rolecert")
+			util.TouchDoneFile(mainDir(opts), "rolecert")
 			return nil
 		}
 		log.Println("Required GetRoleCertificates failed, retrying in 20 seconds")
@@ -326,7 +331,7 @@ func registerSvc(svc sc.Service, ztsUrl string, opts *sc.Options) error {
 	}
 
 	athenzJwk := true
-	athenzJwkModified := util.GetAthenzJwkConfModTime(siaMainDir)
+	athenzJwkModified := util.GetAthenzJwkConfModTime(mainDir(opts))
 
 	info := &zts.InstanceRegisterInformation{
 		Provider:          zts.ServiceName(opts.Provider.GetName()),
@@ -391,7 +396,7 @@ func registerSvc(svc sc.Service, ztsUrl string, opts *sc.Options) error {
 	}
 
 	if ident.AthenzJWK != nil {
-		err = util.WriteAthenzJWKFile(ident.AthenzJWK, siaMainDir, svc.Uid, svc.Gid)
+		err = util.WriteAthenzJWKFile(ident.AthenzJWK, mainDir(opts), svc.Uid, svc.Gid)
 		if err != nil {
 			return err
 		}
@@ -486,7 +491,7 @@ func refreshSvc(svc sc.Service, ztsUrl string, opts *sc.Options) error {
 	}
 
 	athenzJwk := true
-	athenzJwkModified := util.GetAthenzJwkConfModTime(siaMainDir)
+	athenzJwkModified := util.GetAthenzJwkConfModTime(mainDir(opts))
 
 	info := &zts.InstanceRefreshInformation{
 		AttestationData:   attestData,
@@ -545,7 +550,7 @@ func refreshSvc(svc sc.Service, ztsUrl string, opts *sc.Options) error {
 	}
 
 	if ident.AthenzJWK != nil {
-		err = util.WriteAthenzJWKFile(ident.AthenzJWK, siaMainDir, svc.Uid, svc.Gid)
+		err = util.WriteAthenzJWKFile(ident.AthenzJWK, mainDir(opts), svc.Uid, svc.Gid)
 		if err != nil {
 			return err
 		}
@@ -666,10 +671,10 @@ func SetupAgent(opts *sc.Options, siaAgentDir, siaLinkDir string) {
 			log.Printf("Unable to symlink SIA directory '%s': %v\n", siaLinkDir, err)
 		}
 	}
-	if siaAgentDir != siaMainDir {
-		err = util.SetupSIADir(siaMainDir, runUid, runGid)
+	if siaAgentDir != mainDir(opts) {
+		err = util.SetupSIADir(mainDir(opts), runUid, runGid)
 		if err != nil {
-			log.Printf("Unable to setup SIA Main directory '%s': %v\n", siaMainDir, err)
+			log.Printf("Unable to setup SIA Main directory '%s': %v\n", mainDir(opts), err)
 		}
 	}
 	err = util.SetupSIADir(opts.KeyDir, runUid, runGid)
@@ -752,7 +757,7 @@ func runAgentCommand(siaCmd, ztsUrl string, opts *sc.Options) {
 		if count != 0 {
 			util.ExecuteScript(opts.RunAfterCertsOkParts, "", opts.RunAfterFailExit)
 		}
-		util.TouchDoneFile(siaMainDir, "rolecert")
+		util.TouchDoneFile(mainDir(opts), "rolecert")
 	case "token":
 		if tokenOpts != nil {
 			err := fetchAccessToken(tokenOpts)
@@ -766,14 +771,14 @@ func runAgentCommand(siaCmd, ztsUrl string, opts *sc.Options) {
 		} else {
 			log.Print("unable to fetch access tokens, invalid or missing configuration")
 		}
-		util.TouchDoneFile(siaMainDir, "token")
+		util.TouchDoneFile(mainDir(opts), "token")
 	case "post", "register":
 		err := RegisterInstance(ztsUrl, opts, false)
 		if err != nil {
 			log.Fatalf("Unable to register identity, err: %v\n", err)
 		}
 		util.ExecuteScript(opts.RunAfterCertsOkParts, "", opts.RunAfterFailExit)
-		util.TouchDoneFile(siaMainDir, "register")
+		util.TouchDoneFile(mainDir(opts), "register")
 		log.Printf("identity registered for services: %s\n", svcs)
 	case "rotate", "refresh":
 		err = RefreshInstance(ztsUrl, opts)
@@ -781,7 +786,7 @@ func runAgentCommand(siaCmd, ztsUrl string, opts *sc.Options) {
 			log.Fatalf("Refresh identity failed, err: %v\n", err)
 		}
 		util.ExecuteScript(opts.RunAfterCertsOkParts, "", opts.RunAfterFailExit)
-		util.TouchDoneFile(siaMainDir, "refresh")
+		util.TouchDoneFile(mainDir(opts), "refresh")
 		log.Printf("Identity successfully refreshed for services: %s\n", svcs)
 	case "init":
 		err := RegisterInstance(ztsUrl, opts, false)
@@ -807,7 +812,7 @@ func runAgentCommand(siaCmd, ztsUrl string, opts *sc.Options) {
 			}
 			util.ExecuteScript(opts.RunAfterTokensOkParts, "", opts.RunAfterFailExit)
 		}
-		util.TouchDoneFile(siaMainDir, "init")
+		util.TouchDoneFile(mainDir(opts), "init")
 	default:
 		// we're going to iterate through our configured services.
 		// if the service key and certificate files exist then we're

--- a/libs/go/sia/agent/agent_test.go
+++ b/libs/go/sia/agent/agent_test.go
@@ -192,6 +192,16 @@ func testInternalUpdateFileExisting(test *testing.T, fileDirectUpdate bool) {
 	_ = os.Remove(fileName)
 }
 
+func TestMainDirDefault(test *testing.T) {
+	opts := &sc.Options{}
+	assert.Equal(test, "/var/lib/sia", mainDir(opts))
+}
+
+func TestMainDirOverride(test *testing.T) {
+	opts := &sc.Options{MainDir: "/custom/sia"}
+	assert.Equal(test, "/custom/sia", mainDir(opts))
+}
+
 func TestRegisterInstance(test *testing.T) {
 
 	siaDir := test.TempDir()

--- a/libs/go/sia/aws/options/data/sia_config_ssh_ecdsa
+++ b/libs/go/sia/aws/options/data/sia_config_ssh_ecdsa
@@ -12,5 +12,6 @@
     "sia_key_dir": "/var/athenz/keys",
     "sia_cert_dir": "/var/athenz/certs",
     "sia_token_dir": "/var/athenz/tokens",
-    "sia_backup_dir": "/var/athenz/backup"
+    "sia_backup_dir": "/var/athenz/backup",
+    "sia_main_dir": "/var/athenz/main"
 }

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -251,6 +251,9 @@ func InitEnvConfig(config *sc.Config) (*sc.Config, *sc.ConfigAccount, error) {
 	if config.SiaBackupDir == "" {
 		config.SiaBackupDir = os.Getenv("ATHENZ_SIA_BACKUP_DIR")
 	}
+	if config.SiaMainDir == "" {
+		config.SiaMainDir = os.Getenv("ATHENZ_SIA_MAIN_DIR")
+	}
 	if config.SshPrincipals == "" {
 		config.SshPrincipals = os.Getenv("ATHENZ_SIA_SSH_PRINCIPALS")
 	}
@@ -412,6 +415,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 	certDir := fmt.Sprintf("%s/certs", siaDir)
 	keyDir := fmt.Sprintf("%s/keys", siaDir)
 	backupDir := fmt.Sprintf("%s/backup", siaDir)
+	mainDir := siaDir
 	sshHostKeyType := hostkey.Rsa
 	sshPrincipals := ""
 	accessManagement := false
@@ -471,6 +475,9 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		}
 		if config.SiaBackupDir != "" {
 			backupDir = config.SiaBackupDir
+		}
+		if config.SiaMainDir != "" {
+			mainDir = config.SiaMainDir
 		}
 		//update account user/group settings if override provided at the config level
 		if account.User == "" && config.User != "" {
@@ -682,6 +689,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		TokenDir:               tokenDir,
 		CertDir:                certDir,
 		KeyDir:                 keyDir,
+		MainDir:                mainDir,
 		AthenzCACertFile:       fmt.Sprintf("%s/ca.cert.pem", certDir),
 		GenerateRoleKey:        generateRoleKey,
 		RotateKey:              rotateKey,

--- a/libs/go/sia/aws/options/options_test.go
+++ b/libs/go/sia/aws/options/options_test.go
@@ -334,6 +334,7 @@ func TestOptionsWithConfig(t *testing.T) {
 	assert.Equal(t, "", cfg.SiaCertDir)
 	assert.Equal(t, "", cfg.SiaTokenDir)
 	assert.Equal(t, "", cfg.SiaBackupDir)
+	assert.Equal(t, "", cfg.SiaMainDir)
 
 	opts, e := setOptions(cfg, cfgAccount, nil, "/var/lib/sia", "1.0.0")
 	require.Nilf(t, e, "error should be empty, error: %v", e)
@@ -344,6 +345,7 @@ func TestOptionsWithConfig(t *testing.T) {
 	assert.Equal(t, "/var/lib/sia/certs", opts.CertDir)
 	assert.Equal(t, "/var/lib/sia/tokens", opts.TokenDir)
 	assert.Equal(t, "/var/lib/sia/backup", opts.BackupDir)
+	assert.Equal(t, "/var/lib/sia", opts.MainDir)
 	assert.Equal(t, "host1.athenz.io,host2.athenz.io", opts.SshPrincipals)
 
 	// Make sure services are set
@@ -725,6 +727,7 @@ func TestInitEnvConfig(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_KEY_DIR", "/var/athenz/keys")
 	os.Setenv("ATHENZ_SIA_CERT_DIR", "/var/athenz/certs")
 	os.Setenv("ATHENZ_SIA_TOKEN_DIR", "/var/athenz/tokens")
+	os.Setenv("ATHENZ_SIA_MAIN_DIR", "/var/athenz/main")
 	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
 	os.Setenv("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", "10")
 	os.Setenv("ATHENZ_SIA_SPIFFE_TRUST_DOMAIN", "athenz.io")
@@ -760,6 +763,7 @@ func TestInitEnvConfig(t *testing.T) {
 	assert.Equal(t, "/var/athenz/keys", cfg.SiaKeyDir)
 	assert.Equal(t, "/var/athenz/certs", cfg.SiaCertDir)
 	assert.Equal(t, "/var/athenz/tokens", cfg.SiaTokenDir)
+	assert.Equal(t, "/var/athenz/main", cfg.SiaMainDir)
 	assert.Equal(t, "zts.athenz.cloud", cfg.HostnameSuffix)
 	assert.Equal(t, "athenz.io", cfg.SpiffeTrustDomain)
 	assert.Equal(t, "svc1.athenz.io,svc2.athenz.io", cfg.SanDnsX509Cnames)
@@ -884,6 +888,7 @@ func TestOptionsWithSiaDirs(t *testing.T) {
 	assert.Equal(t, "/var/athenz/certs", cfg.SiaCertDir)
 	assert.Equal(t, "/var/athenz/tokens", cfg.SiaTokenDir)
 	assert.Equal(t, "/var/athenz/backup", cfg.SiaBackupDir)
+	assert.Equal(t, "/var/athenz/main", cfg.SiaMainDir)
 
 	opts, e := setOptions(cfg, cfgAccount, nil, "/tmp", "1.0.0")
 	require.Nilf(t, e, "error should not be thrown, error: %v", e)
@@ -891,6 +896,7 @@ func TestOptionsWithSiaDirs(t *testing.T) {
 	assert.Equal(t, "/var/athenz/certs", opts.CertDir)
 	assert.Equal(t, "/var/athenz/tokens", opts.TokenDir)
 	assert.Equal(t, "/var/athenz/backup", opts.BackupDir)
+	assert.Equal(t, "/var/athenz/main", opts.MainDir)
 }
 
 func TestOptionsWithServiceOnlySetup(t *testing.T) {

--- a/libs/go/sia/config/config.go
+++ b/libs/go/sia/config/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	SiaCertDir        string                   `json:"sia_cert_dir,omitempty"`               //sia certs directory to override /var/lib/sia/certs
 	SiaTokenDir       string                   `json:"sia_token_dir,omitempty"`              //sia tokens directory to override /var/lib/sia/tokens
 	SiaBackupDir      string                   `json:"sia_backup_dir,omitempty"`             //sia backup directory to override /var/lib/sia/backup
+	SiaMainDir        string                   `json:"sia_main_dir,omitempty"`               //sia main directory to override /var/lib/sia
 	HostnameSuffix    string                   `json:"hostname_suffix,omitempty"`            //hostname suffix in case we need to auto-generate hostname
 	Zts               string                   `json:"zts,omitempty"`                        //the ZTS to contact
 	Roles             map[string]ConfigRole    `json:"roles,omitempty"`                      //map of roles to retrieve certificates for
@@ -184,6 +185,7 @@ type Options struct {
 	UseRegionalSTS         bool                //use regional sts endpoint
 	KeyDir                 string              //private key directory path
 	CertDir                string              //x.509 certificate directory path
+	MainDir                string              //sia main directory path (athenz.conf, done files)
 	AthenzCACertFile       string              //filename to store Athenz CA certs
 	ZTSCACertFile          string              //filename for CA certs when communicating with ZTS
 	ZTSServerName          string              //ZTS server name, if necessary for tls

--- a/libs/go/sia/options/data/sia_config_ssh_ecdsa
+++ b/libs/go/sia/options/data/sia_config_ssh_ecdsa
@@ -14,5 +14,6 @@
     "sia_key_dir": "/var/athenz/keys",
     "sia_cert_dir": "/var/athenz/certs",
     "sia_token_dir": "/var/athenz/tokens",
-    "sia_backup_dir": "/var/athenz/backup"
+    "sia_backup_dir": "/var/athenz/backup",
+    "sia_main_dir": "/var/athenz/main"
 }

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -292,6 +292,9 @@ func InitEnvConfig(config *sc.Config, provider provider.Provider) (*sc.Config, *
 	if config.SiaBackupDir == "" {
 		config.SiaBackupDir = os.Getenv("ATHENZ_SIA_BACKUP_DIR")
 	}
+	if config.SiaMainDir == "" {
+		config.SiaMainDir = os.Getenv("ATHENZ_SIA_MAIN_DIR")
+	}
 	if config.SshPrincipals == "" {
 		config.SshPrincipals = os.Getenv("ATHENZ_SIA_SSH_PRINCIPALS")
 	}
@@ -455,6 +458,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 	certDir := fmt.Sprintf("%s/certs", siaDir)
 	keyDir := fmt.Sprintf("%s/keys", siaDir)
 	backupDir := fmt.Sprintf("%s/backup", siaDir)
+	mainDir := siaDir
 	sshHostKeyType := hostkey.Rsa
 	sshPrincipals := ""
 	accessManagement := false
@@ -503,6 +507,9 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		}
 		if config.SiaBackupDir != "" {
 			backupDir = config.SiaBackupDir
+		}
+		if config.SiaMainDir != "" {
+			mainDir = config.SiaMainDir
 		}
 
 		//update account user/group settings if override provided at the config level
@@ -722,6 +729,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		TokenDir:               tokenDir,
 		CertDir:                certDir,
 		KeyDir:                 keyDir,
+		MainDir:                mainDir,
 		AthenzCACertFile:       fmt.Sprintf("%s/ca.cert.pem", certDir),
 		GenerateRoleKey:        generateRoleKey,
 		RotateKey:              rotateKey,

--- a/libs/go/sia/options/options_test.go
+++ b/libs/go/sia/options/options_test.go
@@ -332,6 +332,7 @@ func TestOptionsWithConfig(t *testing.T) {
 	assert.Equal(t, "", cfg.SiaCertDir)
 	assert.Equal(t, "", cfg.SiaTokenDir)
 	assert.Equal(t, "", cfg.SiaBackupDir)
+	assert.Equal(t, "", cfg.SiaMainDir)
 
 	opts, e := setOptions(cfg, cfgAccount, nil, "/var/lib/sia", "1.0.0")
 	require.Nilf(t, e, "error should be empty, error: %v", e)
@@ -342,6 +343,7 @@ func TestOptionsWithConfig(t *testing.T) {
 	assert.Equal(t, "/var/lib/sia/certs", opts.CertDir)
 	assert.Equal(t, "/var/lib/sia/tokens", opts.TokenDir)
 	assert.Equal(t, "/var/lib/sia/backup", opts.BackupDir)
+	assert.Equal(t, "/var/lib/sia", opts.MainDir)
 	assert.Equal(t, "host1.athenz.io,host2.athenz.io", opts.SshPrincipals)
 
 	assert.Equal(t, 2, len(opts.AddlSanDNSEntries))
@@ -707,6 +709,7 @@ func TestInitEnvConfigAwsProvider(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_KEY_DIR", "/var/athenz/keys")
 	os.Setenv("ATHENZ_SIA_CERT_DIR", "/var/athenz/certs")
 	os.Setenv("ATHENZ_SIA_TOKEN_DIR", "/var/athenz/tokens")
+	os.Setenv("ATHENZ_SIA_MAIN_DIR", "/var/athenz/main")
 	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
 	os.Setenv("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", "10")
 	os.Setenv("ATHENZ_SIA_SPIFFE_TRUST_DOMAIN", "athenz.io")
@@ -745,6 +748,7 @@ func TestInitEnvConfigAwsProvider(t *testing.T) {
 	assert.Equal(t, "/var/athenz/keys", cfg.SiaKeyDir)
 	assert.Equal(t, "/var/athenz/certs", cfg.SiaCertDir)
 	assert.Equal(t, "/var/athenz/tokens", cfg.SiaTokenDir)
+	assert.Equal(t, "/var/athenz/main", cfg.SiaMainDir)
 	assert.Equal(t, "zts.athenz.cloud", cfg.HostnameSuffix)
 	assert.Equal(t, "athenz.io", cfg.SpiffeTrustDomain)
 	assert.Equal(t, "svc1.athenz.io,svc2.athenz.io", cfg.SanDnsX509Cnames)
@@ -798,6 +802,7 @@ func TestInitEnvConfigGcpProvider(t *testing.T) {
 	os.Setenv("ATHENZ_SIA_KEY_DIR", "/var/athenz/keys")
 	os.Setenv("ATHENZ_SIA_CERT_DIR", "/var/athenz/certs")
 	os.Setenv("ATHENZ_SIA_TOKEN_DIR", "/var/athenz/tokens")
+	os.Setenv("ATHENZ_SIA_MAIN_DIR", "/var/athenz/main")
 	os.Setenv("ATHENZ_SIA_SSH_PRINCIPALS", "host1.athenz.io")
 	os.Setenv("ATHENZ_SIA_FAIL_COUNT_FOR_EXIT", "10")
 	os.Setenv("ATHENZ_SIA_SPIFFE_TRUST_DOMAIN", "athenz.io")
@@ -835,6 +840,7 @@ func TestInitEnvConfigGcpProvider(t *testing.T) {
 	assert.Equal(t, "/var/athenz/keys", cfg.SiaKeyDir)
 	assert.Equal(t, "/var/athenz/certs", cfg.SiaCertDir)
 	assert.Equal(t, "/var/athenz/tokens", cfg.SiaTokenDir)
+	assert.Equal(t, "/var/athenz/main", cfg.SiaMainDir)
 	assert.Equal(t, "zts.athenz.cloud", cfg.HostnameSuffix)
 	assert.Equal(t, "athenz.io", cfg.SpiffeTrustDomain)
 	assert.Equal(t, "svc1.athenz.io,svc2.athenz.io", cfg.SanDnsX509Cnames)
@@ -1022,6 +1028,7 @@ func TestOptionsWithSiaDirs(t *testing.T) {
 	assert.Equal(t, "/var/athenz/certs", cfg.SiaCertDir)
 	assert.Equal(t, "/var/athenz/tokens", cfg.SiaTokenDir)
 	assert.Equal(t, "/var/athenz/backup", cfg.SiaBackupDir)
+	assert.Equal(t, "/var/athenz/main", cfg.SiaMainDir)
 
 	opts, e := setOptions(cfg, cfgAccount, nil, "/tmp", "1.0.0")
 	require.Nilf(t, e, "error should not be thrown, error: %v", e)
@@ -1029,6 +1036,7 @@ func TestOptionsWithSiaDirs(t *testing.T) {
 	assert.Equal(t, "/var/athenz/certs", opts.CertDir)
 	assert.Equal(t, "/var/athenz/tokens", opts.TokenDir)
 	assert.Equal(t, "/var/athenz/backup", opts.BackupDir)
+	assert.Equal(t, "/var/athenz/main", opts.MainDir)
 }
 
 func TestOptionsWithServiceOnlySetup(t *testing.T) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -185,7 +185,7 @@ public class ZMSUtils {
 
     public static RuntimeException error(ServerResourceException ex) {
         LOG.error("Server Common Error: {} message: {}", ex.getCode(), ex.getMessage());
-        return new ResourceException(ex.getCode(), new ResourceError().code(ex.getCode()).message(ex.getMessage()));
+        return new ResourceException(ex.getCode(), new ResourceError().code(ex.getCode()).message("Internal Server Error"));
     }
 
     public static RuntimeException error(int code, String msg, String caller) {


### PR DESCRIPTION
# Description
The SIA main directory (used for `athenz.conf` and the done-marker files) was hardcoded to `/var/lib/sia`. This PR makes it configurable via a new `sia_main_dir`  field in `sia_config` (or the `ATHENZ_SIA_MAIN_DIR` env var), matching how the key/cert/token/backup directories are already configurable. Fully backward compatible — unset, it still defaults to `/var/lib/sia`. 

Addresses issue raised [here](https://github.com/AthenZ/athenz/issues/3471).

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

