### PR TITLE
Add ID-JAG token based instance provider

### DIFF
--- a/docs/cert_id_jag_provider.md
+++ b/docs/cert_id_jag_provider.md
@@ -125,7 +125,7 @@ it is rejected the same way if it is explicitly configured with an empty value.
 | `athenz.zts.id_jag.act_sub_profile` | no | `ai_agent` | The expected `sub_profile` value of the outermost actor in the `act` claim. Must not be configured with an empty value. |
 | `athenz.zts.id_jag.jwks_uri` | no | none | The JWKS uri used to fetch the issuer's public keys. If not specified, the uri is extracted from the issuer's openid configuration document. |
 | `athenz.zts.id_jag.provider_dns_suffix` | no | `id-jag.athenz.io` | Comma separated list of dns suffixes allowed in the `sanDNS` entries of the certificate request. |
-| `athenz.zts.id_jag.boot_time_offset` | no | `300` | How many seconds in the past the token may have been issued (`iat` claim) and still be accepted. This is a dynamic configuration value and can be updated without restarting the server. |
+| `athenz.zts.id_jag.issue_time_offset` | no | `300` | How many seconds in the past the token may have been issued (`iat` claim) and still be accepted. This is a dynamic configuration value and can be updated without restarting the server. |
 | `athenz.zts.id_jag.cert_expiry_time` | no | `360` | Default/max expiry time in minutes for the issued certificates. |
 
 In addition, ZTS enforces IP ranges where services are authorized to request identities from a given provider, so

--- a/docs/cert_id_jag_provider.md
+++ b/docs/cert_id_jag_provider.md
@@ -1,0 +1,147 @@
+# Service Identity Provider for ID-JAG Tokens
+---------------------------------------------
+
+The document describes support for issuing Athenz Identity X.509 certificates to workloads - typically AI agents -
+that authenticate with an Identity Assertion JWT Authorization Grant (ID-JAG) token issued by an external
+Identity Provider.
+
+The provider is implemented by the `com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider` class as an
+in-service class based provider, and it runs as part of the ZTS Server deployment. No changes are required for the
+current deployment model.
+
+## Request Attestation Data
+
+The attestation data for the X.509 certificate identity registration request is the ID-JAG token itself, passed
+as the raw JWT string in the `attestationData` field of the instance register request.
+
+An ID-JAG token is a signed JWT that carries the `oauth-id-jag+jwt` value in its `typ` header field, and includes
+an `act` claim describing the delegation chain that led to the request. Here is a sample payload of an ID-JAG token:
+
+```json
+{
+    "iss": "https://issuer.athenz.io/oauth2/default",
+    "aud": "https://audience.athenz.io",
+    "sub": "user1234",
+    "client_id": "aiclientid12tsy8084bo8FU1d8",
+    "act": {
+        "act": {
+            "sub": "clientsvcid1234355",
+            "sub_profile": "service"
+        },
+        "sub": "aiclientid12tsy8084bo8FU1d8",
+        "sub_profile": "ai_agent"
+    },
+    "jti": "15a2c4d7-f60e-460d-b034-dbd49e757a0a",
+    "nbf": 1706833037,
+    "exp": 1706833937,
+    "iat": 1706833637
+}
+```
+
+The `act` claim is nested: the outermost object identifies the actor that is directly requesting the identity,
+and each nested `act` object identifies the party that the actor is itself acting on behalf of. The provider only
+enforces its checks against the outermost actor; the rest of the chain is carried in the token but not validated
+by the provider.
+
+## Athenz Identities For ID-JAG Workloads
+
+The provider issues identities in a single, configured Athenz domain, and the service name within that domain must
+be the `client_id` of the workload as asserted by the identity provider. This means the domain administrator must
+register a service whose name matches the client id of the agent before any certificate can be issued.
+
+For example, for the sample token above and a provider configured with the domain `sports`, the workload can only
+obtain the identity `sports.aiclientid12tsy8084bo8fu1d8`. Note that ZTS converts all incoming domain and service
+names to lower case, so the provider compares the requested service name against the token's `client_id` value
+without regard to case.
+
+Since the identity is fully determined by the configured domain and the client id in the token, the provider does
+not carry out any additional Athenz authorization check. The launch authorization for the provider service itself
+still applies as it does for every Copper Argos provider.
+
+## Service Identity ID-JAG Provider
+
+### Register Instance
+
+The provider carries out the following checks during the instance registration process:
+
+- The domain in the instance confirmation object must match the configured domain
+  (`athenz.zts.id_jag.domain`). The comparison ignores case.
+- The certificate request must not include any `sanIP` addresses.
+- The certificate request must not include any hostname values.
+- If the request includes any `sanURI` values, they must only be `spiffe://` or `athenz://instanceid/` URIs.
+- The attestation data must be present.
+- Obtain the public keys from the configured issuer to validate the ID-JAG token signature. The keys are cached to
+  avoid unnecessary calls, and the frequency of key fetches is limited. Only the RS256, RS384, RS512, ES256, ES384
+  and ES512 signature algorithms are accepted.
+- Validate the signature of the token and parse the claims. As part of this validation, the library verifies that
+  the token type (`typ` header) is `oauth-id-jag+jwt` and that the token is not expired.
+- Validate the following claims from the token:
+    - Issuer (`iss`) - must match the configured issuer (`athenz.zts.id_jag.issuer`)
+    - Audience (`aud`) - must match the configured audience (`athenz.zts.id_jag.audience`)
+    - Issue Time (`iat`) - the timestamp must be within the configured number of seconds (default 5 mins)
+    - Actor (`act`) - the claim must be present and must be a JSON object
+    - Actor Profile (`act.sub_profile`) - must match the configured profile value
+      (`athenz.zts.id_jag.act_sub_profile`), which defaults to `ai_agent`
+    - Actor Subject (`act.sub`) - must be present
+    - Client Id (`client_id`) - must be present and must match the `act.sub` value
+- The service name in the instance confirmation object must be the `client_id` value from the token. The
+  comparison ignores case.
+- Validate the `sanDNS` entries in the certificate request. Each entry must be in the format
+  `<service-name>.<domain-name-with-dashes>.<dns-domain-suffix>` where the suffix is one of the configured
+  values (`athenz.zts.id_jag.provider_dns_suffix`). The request must also carry an instance id, either as an
+  `instanceid` `sanDNS` entry or as the ZTS provided instance id attribute.
+
+If all the checks pass, the provider returns the confirmation object with the following certificate attributes:
+
+- `certRefresh` is set to `false` - the issued certificate cannot be refreshed
+- `certUsage` is set to `client` - the issued certificate can only be used by clients and not servers
+- `certExpiryTime` is set to the configured value (default 6 hours)
+
+The identity is issued for the min(requested number of minutes, max expiry) where max expiry has a default
+configuration value of 6 hours.
+
+### Refresh Instance
+
+The provider does not support refreshing identity X.509 certificates. The workload must present a new ID-JAG token
+and register again every time it needs a certificate.
+
+### SSH Host Certificates
+
+The provider does not support ssh host certificates.
+
+## ZTS Server Configuration Changes
+
+The following system properties configure the provider. The `athenz.zts.id_jag.domain`,
+`athenz.zts.id_jag.audience` and `athenz.zts.id_jag.issuer` settings are required - the provider will throw an
+`IllegalArgumentException` during initialization if any of them is not specified, since accepting any value for
+those checks would defeat their purpose. The `athenz.zts.id_jag.act_sub_profile` setting has a default value, but
+it is rejected the same way if it is explicitly configured with an empty value.
+
+| Property | Required | Default | Description |
+| --- | --- | --- | --- |
+| `athenz.zts.id_jag.domain` | yes | none | The only Athenz domain that this provider will issue identities in. |
+| `athenz.zts.id_jag.issuer` | yes | none | The expected `iss` claim value. Also used to look up the issuer's JWKS uri from its `/.well-known/openid-configuration` document if the jwks uri is not configured explicitly. |
+| `athenz.zts.id_jag.audience` | yes | none | The expected `aud` claim value. |
+| `athenz.zts.id_jag.act_sub_profile` | no | `ai_agent` | The expected `sub_profile` value of the outermost actor in the `act` claim. Must not be configured with an empty value. |
+| `athenz.zts.id_jag.jwks_uri` | no | none | The JWKS uri used to fetch the issuer's public keys. If not specified, the uri is extracted from the issuer's openid configuration document. |
+| `athenz.zts.id_jag.provider_dns_suffix` | no | `id-jag.athenz.io` | Comma separated list of dns suffixes allowed in the `sanDNS` entries of the certificate request. |
+| `athenz.zts.id_jag.boot_time_offset` | no | `300` | How many seconds in the past the token may have been issued (`iat` claim) and still be accepted. This is a dynamic configuration value and can be updated without restarting the server. |
+| `athenz.zts.id_jag.cert_expiry_time` | no | `360` | Default/max expiry time in minutes for the issued certificates. |
+
+In addition, ZTS enforces IP ranges where services are authorized to request identities from a given provider, so
+the IP addresses that the workloads will be connecting from must be authorized for the provider.
+
+## ZMS Server Configuration Changes
+
+The following changes are necessary for the ZMS server to support the ID-JAG provider:
+
+- Register `sys.auth.id-jag` as a service with the class provider endpoint pointing to the implementation of the
+  ID-JAG provider class:
+  `class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider`
+- Add the provider identity (e.g. `sys.auth.id-jag`) to the providers role in the `sys.auth` domain to be
+  authorized as an official provider.
+- Create a role called `provider.sys.auth.id-jag` that includes `sys.auth.id-jag` as a member and create a policy
+  that allows the `launch` action to that role on the resource `dns.<dns-domain-suffix>`. This allows adding
+  `sanDNS` values in the certificate in the format `<service-name>.<domain-name>.<dns-domain-suffix>`.
+- In the configured tenant domain, register a service for each agent using the agent's client id as the service
+  name, and authorize the provider to launch it.

