### PR TITLE
Support client-selected signing key type on the access token endpoint (key_type)

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/OAuthTokenRequestBuilder.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/OAuthTokenRequestBuilder.java
@@ -56,6 +56,7 @@ public class OAuthTokenRequestBuilder {
     String actor;
     String actorToken;
     String actorTokenType;
+    String keyType;
     long expiryTime = 0;
     boolean openIdIssuer = false;
     ServiceIdentityProvider clientAssertionProvider = null;
@@ -257,6 +258,16 @@ public class OAuthTokenRequestBuilder {
     }
 
     /**
+     * Set the signature key type for the access token request.
+     * @param keyType type of the signing key - RSA or EC
+     * @return this builder instance
+     */
+    public OAuthTokenRequestBuilder keyType(String keyType) {
+        this.keyType = keyType;
+        return this;
+    }
+
+    /**
      * Set the domain name for the request
      * @param domainName request domain name
      * @return this builder instance
@@ -336,6 +347,11 @@ public class OAuthTokenRequestBuilder {
         } else if (!ZTSClient.isEmpty(clientAssertion)) {
             cacheKey.append(";a=");
             cacheKey.append(DigestUtils.md5Hex(clientAssertion));
+        }
+
+        if (!ZTSClient.isEmpty(keyType)) {
+            cacheKey.append(";k=");
+            cacheKey.append(keyType);
         }
 
         return cacheKey.toString();
@@ -444,6 +460,10 @@ public class OAuthTokenRequestBuilder {
 
         if (!ZTSClient.isEmpty(actor)) {
             body.append("&actor=").append(URLEncoder.encode(actor, StandardCharsets.UTF_8));
+        }
+
+        if (!ZTSClient.isEmpty(keyType)) {
+            body.append("&key_type=").append(URLEncoder.encode(keyType, StandardCharsets.UTF_8));
         }
 
         return body.toString();

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/OAuthTokenRequestBuilderTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/OAuthTokenRequestBuilderTest.java
@@ -859,6 +859,51 @@ public class OAuthTokenRequestBuilderTest {
     }
 
     @Test
+    public void testGetRequestBodyWithKeyType() {
+        OAuthTokenRequestBuilder builder = OAuthTokenRequestBuilder.newBuilder(OAuthTokenRequestBuilder.OAUTH_GRANT_CLIENT_CREDENTIALS)
+                .domainName("test.domain")
+                .keyType("RSA");
+        String body = builder.getRequestBody();
+        assertNotNull(body);
+        assertTrue(body.contains("&key_type=RSA"));
+    }
+
+    @Test
+    public void testGetRequestBodyWithoutKeyType() {
+        OAuthTokenRequestBuilder builder = OAuthTokenRequestBuilder.newBuilder(OAuthTokenRequestBuilder.OAUTH_GRANT_CLIENT_CREDENTIALS)
+                .domainName("test.domain");
+        String body = builder.getRequestBody();
+        assertNotNull(body);
+        assertFalse(body.contains("key_type="));
+    }
+
+    @Test
+    public void testGetCacheKeyWithKeyType() {
+        OAuthTokenRequestBuilder builder = OAuthTokenRequestBuilder.newBuilder(OAuthTokenRequestBuilder.OAUTH_GRANT_CLIENT_CREDENTIALS)
+                .domainName("test.domain")
+                .keyType("RSA");
+        String cacheKey = builder.getCacheKey("principal.domain", "service", null);
+        assertNotNull(cacheKey);
+        assertTrue(cacheKey.contains(";k=RSA"));
+    }
+
+    @Test
+    public void testGetCacheKeyWithoutKeyType() {
+        OAuthTokenRequestBuilder builder = OAuthTokenRequestBuilder.newBuilder(OAuthTokenRequestBuilder.OAUTH_GRANT_CLIENT_CREDENTIALS)
+                .domainName("test.domain");
+        String cacheKey = builder.getCacheKey("principal.domain", "service", null);
+        assertNotNull(cacheKey);
+        assertFalse(cacheKey.contains(";k="));
+    }
+
+    @Test
+    public void testBuilderPatternKeyType() {
+        OAuthTokenRequestBuilder builder = OAuthTokenRequestBuilder.newBuilder(OAuthTokenRequestBuilder.OAUTH_GRANT_CLIENT_CREDENTIALS);
+        OAuthTokenRequestBuilder result = builder.keyType("EC");
+        assertSame(result, builder);
+    }
+
+    @Test
     public void testBuilderPatternClientAssertionProvider() {
         ServiceIdentityProvider provider = new ServiceIdentityProvider() {
             @Override

--- a/libs/go/sia/access/config/config.go
+++ b/libs/go/sia/access/config/config.go
@@ -26,6 +26,7 @@ type Role struct {
 	ProxyPrincipalSpiffeUris string   `json:"proxy_principal_spiffe_uris,omitempty"` // Proxy Principal Spiffe URIs to be included in the token
 	RoleInAudClaim           bool     `json:"role_in_aud_claim,omitempty"`           // include the role name in the audience claim when a single role is returned
 	UseOpenIDIssuer          bool     `json:"openid_issuer,omitempty"`               // use OpenID Connect issuer instead of default athenz issuer
+	KeyType                  string   `json:"key_type,omitempty"`                    // signing key type for the issued token - RSA or EC
 }
 
 // AccessToken is the type that holds information AFTER processing the configuration
@@ -41,6 +42,7 @@ type AccessToken struct {
 	ProxyPrincipalSpiffeUris string   // Proxy Principal Spiffe URIs to be included in the token
 	RoleInAudClaim           bool     // include the role name in the audience claim when a single role is returned
 	UseOpenIDIssuer          bool     // use OpenID Connect issuer instead of default athenz issuer
+	KeyType                  string   // signing key type for the issued token - RSA or EC
 }
 
 type StoreTokenOptions int

--- a/libs/go/sia/access/tokens/tokens.go
+++ b/libs/go/sia/access/tokens/tokens.go
@@ -162,7 +162,7 @@ func Fetch(opts *config.TokenOptions) ([]string, []error) {
 		}
 		client.AddCredentials(UserAgent, opts.UserAgent)
 
-		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris, t.RoleInAudClaim, t.UseOpenIDIssuer)))
+		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris, t.RoleInAudClaim, t.UseOpenIDIssuer, t.KeyType)))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("unable to post access token request for domain: %q, roles: %v, err: %v", t.Domain, t.Roles, err))
 			continue
@@ -226,7 +226,7 @@ func TokenDirs(root string, tokens []config.AccessToken) []string {
 	return dirs
 }
 
-func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string, roleInAudClaim bool, useOpenIDIssuer bool) string {
+func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string, roleInAudClaim bool, useOpenIDIssuer bool, keyType string) string {
 	params := url.Values{}
 	params.Add("grant_type", "client_credentials")
 	params.Add("expires_in", strconv.Itoa(expiryTime))
@@ -238,6 +238,9 @@ func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrinci
 	}
 	if useOpenIDIssuer {
 		params.Add("openid_issuer", "true")
+	}
+	if keyType != "" {
+		params.Add("key_type", keyType)
 	}
 
 	var scope string

--- a/libs/go/sia/access/tokens/tokens_test.go
+++ b/libs/go/sia/access/tokens/tokens_test.go
@@ -1080,12 +1080,12 @@ func assertParseJwt(a *assert.Assertions, token []byte) jwt.MapClaims {
 func TestMakeTokenRequestRoleInAudClaim(t *testing.T) {
 	a := assert.New(t)
 
-	withoutFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, false)
+	withoutFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, false, "")
 	v, err := url.ParseQuery(withoutFlag)
 	a.NoError(err)
 	a.Empty(v.Get("role_in_aud_claim"), "role_in_aud_claim should be absent when flag is false")
 
-	withFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", true, false)
+	withFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", true, false, "")
 	v, err = url.ParseQuery(withFlag)
 	a.NoError(err)
 	a.Equal("true", v.Get("role_in_aud_claim"), "role_in_aud_claim should be 'true' when flag is set")
@@ -1094,15 +1094,29 @@ func TestMakeTokenRequestRoleInAudClaim(t *testing.T) {
 func TestMakeTokenRequestOpenIDIssuer(t *testing.T) {
 	a := assert.New(t)
 
-	withoutFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, false)
+	withoutFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, false, "")
 	v, err := url.ParseQuery(withoutFlag)
 	a.NoError(err)
 	a.Empty(v.Get("openid_issuer"), "openid_issuer should be absent when flag is false")
 
-	withFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, true)
+	withFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, true, "")
 	v, err = url.ParseQuery(withFlag)
 	a.NoError(err)
 	a.Equal("true", v.Get("openid_issuer"), "openid_issuer should be 'true' when flag is set")
+}
+
+func TestMakeTokenRequestKeyType(t *testing.T) {
+	a := assert.New(t)
+
+	withoutKeyType := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, false, "")
+	v, err := url.ParseQuery(withoutKeyType)
+	a.NoError(err)
+	a.Empty(v.Get("key_type"), "key_type should be absent when not set")
+
+	withKeyType := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false, false, "EC")
+	v, err = url.ParseQuery(withKeyType)
+	a.NoError(err)
+	a.Equal("EC", v.Get("key_type"), "key_type should match the requested value when set")
 }
 
 // uid returns current user's uid

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -780,6 +780,7 @@ func processAccessTokens(config *sc.Config, processedSvcs []sc.Service) ([]ac.Ac
 			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
 			RoleInAudClaim:           t.RoleInAudClaim,
 			UseOpenIDIssuer:          t.UseOpenIDIssuer,
+			KeyType:                  t.KeyType,
 		})
 	}
 	return accessTokens, nil

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -815,6 +815,7 @@ func processAccessTokens(config *sc.Config, processedSvcs []sc.Service) ([]ac.Ac
 			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
 			RoleInAudClaim:           t.RoleInAudClaim,
 			UseOpenIDIssuer:          t.UseOpenIDIssuer,
+			KeyType:                  t.KeyType,
 		})
 	}
 	return accessTokens, nil

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2775,6 +2775,10 @@ public class ZTSImpl implements ZTSHandler {
             throw authError("Unauthenticated request", caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN, principalDomain);
         }
 
+        if (!StringUtil.isEmpty(accessTokenRequest.getKeyType())) {
+            validate(accessTokenRequest.getKeyType(), TYPE_SIMPLE_NAME, principalDomain, caller);
+        }
+
         // handle the request based on the type of token requested
 
         switch (accessTokenRequest.getRequestType()) {
@@ -2936,7 +2940,7 @@ public class ZTSImpl implements ZTSHandler {
 
         setAccessTokenConfirmation(accessToken, principal, accessTokenRequest);
 
-        ServerPrivateKey privateKey = getServerPrivateKey(keyAlgoForJsonWebObjects);
+        ServerPrivateKey privateKey = getSignPrivateKey(accessTokenRequest.getKeyType());
         String accessJwts = accessToken.getSignedToken(privateKey.getKey(), privateKey.getId(), privateKey.getAlgorithm());
 
         return new AccessTokenResponse().setAccess_token(accessJwts)
@@ -3126,7 +3130,7 @@ public class ZTSImpl implements ZTSHandler {
 
         setAccessTokenConfirmation(accessToken, principal, accessTokenRequest);
 
-        ServerPrivateKey privateKey = getServerPrivateKey(keyAlgoForJsonWebObjects);
+        ServerPrivateKey privateKey = getSignPrivateKey(accessTokenRequest.getKeyType());
         String accessJwts = accessToken.getSignedToken(privateKey.getKey(), privateKey.getId(), privateKey.getAlgorithm());
 
         return new AccessTokenResponse().setAccess_token(accessJwts)
@@ -3288,7 +3292,7 @@ public class ZTSImpl implements ZTSHandler {
         int tokenTimeout = determineOIDCIdTokenTimeout(principalDomain, subjectPrincipal.getFullName(), null);
         idToken.setExpiryTime(iat + tokenTimeout);
 
-        ServerPrivateKey signPrivateKey = getSignPrivateKey(null);
+        ServerPrivateKey signPrivateKey = getSignPrivateKey(accessTokenRequest.getKeyType());
         final String signedIdToken = idToken.getSignedToken(signPrivateKey.getKey(), signPrivateKey.getId(),
                 signPrivateKey.getAlgorithm());
 
@@ -3460,7 +3464,7 @@ public class ZTSImpl implements ZTSHandler {
             }
         }
 
-        ServerPrivateKey privateKey = getServerPrivateKey(keyAlgoForJsonWebObjects);
+        ServerPrivateKey privateKey = getSignPrivateKey(accessTokenRequest.getKeyType());
         String accessJwts = accessToken.getSignedToken(privateKey.getKey(), privateKey.getId(),
                 privateKey.getAlgorithm(), AccessToken.HDR_TOKEN_JAG);
 
@@ -3717,7 +3721,7 @@ public class ZTSImpl implements ZTSHandler {
 
         setAccessTokenConfirmation(accessToken, principal, accessTokenRequest);
 
-        ServerPrivateKey privateKey = getServerPrivateKey(keyAlgoForJsonWebObjects);
+        ServerPrivateKey privateKey = getSignPrivateKey(accessTokenRequest.getKeyType());
         String accessJwts = accessToken.getSignedToken(privateKey.getKey(), privateKey.getId(), privateKey.getAlgorithm());
 
         AccessTokenResponse response = new AccessTokenResponse().setAccess_token(accessJwts)
@@ -3883,7 +3887,7 @@ public class ZTSImpl implements ZTSHandler {
 
         setAccessTokenConfirmation(accessToken, principal, accessTokenRequest);
 
-        ServerPrivateKey privateKey = getServerPrivateKey(keyAlgoForJsonWebObjects);
+        ServerPrivateKey privateKey = getSignPrivateKey(accessTokenRequest.getKeyType());
         String accessJwts = accessToken.getSignedToken(privateKey.getKey(), privateKey.getId(), privateKey.getAlgorithm());
 
         // now let's check to see if we need to create openid token

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/token/AccessTokenRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/token/AccessTokenRequest.java
@@ -71,6 +71,7 @@ public class AccessTokenRequest {
     private static final String KEY_ACTOR_TOKEN_TYPE = "actor_token_type";
     private static final String KEY_FULL_ARN = "full_arn";
     private static final String KEY_ROLE_IN_AUD_CLAIM = "role_in_aud_claim";
+    private static final String KEY_KEY_TYPE = "key_type";
 
     private static final String OAUTH_ASSERTION_TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
@@ -93,6 +94,7 @@ public class AccessTokenRequest {
     String actor = null;
     String actorToken = null;
     String actorTokenType = null;
+    String keyType = null;
     List<String> proxyPrincipalsSpiffeUris = null;
     Principal principal = null;
     int expiryTime = 0;
@@ -186,6 +188,9 @@ public class AccessTokenRequest {
                     break;
                 case KEY_ACTOR_TOKEN_TYPE:
                     actorTokenType = value.toLowerCase();
+                    break;
+                case KEY_KEY_TYPE:
+                    keyType = value;
                     break;
             }
         }
@@ -481,6 +486,10 @@ public class AccessTokenRequest {
         return actorTokenType;
     }
 
+    public String getKeyType() {
+        return keyType;
+    }
+
     public RequestType getRequestType() {
         return requestType;
     }
@@ -594,6 +603,9 @@ public class AccessTokenRequest {
                 stringBuilder.append(URLEncoder.encode(uri, StandardCharsets.UTF_8)).append(',');
             }
             stringBuilder.setLength(stringBuilder.length() - 1);
+        }
+        if (!StringUtil.isEmpty(keyType)) {
+            stringBuilder.append("&key_type=").append(URLEncoder.encode(keyType, StandardCharsets.UTF_8));
         }
 
         // make sure our log line is limited to 1024 characters

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -732,6 +732,103 @@ public class ZTSImplAccessTokenTest {
     }
 
     @Test
+    public void testPostAccessTokenRequestKeyTypeRSA() throws JOSEException, ParseException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY, "src/test/resources/unit_test_zts_private_ec.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        // restore back to our default single key setup
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY);
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=U1;d=user_domain;n=user;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=client_credentials&scope=coretech:domain&key_type=RSA");
+        assertNotNull(resp);
+
+        String accessTokenStr = resp.getAccess_token();
+        assertNotNull(accessTokenStr);
+
+        SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
+        assertEquals(signedJWT.getHeader().getAlgorithm(), JWSAlgorithm.RS256);
+
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(ztsImpl.privateRSAKey.getKey()));
+        assertTrue(signedJWT.verify(verifier));
+    }
+
+    @Test
+    public void testPostAccessTokenRequestKeyTypeInvalidFallsBackToDefault() throws JOSEException, ParseException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY, "src/test/resources/unit_test_zts_private_ec.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        // restore back to our default single key setup
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY);
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=U1;d=user_domain;n=user;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        // a valid SimpleName, so it passes validation, but neither RSA
+        // nor EC - the server falls back to its default (EC) signing key
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=client_credentials&scope=coretech:domain&key_type=unknown-type");
+        assertNotNull(resp);
+
+        String accessTokenStr = resp.getAccess_token();
+        assertNotNull(accessTokenStr);
+
+        SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
+        assertEquals(signedJWT.getHeader().getAlgorithm(), JWSAlgorithm.ES256);
+
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(ztsImpl.privateECKey.getKey()));
+        assertTrue(signedJWT.verify(verifier));
+    }
+
+    @Test
+    public void testPostAccessTokenRequestKeyTypeInvalidSimpleName() {
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=U1;d=user_domain;n=user;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        try {
+            zts.postAccessTokenRequest(context,
+                    "grant_type=client_credentials&scope=coretech:domain&key_type=" +
+                            URLEncoder.encode("bad key", StandardCharsets.UTF_8));
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
+        }
+    }
+
+    @Test
     public void testPostAccessTokenRequestSingleRole() {
 
         System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/token/AccessTokenRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/token/AccessTokenRequestTest.java
@@ -1624,6 +1624,73 @@ public class AccessTokenRequestTest {
         }
     }
 
+    @Test
+    public void testAccessTokenRequestKeyType() {
+
+        AccessTokenRequest request = new AccessTokenRequest("grant_type=client_credentials&scope=coretech:role.writers"
+                + "&key_type=RSA", defaultConfigOptions);
+        assertNotNull(request);
+        assertEquals(request.getKeyType(), "RSA");
+
+        // value is not lower-cased since getSignPrivateKey uppercases internally
+        // and ZTSImpl validates it as a SimpleName
+
+        request = new AccessTokenRequest("grant_type=client_credentials&scope=coretech:role.writers"
+                + "&key_type=ec", defaultConfigOptions);
+        assertNotNull(request);
+        assertEquals(request.getKeyType(), "ec");
+    }
+
+    @Test
+    public void testAccessTokenRequestKeyTypeTokenExchange() {
+
+        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        String subjectToken = createToken(privateKey, "0", "user_domain.user",
+                "user_domain.proxy-user1", expiryTime, null);
+
+        AccessTokenRequest request = new AccessTokenRequest("grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+                + "&requested_token_type=urn:ietf:params:oauth:token-type:id-jag"
+                + "&audience=sports&subject_token=" + subjectToken
+                + "&scope=readers&key_type=RSA"
+                + "&subject_token_type=urn:ietf:params:oauth:token-type:id_token", defaultConfigOptions);
+        assertNotNull(request);
+        assertEquals(request.getRequestType(), AccessTokenRequest.RequestType.JAG_TOKEN_EXCHANGE);
+        assertEquals(request.getKeyType(), "RSA");
+    }
+
+    @Test
+    public void testAccessTokenRequestKeyTypeAbsentByDefault() {
+
+        AccessTokenRequest request = new AccessTokenRequest("grant_type=client_credentials&scope=test", defaultConfigOptions);
+        assertNotNull(request);
+        assertNull(request.getKeyType());
+    }
+
+    @Test
+    public void testAccessTokenRequestQueryDataWithKeyType() {
+
+        AccessTokenRequest request = new AccessTokenRequest("grant_type=client_credentials&scope=test&key_type=RSA",
+                defaultConfigOptions);
+        String queryData = request.getQueryLogData();
+        assertNotNull(queryData);
+        assertTrue(queryData.contains("scope=test"));
+        assertTrue(queryData.contains("&key_type=RSA"));
+    }
+
+    @Test
+    public void testAccessTokenRequestQueryDataWithoutKeyType() {
+
+        AccessTokenRequest request = new AccessTokenRequest("grant_type=client_credentials&scope=test",
+                defaultConfigOptions);
+        String queryData = request.getQueryLogData();
+        assertNotNull(queryData);
+        assertTrue(queryData.contains("scope=test"));
+        assertFalse(queryData.contains("key_type="));
+    }
+
     private String createAccessTokenAssertion(PrivateKey privateKey, String keyId, String subject,
             String audience, String issuer, long expiryTime, String scope, String tokenType) {
 

--- a/utils/zts-accesstoken/zts-accesstoken.go
+++ b/utils/zts-accesstoken/zts-accesstoken.go
@@ -58,7 +58,7 @@ func printVersion() {
 }
 
 func main() {
-	var domain, service, actor, svcKeyFile, svcCertFile, svcCACertFile, roles, ntokenFile, ztsURL, hdr, conf, accessToken, authzDetails, proxyPrincipalSpiffeUris string
+	var domain, service, actor, svcKeyFile, svcCertFile, svcCACertFile, roles, ntokenFile, ztsURL, hdr, conf, accessToken, authzDetails, proxyPrincipalSpiffeUris, keyType string
 	var grantType, subjectToken, subjectTokenType, requestedTokenType, audience, assertion, actorToken, actorTokenType string
 	var expireTime int
 	var proxy, validate, claims, tokenOnly, showVersion, roleInAudClaim, openidIssuer bool
@@ -84,6 +84,7 @@ func main() {
 	flag.StringVar(&actor, "actor", "", "actor that may request on behalf of the principal")
 	flag.BoolVar(&roleInAudClaim, "role-in-aud-claim", false, "include the role name in the audience claim when a single role is returned")
 	flag.BoolVar(&openidIssuer, "openid-issuer", false, "use OpenID Connect issuer instead of default athenz issuer")
+	flag.StringVar(&keyType, "key-type", "", "signing key type for the issued token - RSA or EC")
 	flag.StringVar(&grantType, "grant-type", "", "grant type: token-exchange (for ID-JAG issue or access token exchange) or jwt-bearer (for JAG exchange)")
 	flag.StringVar(&subjectToken, "subject-token", "", "file path to the subject token for token exchange")
 	flag.StringVar(&subjectTokenType, "subject-token-type", "urn:ietf:params:oauth:token-type:id_token", "subject token type")
@@ -115,7 +116,7 @@ func main() {
 	} else if grantType == "jwt-bearer" {
 		fetchAccessTokenViaJAG(domain, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, assertion, proxy, tokenOnly)
 	} else {
-		fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor, proxy, expireTime, tokenOnly, roleInAudClaim, openidIssuer)
+		fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor, proxy, expireTime, tokenOnly, roleInAudClaim, openidIssuer, keyType)
 	}
 }
 
@@ -176,7 +177,7 @@ func validateAccessToken(accessToken, conf string, showClaims bool) {
 	fmt.Println("Access Token successfully validated")
 }
 
-func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor string, proxy bool, expireTime int, tokenOnly bool, roleInAudClaim bool, openidIssuer bool) {
+func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor string, proxy bool, expireTime int, tokenOnly bool, roleInAudClaim bool, openidIssuer bool, keyType string) {
 
 	defaultConfig, _ := athenzutils.ReadDefaultConfig()
 	// check to see if we need to use zts url from our default config file
@@ -233,6 +234,11 @@ func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, s
 	if openidIssuer {
 		params := url.Values{}
 		params.Add("openid_issuer", "true")
+		request += "&" + params.Encode()
+	}
+	if keyType != "" {
+		params := url.Values{}
+		params.Add("key_type", keyType)
 		request += "&" + params.Encode()
 	}
 


### PR DESCRIPTION
# Description

Adds a `key_type` request parameter to the ZTS access-token endpoint
(`POST /zts/v1/oauth2/token`) that lets the caller select the signing key —
and therefore the JWS algorithm — for the issued token. This mirrors the
`keyType` query parameter the OIDC id-token endpoint
(`GET /zts/v1/oauth2/auth`) has supported since #1755.

Today every flow on the access-token endpoint signs with
`getServerPrivateKey(keyAlgoForJsonWebObjects)`, i.e. whatever the server-wide
`athenz.zts.key_algo_json_web_objects` property selects (default `EC` →
`ES256`). A relying party that can only verify RS256 therefore cannot be
served by the same ZTS instance as one expecting ES256 — the choice is
per-deployment, not per-request. The id-token flow already solved this with
`getSignPrivateKey(keyType)`; this change routes the access-token flows
through the same helper.

## Server (ZTS)

- `AccessTokenRequest` parses a new `key_type` form-body parameter and exposes
  it via `getKeyType()`.
- `postAccessTokenRequest` validates it as a `SimpleName` (same check
  `getOIDCResponse` applies to `keyType`), so one validation covers all
  request types on the endpoint.
- Every signing site on the endpoint now calls
  `getSignPrivateKey(accessTokenRequest.getKeyType())` instead of
  `getServerPrivateKey(keyAlgoForJsonWebObjects)`: standard
  `client_credentials`, access-token impersonation and delegation exchange,
  id-token exchange, and both JAG paths. The optional `openid`-scope id_token
  returned alongside a standard access token is signed with the same
  requested key.
- Behavior is unchanged when `key_type` is absent: `getSignPrivateKey("")`
  returns `getServerPrivateKey(keyAlgoForJsonWebObjects)`. As with the
  id-token flow, an unrecognized value or one the server has no key for falls
  back to the server default rather than erroring.
- No RDL / schema / generated-client change is needed — `key_type` is a
  form-body parameter parsed by `AccessTokenRequest`.

## Java client

- `OAuthTokenRequestBuilder.keyType(...)`, emitted as `key_type` in the
  request body and included in the cache key so a token signed with one
  algorithm isn't served from cache to a request asking for another.

## zts-accesstoken CLI

- New `-key-type` flag.

## SIA

- New `key_type` per-role option under `access_tokens`, threaded through the
  access-token request the SIA agent builds.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**
