### PR TITLE
Make the GitHub OIDC token request timeout and retry configurable

### DIFF
--- a/provider/github/sia-actions/authn.go
+++ b/provider/github/sia-actions/authn.go
@@ -20,6 +20,8 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io"
+	"log"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,7 +34,82 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
+const (
+	// DefaultOIDCRequestTimeout is the timeout applied to the http request
+	// carried out against the GitHub OIDC token endpoint.
+	DefaultOIDCRequestTimeout = 10 * time.Second
+
+	// DefaultOIDCRequestRetries is the number of additional attempts carried out
+	// when the OIDC token request fails with a transient error. The default of 0
+	// retains the original single attempt behavior.
+	DefaultOIDCRequestRetries = 0
+
+	// DefaultOIDCRequestRetryDelay is the base delay for the exponential backoff
+	// applied between retry attempts.
+	DefaultOIDCRequestRetryDelay = time.Second
+
+	// maxOIDCRequestRetryDelay is the ceiling applied to the exponential backoff
+	// so that the delay between attempts cannot grow without bound.
+	maxOIDCRequestRetryDelay = 30 * time.Second
+)
+
+// OIDCTokenOptions carries the tunables for the http request issued against the
+// GitHub OIDC token endpoint. Use DefaultOIDCTokenOptions to obtain a value
+// pre-populated with the defaults and override only the fields of interest.
+type OIDCTokenOptions struct {
+	// RequestTimeout is the http client timeout for a single attempt. It must be
+	// greater than 0 - a value of 0 is rejected rather than being passed through
+	// to http.Client, where it would mean no timeout at all.
+	RequestTimeout time.Duration
+
+	// Retries is the number of additional attempts carried out when the request
+	// fails with a transient error. 0 disables retries.
+	Retries int
+
+	// RetryDelay is the base delay for the exponential backoff between attempts.
+	// The effective delay is jittered and capped at maxOIDCRequestRetryDelay.
+	RetryDelay time.Duration
+}
+
+// DefaultOIDCTokenOptions returns the OIDC token request options with the
+// default settings applied.
+func DefaultOIDCTokenOptions() OIDCTokenOptions {
+	return OIDCTokenOptions{
+		RequestTimeout: DefaultOIDCRequestTimeout,
+		Retries:        DefaultOIDCRequestRetries,
+		RetryDelay:     DefaultOIDCRequestRetryDelay,
+	}
+}
+
+func (options OIDCTokenOptions) validate() error {
+	if options.RequestTimeout <= 0 {
+		return fmt.Errorf("invalid oidc request timeout: %v - must be greater than 0", options.RequestTimeout)
+	}
+	if options.Retries < 0 {
+		return fmt.Errorf("invalid oidc request retries: %d - must not be negative", options.Retries)
+	}
+	if options.Retries > 0 && options.RetryDelay <= 0 {
+		return fmt.Errorf("invalid oidc request retry delay: %v - must be greater than 0", options.RetryDelay)
+	}
+	return nil
+}
+
+// GetOIDCToken retrieves the OIDC token from the GitHub Actions token endpoint
+// for the given audience using the default request options.
 func GetOIDCToken(ztsUrl string) (string, map[string]interface{}, error) {
+	return GetOIDCTokenWithOptions(ztsUrl, DefaultOIDCTokenOptions())
+}
+
+// GetOIDCTokenWithOptions retrieves the OIDC token from the GitHub Actions token
+// endpoint for the given audience, honoring the given request options. GitHub's
+// token endpoint is occasionally slow enough to exceed the default 10 second
+// timeout, which fails the identity request outright, so the caller is given the
+// ability to extend the timeout and, optionally, to retry transient failures.
+func GetOIDCTokenWithOptions(ztsUrl string, options OIDCTokenOptions) (string, map[string]interface{}, error) {
+
+	if err := options.validate(); err != nil {
+		return "", nil, err
+	}
 
 	requestUrl := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
 	if requestUrl == "" {
@@ -56,20 +133,9 @@ func GetOIDCToken(ztsUrl string) (string, map[string]interface{}, error) {
 	req.Header.Add("User-Agent", "actions/oidc-client")
 	req.Header.Add("Authorization", "Bearer "+requestToken)
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
+	contents, err := fetchOIDCToken(req, options)
 	if err != nil {
-		return "", nil, fmt.Errorf("unable to execute http get request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", nil, fmt.Errorf("oidc token get status error: %d", resp.StatusCode)
-	}
-
-	contents, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", nil, fmt.Errorf("uanble to read response body: %v", err)
+		return "", nil, err
 	}
 
 	var jsonData map[string]interface{}
@@ -91,6 +157,92 @@ func GetOIDCToken(ztsUrl string) (string, map[string]interface{}, error) {
 		return "", nil, fmt.Errorf("unable to extract oidc token claims: %v", err)
 	}
 	return oidcToken, claims, nil
+}
+
+// fetchOIDCToken carries out the token request, retrying transient failures up
+// to options.Retries additional times. Only the token fetch is retried - the
+// caller has not written any state at this point - and only failures that stand
+// a chance of succeeding on a subsequent attempt are retried.
+func fetchOIDCToken(req *http.Request, options OIDCTokenOptions) ([]byte, error) {
+
+	client := &http.Client{Timeout: options.RequestTimeout}
+
+	var lastErr error
+	for attempt := 0; attempt <= options.Retries; attempt++ {
+		if attempt > 0 {
+			delay := oidcRetryDelay(options.RetryDelay, attempt-1)
+			log.Printf("oidc token request failed: %v - retrying in %v (attempt %d of %d)\n", lastErr, delay, attempt+1, options.Retries+1)
+			time.Sleep(delay)
+		}
+		contents, retryable, err := oidcTokenRequest(client, req)
+		if err == nil {
+			return contents, nil
+		}
+		lastErr = err
+		if !retryable {
+			return nil, err
+		}
+	}
+	return nil, lastErr
+}
+
+// oidcTokenRequest carries out a single token request attempt and reports
+// whether the failure, if any, is worth retrying.
+func oidcTokenRequest(client *http.Client, req *http.Request) ([]byte, bool, error) {
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// transport level failures, which include the client timeout being
+		// exceeded, are the transient case we are guarding against
+		return nil, true, fmt.Errorf("unable to execute http get request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, retryableStatusCode(resp.StatusCode), fmt.Errorf("oidc token get status error: %d", resp.StatusCode)
+	}
+
+	contents, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false, fmt.Errorf("uanble to read response body: %v", err)
+	}
+	return contents, false, nil
+}
+
+// retryableStatusCode reports whether the given status code represents a
+// transient server side failure. Client errors - an invalid request or a
+// rejected credential - will fail identically on every attempt, so they are
+// returned to the caller right away.
+func retryableStatusCode(statusCode int) bool {
+	switch statusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	}
+	return statusCode >= http.StatusInternalServerError
+}
+
+// oidcRetryDelay returns the jittered exponential backoff delay for the given
+// zero based retry attempt. The delay is doubled per attempt but capped at
+// maxOIDCRequestRetryDelay, so it cannot overflow or grow without bound, and it
+// is jittered so that concurrent jobs failing at the same instant do not march
+// back into the token endpoint in lockstep.
+func oidcRetryDelay(baseDelay time.Duration, attempt int) time.Duration {
+
+	delay := baseDelay
+	for i := 0; i < attempt && delay < maxOIDCRequestRetryDelay; i++ {
+		delay *= 2
+	}
+	if delay > maxOIDCRequestRetryDelay {
+		delay = maxOIDCRequestRetryDelay
+	}
+
+	// apply jitter over the upper half of the interval so that the delay stays
+	// within [delay/2, delay]
+	half := delay / 2
+	if half <= 0 {
+		return delay
+	}
+	return half + time.Duration(rand.Int63n(int64(half)+1))
 }
 
 func GetCSRDetails(privateKey *rsa.PrivateKey, domain, service, provider, instanceId, dnsDomain, spiffeTrustDomain, subjC, subjO, subjOU string) (string, error) {

--- a/provider/github/sia-actions/authn.go
+++ b/provider/github/sia-actions/authn.go
@@ -204,7 +204,7 @@ func oidcTokenRequest(client *http.Client, req *http.Request) ([]byte, bool, err
 
 	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, false, fmt.Errorf("uanble to read response body: %v", err)
+		return nil, false, fmt.Errorf("unable to read response body: %v", err)
 	}
 	return contents, false, nil
 }