--- a/libs/java/instance_provider/conf/id_jag_provider.properties
+++ b/libs/java/instance_provider/conf/id_jag_provider.properties
@@ -64,7 +64,7 @@
 # certificate request. This setting is dynamic and does not require a server
 # restart.
 # Default: 300 (5 minutes)
-#athenz.zts.id_jag.boot_time_offset=300
+#athenz.zts.id_jag.issue_time_offset=300
 
 # Maximum lifetime in minutes of the issued X.509 certificate. The certificate
 # is issued for the min(requested lifetime, this value).

--- a/libs/java/instance_provider/conf/id_jag_provider.properties
+++ b/libs/java/instance_provider/conf/id_jag_provider.properties
@@ -1,0 +1,72 @@
+# This file contains ID-JAG Instance Provider properties for Athenz ZTS server.
+# Used by com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider
+#
+# The ID-JAG Instance Provider validates workload identity - typically for AI
+# agents - by verifying an Identity Assertion JWT Authorization Grant (ID-JAG)
+# token issued by an external identity provider and submitted as the attestation
+# data. The token must carry the oauth-id-jag+jwt value in its typ header and
+# include an act claim describing the delegation chain. The provider issues
+# short-lived X.509 client certificates that cannot be refreshed.
+#
+# The domain, issuer and audience properties below are required. The provider
+# throws an IllegalArgumentException during initialization if any of them is not
+# specified, since accepting any value for those checks would defeat their
+# purpose. The act_sub_profile property has a default value, but it is rejected
+# the same way if it is explicitly configured with an empty value.
+
+# The single Athenz domain that this provider is allowed to issue identities in.
+# The domain in the instance confirmation object must match this value - the
+# comparison ignores case since ZTS lowercases all incoming domain names. The
+# service name is not configured here: it is always taken from the client_id
+# claim in the presented ID-JAG token.
+# Required - no default value
+#athenz.zts.id_jag.domain=
+
+# Expected issuer value (iss claim) in the ID-JAG token. This value is also used
+# to derive the JWKS URI from the issuer's OpenID Connect discovery document
+# (issuer/.well-known/openid-configuration) when athenz.zts.id_jag.jwks_uri is
+# not set.
+# Required - no default value
+#athenz.zts.id_jag.issuer=
+
+# Expected audience value (aud claim) in the ID-JAG token. Only the first
+# audience value in the token is compared against this setting.
+# Required - no default value
+#athenz.zts.id_jag.audience=
+
+# Expected sub_profile value of the outermost actor in the act claim. Only the
+# outermost actor is validated; any nested act objects describing the rest of the
+# delegation chain are carried in the token but not checked by the provider.
+# This property must not be configured with an empty value - the provider rejects
+# it during initialization since matching against an empty profile would defeat
+# the check.
+# Default: ai_agent
+#athenz.zts.id_jag.act_sub_profile=ai_agent
+
+# URL of the JWKS endpoint used to retrieve the public keys for verifying the
+# ID-JAG token signatures. When not set the provider derives the JWKS URI from
+# the issuer's OpenID Connect discovery document
+# (issuer/.well-known/openid-configuration). Override this only when the
+# discovery document is unavailable or when testing with a local key set.
+# Default: not set (derived from issuer discovery document)
+#athenz.zts.id_jag.jwks_uri=
+
+# DNS suffix used to construct and validate the SAN DNS names in the issued
+# certificate. Multiple suffixes may be specified as a comma-separated list.
+# Each sanDNS entry must be in the format
+# <service-name>.<domain-name-with-dashes>.<dns-domain-suffix>
+# Default: id-jag.athenz.io
+#athenz.zts.id_jag.provider_dns_suffix=id-jag.athenz.io
+
+# Maximum age in seconds of the ID-JAG token's issue time (iat claim). Tokens
+# issued earlier than this many seconds ago are rejected, as are tokens without
+# an iat claim. This bounds how long a captured token remains usable for a
+# certificate request. This setting is dynamic and does not require a server
+# restart.
+# Default: 300 (5 minutes)
+#athenz.zts.id_jag.boot_time_offset=300
+
+# Maximum lifetime in minutes of the issued X.509 certificate. The certificate
+# is issued for the min(requested lifetime, this value).
+# Default: 360 (6 hours)
+#athenz.zts.id_jag.cert_expiry_time=360

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProvider.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.yahoo.athenz.auth.KeyStore;
+import com.yahoo.athenz.auth.token.jwts.JwtsHelper;
+import com.yahoo.athenz.auth.token.jwts.JwtsSigningKeyResolver;
+import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigLong;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ProviderResourceException;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
+
+/**
+ * Instance provider for workloads that authenticate with an Identity Assertion
+ * JWT Authorization Grant (ID-JAG) token as their attestation data. The token
+ * carries an <code>act</code> claim describing the delegation chain, e.g.
+ * <pre>
+ *   "act": {
+ *     "act": {
+ *       "sub": "clientsvcid1234355",
+ *       "sub_profile": "service"
+ *     },
+ *     "sub": "aiclientid12tsy8084bo8FU1d8",
+       "sub_profile": "ai_agent"
+ *   },
+ *   "aud": "https://audience.athenz.io",
+ *   "client_id": "aiclientid12tsy8084bo8FU1d8"
+ * </pre>
+ * The provider validates the token issuer and audience against its configured
+ * values, requires the outermost actor to carry the configured
+ * <code>sub_profile</code> value, and requires the <code>client_id</code> claim
+ * to match the <code>sub</code> field of that actor. The requested identity must
+ * be in the configured domain and its service name must be the client id.
+ */
+public class InstanceIDJAGProvider implements InstanceProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceIDJAGProvider.class);
+
+    private static final String URI_INSTANCE_ID_PREFIX = "athenz://instanceid/";
+    private static final String URI_SPIFFE_PREFIX      = "spiffe://";
+
+    static final String ID_JAG_PROP_PROVIDER_DNS_SUFFIX = "athenz.zts.id_jag.provider_dns_suffix";
+    static final String ID_JAG_PROP_BOOT_TIME_OFFSET    = "athenz.zts.id_jag.boot_time_offset";
+    static final String ID_JAG_PROP_CERT_EXPIRY_TIME    = "athenz.zts.id_jag.cert_expiry_time";
+    static final String ID_JAG_PROP_ACT_SUB_PROFILE     = "athenz.zts.id_jag.act_sub_profile";
+    static final String ID_JAG_PROP_AUDIENCE            = "athenz.zts.id_jag.audience";
+    static final String ID_JAG_PROP_DOMAIN              = "athenz.zts.id_jag.domain";
+    static final String ID_JAG_PROP_ISSUER              = "athenz.zts.id_jag.issuer";
+    static final String ID_JAG_PROP_JWKS_URI            = "athenz.zts.id_jag.jwks_uri";
+
+    static final String CLAIM_ACT         = "act";
+    static final String CLAIM_CLIENT_ID   = "client_id";
+    static final String CLAIM_SUB         = "sub";
+    static final String CLAIM_SUB_PROFILE = "sub_profile";
+
+    Set<String> dnsSuffixes = null;
+    String provider = null;
+    String idJagIssuer = null;
+    String idJagDomain = null;
+    String actSubProfile = null;
+    String audience = null;
+    ConfigurableJWTProcessor<SecurityContext> jwtProcessor = null;
+    DynamicConfigLong bootTimeOffsetSeconds;
+    long certExpiryTime;
+
+    @Override
+    public Scheme getProviderScheme() {
+        return Scheme.CLASS;
+    }
+
+    @Override
+    public void initialize(String provider, String providerEndpoint, SSLContext sslContext, KeyStore keyStore) {
+
+        // save our provider name
+
+        this.provider = provider;
+
+        // the domain that this provider is authorized to issue identities in.
+        // there is no default value since accepting any domain would defeat
+        // the purpose of the check
+
+        idJagDomain = System.getProperty(ID_JAG_PROP_DOMAIN);
+        if (StringUtil.isEmpty(idJagDomain)) {
+            throw new IllegalArgumentException("InstanceIDJAGProvider: Domain not specified");
+        }
+
+        // the audience that the id jag token must have been issued for
+
+        audience = System.getProperty(ID_JAG_PROP_AUDIENCE);
+        if (StringUtil.isEmpty(audience)) {
+            throw new IllegalArgumentException("InstanceIDJAGProvider: Audience not specified");
+        }
+
+        // the sub_profile value that the actor in the act claim must carry.
+        // if this is not specified we'll just default to ai_agent. we still
+        // reject an empty value in case it was configured incorrectly since
+        // matching against an empty profile would defeat the check
+
+        actSubProfile = System.getProperty(ID_JAG_PROP_ACT_SUB_PROFILE, "ai_agent");
+        if (StringUtil.isEmpty(actSubProfile)) {
+            throw new IllegalArgumentException("InstanceIDJAGProvider: Act sub profile not specified");
+        }
+
+        // determine the dns suffix. if this is not specified we'll just default to id-jag.athenz.io
+
+        final String dnsSuffix = System.getProperty(ID_JAG_PROP_PROVIDER_DNS_SUFFIX, "id-jag.athenz.io");
+        dnsSuffixes = Set.of(dnsSuffix.split(","));
+
+        // how long the instance must be booted in the past before we
+        // stop validating the instance requests
+
+        long timeout = TimeUnit.SECONDS.convert(5, TimeUnit.MINUTES);
+        bootTimeOffsetSeconds = new DynamicConfigLong(CONFIG_MANAGER, ID_JAG_PROP_BOOT_TIME_OFFSET, timeout);
+
+        // get default/max expiry time for any generated certificates - 6 hours
+
+        certExpiryTime = Long.parseLong(System.getProperty(ID_JAG_PROP_CERT_EXPIRY_TIME, "360"));
+
+        // initialize our jwt processor. the issuer is required since it is
+        // both the source of our signing keys and one of our validation checks
+
+        idJagIssuer = System.getProperty(ID_JAG_PROP_ISSUER);
+        if (StringUtil.isEmpty(idJagIssuer)) {
+            throw new IllegalArgumentException("InstanceIDJAGProvider: Issuer not specified");
+        }
+
+        jwtProcessor = JwtsHelper.getJWTProcessor(new JwtsSigningKeyResolver(extractIssuerJwksUri(idJagIssuer), null),
+                JwtsHelper.JWT_JAG_TYPE_VERIFIER);
+    }
+
+    String extractIssuerJwksUri(final String issuer) {
+
+        // if we have the value configured then that's what we're going to use
+
+        final String jwksUri = System.getProperty(ID_JAG_PROP_JWKS_URI);
+        if (!StringUtil.isEmpty(jwksUri)) {
+            return jwksUri;
+        }
+
+        // otherwise we'll assume the issuer follows the standard and
+        // includes the jwks uri in its openid configuration
+
+        final String openIdConfigUri = issuer + "/.well-known/openid-configuration";
+        JwtsHelper helper = new JwtsHelper();
+        return helper.extractJwksUri(openIdConfigUri, null);
+    }
+
+    private ProviderResourceException forbiddenError(String message) {
+        LOGGER.error(message);
+        return new ProviderResourceException(ProviderResourceException.FORBIDDEN, message);
+    }
+
+    @Override
+    public InstanceConfirmation confirmInstance(InstanceConfirmation confirmation) throws ProviderResourceException {
+
+        final String instanceDomain = confirmation.getDomain();
+        final String instanceService = confirmation.getService();
+        final Map<String, String> instanceAttributes = confirmation.getAttributes();
+
+        // the identity must be requested in our configured domain
+
+        if (!idJagDomain.equalsIgnoreCase(instanceDomain)) {
+            throw forbiddenError("Domain: " + instanceDomain + " is not the configured domain: " + idJagDomain);
+        }
+
+        // our request must not have any sanIPs or hostnames
+
+        if (!StringUtil.isEmpty(InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_SAN_IP))) {
+            throw forbiddenError("Request must not have any sanIP addresses");
+        }
+
+        if (!StringUtil.isEmpty(InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_HOSTNAME))) {
+            throw forbiddenError("Request must not have any hostname values");
+        }
+
+        // validate san URI
+
+        if (!validateSanUri(InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_SAN_URI))) {
+            throw forbiddenError("Unable to validate certificate request URI values");
+        }
+
+        // we need to validate the id jag token which is our attestation
+        // data for the service requesting a certificate
+
+        final String attestationData = confirmation.getAttestationData();
+        if (StringUtil.isEmpty(attestationData)) {
+            throw forbiddenError("Service credentials not provided");
+        }
+
+        StringBuilder errMsg = new StringBuilder(256);
+        if (!validateIDJAGToken(attestationData, instanceService, errMsg)) {
+            throw forbiddenError("Unable to validate Certificate Request: " + errMsg);
+        }
+
+        // validate the certificate san DNS names
+
+        StringBuilder instanceId = new StringBuilder(256);
+        if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
+                instanceService, dnsSuffixes, null, null, false, instanceId, null)) {
+            throw forbiddenError("Unable to validate certificate request sanDNS entries");
+        }
+
+        // set our cert attributes in the return object. we do not allow refresh
+        // of those certificates since the client must present a new id jag token,
+        // and the issued certificate can only be used by clients and not servers
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(InstanceProvider.ZTS_CERT_REFRESH, "false");
+        attributes.put(InstanceProvider.ZTS_CERT_USAGE, ZTS_CERT_USAGE_CLIENT);
+        attributes.put(InstanceProvider.ZTS_CERT_EXPIRY_TIME, Long.toString(certExpiryTime));
+
+        confirmation.setAttributes(attributes);
+        return confirmation;
+    }
+
+    @Override
+    public InstanceConfirmation refreshInstance(InstanceConfirmation confirmation) throws ProviderResourceException {
+
+        // we do not allow refresh of ID JAG based certificates
+
+        throw forbiddenError("ID JAG X.509 Certificates cannot be refreshed");
+    }
+
+    /**
+     * verifies that sanUri only contains the spiffe and instance id uris
+     * @param sanUri the SAN URI value
+     * @return true if it only contains spiffe and instance id uris, otherwise false
+     */
+    boolean validateSanUri(final String sanUri) {
+
+        if (StringUtil.isEmpty(sanUri)) {
+            LOGGER.debug("Request contains no sanURI to verify");
+            return true;
+        }
+
+        for (String uri : sanUri.split(",")) {
+            if (uri.startsWith(URI_SPIFFE_PREFIX) || uri.startsWith(URI_INSTANCE_ID_PREFIX)) {
+                continue;
+            }
+            LOGGER.error("Request contains unsupported uri value: {}", uri);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * validates the given id jag token against our configured issuer, audience
+     * and act claim requirements, and verifies that the requested service name
+     * matches the client id in the token
+     * @param jwToken the id jag token presented as attestation data
+     * @param serviceName the service name from the instance confirmation object
+     * @param errMsg the buffer to append any failure details to
+     * @return true if the token is valid for the requested service, false otherwise
+     */
+    boolean validateIDJAGToken(final String jwToken, final String serviceName, StringBuilder errMsg) {
+
+        if (jwtProcessor == null) {
+            errMsg.append("JWT Processor not initialized");
+            return false;
+        }
+
+        JWTClaimsSet claimsSet;
+        try {
+            claimsSet = jwtProcessor.process(jwToken, null);
+        } catch (Exception ex) {
+            errMsg.append("Unable to parse and validate token: ").append(ex.getMessage());
+            return false;
+        }
+
+        // verify the issuer matches our configured value
+
+        if (!idJagIssuer.equals(claimsSet.getIssuer())) {
+            errMsg.append("token issuer is not the configured issuer: ").append(claimsSet.getIssuer());
+            return false;
+        }
+
+        // verify that the token audience matches our configured value
+
+        if (!audience.equals(JwtsHelper.getAudience(claimsSet))) {
+            errMsg.append("token audience is not the configured audience: ").append(JwtsHelper.getAudience(claimsSet));
+            return false;
+        }
+
+        // need to verify that the issue time is within our configured bootstrap time
+
+        Date issueDate = claimsSet.getIssueTime();
+        if (issueDate == null || issueDate.getTime() < System.currentTimeMillis() -
+                TimeUnit.SECONDS.toMillis(bootTimeOffsetSeconds.get())) {
+            errMsg.append("token issue time is not recent enough, issued at: ").append(issueDate);
+            return false;
+        }
+
+        // the token must include the act claim which identifies the actor
+        // requesting the identity along with its delegation chain
+
+        Object actClaim = claimsSet.getClaim(CLAIM_ACT);
+        if (!(actClaim instanceof Map)) {
+            errMsg.append("token does not contain required act claim");
+            return false;
+        }
+        Map<?, ?> actMap = (Map<?, ?>) actClaim;
+
+        // the profile of the actor must match our configured value
+
+        final String tokenSubProfile = getActStringField(actMap, CLAIM_SUB_PROFILE);
+        if (!actSubProfile.equals(tokenSubProfile)) {
+            errMsg.append("token act sub_profile: ").append(tokenSubProfile)
+                    .append(" does not match configured value: ").append(actSubProfile);
+            return false;
+        }
+
+        // the client id must match the subject of the actor
+
+        final String actSubject = getActStringField(actMap, CLAIM_SUB);
+        if (StringUtil.isEmpty(actSubject)) {
+            errMsg.append("token act claim does not contain required sub field");
+            return false;
+        }
+
+        final String clientId = JwtsHelper.getStringClaim(claimsSet, CLAIM_CLIENT_ID);
+        if (StringUtil.isEmpty(clientId)) {
+            errMsg.append("token does not contain required client_id claim");
+            return false;
+        }
+
+        if (!clientId.equals(actSubject)) {
+            errMsg.append("token client_id: ").append(clientId)
+                    .append(" does not match act sub: ").append(actSubject);
+            return false;
+        }
+
+        // finally, the requested service name must be the client id. ZTS
+        // lowercases all service names so our comparison ignores case
+
+        if (!clientId.equalsIgnoreCase(serviceName)) {
+            errMsg.append("service name: ").append(serviceName)
+                    .append(" does not match token client_id: ").append(clientId);
+            return false;
+        }
+
+        return true;
+    }
+
+    String getActStringField(final Map<?, ?> actMap, final String field) {
+        Object value = actMap.get(field);
+        return (value instanceof String) ? (String) value : null;
+    }
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProvider.java
@@ -49,7 +49,7 @@ import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.
  *       "sub_profile": "service"
  *     },
  *     "sub": "aiclientid12tsy8084bo8FU1d8",
-       "sub_profile": "ai_agent"
+ *     "sub_profile": "ai_agent"
  *   },
  *   "aud": "https://audience.athenz.io",
  *   "client_id": "aiclientid12tsy8084bo8FU1d8"
