### PR TITLE
Include proxy principal spiffe uris in access tokens without mTLS binding

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/AccessToken.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/token/AccessToken.java
@@ -333,7 +333,7 @@ public class AccessToken extends OAuth2Token {
 
         List<String> spiffeUris = null;
         try {
-            spiffeUris = (List<String>) confirm.get(CLAIM_CONFIRM_PROXY_SPIFFE);
+            spiffeUris = (List<String>) getConfirmEntry(CLAIM_CONFIRM_PROXY_SPIFFE);
         } catch (Exception ignored) {
         }
         return spiffeUris;
@@ -346,13 +346,12 @@ public class AccessToken extends OAuth2Token {
             return false;
         }
 
-        // extract our confirmation hash claim
+        // extract our confirmation hash claim. the token might not be
+        // bound to a certificate if the client was not authenticated
+        // with a certificate when the token was issued, so the hash
+        // could be null and the remaining checks must handle that case
 
         final String cnfHash = (String) getConfirmEntry(CLAIM_CONFIRM_X509_HASH);
-        if (cnfHash == null) {
-            LOG.error("confirmMTLSBoundToken: token does not have confirmation entry");
-            return false;
-        }
 
         // first we're going to verify our expected
         // x.509 certificate hash
@@ -373,6 +372,7 @@ public class AccessToken extends OAuth2Token {
         // check if the certificate principal matches and the
         // creation time for our cert is within our configured
         // offset timeouts
+
         StringBuilder errorStore = new StringBuilder();
         if (confirmX509CertPrincipal(x509Cert, cn, errorStore)) {
             return true;
@@ -395,12 +395,13 @@ public class AccessToken extends OAuth2Token {
 
         List<String> spiffeUris;
         try {
-            spiffeUris = (List<String>) confirm.get(CLAIM_CONFIRM_PROXY_SPIFFE);
+            spiffeUris = (List<String>) getConfirmEntry(CLAIM_CONFIRM_PROXY_SPIFFE);
         } catch (Exception ex) {
             errorStore.append("Unable to parse proxy principal claim: ").append(ex.getMessage()).append(";");
             return false;
         }
         if (spiffeUris == null) {
+            errorStore.append("confirmX509CertPrincipalAuthzDetails: no proxy principals in access token;");
             return false;
         }
 
@@ -417,6 +418,12 @@ public class AccessToken extends OAuth2Token {
 
     boolean confirmX509CertHash(X509Certificate cert, final String cnfHash) {
 
+        // if the token is not bound to a certificate then
+        // there is no hash to compare against
+
+        if (cnfHash == null) {
+            return false;
+        }
         final String certHash = getX509CertificateHash(cert);
         return cnfHash.equals(certHash);
     }
@@ -426,11 +433,22 @@ public class AccessToken extends OAuth2Token {
         // if the proxy principal set is not null then the client
         // has specified some value so we'll enforce it (even if
         // the set is empty thus rejecting all requests)
+
         if (ACCESS_TOKEN_PROXY_PRINCIPALS != null && !ACCESS_TOKEN_PROXY_PRINCIPALS.contains(cn)) {
             errorStore.append("confirmX509ProxyPrincipal: unauthorized proxy principal: ").append(cn).append(";");
             LOG.error(errorStore.toString());
             return false;
         }
+
+        // if the token is not bound to a certificate then there is
+        // no hash to compare the forwarded certificate hash against
+
+        if (cnfHash == null) {
+            errorStore.append("confirmX509ProxyPrincipal: token does not have certificate confirmation entry;");
+            LOG.error(errorStore.toString());
+            return false;
+        }
+
         if (!cnfHash.equals(certHash)) {
             LOG.error(errorStore.toString());
             return false;

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/AccessTokenTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/token/AccessTokenTest.java
@@ -728,6 +728,107 @@ public class AccessTokenTest {
         }
     }
 
+    AccessToken createUnboundAccessToken(long now) {
+
+        // access token that is not bound to a certificate
+        // thus no x5t#S256 confirmation entry
+
+        AccessToken accessToken = new AccessToken();
+        accessToken.setAuthTime(now);
+        accessToken.setJwtId("jwt-id001");
+        accessToken.setSubject("athenz.api");
+        accessToken.setUserId("userid");
+        accessToken.setExpiryTime(now + 3600);
+        accessToken.setIssueTime(now);
+        accessToken.setClientId("mtls");
+        accessToken.setAudience("coretech");
+        accessToken.setVersion(1);
+        accessToken.setIssuer("athenz");
+        accessToken.setScope(Collections.singletonList("readers"));
+        return accessToken;
+    }
+
+    @Test
+    public void testConfirmMTLSBoundTokenNoHashWithProxyPrincipal() throws IOException {
+
+        long now = System.currentTimeMillis() / 1000;
+        AccessToken accessToken = createUnboundAccessToken(now);
+        accessToken.setConfirmProxyPrincipalSpiffeUris(Collections.singletonList("spiffe://athenz/domain1/service1"));
+        assertNull(accessToken.getConfirmEntry("x5t#S256"));
+
+        Path path = Paths.get("src/test/resources/x509_altnames_singleuri.cert");
+        String certStr = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(certStr);
+
+        // the certificate spiffe uri matches one of the proxy principals
+        // so the token must be accepted even without a certificate hash
+
+        assertTrue(accessToken.confirmMTLSBoundToken(cert, null));
+        assertTrue(accessToken.confirmMTLSBoundToken(cert, "cnf-hash"));
+
+        // now verify the same behavior with a signed token
+
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        String accessJws = accessToken.getSignedToken(privateKey, "eckey1", "ES256");
+        assertNotNull(accessJws);
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        JwtsSigningKeyResolver resolver = new JwtsSigningKeyResolver(jwksUri, null);
+
+        AccessToken checkToken = new AccessToken(accessJws, resolver, cert);
+        assertNotNull(checkToken);
+        assertNull(checkToken.getConfirmEntry("x5t#S256"));
+        List<String> spiffeUris = checkToken.getConfirmProxyPrincpalSpiffeUris();
+        assertEquals(spiffeUris.size(), 1);
+        assertEquals(spiffeUris.get(0), "spiffe://athenz/domain1/service1");
+    }
+
+    @Test
+    public void testConfirmMTLSBoundTokenNoHashWithProxyPrincipalMismatch() throws IOException {
+
+        long now = System.currentTimeMillis() / 1000;
+        AccessToken accessToken = createUnboundAccessToken(now);
+        accessToken.setConfirmProxyPrincipalSpiffeUris(Collections.singletonList("spiffe://athenz/sports/service1"));
+
+        Path path = Paths.get("src/test/resources/x509_altnames_singleuri.cert");
+        String certStr = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(certStr);
+
+        // the certificate spiffe uri is not in the proxy principal
+        // list so the token must be rejected
+
+        assertFalse(accessToken.confirmMTLSBoundToken(cert, null));
+
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        String accessJws = accessToken.getSignedToken(privateKey, "eckey1", "ES256");
+        assertNotNull(accessJws);
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        JwtsSigningKeyResolver resolver = new JwtsSigningKeyResolver(jwksUri, null);
+
+        try {
+            new AccessToken(accessJws, resolver, cert);
+            fail();
+        } catch (CryptoException ex) {
+            assertTrue(ex.getMessage().contains("Confirmation failure"));
+        }
+    }
+
+    @Test
+    public void testConfirmMTLSBoundTokenNoHashNoProxyPrincipals() throws IOException {
+
+        // token has neither a certificate hash nor proxy principals
+
+        long now = System.currentTimeMillis() / 1000;
+        AccessToken accessToken = createUnboundAccessToken(now);
+
+        Path path = Paths.get("src/test/resources/x509_altnames_singleuri.cert");
+        String certStr = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(certStr);
+
+        assertFalse(accessToken.confirmMTLSBoundToken(cert, null));
+    }
+
     @Test
     public void testConfirmMTLSBoundTokenWithProxyNotAllowed() throws IOException {
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2953,14 +2953,16 @@ public class ZTSImpl implements ZTSHandler {
 
         // if we have a certificate used for mTLS authentication then
         // we're going to bind the certificate to the access token
-        // and the optional proxy principals if specified
 
         X509Certificate cert = principal.getX509Certificate();
         if (cert != null) {
             accessToken.setConfirmX509CertHash(cert);
-            if (accessTokenRequest.getProxyPrincipalsSpiffeUris() != null) {
-                accessToken.setConfirmProxyPrincipalSpiffeUris(accessTokenRequest.getProxyPrincipalsSpiffeUris());
-            }
+        }
+
+        // include the optional proxy principals if specified
+
+        if (accessTokenRequest.getProxyPrincipalsSpiffeUris() != null) {
+            accessToken.setConfirmProxyPrincipalSpiffeUris(accessTokenRequest.getProxyPrincipalsSpiffeUris());
         }
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -566,6 +566,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -623,6 +625,8 @@ public class ZTSImplAccessTokenTest {
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -667,6 +671,8 @@ public class ZTSImplAccessTokenTest {
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -746,6 +752,7 @@ public class ZTSImplAccessTokenTest {
                 "grant_type=client_credentials&proxy_for_principal=&scope=" + scope);
         assertNotNull(resp);
         assertEquals(resp.getScope(), "coretech:role.writers");
+        cloudStore.close();
     }
 
     @Test
@@ -788,6 +795,7 @@ public class ZTSImplAccessTokenTest {
                 "grant_type=client_credentials&scope=coretech:domain&expires_in=100");
         assertNotNull(resp);
         assertEquals(resp.getScope(), "coretech:role.readers coretech:role.writers");
+        cloudStore.close();
     }
 
     @Test
@@ -854,6 +862,7 @@ public class ZTSImplAccessTokenTest {
         }
 
         System.clearProperty(ZTSConsts.ZTS_PROP_PRINCIPAL_IDENTITY_ISSUER_MAP_FNAME);
+        cloudStore.close();
     }
 
     @Test
@@ -905,6 +914,7 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+        cloudStore.close();
     }
 
     @Test
@@ -942,6 +952,8 @@ public class ZTSImplAccessTokenTest {
 
         JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(ztsImpl.privateRSAKey.getKey()));
         assertTrue(signedJWT.verify(verifier));
+
+        cloudStore.close();
     }
 
     @Test
@@ -982,6 +994,8 @@ public class ZTSImplAccessTokenTest {
 
         JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(ztsImpl.privateECKey.getKey()));
         assertTrue(signedJWT.verify(verifier));
+
+        cloudStore.close();
     }
 
     @Test
@@ -1025,6 +1039,8 @@ public class ZTSImplAccessTokenTest {
                 "grant_type=client_credentials&scope=coretech:role.writers");
         assertNotNull(resp);
         assertNull(resp.getScope());
+
+        cloudStore.close();
     }
 
     @Test
@@ -1077,6 +1093,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1159,6 +1177,8 @@ public class ZTSImplAccessTokenTest {
         }
         assertNotNull(claimSet);
         assertEquals(issuer, claimSet.getIssuer());
+
+        cloudStore.close();
     }
 
     @Test
@@ -1207,6 +1227,8 @@ public class ZTSImplAccessTokenTest {
         // the value should be 12 hours - the default max
 
         assertEquals(claimSet.getExpirationTime().getTime() - claimSet.getIssueTime().getTime(), 12 * 60 * 60 * 1000);
+
+        cloudStore.close();
     }
 
     @Test
@@ -1265,6 +1287,8 @@ public class ZTSImplAccessTokenTest {
 
         assertNotNull(resp.getAccess_token());
         assertNull(resp.getId_token());
+
+        cloudStore.close();
     }
 
     @Test
@@ -1440,6 +1464,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1500,6 +1526,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1618,6 +1646,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1667,6 +1697,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1774,6 +1806,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1875,6 +1909,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ResourceException ex) {
             assertTrue(ex.getMessage().contains("Authorization Details configuration mismatch"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -1972,6 +2008,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ResourceException ex) {
             assertTrue(ex.getMessage().contains("Authorization Details configuration mismatch"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -2033,6 +2071,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -2079,6 +2119,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -2162,6 +2204,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -2259,6 +2303,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     private String createJagToken(PrivateKey key, String keyId, String subject, String clientId,
@@ -2358,6 +2404,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -2439,6 +2487,8 @@ public class ZTSImplAccessTokenTest {
         }
 
         System.clearProperty(ZTSConsts.ZTS_PROP_PROVIDER_CONFIG_FILE);
+
+        cloudStore.close();
     }
 
     @Test
@@ -2494,6 +2544,8 @@ public class ZTSImplAccessTokenTest {
 
         System.clearProperty(ZTSConsts.ZTS_PROP_OPENID_ISSUER);
         System.clearProperty(ZTSConsts.ZTS_PROP_OAUTH_ISSUER);
+
+        cloudStore.close();
     }
 
     @Test
@@ -2897,6 +2949,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3091,6 +3145,8 @@ public class ZTSImplAccessTokenTest {
                 fail("Want error: " + wantErrorMessage + ", Got error: " + ex.getMessage());
             }
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3130,6 +3186,8 @@ public class ZTSImplAccessTokenTest {
             assertEquals(ex.getCode(), ResourceException.FORBIDDEN);
             assertTrue(ex.getMessage().contains("Authorized service principal forbidden for jag token exchange"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3164,6 +3222,8 @@ public class ZTSImplAccessTokenTest {
             assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid assertion token"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3202,6 +3262,8 @@ public class ZTSImplAccessTokenTest {
             assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Unknown jag assertion audience"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3240,6 +3302,8 @@ public class ZTSImplAccessTokenTest {
             assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid jag assertion client_id"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3278,6 +3342,8 @@ public class ZTSImplAccessTokenTest {
             assertEquals(ex.getCode(), 400);
             assertTrue(ex.getMessage().contains("Invalid jag assertion - missing subject"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3315,6 +3381,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3354,6 +3422,8 @@ public class ZTSImplAccessTokenTest {
             assertEquals(ex.getCode(), 404);
             assertTrue(ex.getMessage().contains("No such domain"));
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3391,6 +3461,8 @@ public class ZTSImplAccessTokenTest {
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 403);
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -3429,6 +3501,8 @@ public class ZTSImplAccessTokenTest {
         // Should return all roles user has access to
         assertTrue(resp.getScope().contains("coretech:role."));
         assertNotNull(resp.getAccess_token());
+
+        cloudStore.close();
     }
 
     @Test
@@ -3467,6 +3541,8 @@ public class ZTSImplAccessTokenTest {
         // Should return scope response since requested != returned
         assertTrue(resp.getScope().contains("coretech:role."));
         assertNotNull(resp.getAccess_token());
+
+        cloudStore.close();
     }
 
     private String createClientAssertionToken(PrivateKey privateKey) {
@@ -3985,6 +4061,8 @@ public class ZTSImplAccessTokenTest {
         } finally {
             cloudStore.close();
         }
+
+        cloudStore.close();
     }
 
     @Test
@@ -4667,6 +4745,8 @@ public class ZTSImplAccessTokenTest {
         cloudStore.close();
 
         System.clearProperty(ZTSConsts.ZTS_PROP_PROVIDER_CONFIG_FILE);
+
+        cloudStore.close();
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -2024,11 +2024,58 @@ public class ZTSImplAccessTokenTest {
 
             Map<String, Object> cnf = (Map<String, Object>) claimSet.getClaim("cnf");
             assertNotNull(cnf);
+            assertNotNull(cnf.get("x5t#S256"));
             List<String> spiffeUris = (List<String>) cnf.get("proxy-principals#spiffe");
             assertNotNull(spiffeUris);
             assertEquals(spiffeUris.size(), 2);
             assertTrue(spiffeUris.contains("spiffe://athenz/sa/api"));
             assertTrue(spiffeUris.contains("spiffe://sports/sa/api"));
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testPostAccessTokenRequestWithProxyPrincipalsNoCertificate() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        // set back to our zts rsa private key
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        // principal is not authenticated with a certificate so the token
+        // must not be certificate bound but must still include the
+        // requested proxy principals in the confirmation claim
+
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=U1;d=user_domain;n=user;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=client_credentials&scope=coretech:role.writers&proxy_principal_spiffe_uris="
+                + PROXY_PRINCIPAL_SPIFFE_URIS);
+        assertNotNull(resp);
+        assertNull(resp.getScope());
+
+        ServerPrivateKey privateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(privateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+
+            assertEquals(claimSet.getAudience().get(0), "coretech");
+            assertEquals(claimSet.getIssuer(), ztsImpl.ztsOAuthIssuer);
+
+            Map<String, Object> cnf = claimSet.getJSONObjectClaim("cnf");
+            assertNotNull(cnf);
+            assertNull(cnf.get("x5t#S256"));
+            assertEquals(cnf.get("proxy-principals#spiffe"), EXPECTED_PROXY_PRINCIPAL_SPIFFE_URIS);
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }
@@ -2549,6 +2596,67 @@ public class ZTSImplAccessTokenTest {
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 403);
             assertTrue(ex.getMessage().contains("Actor parameter requires X.509 authenticated principal"));
+        }
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestProxyPrincipalsNoCertificate() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:domain", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        // client is authenticated with a client assertion and not a certificate
+        // so the token must not be certificate bound but must still include
+        // the requested proxy principals in the confirmation claim
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey)
+                        + "&proxy_principal_spiffe_uris=" + PROXY_PRINCIPAL_SPIFFE_URIS);
+
+        assertNotNull(resp);
+        assertEquals(resp.getScope(), "coretech:role.writers");
+        assertNotNull(resp.getAccess_token());
+        assertEquals(resp.getToken_type(), "Bearer");
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "coretech");
+            assertEquals(claimSet.getStringClaim("client_id"), "coretech.jwt");
+
+            Map<String, Object> cnfClaim = claimSet.getJSONObjectClaim("cnf");
+            assertNotNull(cnfClaim);
+            assertNull(cnfClaim.get("x5t#S256"));
+            assertEquals(cnfClaim.get("proxy-principals#spiffe"), EXPECTED_PROXY_PRINCIPAL_SPIFFE_URIS);
+
+            // impersonation does not include `may_act` or `act` claim:
+            assertNull(claimSet.getJSONObjectClaim("may_act"));
+            assertNull(claimSet.getJSONObjectClaim("act"));
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
         }
     }
 
@@ -5941,6 +6049,94 @@ public class ZTSImplAccessTokenTest {
     }
 
     @Test
+    public void testProcessAccessTokenExchangeDelegationRequestWithProxyPrincipalsNoCertificate() throws JOSEException {
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain sourceDomain = createSignedDomain("sourcedomain", "weather", "storage", true);
+        store.processSignedDomain(sourceDomain, false);
+
+        SignedDomain targetDomain = createSignedDomain("targetdomain", "weather", "storage", true);
+        store.processSignedDomain(targetDomain, false);
+
+        addTokenTargetExchangePolicy("targetdomain", "sourcedomain", "user_domain.proxy-user1", "writers");
+
+        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        KeyStore keyStore = getServerPublicKeyProvider(privateKey);
+
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        List<String> subjectRoles = List.of("targetdomain:role.writers");
+        String subjectTokenStr = createAccessToken(privateKey, "0", "user_domain.user",
+                "sourcedomain", subjectRoles, "user_domain.proxy-user1", null, expiryTime);
+
+        String actorTokenStr = createActorToken(privateKey, "0", "user_domain.proxy-user1",
+                "targetdomain", expiryTime);
+
+        // principal is not authenticated with a certificate so the token
+        // must not be certificate bound but must still include the
+        // requested proxy principals in the confirmation claim
+
+        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
+                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
+        assertNotNull(principal);
+
+        ResourceContext context = createResourceContext(principal);
+        TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
+        tokenConfigOptions.setOauth2Issuers(Set.of("https://athenz.io:4443/zts/v1"));
+        tokenConfigOptions.setPublicKeyProvider(keyStore);
+        ztsImpl.tokenConfigOptions = tokenConfigOptions;
+
+        final String requestBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+                        + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&subject_token=" + subjectTokenStr
+                        + "&subject_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&actor_token=" + actorTokenStr
+                        + "&actor_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&audience=targetdomain"
+                        + "&scope=targetdomain:role.writers"
+                        + "&proxy_principal_spiffe_uris=" + PROXY_PRINCIPAL_SPIFFE_URIS;
+
+        AccessTokenResponse response = ztsImpl.postAccessTokenRequest(context, requestBody);
+
+        assertNotNull(response);
+        assertNotNull(response.getAccess_token());
+        assertEquals(response.getToken_type(), "Bearer");
+        assertEquals(response.getScope(), "targetdomain:role.writers");
+
+        String accessTokenStr = response.getAccess_token();
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
+            assertTrue(signedJWT.verify(verifier));
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "targetdomain");
+
+            Map actMap = (Map) claimSet.getClaim("act");
+            assertNotNull(actMap);
+            assertEquals(actMap.get("sub"), "user_domain.proxy-user1");
+
+            Map<String, Object> cnfClaim = claimSet.getJSONObjectClaim("cnf");
+            assertNotNull(cnfClaim);
+            assertNull(cnfClaim.get("x5t#S256"));
+            assertEquals(cnfClaim.get("proxy-principals#spiffe"), EXPECTED_PROXY_PRINCIPAL_SPIFFE_URIS);
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        cloudStore.close();
+    }
+
+    @Test
     public void testProcessAccessTokenDelegationRequestPrincipalMismatch() {
         System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
 
@@ -7597,7 +7793,77 @@ public class ZTSImplAccessTokenTest {
             SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
             assertTrue(signedJWT.verify(verifier));
             JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
-            assertNotNull(claimSet.getClaim("cnf"));
+            Map<String, Object> cnfClaim = claimSet.getJSONObjectClaim("cnf");
+            assertNotNull(cnfClaim);
+            assertNotNull(cnfClaim.get("x5t#S256"));
+            assertEquals(cnfClaim.get("proxy-principals#spiffe"), EXPECTED_PROXY_PRINCIPAL_SPIFFE_URIS);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        cloudStore.close();
+    }
+
+    @Test
+    public void testProcessAccessTokenImpersonationRequestSuccessWithProxyPrincipalsNoCertificate() throws Exception {
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain sourceDomain = createSignedDomain("sourcedomain", "weather", "storage", true);
+        store.processSignedDomain(sourceDomain, false);
+
+        SignedDomain targetDomain = createSignedDomain("targetdomain", "weather", "storage", true);
+        store.processSignedDomain(targetDomain, false);
+
+        addTokenSourceExchangePolicy("sourcedomain", "targetdomain", "user_domain.proxy-user1");
+        addTokenTargetExchangePolicy("targetdomain", "sourcedomain", "user_domain.proxy-user1", "writers");
+
+        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        KeyStore keyStore = getServerPublicKeyProvider(privateKey);
+
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        List<String> subjectRoles = List.of("targetdomain:role.writers");
+        String subjectTokenStr = createSubjectToken(privateKey, "0", "user_domain.user",
+                "sourcedomain", subjectRoles, expiryTime);
+
+        // principal is not authenticated with a certificate so the token
+        // must not be certificate bound but must still include the
+        // requested proxy principals in the confirmation claim
+
+        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
+                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
+        assertNotNull(principal);
+
+        ResourceContext context = createResourceContext(principal);
+        TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
+        tokenConfigOptions.setOauth2Issuers(Set.of("https://athenz.io:4443/zts/v1"));
+        tokenConfigOptions.setPublicKeyProvider(keyStore);
+
+        AccessTokenRequest accessTokenRequest = getAccessTokenRequest(subjectTokenStr, tokenConfigOptions);
+
+        AccessTokenResponse response = ztsImpl.processAccessTokenImpersonationRequest(context, principal,
+                accessTokenRequest, "user_domain", "postAccessTokenRequest");
+
+        assertNotNull(response);
+        assertNotNull(response.getAccess_token());
+
+        String accessTokenStr = response.getAccess_token();
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
+            assertTrue(signedJWT.verify(verifier));
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            Map<String, Object> cnfClaim = claimSet.getJSONObjectClaim("cnf");
+            assertNotNull(cnfClaim);
+            assertNull(cnfClaim.get("x5t#S256"));
+            assertEquals(cnfClaim.get("proxy-principals#spiffe"), EXPECTED_PROXY_PRINCIPAL_SPIFFE_URIS);
         } catch (Exception ex) {
             fail(ex.getMessage());
         }


### PR DESCRIPTION
ZTS previously added the requested proxy_principal_spiffe_uris to the cnf claim only when the client authenticated with an X.509 certificate. Clients using the JAG and token exchange flows typically authenticate with a client assertion instead, so the requested proxy principals were silently dropped. The shared confirmation helper now includes the proxy principals whenever they are specified in the request, while the x5t#S256 binding is still added only when a certificate is present.

The auth_core verifier is updated accordingly: confirmMTLSBoundToken no longer rejects a token that lacks the x5t#S256 entry and instead continues with the remaining checks, so a certificate whose SPIFFE URI is listed in proxy-principals#spiffe can present an unbound token. The hash based checks treat a missing hash as a non-match instead of throwing.

Tests cover the no-certificate case for the client credentials, JAG exchange, impersonation and delegation flows in ZTS, and the accept, reject and no-proxy-list cases for unbound tokens in auth_core.

# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