--- a/provider/github/sia-actions/authn_test.go
+++ b/provider/github/sia-actions/authn_test.go
@@ -27,10 +27,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// validOIDCToken is a signed jwt carrying the run_id, enterprise, repository,
+// sub and event_name claims the provider reads.
+const validOIDCToken = "eyJraWQiOiIwIiwiYWxnIjoiRVMyNTYifQ.eyJleHAiOjE3MDgwMjc4MTcsImlzcyI6Imh0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20iLCJhdWQiOiJodHRwczovL2F0aGVuei5pbyIsInJ1bl9pZCI6IjAwMDEiLCJlbnRlcnByaXNlIjoiYXRoZW56Iiwic3ViIjoicmVwbzphdGhlbnovc2lhOnJlZjpyZWZzL2hlYWRzL21haW4iLCJldmVudF9uYW1lIjoicHVzaCIsImlhdCI6MTcwODAyNDIxN30.ykt6O1mIjIjalTrmaU9AuSSsQghZ7Mx61gDsjVPHV0-SCqYpZNy7RtEbvgjKVCZ0kJ6BijH3aEf3EGArLHjTOQ"
 
 type customFormatter struct{}
 
@@ -59,9 +66,7 @@ func startHttpServer(token string, statusCode int) *httptest.Server {
 
 func TestGetOIDCToken(t *testing.T) {
 
-	validToken := "eyJraWQiOiIwIiwiYWxnIjoiRVMyNTYifQ.eyJleHAiOjE3MDgwMjc4MTcsImlzcyI6Imh0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20iLCJhdWQiOiJodHRwczovL2F0aGVuei5pbyIsInJ1bl9pZCI6IjAwMDEiLCJlbnRlcnByaXNlIjoiYXRoZW56Iiwic3ViIjoicmVwbzphdGhlbnovc2lhOnJlZjpyZWZzL2hlYWRzL21haW4iLCJldmVudF9uYW1lIjoicHVzaCIsImlhdCI6MTcwODAyNDIxN30.ykt6O1mIjIjalTrmaU9AuSSsQghZ7Mx61gDsjVPHV0-SCqYpZNy7RtEbvgjKVCZ0kJ6BijH3aEf3EGArLHjTOQ"
-
-	ts := startHttpServer(validToken, http.StatusOK)
+	ts := startHttpServer(validOIDCToken, http.StatusOK)
 	defer ts.Close()
 
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", ts.URL+"/oidc?type=jwt")
@@ -139,4 +144,219 @@ func TestGetCSRDetailsWithCustomSpiffeFormatter(t *testing.T) {
 	parsedCSR, err := x509.ParseCertificateRequest(block.Bytes)
 	assert.Nil(t, err)
 	assert.Equal(t, "spiffe://custom.github/svc/sports/api", parsedCSR.URIs[0].String())
+}
+
+// startCountingHttpServer returns a server that fails the first failureCount
+// requests with the given status code and serves the token afterwards, along
+// with a counter of the requests it has received.
+func startCountingHttpServer(token string, failureStatusCode, failureCount int) (*httptest.Server, *int32) {
+	var requests int32
+	router := http.NewServeMux()
+	router.HandleFunc("GET /oidc", func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&requests, 1) <= int32(failureCount) {
+			w.WriteHeader(failureStatusCode)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "{\"value\": \""+token+"\"}")
+	})
+	return httptest.NewServer(router), &requests
+}
+
+// startSlowHttpServer returns a server that waits for the given delay before
+// serving the token, so that a request timeout can be exercised.
+func startSlowHttpServer(token string, delay time.Duration) *httptest.Server {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /oidc", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "{\"value\": \""+token+"\"}")
+	})
+	return httptest.NewServer(router)
+}
+
+func TestDefaultOIDCTokenOptions(t *testing.T) {
+
+	// the defaults must retain the original behavior: a 10 second timeout
+	// and no retries
+
+	options := DefaultOIDCTokenOptions()
+	assert.Equal(t, 10*time.Second, options.RequestTimeout)
+	assert.Equal(t, DefaultOIDCRequestTimeout, options.RequestTimeout)
+	assert.Equal(t, 0, options.Retries)
+	assert.Equal(t, time.Second, options.RetryDelay)
+	assert.Nil(t, options.validate())
+}
+
+func TestGetOIDCTokenWithOptions(t *testing.T) {
+
+	ts := startHttpServer(validOIDCToken, http.StatusOK)
+	defer ts.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", ts.URL+"/oidc?type=jwt")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-token")
+
+	options := DefaultOIDCTokenOptions()
+	options.RequestTimeout = 30 * time.Second
+	_, claims, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.Nil(t, err)
+	assert.Equal(t, "0001", claims["run_id"].(string))
+}
+
+func TestGetOIDCTokenWithOptionsCustomTimeoutHonored(t *testing.T) {
+
+	// the server takes longer than our short timeout, so the request must fail,
+	// and then succeed once the timeout is extended past the server's delay
+
+	ts := startSlowHttpServer(validOIDCToken, 300*time.Millisecond)
+	defer ts.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", ts.URL+"/oidc?type=jwt")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-token")
+
+	options := DefaultOIDCTokenOptions()
+	options.RequestTimeout = 50 * time.Millisecond
+	_, _, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.True(t, strings.HasPrefix(err.Error(), "unable to execute http get request:"), err.Error())
+
+	options.RequestTimeout = 30 * time.Second
+	_, claims, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.Nil(t, err)
+	assert.Equal(t, "0001", claims["run_id"].(string))
+}
+
+func TestGetOIDCTokenWithOptionsInvalidTimeout(t *testing.T) {
+
+	// a 0 timeout must be rejected rather than silently handed to http.Client,
+	// where it means no timeout at all
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "http://localhost:0/oidc?type=jwt")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-token")
+
+	options := DefaultOIDCTokenOptions()
+	options.RequestTimeout = 0
+	_, _, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid oidc request timeout: 0s - must be greater than 0", err.Error())
+
+	options.RequestTimeout = -5 * time.Second
+	_, _, err = GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid oidc request timeout: -5s - must be greater than 0", err.Error())
+}
+
+func TestGetOIDCTokenWithOptionsInvalidRetries(t *testing.T) {
+
+	options := DefaultOIDCTokenOptions()
+	options.Retries = -1
+	_, _, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid oidc request retries: -1 - must not be negative", err.Error())
+}
+
+func TestGetOIDCTokenWithOptionsInvalidRetryDelay(t *testing.T) {
+
+	options := DefaultOIDCTokenOptions()
+	options.Retries = 2
+	options.RetryDelay = 0
+	_, _, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.Equal(t, "invalid oidc request retry delay: 0s - must be greater than 0", err.Error())
+
+	// the retry delay is irrelevant when retries are disabled, so it must not
+	// be rejected in that case
+	options.Retries = 0
+	assert.Nil(t, options.validate())
+}
+
+func TestGetOIDCTokenWithOptionsRetriesTransientFailure(t *testing.T) {
+
+	ts, requests := startCountingHttpServer(validOIDCToken, http.StatusServiceUnavailable, 2)
+	defer ts.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", ts.URL+"/oidc?type=jwt")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-token")
+
+	options := DefaultOIDCTokenOptions()
+	options.Retries = 3
+	options.RetryDelay = time.Millisecond
+	_, claims, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.Nil(t, err)
+	assert.Equal(t, "0001", claims["run_id"].(string))
+	assert.Equal(t, int32(3), atomic.LoadInt32(requests))
+}
+
+func TestGetOIDCTokenWithOptionsRetriesExhausted(t *testing.T) {
+
+	ts, requests := startCountingHttpServer(validOIDCToken, http.StatusBadGateway, 100)
+	defer ts.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", ts.URL+"/oidc?type=jwt")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-token")
+
+	options := DefaultOIDCTokenOptions()
+	options.Retries = 2
+	options.RetryDelay = time.Millisecond
+	_, _, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.Equal(t, "oidc token get status error: 502", err.Error())
+	assert.Equal(t, int32(3), atomic.LoadInt32(requests))
+}
+
+func TestGetOIDCTokenWithOptionsNoRetryOnPermanentFailure(t *testing.T) {
+
+	// a rejected credential fails identically on every attempt, so retrying it
+	// only multiplies the wait
+
+	ts, requests := startCountingHttpServer(validOIDCToken, http.StatusForbidden, 100)
+	defer ts.Close()
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", ts.URL+"/oidc?type=jwt")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "test-token")
+
+	options := DefaultOIDCTokenOptions()
+	options.Retries = 5
+	options.RetryDelay = time.Millisecond
+	_, _, err := GetOIDCTokenWithOptions("https://athenz.io", options)
+	assert.NotNil(t, err)
+	assert.Equal(t, "oidc token get status error: 403", err.Error())
+	assert.Equal(t, int32(1), atomic.LoadInt32(requests))
+}
+
+func TestRetryableStatusCode(t *testing.T) {
+
+	assert.True(t, retryableStatusCode(http.StatusRequestTimeout))
+	assert.True(t, retryableStatusCode(http.StatusTooManyRequests))
+	assert.True(t, retryableStatusCode(http.StatusInternalServerError))
+	assert.True(t, retryableStatusCode(http.StatusBadGateway))
+	assert.True(t, retryableStatusCode(http.StatusServiceUnavailable))
+	assert.True(t, retryableStatusCode(http.StatusGatewayTimeout))
+
+	assert.False(t, retryableStatusCode(http.StatusBadRequest))
+	assert.False(t, retryableStatusCode(http.StatusUnauthorized))
+	assert.False(t, retryableStatusCode(http.StatusForbidden))
+	assert.False(t, retryableStatusCode(http.StatusNotFound))
+}
+
+func TestOidcRetryDelay(t *testing.T) {
+
+	// the delay doubles per attempt and is jittered into the upper half of the
+	// interval, so each value must fall within [delay/2, delay]
+
+	for attempt, expected := range []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second} {
+		delay := oidcRetryDelay(time.Second, attempt)
+		assert.True(t, delay >= expected/2 && delay <= expected, "attempt %d: %v", attempt, delay)
+	}
+
+	// a delay too small to jitter is returned as is
+	assert.Equal(t, time.Duration(1), oidcRetryDelay(time.Duration(1), 0))
+
+	// the backoff must be clamped rather than growing without bound or
+	// overflowing for large attempt counts
+	for _, attempt := range []int{10, 62, 63, 64, 1000} {
+		delay := oidcRetryDelay(time.Second, attempt)
+		assert.True(t, delay >= maxOIDCRequestRetryDelay/2 && delay <= maxOIDCRequestRetryDelay,
+			"attempt %d: %v", attempt, delay)
+	}
 }