@@ -68,7 +68,7 @@ public class InstanceIDJAGProvider implements InstanceProvider {
     private static final String URI_SPIFFE_PREFIX      = "spiffe://";
 
     static final String ID_JAG_PROP_PROVIDER_DNS_SUFFIX = "athenz.zts.id_jag.provider_dns_suffix";
-    static final String ID_JAG_PROP_BOOT_TIME_OFFSET    = "athenz.zts.id_jag.boot_time_offset";
+    static final String ID_JAG_PROP_ISSUE_TIME_OFFSET   = "athenz.zts.id_jag.issue_time_offset";
     static final String ID_JAG_PROP_CERT_EXPIRY_TIME    = "athenz.zts.id_jag.cert_expiry_time";
     static final String ID_JAG_PROP_ACT_SUB_PROFILE     = "athenz.zts.id_jag.act_sub_profile";
     static final String ID_JAG_PROP_AUDIENCE            = "athenz.zts.id_jag.audience";
@@ -88,7 +88,7 @@ public class InstanceIDJAGProvider implements InstanceProvider {
     String actSubProfile = null;
     String audience = null;
     ConfigurableJWTProcessor<SecurityContext> jwtProcessor = null;
-    DynamicConfigLong bootTimeOffsetSeconds;
+    DynamicConfigLong issueTimeOffsetSeconds;
     long certExpiryTime;
 
     @Override
@@ -134,11 +134,11 @@ public class InstanceIDJAGProvider implements InstanceProvider {
         final String dnsSuffix = System.getProperty(ID_JAG_PROP_PROVIDER_DNS_SUFFIX, "id-jag.athenz.io");
         dnsSuffixes = Set.of(dnsSuffix.split(","));
 
-        // how long the instance must be booted in the past before we
-        // stop validating the instance requests
+        // maximum allowed age (in seconds) of the token issue time (iat). tokens issued earlier
+        // than this many seconds ago are rejected
 
         long timeout = TimeUnit.SECONDS.convert(5, TimeUnit.MINUTES);
-        bootTimeOffsetSeconds = new DynamicConfigLong(CONFIG_MANAGER, ID_JAG_PROP_BOOT_TIME_OFFSET, timeout);
+        issueTimeOffsetSeconds = new DynamicConfigLong(CONFIG_MANAGER, ID_JAG_PROP_ISSUE_TIME_OFFSET, timeout);
 
         // get default/max expiry time for any generated certificates - 6 hours
 
@@ -313,11 +313,11 @@ public class InstanceIDJAGProvider implements InstanceProvider {
             return false;
         }
 
-        // need to verify that the issue time is within our configured bootstrap time
+        // need to verify that the issue time is within our configured offset
 
         Date issueDate = claimsSet.getIssueTime();
         if (issueDate == null || issueDate.getTime() < System.currentTimeMillis() -
-                TimeUnit.SECONDS.toMillis(bootTimeOffsetSeconds.get())) {
+                TimeUnit.SECONDS.toMillis(issueTimeOffsetSeconds.get())) {
             errMsg.append("token issue time is not recent enough, issued at: ").append(issueDate);
             return false;
         }

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceUtils.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceUtils.java
@@ -161,7 +161,7 @@ public class InstanceUtils {
 
         final String prefix = hostname.substring(0, suffixIdx);
         for (String comp : prefix.split("\\.")) {
-            if (service.equals(comp)) {
+            if (service.equalsIgnoreCase(comp)) {
                 return true;
             }
         }

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProviderTest.java
@@ -268,6 +268,30 @@ public class InstanceIDJAGProviderTest {
     }
 
     @Test
+    public void testConfirmInstanceMixedCaseSanDNS() throws ProviderResourceException {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        // the workload generates its CSR with the mixed case client id as the
+        // service component of the sanDNS entry while ZTS lowercases the
+        // service name in the confirmation object, so the sanDNS service
+        // component comparison must ignore case
+
+        Map<String, String> attributes = testAttributes();
+        attributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, ID_JAG_CLIENT_ID + ".sports.id-jag.athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttestationData(generateIdJagToken(Duration.ZERO, testClaims()));
+        confirmation.setAttributes(attributes);
+
+        InstanceConfirmation confirmResponse = provider.confirmInstance(confirmation);
+        assertNotNull(confirmResponse);
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_USAGE), "client");
+    }
+
+    @Test
     public void testConfirmInstanceInvalidDomain() {
 
         InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceIDJAGProviderTest.java
@@ -1,0 +1,648 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.yahoo.athenz.auth.token.jwts.JwtsHelper;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ProviderResourceException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class InstanceIDJAGProviderTest {
+
+    private final File ecPrivateKey = new File("./src/test/resources/unit_test_ec_private.key");
+
+    private final ClassLoader classLoader = this.getClass().getClassLoader();
+
+    private static final String ID_JAG_ISSUER = "https://ouryahoo-qa.oktapreview.com/oauth2/auszk0d21jOU4XApV1d7";
+    private static final String ID_JAG_AUDIENCE = "https://ouryahoo-qa.oktapreview.com/oauth2/auszk0d21jOU4XApV1d7";
+    private static final String ID_JAG_DOMAIN = "sports";
+    private static final String ID_JAG_CLIENT_ID = "wlp12tsy8084bo8FU1d8";
+    private static final String ID_JAG_SERVICE = "wlp12tsy8084bo8fu1d8";
+    private static final String ID_JAG_SUB_PROFILE = "ai_agent";
+
+    private static Map<String, Object> actClaim() {
+
+        Map<String, Object> innerAct = new LinkedHashMap<>();
+        innerAct.put("sub", "0oa12h8wsb9KwK0fY1d8");
+        innerAct.put("sub_profile", "service");
+
+        Map<String, Object> middleAct = new LinkedHashMap<>();
+        middleAct.put("act", innerAct);
+        middleAct.put("sub", "wlp12h9yjhs9WonAM1d8");
+        middleAct.put("sub_profile", "ai_agent");
+
+        Map<String, Object> outerAct = new LinkedHashMap<>();
+        outerAct.put("act", middleAct);
+        outerAct.put("sub", ID_JAG_CLIENT_ID);
+        outerAct.put("sub_profile", ID_JAG_SUB_PROFILE);
+
+        return outerAct;
+    }
+
+    private static Map<String, Object> testClaims() {
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("iss", ID_JAG_ISSUER);
+        claims.put("aud", ID_JAG_AUDIENCE);
+        claims.put("sub", "0oa12h8wsb9KwK0fY1d8");
+        claims.put("client_id", ID_JAG_CLIENT_ID);
+        claims.put("act", actClaim());
+        return claims;
+    }
+
+    private static Map<String, String> testAttributes() {
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(InstanceProvider.ZTS_INSTANCE_ID, "id-jag-instance-001");
+        attributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI,
+                "spiffe://ns/default/sports/" + ID_JAG_SERVICE + ",athenz://instanceid/sys.auth.id_jag/id-jag-instance-001");
+        attributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, ID_JAG_SERVICE + ".sports.id-jag.athenz.io");
+        return attributes;
+    }
+
+    private static void setStandardProperties(final String jwksUri) {
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER, ID_JAG_ISSUER);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_AUDIENCE, ID_JAG_AUDIENCE);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_DOMAIN, ID_JAG_DOMAIN);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ACT_SUB_PROFILE, ID_JAG_SUB_PROFILE);
+    }
+
+    private InstanceIDJAGProvider createProvider(final String jwksResource) {
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource(jwksResource)).toString();
+        setStandardProperties(jwksUri);
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        provider.initialize("sys.auth.id_jag",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+        return provider;
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI);
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER);
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_AUDIENCE);
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_DOMAIN);
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_ACT_SUB_PROFILE);
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_PROVIDER_DNS_SUFFIX);
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_CERT_EXPIRY_TIME);
+    }
+
+    @Test
+    public void testInitializeWithConfig() {
+        setStandardProperties("https://test.jwks");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_PROVIDER_DNS_SUFFIX, "id-jag.athenz.io,jag.athenz.io");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_CERT_EXPIRY_TIME, "120");
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        provider.initialize("sys.auth.id_jag",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+
+        assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.CLASS);
+        assertEquals(provider.getSVIDType(), InstanceProvider.SVIDType.X509);
+        assertEquals(provider.dnsSuffixes.size(), 2);
+        assertEquals(provider.certExpiryTime, 120);
+        provider.close();
+    }
+
+    @Test
+    public void testInitializeWithOpenIdConfig() throws IOException {
+
+        File issuerFile = new File("./src/test/resources/config-openid/");
+        File configFile = new File("./src/test/resources/config-openid/.well-known/openid-configuration");
+        File jwksUriFile = new File("./src/test/resources/jwt_jwks.json");
+        InstanceSpaceliftProviderTest.createOpenIdConfigFile(configFile, jwksUriFile);
+
+        setStandardProperties("https://test.jwks");
+        System.clearProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER, "file://" + issuerFile.getCanonicalPath());
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        provider.initialize("sys.auth.id_jag",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+        assertNotNull(provider.jwtProcessor);
+        Files.delete(configFile.toPath());
+    }
+
+    @Test
+    public void testInitializeMissingDomain() {
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI, "https://test.jwks");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER, ID_JAG_ISSUER);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_AUDIENCE, ID_JAG_AUDIENCE);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ACT_SUB_PROFILE, ID_JAG_SUB_PROFILE);
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        try {
+            provider.initialize("sys.auth.id_jag",
+                    "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Domain not specified"));
+        }
+    }
+
+    @Test
+    public void testInitializeMissingAudience() {
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI, "https://test.jwks");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER, ID_JAG_ISSUER);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_DOMAIN, ID_JAG_DOMAIN);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ACT_SUB_PROFILE, ID_JAG_SUB_PROFILE);
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        try {
+            provider.initialize("sys.auth.id_jag",
+                    "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Audience not specified"));
+        }
+    }
+
+    @Test
+    public void testInitializeDefaultActSubProfile() {
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI, "https://test.jwks");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER, ID_JAG_ISSUER);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_AUDIENCE, ID_JAG_AUDIENCE);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_DOMAIN, ID_JAG_DOMAIN);
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        provider.initialize("sys.auth.id_jag",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+        assertEquals(provider.actSubProfile, "ai_agent");
+    }
+
+    @Test
+    public void testInitializeEmptyActSubProfile() {
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI, "https://test.jwks");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ISSUER, ID_JAG_ISSUER);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_AUDIENCE, ID_JAG_AUDIENCE);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_DOMAIN, ID_JAG_DOMAIN);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ACT_SUB_PROFILE, "");
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        try {
+            provider.initialize("sys.auth.id_jag",
+                    "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Act sub profile not specified"));
+        }
+    }
+
+    @Test
+    public void testInitializeMissingIssuer() {
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_JWKS_URI, "https://test.jwks");
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_AUDIENCE, ID_JAG_AUDIENCE);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_DOMAIN, ID_JAG_DOMAIN);
+        System.setProperty(InstanceIDJAGProvider.ID_JAG_PROP_ACT_SUB_PROFILE, ID_JAG_SUB_PROFILE);
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        try {
+            provider.initialize("sys.auth.id_jag",
+                    "class://com.yahoo.athenz.instance.provider.impl.InstanceIDJAGProvider", null, null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Issuer not specified"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstance() throws ProviderResourceException {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttestationData(generateIdJagToken(Duration.ZERO, testClaims()));
+        confirmation.setAttributes(testAttributes());
+
+        InstanceConfirmation confirmResponse = provider.confirmInstance(confirmation);
+        assertNotNull(confirmResponse);
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_REFRESH), "false");
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_USAGE), "client");
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_EXPIRY_TIME), "360");
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidDomain() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain("weather");
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttestationData(generateIdJagToken(Duration.ZERO, testClaims()));
+        confirmation.setAttributes(testAttributes());
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Domain: weather is not the configured domain: sports"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithSanIP() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, String> attributes = testAttributes();
+        attributes.put(InstanceProvider.ZTS_INSTANCE_SAN_IP, "10.1.1.1");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttributes(attributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Request must not have any sanIP addresses"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithHostname() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, String> attributes = testAttributes();
+        attributes.put(InstanceProvider.ZTS_INSTANCE_HOSTNAME, "host1.athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttributes(attributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Request must not have any hostname values"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithSanURI() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, String> attributes = testAttributes();
+        attributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "https://athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttributes(attributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Unable to validate certificate request URI values"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithoutAttestationData() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttributes(testAttributes());
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Service credentials not provided"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidToken() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks_empty.json");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttestationData(generateIdJagToken(Duration.ZERO, testClaims()));
+        confirmation.setAttributes(testAttributes());
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("no matching key(s) found"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceInvalidSanDNS() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, String> attributes = testAttributes();
+        attributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "host1.athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain(ID_JAG_DOMAIN);
+        confirmation.setService(ID_JAG_SERVICE);
+        confirmation.setAttestationData(generateIdJagToken(Duration.ZERO, testClaims()));
+        confirmation.setAttributes(attributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Unable to validate certificate request sanDNS entries"));
+        }
+    }
+
+    @Test
+    public void testRefreshNotSupported() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+        try {
+            provider.refreshInstance(null);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("ID JAG X.509 Certificates cannot be refreshed"));
+        }
+    }
+
+    @Test
+    public void testValidateSanUri() {
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        assertTrue(provider.validateSanUri(null));
+        assertTrue(provider.validateSanUri(""));
+        assertTrue(provider.validateSanUri("spiffe://ns/athenz.production/instanceid"));
+        assertTrue(provider.validateSanUri("athenz://instanceid/athenz.production/instanceid"));
+        assertTrue(provider.validateSanUri("athenz://instanceid/athenz.production/instanceid,spiffe://ns/athenz.production/instanceid"));
+        assertFalse(provider.validateSanUri("athenz://instanceid/athenz.production/instanceid,https://athenz.io"));
+        assertFalse(provider.validateSanUri("athenz://hostname/host1"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenWithoutJWTProcessor() {
+
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken("some-jwt", ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("JWT Processor not initialized"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenInvalidTokenType() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        // a standard id token type is not accepted as an id jag token
+
+        final String idToken = generateToken(JwtsHelper.TYPE_JWT, Duration.ZERO, testClaims());
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(idToken, ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("Unable to parse and validate token"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenIssuerMismatch() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, Object> claims = testClaims();
+        claims.put("iss", "https://some-other-issuer.com");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token issuer is not the configured issuer"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenAudienceMismatch() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, Object> claims = testClaims();
+        claims.put("aud", "https://some-other-audience.com");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token audience is not the configured audience"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenIssueTimeNotRecentEnough() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        final String token = generateIdJagToken(Duration.ofSeconds(400).negated(), testClaims());
+        assertFalse(provider.validateIDJAGToken(token, ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token issue time is not recent enough"));
+
+        // a token without an issue time at all is rejected as well
+
+        errMsg.setLength(0);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(null, testClaims()), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token issue time is not recent enough, issued at: null"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenMissingActClaim() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        // without the act claim at all
+
+        Map<String, Object> claims = testClaims();
+        claims.remove("act");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token does not contain required act claim"));
+
+        // with an act claim that is not a json object
+
+        claims.put("act", ID_JAG_CLIENT_ID);
+        errMsg.setLength(0);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token does not contain required act claim"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenSubProfileMismatch() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        // the outermost actor carries a profile we're not configured for
+
+        Map<String, Object> act = actClaim();
+        act.put("sub_profile", "service");
+        Map<String, Object> claims = testClaims();
+        claims.put("act", act);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token act sub_profile: service does not match configured value: ai_agent"));
+
+        // the outermost actor carries no profile at all
+
+        act.remove("sub_profile");
+        claims.put("act", act);
+        errMsg.setLength(0);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token act sub_profile: null does not match configured value: ai_agent"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenMissingActSubject() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, Object> act = actClaim();
+        act.remove("sub");
+        Map<String, Object> claims = testClaims();
+        claims.put("act", act);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token act claim does not contain required sub field"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenMissingClientId() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, Object> claims = testClaims();
+        claims.remove("client_id");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token does not contain required client_id claim"));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenClientIdActSubMismatch() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        Map<String, Object> claims = testClaims();
+        claims.put("client_id", "wlp12h9yjhs9WonAM1d8");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateIDJAGToken(generateIdJagToken(Duration.ZERO, claims), ID_JAG_SERVICE, errMsg));
+        assertTrue(errMsg.toString().contains("token client_id: wlp12h9yjhs9WonAM1d8 does not match act sub: "
+                + ID_JAG_CLIENT_ID));
+    }
+
+    @Test
+    public void testValidateIDJAGTokenServiceMismatch() {
+
+        InstanceIDJAGProvider provider = createProvider("jwt_jwks.json");
+
+        StringBuilder errMsg = new StringBuilder(256);
+        final String token = generateIdJagToken(Duration.ZERO, testClaims());
+        assertFalse(provider.validateIDJAGToken(token, "api", errMsg));
+        assertTrue(errMsg.toString().contains("service name: api does not match token client_id: " + ID_JAG_CLIENT_ID));
+    }
+
+    @Test
+    public void testGetActStringField() {
+        InstanceIDJAGProvider provider = new InstanceIDJAGProvider();
+        Map<String, Object> act = new HashMap<>();
+        act.put("sub", "service1");
+        act.put("act", new HashMap<>());
+        assertEquals(provider.getActStringField(act, "sub"), "service1");
+        assertNull(provider.getActStringField(act, "act"));
+        assertNull(provider.getActStringField(act, "sub_profile"));
+    }
+
+    private String generateIdJagToken(Duration issuedAtOffset, Map<String, ?> claims) {
+        return generateToken(JwtsHelper.TYPE_JWT_JAG, issuedAtOffset, claims);
+    }
+
+    private String generateToken(final String tokenType, Duration issuedAtOffset, Map<String, ?> claims) {
+
+        try {
+            PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+
+            // a null offset generates a token without any issue time
+
+            JWSSigner signer = new ECDSASigner((ECPrivateKey) privateKey);
+            JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder()
+                    .expirationTime(Date.from(Instant.now().plusSeconds(3600)));
+            if (issuedAtOffset != null) {
+                claimsSetBuilder.expirationTime(Date.from(Instant.now().plus(issuedAtOffset).plusSeconds(3600)))
+                        .issueTime(Date.from(Instant.now().plus(issuedAtOffset)));
+            }
+            claims.forEach(claimsSetBuilder::claim);
+
+            SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256)
+                    .type(new JOSEObjectType(tokenType)).keyID("eckey1").build(), claimsSetBuilder.build());
+            signedJWT.sign(signer);
+            return signedJWT.serialize();
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Adds InstanceIDJAGProvider, a class based Copper Argos provider that issues X.509 client certificates to workloads - typically AI agents - authenticating with an Identity Assertion JWT Authorization Grant (ID-JAG) token as their attestation data.

The provider validates the token signature against the configured issuer's JWKS, requires the oauth-id-jag+jwt token type, and checks the issuer, audience and issue time claims. It then requires the outermost actor in the act claim to carry the configured sub_profile value (default ai_agent) and the client_id claim to match that actor's sub field. The requested identity must be in the configured domain and its service name must be the client id.

Also makes the sanDNS service name component comparison in InstanceUtils case-insensitive since ZTS lowercases service names while client ids may be mixed case.

# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [ ] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

