### PR TITLE
nodejs auth_core: parse token claims only from the signed prefix

### DIFF
--- a/clients/nodejs/zpe/src/AuthZPEClient.js
+++ b/clients/nodejs/zpe/src/AuthZPEClient.js
@@ -74,7 +74,24 @@ class AuthZPEClient {
         if (!rToken) {
             logger.debug('allowAccess: Role Token Cache Miss');
 
-            rToken = new RoleToken(roleToken);
+            // parse the token - the constructor throws if the token
+            // is malformed (e.g. missing required components or an
+            // invalid signature component) so we must deny access
+            // rather than let the exception propagate to the caller
+            try {
+                rToken = new RoleToken(roleToken);
+            } catch (e) {
+                logger.error(
+                    'allowAccess: Authorization denied. Unable to parse token: ' +
+                        e.message +
+                        ' token=' +
+                        RoleToken.getUnsignedToken(roleToken)
+                );
+                return cb(
+                    'ERROR: Invalid Role Token',
+                    AccessCheckStatus.DENY_ROLETOKEN_INVALID
+                );
+            }
 
             // validate the token
             if (

--- a/clients/nodejs/zpe/test/unit/AuthZPEClient.js
+++ b/clients/nodejs/zpe/test/unit/AuthZPEClient.js
@@ -384,6 +384,24 @@ describe('AuthZPEClient', function () {
         );
     });
 
+    it('should test AuthZPEClient allowAccess with malformed token expecting result DENY_ROLETOKEN_INVALID', function () {
+        var resource = 'athenz.test:testresgroup.allow';
+        var action = 'read';
+        AuthZPEClient.allowAccess(
+            {
+                roleToken: 'v=Z1;r=users;s=signature',
+                resource: resource,
+                action: action,
+            },
+            (err, accessCheckStatus) => {
+                expect(err).to.equal('ERROR: Invalid Role Token');
+                expect(accessCheckStatus).to.deep.equal(
+                    'Access denied due to invalid RoleToken'
+                );
+            }
+        );
+    });
+
     it('should test AuthZPEClient allowAccess expecting result DENY_DOMAIN_MISMATCH', function () {
         var resource = 'athenz.test:testresgroup.allow';
         var action = 'read';

--- a/libs/nodejs/auth_core/src/token/PrincipalToken.js
+++ b/libs/nodejs/auth_core/src/token/PrincipalToken.js
@@ -52,10 +52,6 @@ class PrincipalToken extends Token {
 
     /*eslint complexity: ["error", 24]*/
     parseSignedToken(signedToken) {
-        logger.debug(
-            'Constructing PrincipalToken with input string: ' + signedToken
-        );
-
         if (!signedToken) {
             throw new Error('Input String signedToken must not be empty');
         }
@@ -84,12 +80,46 @@ class PrincipalToken extends Token {
          *    using Service's private Key for service tokens and ZMS service's
          *    private key for user tokens and y64 encoded
          */
+        var authzSvcToken = null;
         var idx = signedToken.indexOf(';s=');
         if (idx !== -1) {
             this._unsignedToken = signedToken.substring(0, idx);
+
+            /* we might have authorized service token details after the
+             * signature so we're going to extract our signature component */
+
+            var authzIdx = signedToken.indexOf(';', idx + 3);
+            if (
+                authzIdx !== -1 &&
+                signedToken.indexOf(';bs=', idx + 3) !== -1
+            ) {
+                this._signature = signedToken.substring(idx + 3, authzIdx);
+                authzSvcToken = signedToken.substring(authzIdx);
+            } else {
+                this._signature = signedToken.substring(idx + 3);
+            }
+
+            if (!Token.isValidSignature(this._signature)) {
+                throw new Error(
+                    'SignedToken contains an invalid signature component'
+                );
+            }
         }
 
-        var item = signedToken.split(';');
+        /* we must only extract our claims from the part of the token that
+         * is covered by the signature. otherwise anyone could append
+         * additional fields after the signature component and, since our
+         * parser is last-one-wins, override the signed values */
+
+        var parseToken = this._unsignedToken
+            ? this._unsignedToken
+            : signedToken;
+
+        logger.debug(
+            'Constructing PrincipalToken with input string: ' + parseToken
+        );
+
+        var item = parseToken.split(';');
         for (var i = 0; i < item.length; i++) {
             var kv = item[i].split('=');
             if (kv.length === 2) {
@@ -100,20 +130,14 @@ class PrincipalToken extends Token {
                     case 'b':
                         this._authorizedServices = kv[1].split(',');
                         break;
-                    case 'bk':
-                        this._authorizedServiceKeyId = kv[1];
-                        break;
-                    case 'bn':
-                        this._authorizedServiceName = kv[1];
-                        break;
-                    case 'bs':
-                        this._authorizedServiceSignature = kv[1];
-                        break;
                     case 'd':
                         this._domain = kv[1];
                         break;
                     case 'e':
-                        this._expiryTime = Number(kv[1]);
+                        this._expiryTime = Token.parseIntegerAttribute(
+                            kv[1],
+                            'expiry'
+                        );
                         break;
                     case 'h':
                         this._host = kv[1];
@@ -130,11 +154,11 @@ class PrincipalToken extends Token {
                     case 'o':
                         this._originalRequestor = kv[1];
                         break;
-                    case 's':
-                        this._signature = kv[1];
-                        break;
                     case 't':
-                        this._timestamp = Number(kv[1]);
+                        this._timestamp = Token.parseIntegerAttribute(
+                            kv[1],
+                            'timestamp'
+                        );
                         break;
                     case 'v':
                         this._version = kv[1];
@@ -142,6 +166,40 @@ class PrincipalToken extends Token {
                     case 'z':
                         this._keyService = kv[1];
                         break;
+                }
+            }
+        }
+
+        /* now process the authorized service token part. the bs signature
+         * covers the "...;s=<signature>;bk=<keyid>[;bn=<name>]" string so
+         * we only parse the fields that it protects */
+
+        if (authzSvcToken) {
+            idx = authzSvcToken.indexOf(';bs=');
+            if (idx !== -1) {
+                this._authorizedServiceSignature = authzSvcToken.substring(
+                    idx + 4
+                );
+
+                if (!Token.isValidSignature(this._authorizedServiceSignature)) {
+                    throw new Error(
+                        'SignedToken contains an invalid authorized service signature component'
+                    );
+                }
+
+                var authzItem = authzSvcToken.substring(0, idx).split(';');
+                for (var j = 0; j < authzItem.length; j++) {
+                    var authzKv = authzItem[j].split('=');
+                    if (authzKv.length === 2) {
+                        switch (authzKv[0]) {
+                            case 'bk':
+                                this._authorizedServiceKeyId = authzKv[1];
+                                break;
+                            case 'bn':
+                                this._authorizedServiceName = authzKv[1];
+                                break;
+                        }
+                    }
                 }
             }
         }

--- a/libs/nodejs/auth_core/src/token/RoleToken.js
+++ b/libs/nodejs/auth_core/src/token/RoleToken.js
@@ -49,10 +49,6 @@ class RoleToken extends Token {
 
     /*eslint complexity: ["error", 24]*/
     parseSignedToken(signedToken) {
-        logger.debug(
-            'Constructing RoleToken with input string: ' + signedToken
-        );
-
         if (!signedToken) {
             throw new Error('Input String signedToken must not be empty');
         }
@@ -81,10 +77,28 @@ class RoleToken extends Token {
         var idx = signedToken.indexOf(';s=');
         if (idx !== -1) {
             this._unsignedToken = signedToken.substring(0, idx);
+            this._signature = signedToken.substring(idx + 3);
+
+            if (!Token.isValidSignature(this._signature)) {
+                throw new Error(
+                    'SignedToken contains an invalid signature component'
+                );
+            }
         }
 
+        /* we must only extract our claims from the part of the token that
+         * is covered by the signature. otherwise anyone could append
+         * additional fields after the signature component and, since our
+         * parser is last-one-wins, override the signed values */
+
+        var parseToken = this._unsignedToken
+            ? this._unsignedToken
+            : signedToken;
+
+        logger.debug('Constructing RoleToken with input string: ' + parseToken);
+
         var roleNames = null;
-        var item = signedToken.split(';');
+        var item = parseToken.split(';');
         for (var i = 0; i < item.length; i++) {
             var kv = item[i].split('=');
             if (kv.length === 2) {
@@ -101,7 +115,10 @@ class RoleToken extends Token {
                         this._domain = kv[1];
                         break;
                     case 'e':
-                        this._expiryTime = Number(kv[1]);
+                        this._expiryTime = Token.parseIntegerAttribute(
+                            kv[1],
+                            'expiry'
+                        );
                         break;
                     case 'h':
                         this._host = kv[1];
@@ -118,11 +135,11 @@ class RoleToken extends Token {
                     case 'r':
                         roleNames = kv[1];
                         break;
-                    case 's':
-                        this._signature = kv[1];
-                        break;
                     case 't':
-                        this._timestamp = Number(kv[1]);
+                        this._timestamp = Token.parseIntegerAttribute(
+                            kv[1],
+                            'timestamp'
+                        );
                         break;
                     case 'proxy':
                         this._proxyUser = kv[1];

--- a/libs/nodejs/auth_core/src/token/Token.js
+++ b/libs/nodejs/auth_core/src/token/Token.js
@@ -223,6 +223,40 @@ class Token {
     }
 
     /**
+     * Helper method to verify that the given signature component only carries
+     * characters from the ybase64 alphabet. Node's base64 decoder silently
+     * skips characters outside of the alphabet, so without this check anyone
+     * could append arbitrary data after the signature component and still
+     * have the token pass signature validation.
+     * @param signature signature component extracted from a signed token
+     * @return true if the signature is well formed, false otherwise
+     **/
+    static isValidSignature(signature) {
+        return /^[a-zA-Z0-9._-]+$/.test(signature);
+    }
+
+    /**
+     * Helper method to parse a numeric token attribute (e.g. timestamp or
+     * expiry). Number() returns NaN for non-numeric input and every
+     * comparison against NaN evaluates to false which would silently bypass
+     * all of our time based validation checks, so we must reject any value
+     * that is not a well formed integer.
+     * @param value attribute value extracted from the token
+     * @param name attribute name used for the error message
+     * @return parsed integer value
+     **/
+    static parseIntegerAttribute(value, name) {
+        if (!/^-?\d+$/.test(value)) {
+            throw new Error(
+                'SignedToken contains invalid numeric value for ' +
+                    name +
+                    ' component'
+            );
+        }
+        return Number(value);
+    }
+
+    /**
      * Helper method to parse a credential to remove the signature from the
      * raw credential string. Returning the unsigned credential.
      * @param credential full token credentials including signature

--- a/libs/nodejs/auth_core/test/unit/token/PrincipalToken.js
+++ b/libs/nodejs/auth_core/test/unit/token/PrincipalToken.js
@@ -99,7 +99,7 @@ describe('PrincipalToken impl', function() {
 
   it('should test PrincipalToken: using signedToken: domain Null: result error', function() {
     try {
-      var principalToken = new PrincipalToken('v=U1;n=test;h=test.athenz.com;a=01234abc;t=10000;e=30;k=0;z=zms;o=athenz.ci.service;i=172.168.0.1;s=signature;');
+      var principalToken = new PrincipalToken('v=U1;n=test;h=test.athenz.com;a=01234abc;t=10000;e=30;k=0;z=zms;o=athenz.ci.service;i=172.168.0.1;s=signature');
     } catch (e) {
       expect(e.message).to.equal('SignedToken does not contain required domain component');
       return;
@@ -109,7 +109,7 @@ describe('PrincipalToken impl', function() {
 
   it('should test PrincipalToken: using signedToken: name Null: result error', function() {
     try {
-      var principalToken = new PrincipalToken('v=U1;d=athenz;h=test.athenz.com;a=01234abc;t=10000;e=30;k=0;z=zms;o=athenz.ci.service;i=172.168.0.1;s=signature;');
+      var principalToken = new PrincipalToken('v=U1;d=athenz;h=test.athenz.com;a=01234abc;t=10000;e=30;k=0;z=zms;o=athenz.ci.service;i=172.168.0.1;s=signature');
     } catch (e) {
       expect(e.message).to.equal('SignedToken does not contain required name component');
       return;
@@ -300,7 +300,7 @@ describe('PrincipalToken impl', function() {
   });
 
   it('should test isValidAuthorizedServiceToken: authorizedServiceSignature Null: result false', function() {
-    var tokenStr = 'v=S1;d=athenz.user;n=test;a=01234abc;t=10000;e=30;k=0;b=tech.store,tech.item;s=signature;bk=0;';
+    var tokenStr = 'v=S1;d=athenz.user;n=test;a=01234abc;t=10000;e=30;k=0;b=tech.store,tech.item;s=signature';
     var principalToken = new PrincipalToken(tokenStr);
 
     expect(principalToken.isValidAuthorizedServiceToken()).to.be.false;
@@ -318,5 +318,45 @@ describe('PrincipalToken impl', function() {
     var principalToken = new PrincipalToken(tokenStr);
 
     expect(principalToken.isValidAuthorizedServiceToken()).to.be.false;
+  });
+  it('should test PrincipalToken: claims appended after the signature are ignored', function() {
+    var tokenStr = 'v=U1;d=user;n=attacker;a=01234abc;t=10000;e=30;k=0;s=signature;bk=0;bs=bsignature';
+    var principalToken = new PrincipalToken(tokenStr.replace('s=signature', 's=signature;d=user;n=athenz.ui.admin'));
+
+    expect(principalToken.getDomain()).to.equal('user');
+    expect(principalToken.getName()).to.equal('attacker');
+    expect(principalToken.getSignature()).to.equal('signature');
+  });
+
+  it('should test PrincipalToken: signature component with invalid characters: result error', function() {
+    expect(function() {
+      new PrincipalToken('v=U1;d=user;n=attacker;a=01234abc;t=10000;e=30;k=0;s=signature;d=user;n=athenz.ui.admin');
+    }).to.throw(Error, 'SignedToken contains an invalid signature component');
+  });
+
+  it('should test PrincipalToken: authorized service signature with invalid characters: result error', function() {
+    expect(function() {
+      new PrincipalToken('v=U1;d=user;n=attacker;a=01234abc;t=10000;e=30;k=0;b=tech.item;s=signature;bk=0;bs=bsignature;n=athenz.ui.admin');
+    }).to.throw(Error, 'SignedToken contains an invalid authorized service signature component');
+  });
+
+  it('should test PrincipalToken: appended claims must not impersonate another user', function() {
+    var principalToken = new PrincipalToken(tokenObject);
+    principalToken.sign(privateKey);
+
+    expect(function() {
+      new PrincipalToken(principalToken.getSignedToken() + ';d=user;n=athenz.ui.admin');
+    }).to.throw(Error, 'SignedToken contains an invalid signature component');
+  });
+  it('should test PrincipalToken: non-numeric expiry: result error', function() {
+    expect(function() {
+      new PrincipalToken(signedToken.replace('e=30', 'e=abc'));
+    }).to.throw(Error, 'SignedToken contains invalid numeric value for expiry component');
+  });
+
+  it('should test PrincipalToken: non-numeric timestamp: result error', function() {
+    expect(function() {
+      new PrincipalToken(signedToken.replace('t=10000', 't='));
+    }).to.throw(Error, 'SignedToken contains invalid numeric value for timestamp component');
   });
 });

--- a/libs/nodejs/auth_core/test/unit/token/RoleToken.js
+++ b/libs/nodejs/auth_core/test/unit/token/RoleToken.js
@@ -162,4 +162,29 @@ describe('RoleToken impl', function() {
       new RoleToken(tokenObj2);
     }).to.throw(Error, 'version, domain and roles parameters must not be null.');
   });
+  it('should test RoleToken: signature component with invalid characters: result error', function() {
+    expect(function() {
+      new RoleToken(signedToken + ';d=athenz.victim;r=admins');
+    }).to.throw(Error, 'SignedToken contains an invalid signature component');
+  });
+
+  it('should test RoleToken: appended claims must not authenticate as victim domain', function() {
+    var roleToken = new RoleToken(tokenObject);
+    roleToken.sign(privateKey);
+
+    expect(function() {
+      new RoleToken(roleToken.getSignedToken() + ';d=athenz.victim;r=admins');
+    }).to.throw(Error, 'SignedToken contains an invalid signature component');
+  });
+  it('should test RoleToken: non-numeric expiry: result error', function() {
+    expect(function() {
+      new RoleToken(signedToken.replace('e=30', 'e=abc'));
+    }).to.throw(Error, 'SignedToken contains invalid numeric value for expiry component');
+  });
+
+  it('should test RoleToken: non-numeric timestamp: result error', function() {
+    expect(function() {
+      new RoleToken(signedToken.replace('t=10000', 't=1e5'));
+    }).to.throw(Error, 'SignedToken contains invalid numeric value for timestamp component');
+  });
 });


### PR DESCRIPTION
RoleToken and PrincipalToken verified the signature over the substring preceding the first ";s=" separator but extracted their claims by iterating over the full token string with last-occurrence-wins semantics. Any "key=value" pairs appended after the signature therefore overrode the signed values while the signature still verified, so a holder of a valid token could present a different domain, role list, or principal name to RoleAuthority, PrincipalAuthority and the ZPE client. The Java implementation already restricts parsing to the unsigned prefix; this brings the Node.js implementation in line.

- Parse claims only from the unsigned prefix, mirroring the Java parser. PrincipalToken's authorized-service fields (bk/bn/bs) are extracted from their own slice bounded by ";bs=" since they legitimately follow the primary signature.
- Reject signature components containing characters outside the ybase64 alphabet. Node's base64 decoder silently drops invalid characters, so without this check trailing data after the signature would still decode to the original signature bytes.
- Reject non-numeric t= and e= values. Number() yields NaN for these and every comparison against NaN is false, which bypassed all time based validation. Java's Long.parseLong already rejects them.
- ZPE client: deny access with DENY_ROLETOKEN_INVALID when RoleToken construction throws instead of propagating the exception to the caller.

Three existing PrincipalToken test fixtures carried a stray trailing ";" after the signature and are updated; their original assertions (missing domain/name) are unchanged.

# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