--- a/provider/github/sia-actions/cmd/siad/main.go
+++ b/provider/github/sia-actions/cmd/siad/main.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
@@ -39,7 +40,7 @@ func main() {
 	var ztsURL, domain, service, spiffeTrustDomain, subjC, subjO, subjOU, provider string
 	var caCertFile, keyFile, certFile, signerCertFile, dnsDomain, oidcTokenAudience, oidcKeyType string
 	var showVersion, getOIDCToken bool
-	var expiryTime int
+	var expiryTime, oidcRequestTimeout, oidcRequestRetries, oidcRequestRetryDelay int
 	flag.IntVar(&expiryTime, "expiry-time", 360, "expiry time in minutes (optional)")
 	flag.StringVar(&keyFile, "key-file", "", "output private key file")
 	flag.StringVar(&certFile, "cert-file", "", "output certificate file")
@@ -57,6 +58,9 @@ func main() {
 	flag.BoolVar(&getOIDCToken, "get-oidc-token", false, "Get OIDC token from Athenz ZTS along with X.509 identity certificate")
 	flag.StringVar(&oidcTokenAudience, "oidc-token-audience", "", "OIDC token audience (optional)")
 	flag.StringVar(&oidcKeyType, "oidc-key-type", "EC", "OIDC token signing key type: RSA/EC (optional)")
+	flag.IntVar(&oidcRequestTimeout, "oidc-request-timeout", 10, "timeout in seconds for the GitHub OIDC token request (optional)")
+	flag.IntVar(&oidcRequestRetries, "oidc-request-retries", 0, "number of retries for transient GitHub OIDC token request failures (optional)")
+	flag.IntVar(&oidcRequestRetryDelay, "oidc-request-retry-delay", 1, "base delay in seconds for the backoff between GitHub OIDC token request retries (optional)")
 	flag.BoolVar(&showVersion, "version", false, "Show version")
 	flag.Parse()
 
@@ -72,8 +76,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// get the oidc token for the GitHub actions
-	oidcToken, claims, err := sia.GetOIDCToken(ztsURL)
+	// get the oidc token for the GitHub actions. GitHub's token endpoint is
+	// occasionally slow enough to exceed the default timeout, so the timeout and
+	// an optional bounded retry of transient failures are both configurable.
+	oidcTokenOptions := sia.OIDCTokenOptions{
+		RequestTimeout: time.Duration(oidcRequestTimeout) * time.Second,
+		Retries:        oidcRequestRetries,
+		RetryDelay:     time.Duration(oidcRequestRetryDelay) * time.Second,
+	}
+	oidcToken, claims, err := sia.GetOIDCTokenWithOptions(ztsURL, oidcTokenOptions)
 	if err != nil {
 		log.Fatalf("unable to obtain oidc token from GitHub: %v\n", err)
 	}


### PR DESCRIPTION
# Description

Fixes #3474

`siad` fetched the GitHub Actions OIDC token with a hardcoded 10 second HTTP client timeout and no retry (`provider/github/sia-actions/authn.go`), with no way to change either. When GitHub's OIDC token endpoint is transiently slow the request exceeds that timeout and the whole identity mint fails, even though the failure is transient and a rerun succeeds. Consumers are left wrapping the entire action in a retry loop, paying for a full re-mint (RSA keygen, CSR, ZTS registration) to recover from a single slow HTTP GET.

## What changed

### `provider/github/sia-actions/authn.go`

- New `OIDCTokenOptions` struct — `RequestTimeout`, `Retries`, `RetryDelay` — plus `DefaultOIDCTokenOptions()` returning today's behaviour (10s timeout, no retries).
- New exported `GetOIDCTokenWithOptions(ztsUrl string, options OIDCTokenOptions)`.
- **`GetOIDCToken(ztsUrl string)` keeps its exact signature and behaviour**, now a thin wrapper over `GetOIDCTokenWithOptions` with the defaults. No caller has to change — `provider/harness/sia-harness` and `provider/buildkite/sia-buildkite`, which use this package's API, are untouched.
- Options are validated. A `RequestTimeout` of 0 or less is rejected with a clear error rather than being handed to `http.Client`, where `Timeout: 0` means *no* timeout at all — a hung request would hang the job indefinitely instead of failing in 10 seconds.

### Retry — off by default

- `Retries` defaults to `0`, so behaviour is unchanged unless explicitly asked for.
- Only transient failures are retried: a transport-level error (which is where the client timeout surfaces) or a `408`, `429` or `5xx` response. A rejected credential or a malformed request is returned to the caller immediately — it fails identically on every attempt, and retrying only multiplies the wait while someone is iterating on configuration.
- The backoff doubles per attempt, is clamped at 30s so it cannot grow without bound or overflow, and is jittered into `[delay/2, delay]` so that fan-out jobs failing at the same instant do not march back into the token endpoint in lockstep.
- Only the token fetch is retried, before any key or certificate has been written. This is the main advantage over a wrapper-level retry, which has to clear the read-only (`0400`) private key file between attempts or fail with a confusing `unable to write private key file: ...: permission denied`.

### `provider/github/sia-actions/cmd/siad/main.go`

Three new optional flags, all in seconds, all defaulting to the previous behaviour:

| Flag | Default | Meaning |
|---|---|---|
| `-oidc-request-timeout` | `10` | timeout for the GitHub OIDC token request |
| `-oidc-request-retries` | `0` | retries for transient OIDC token request failures |
| `-oidc-request-retry-delay` | `1` | base delay for the retry backoff |

## Tests

11 new tests in `authn_test.go` covering:

- the defaults are unchanged (10s timeout, 0 retries)
- a custom timeout is honoured in both directions — too short fails against a slow endpoint, extended succeeds against the same endpoint
- invalid values are rejected: a `0` and a negative timeout, negative retries, and a zero retry delay when retries are enabled
- transient failures are retried to success, and retries are correctly exhausted
- permanent failures are **not** retried, asserted by the server-side request count
- retryable status-code classification
- backoff clamping and jitter, including large attempt counts that would overflow an unbounded shift

Package coverage goes from 90.2% to 95.6%.

`go build ./provider/...`, `go vet ./provider/github/...` and `go test ./provider/github/... -race` all pass. (Two unrelated packages, `clients/go/zts/token` and `utils/hostdoc`, fail `go build ./...` with pre-existing missing `go.sum` entries on master; this PR does not touch `go.mod` or `go.sum`.)

## Note on the sibling providers

`provider/harness/sia-harness/authn.go#L97` has the identical hardcoded `&http.Client{Timeout: 10 * time.Second}` in its own `GetOIDCToken`. I have deliberately left it alone and scoped this PR to the GitHub provider, where the evidence is — happy to extend the same treatment to harness here or in a follow-up if you would prefer.

`provider/buildkite/sia-buildkite` is not affected: it receives the OIDC token via a `-build-kite-token` flag and makes no HTTP request for it.

Also happy to change the retry default from `0` to a small non-zero value if you would rather it be on by default.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**


